### PR TITLE
Core/Player: Fix to save pet.

### DIFF
--- a/src/world/Player.cpp
+++ b/src/world/Player.cpp
@@ -1867,7 +1867,7 @@ void Player::_SavePet(QueryBuffer* buf)
     {
         ss.rdbuf()->str("");
 
-        ss << "INSERT INTO playerpets VALUES('"
+        ss << "REPLACE INTO playerpets VALUES('"
             << GetLowGUID() << "','"
             << itr->second->number << "','"
             << itr->second->name << "','"


### PR DESCRIPTION
[11:03:46] Sql query failed due to [Duplicate entry '1-1' for key 'PRIMARY'], Query: [INSERT INTO playerpets VALUES('1','1','Raptor','3254','64046','20','80','117440514 0,117440513 0,117440512 0,52472 49408,53582 49408,61676 49408,0 0,100663298 0,100663297 0,100663296 0,','2547','0','0','0','1','1','16','100','8810','824984','1','1')]

The statement "INSERT" produces duplication rates.