### PR TITLE
Added clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ only:
 
 # define complier for build
 compiler:
-- gcc
+- clang
+#- gcc
 
 env:
  global:
@@ -22,9 +23,10 @@ env:
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get -qq install zlib1g-dev libssl-dev libpcre3-dev libbz2-dev libmysqlclient-dev libmysql++-dev gcc-4.8 g++-4.8
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+  - sudo apt-get -qq install zlib1g-dev libssl-dev libpcre3-dev libbz2-dev libmysqlclient-dev libmysql++-dev
+#  - sudo sudo apt-get -qq install g++-4.8 gcc-4.8
+#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+#  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
 
 addons:
  coverity_scan:
@@ -41,10 +43,13 @@ install:
  - cd bin
  - cmake ../
 
-script:
- - cd ..
- - cd bin
- - gcc --version
- - g++ --version
+before_script:
+# - gcc --version
+# - g++ --version
+ - clang --version
+ - clang++ --version
  - cmake --version
- - make -j 2
+
+script:
+- if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then cd ..; cd bin; make -j 2; fi
+

--- a/cmake/CheckSystem.cmake
+++ b/cmake/CheckSystem.cmake
@@ -28,6 +28,7 @@ endif()
 
 # set default architecture identifier
 if(IS_64BIT)
+    message(STATUS "Detected 64 bit system")
     add_definitions(-DX64)
 endif()
 

--- a/cmake/Compilers/clang.cmake
+++ b/cmake/Compilers/clang.cmake
@@ -1,0 +1,24 @@
+# Copyright (C) 2014-2015 AscEmu Team <http://www.ascemu.org>
+
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS REQUIRED_MIN_CLANG_VERSION)
+    message(FATAL_ERROR "Unsupported clang version")
+endif()
+
+message(STATUS "Applying settings for \"LLVM clang\" compiler")
+
+add_definitions(-DHAS_CXX0X)
+
+#apply platform specific flags
+if(APPLE)
+    set( EXTRA_LIBS "${EXTRA_LIBS} -framework Carbon" )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set( EXTRA_LIBS ${EXTRA_LIBS} dl)
+endif()
+
+# apply base flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Wno-deprecated")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-deprecated")
+
+# apply flags for debug build
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")

--- a/cmake/Requirements.cmake
+++ b/cmake/Requirements.cmake
@@ -2,3 +2,4 @@
 
 set(REQUIRED_MIN_MSVC_VERSION 1800) # visual studio 2013
 set(REQUIRED_MIN_GCC_VERSION "4.7") # gcc 4.7
+set(REQUIRED_MIN_CLANG_VERSION "3.4") # clang 3.4

--- a/cmake/Systems/Apple.cmake
+++ b/cmake/Systems/Apple.cmake
@@ -13,6 +13,8 @@ find_package(BZip2 REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()

--- a/cmake/Systems/FreeBSD.cmake
+++ b/cmake/Systems/FreeBSD.cmake
@@ -12,6 +12,8 @@ find_package(BZip2 REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()

--- a/cmake/Systems/Linux.cmake
+++ b/cmake/Systems/Linux.cmake
@@ -12,6 +12,8 @@ find_package(BZip2 REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()

--- a/dep/g3dlite/include/G3D/platform.h
+++ b/dep/g3dlite/include/G3D/platform.h
@@ -104,14 +104,18 @@ These control the version of Winsock used by G3D.
 
 #ifdef G3D_LINUX
 #   ifndef __GNUC__
-#       error G3D only supports the gcc compiler on Linux.
+#       ifndef(__clang__)
+#           error G3D only supports the gcc and clang compilers on Linux.
+#       endif
 #   endif
 #   define G3D_NO_FFMPEG
 #endif
 
 #ifdef G3D_OSX
 #    ifndef __GNUC__
-#        error G3D only supports the gcc compiler on OS X.
+#        ifndef __clang__
+#           error G3D only supports the gcc and clang compilers on OS X.
+#        endif
 #    endif
     
 #    if defined(__i386__)
@@ -250,7 +254,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
 
 #endif  // win32
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 
 #    include <stdint.h>
 
@@ -337,7 +341,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
 
 
     See G3D::Color3uint8 for an example.*/
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #    define G3D_BEGIN_PACKED_CLASS(byteAlign)  class __attribute((__packed__))
 #elif defined(_MSC_VER)
 #    define G3D_BEGIN_PACKED_CLASS(byteAlign)  PRAGMA( pack(push, byteAlign) ) class
@@ -349,7 +353,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
     End switch to tight alignment
  
     See G3D::Color3uint8 for an example.*/
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #    define G3D_END_PACKED_CLASS(byteAlign)  __attribute((aligned(byteAlign))) ;
 #elif defined(_MSC_VER)
 #    define G3D_END_PACKED_CLASS(byteAlign)  ; PRAGMA( pack(pop) )
@@ -359,7 +363,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
 
 
 // Bring in shared_ptr and weak_ptr
-#if (defined(__GNUC__) && defined(__APPLE__)) || defined(__linux__)
+#if ((defined(__GNUC__) || defined(__clang__)) && defined(__APPLE__)) || defined(__linux__)
 #include <ciso646> // Defines _LIBCC_VERSION if linking against libc++ or does nothing
 #endif
 #if (!defined(_LIBCPP_VERSION) && defined(__APPLE__)) || (!defined(_LIBCPP_VERSION) && defined(__linux__))

--- a/src/logonserver/AuthStructs.h
+++ b/src/logonserver/AuthStructs.h
@@ -20,12 +20,7 @@
 #ifndef AUTHSTRUCTS_H
 #define AUTHSTRUCTS_H
 
-#if __GNUC__ && (GCC_MAJOR < 4 || GCC_MAJOR == 4 && GCC_MINOR < 1)
-#pragma pack(1)
-#else
 #pragma pack(push,1)
-#endif
-
 typedef struct
 {
     uint8   cmd;
@@ -89,11 +84,6 @@ typedef struct
     uint16  unk203;
 } sAuthLogonProof_S;
 
-
-#if __GNUC__ && (GCC_MAJOR < 4 || GCC_MAJOR == 4 && GCC_MINOR < 1)
-#pragma pack()
-#else
 #pragma pack(pop)
-#endif
 
 #endif  //AUTHSTRUCTS_H

--- a/src/shared/Common.h
+++ b/src/shared/Common.h
@@ -27,10 +27,10 @@
 #define REPACK_WEBSITE "www.google.com"*/
 
 #ifdef WIN32
-#pragma warning(disable:4996)
-#define _CRT_SECURE_NO_DEPRECATE 1
-#define _CRT_SECURE_COPP_OVERLOAD_STANDARD_NAMES 1
-#pragma warning(disable:4251)        // dll-interface bullshit
+    #pragma warning(disable:4996)
+    #define _CRT_SECURE_NO_DEPRECATE 1
+    #define _CRT_SECURE_COPP_OVERLOAD_STANDARD_NAMES 1
+    #pragma warning(disable:4251)        // dll-interface bullshit
 #endif
 
 enum TimeVariables
@@ -53,13 +53,13 @@ enum MsTimeVariables
 };
 
 #ifdef WIN32
-#define ARCEMU_FORCEINLINE __forceinline
+    #define ARCEMU_FORCEINLINE __forceinline
 #else
-#define ARCEMU_FORCEINLINE inline
+    #define ARCEMU_FORCEINLINE inline
 #endif
 
 #ifdef HAVE_CONFIG_H
-# include <config.h>
+    #include <config.h>
 #endif
 
 #include "AscemuServerDefines.hpp"
@@ -119,30 +119,33 @@ enum MsTimeVariables
 #define COMPILER_MICROSOFT 0
 #define COMPILER_GNU       1
 #define COMPILER_BORLAND   2
+#define COMPILER_CLANG     3
 
 #ifdef _MSC_VER
 #  define COMPILER COMPILER_MICROSOFT
 #elif defined( __BORLANDC__ )
 #  define COMPILER COMPILER_BORLAND
-#elif defined( __GNUC__ )
+#elif defined(__GNUC__)
 #  define COMPILER COMPILER_GNU
+#elif defined(__clang__)
+#  define COMPILER COMPILER_CLANG
 #else
 #  pragma error "FATAL ERROR: Unknown compiler."
 #endif
 
 #if PLATFORM == PLATFORM_UNIX || PLATFORM == PLATFORM_APPLE
-#ifdef HAVE_DARWIN
-#define PLATFORM_TEXT "MacOSX"
-#define UNIX_FLAVOUR UNIX_FLAVOUR_OSX
-#else
-#ifdef USE_KQUEUE
-#define PLATFORM_TEXT "FreeBSD"
-#define UNIX_FLAVOUR UNIX_FLAVOUR_BSD
-#else
-#define PLATFORM_TEXT "Linux"
-#define UNIX_FLAVOUR UNIX_FLAVOUR_LINUX
-#endif
-#endif
+    #ifdef HAVE_DARWIN
+        #define PLATFORM_TEXT "MacOSX"
+        #define UNIX_FLAVOUR UNIX_FLAVOUR_OSX
+    #else
+        #ifdef USE_KQUEUE
+            #define PLATFORM_TEXT "FreeBSD"
+            #define UNIX_FLAVOUR UNIX_FLAVOUR_BSD
+        #else
+            #define PLATFORM_TEXT "Linux"
+            #define UNIX_FLAVOUR UNIX_FLAVOUR_LINUX
+        #endif
+    #endif
 #endif
 
 #if PLATFORM == PLATFORM_WIN32
@@ -210,34 +213,6 @@ enum MsTimeVariables
 
 #include "CommonHelpers.hpp"
 
-#if defined (__GNUC__)
-#  define GCC_VERSION (__GNUC__ * 10000 \
-                       + __GNUC_MINOR__ * 100 \
-                       + __GNUC_PATCHLEVEL__)
-#endif
-
-
-#ifndef WIN32
-#ifndef X64
-#  if defined (__GNUC__)
-#    if GCC_VERSION >= 30400
-#         ifdef HAVE_DARWIN
-#          define __fastcall
-#         else
-#              define __fastcall __attribute__((__fastcall__))
-#         endif
-#    else
-#      define __fastcall __attribute__((__regparm__(3)))
-#    endif
-#  else
-#    define __fastcall __attribute__((__fastcall__))
-#  endif
-#else
-#define __fastcall
-#endif
-#endif
-
-
 // TEST SUPPORT FOR TR1
 
 #ifdef HAS_CXX0X
@@ -248,7 +223,7 @@ enum MsTimeVariables
 #define hash_multimap unordered_multimap
 #define hash_set unordered_set
 #define hash_multiset tr1::unordered_multiset
-#elif COMPILER == COMPILER_GNU && __GNUC__ >= 3
+#elif COMPILER == COMPILER_GNU && __GNUC__ >= 3  || (COMPILER == COMPILER_CLANG && __clang_major__ >= 3)
 #include <ext/hash_map>
 #include <ext/hash_set>
 #define HM_NAMESPACE __gnu_cxx

--- a/src/world/DBC/DBCStores.h
+++ b/src/world/DBC/DBCStores.h
@@ -489,7 +489,7 @@ struct SpellEntry
     uint32 baseLevel;                                         // 38
     uint32 spellLevel;                                        // 39
     uint32 DurationIndex;                                     // 40
-    uint32 powerType;                                         // 41
+    int32 powerType;                                         // 41
     uint32 manaCost;                                          // 42
     uint32 manaCostPerlevel;                                  // 43
     uint32 manaPerSecond;                                     // 44


### PR DESCRIPTION
updated travis to use clang instead gcc (to use gcc, just uncomment gcc
lines and comment clang)
base clang requirement is 3.4 version
removed __fastcall redefinition
added addiitonal message that x64 build environment is detected