### PR TITLE
Configuration for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+os: 
+  - Visual Studio 2013
+#  - Visual Studio 2015
+
+clone_depth: 1
+
+branches:
+  except:
+    - coverity_scan
+
+environment:
+  matrix:
+  - VS_VER: Visual Studio 12 2013
+  - VS_VER: Visual Studio 12 2013 Win64
+#  - VS_VER: Visual Studio 14 2015
+#  - VS_VER: Visual Studio 14 2015 Win64
+
+configuration: Release
+
+init:
+  - cmd: cmake --version
+  - cmd: msbuild /version
+
+before_build:
+  - cmd: echo %VS_VER%
+  - cmd: echo %Configuration%
+
+build_script:
+  - cmd: mkdir ascemu_build
+  - cmd: cd ascemu_build
+  - cmd: cmake ../ -G "%VS_VER%" -DBUILD_WITH_WARNINGS=1 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_TOOLS=1
+  - cmd: msbuild Ascemu.sln


### PR DESCRIPTION
This service tests msvc builds but firstly you must register project in https://ci.appveyor.com and enable it in github settings to get this configuration working.
Also there is issue with msvc warnings in release mode - I added patch but in different pull request (optimization), so just in case, just set -DBUILD_WITH_WARNINGS=0 to make this working if past pull request wont be merged

Also theres badges for appveyor, you can find links in appveyor project settings (registered project settings)

example:
https://ci.appveyor.com/project/Lectro/ascemu/build/1.0.253 - ignore commit message :)

about messages tab - messages are generated after complete build