### PR TITLE
Make SpellInfo no longer modifeable

### DIFF
--- a/src/scripts/Battlegrounds/ArathiBasin.cpp
+++ b/src/scripts/Battlegrounds/ArathiBasin.cpp
@@ -652,7 +652,7 @@ void ArathiBasin::HookOnAreaTrigger(Player* plr, uint32 trigger)
             sEventMgr.AddEvent(this, &ArathiBasin::SpawnBuff, static_cast<uint32>(buffslot), EVENT_AB_RESPAWN_BUFF, AB_BUFF_RESPAWN_TIME, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
 
             // cast the spell on the player
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
             if (sp)
             {
                 Spell* pSpell = sSpellFactoryMgr.NewSpell(plr, sp, true, nullptr);

--- a/src/scripts/Battlegrounds/EyeOfTheStorm.cpp
+++ b/src/scripts/Battlegrounds/EyeOfTheStorm.cpp
@@ -327,7 +327,7 @@ void EyeOfTheStorm::HookOnAreaTrigger(Player* plr, uint32 id)
         if (EOTSm_buffs[x] && EOTSm_buffs[x]->IsInWorld())
         {
             spellid = EOTSm_buffs[x]->GetGameObjectProperties()->raw.parameter_3;
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
             if (sp)
             {
                 Spell* pSpell = sSpellFactoryMgr.NewSpell(plr, sp, true, NULL);

--- a/src/scripts/Battlegrounds/WarsongGulch.cpp
+++ b/src/scripts/Battlegrounds/WarsongGulch.cpp
@@ -168,7 +168,7 @@ void WarsongGulch::HookOnAreaTrigger(Player* plr, uint32 id)
         if (m_buffs[buffslot] != 0 && m_buffs[buffslot]->IsInWorld())
         {
             // apply the buff
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(m_buffs[buffslot]->GetGameObjectProperties()->raw.parameter_3);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(m_buffs[buffslot]->GetGameObjectProperties()->raw.parameter_3);
             Spell* s = sSpellFactoryMgr.NewSpell(plr, sp, true, 0);
             SpellCastTargets targets(plr->GetGUID());
             s->prepare(&targets);
@@ -344,7 +344,7 @@ void WarsongGulch::HookFlagDrop(Player* plr, GameObject* obj)
      */
     m_dropFlags[plr->GetTeam()]->SetNewGuid(m_mapMgr->GenerateGameobjectGuid());
 
-    SpellInfo* pSp = sSpellCustomizations.GetSpellInfo(23333 + (plr->GetTeam() * 2));
+    SpellInfo const* pSp = sSpellCustomizations.GetSpellInfo(23333 + (plr->GetTeam() * 2));
     Spell* sp = sSpellFactoryMgr.NewSpell(plr, pSp, true, 0);
     SpellCastTargets targets(plr->GetGUID());
     sp->prepare(&targets);
@@ -399,7 +399,7 @@ void WarsongGulch::HookFlagStand(Player* plr, GameObject* obj)
         return;
     }
 
-    SpellInfo* pSp = sSpellCustomizations.GetSpellInfo(23333 + (plr->GetTeam() * 2));
+    SpellInfo const* pSp = sSpellCustomizations.GetSpellInfo(23333 + (plr->GetTeam() * 2));
     Spell* sp = sSpellFactoryMgr.NewSpell(plr, pSp, true, 0);
     SpellCastTargets targets(plr->GetGUID());
     sp->prepare(&targets);

--- a/src/scripts/Common/Base.cpp
+++ b/src/scripts/Common/Base.cpp
@@ -37,7 +37,7 @@ TargetType::~TargetType()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //Class SpellDesc
-SpellDesc::SpellDesc(SpellInfo* pInfo, SpellFunc pFnc, TargetType pTargetType, float pChance, float pCastTime, int32 pCooldown, float pMinRange, float pMaxRange,
+SpellDesc::SpellDesc(SpellInfo const* pInfo, SpellFunc pFnc, TargetType pTargetType, float pChance, float pCastTime, int32 pCooldown, float pMinRange, float pMaxRange,
                      bool pStrictRange, const char* pText, TextType pTextType, uint32 pSoundId, const char* pAnnouncement)
 {
     mInfo = pInfo;
@@ -533,7 +533,7 @@ SpellDesc* MoonScriptCreatureAI::AddSpell(uint32 pSpellId, TargetType pTargetTyp
     SpellDesc* NewSpell = NULL;
 
     //Find spell info from spell id
-    SpellInfo* Info = sSpellCustomizations.GetSpellInfo(pSpellId);
+    SpellInfo const* Info = sSpellCustomizations.GetSpellInfo(pSpellId);
 
 #ifdef USE_DBC_SPELL_INFO
     float CastTime = (Info->CastingTimeIndex) ? GetCastTime(sSpellCastTimesStore.LookupEntry(Info->CastingTimeIndex)) : pCastTime;
@@ -1255,7 +1255,7 @@ bool MoonScriptCreatureAI::CastSpellInternal(SpellDesc* pSpell, uint32 pCurrentT
     return true;            //No targets possible? Consider spell casted nonetheless
 }
 
-void MoonScriptCreatureAI::CastSpellOnTarget(Unit* pTarget, TargetType pType, SpellInfo* pEntry, bool pInstant)
+void MoonScriptCreatureAI::CastSpellOnTarget(Unit* pTarget, TargetType pType, SpellInfo const* pEntry, bool pInstant)
 {
     switch (pType.mTargetGenerator)
     {

--- a/src/scripts/Common/Base.h
+++ b/src/scripts/Common/Base.h
@@ -256,7 +256,7 @@ class SpellDesc
 {
     public:
 
-        SpellDesc(SpellInfo* pInfo, SpellFunc pFnc, TargetType pTargetType, float pChance, float pCastTime, int32 pCooldown, float pMinRange, float pMaxRange, 
+        SpellDesc(SpellInfo const* pInfo, SpellFunc pFnc, TargetType pTargetType, float pChance, float pCastTime, int32 pCooldown, float pMinRange, float pMaxRange,
                   bool pStrictRange, const char* pText, TextType pTextType, uint32 pSoundId, const char* pAnnouncement);
 
         virtual ~SpellDesc();
@@ -266,7 +266,7 @@ class SpellDesc
         void TriggerCooldown(uint32 pCurrentTime = 0);
         void AddAnnouncement(const char* pText);
 
-        SpellInfo* mInfo;              //Spell Entry information (generally you either want a SpellEntry OR a SpellFunc, not both)
+        SpellInfo const* mInfo;              //Spell Entry information (generally you either want a SpellEntry OR a SpellFunc, not both)
         SpellFunc mSpellFunc;           //Spell Function to be executed (generally you either want a SpellEntry OR a SpellFunc, not both)
         TargetType mTargetType;         //Target type (see class above)
 
@@ -444,7 +444,7 @@ class MoonScriptCreatureAI : public CreatureAIScript
 
         bool IsSpellScheduled(SpellDesc* pSpell);
         bool CastSpellInternal(SpellDesc* pSpell, uint32 pCurrentTime = 0);
-        void CastSpellOnTarget(Unit* pTarget, TargetType pType, SpellInfo* pEntry, bool pInstant);
+        void CastSpellOnTarget(Unit* pTarget, TargetType pType, SpellInfo const* pEntry, bool pInstant);
         int32 CalcSpellAttackTime(SpellDesc* pSpell);
         void CancelAllSpells();
 

--- a/src/scripts/Common/Instance_Base.cpp
+++ b/src/scripts/Common/Instance_Base.cpp
@@ -488,7 +488,7 @@ void MoonInstanceScript::OnGameObjectPushToWorld(GameObject* pGameObject)
         pGameObject->SetState((*Iter).second);
 };
 
-GameObject* MoonInstanceScript::GetObjectForOpenLock(Player* pCaster, Spell* pSpell, SpellInfo* pSpellEntry)
+GameObject* MoonInstanceScript::GetObjectForOpenLock(Player* pCaster, Spell* pSpell, SpellInfo const* pSpellEntry)
 {
     return NULL;
 };

--- a/src/scripts/Common/Instance_Base.h
+++ b/src/scripts/Common/Instance_Base.h
@@ -193,7 +193,7 @@ class MoonInstanceScript : public InstanceScript
         virtual void OnGameObjectPushToWorld(GameObject* pGameObject);
 
         // Reimplemented events
-        virtual GameObject* GetObjectForOpenLock(Player* pCaster, Spell* pSpell, SpellInfo* pSpellEntry);
+        virtual GameObject* GetObjectForOpenLock(Player* pCaster, Spell* pSpell, SpellInfo const* pSpellEntry);
         virtual void SetLockOptions(uint32 pEntryId, GameObject* pGameObject);
         virtual uint32 GetRespawnTimeForCreature(uint32 pEntryId, Creature* pCreature);
 

--- a/src/scripts/InstanceScripts/Instance_MagistersTerrace.cpp
+++ b/src/scripts/InstanceScripts/Instance_MagistersTerrace.cpp
@@ -213,7 +213,7 @@ class SelinFireheartAI : public MoonScriptCreatureAI
         _unit->setUInt32Value(UNIT_FIELD_POWER1, _unit->GetPower(POWER_TYPE_MANA) - 3231);
     }
 
-    SpellInfo* ManaRage;
+    SpellInfo const* ManaRage;
     SpellDesc* ManaRageTrigger;
     SpellDesc* FelExplosion;
 };

--- a/src/scripts/InstanceScripts/Instance_ZulFarrak.cpp
+++ b/src/scripts/InstanceScripts/Instance_ZulFarrak.cpp
@@ -149,8 +149,8 @@ class ThekaAI : public CreatureAIScript
     protected:
         int plaguecount, randomplague;
         bool morphcheck;
-        SpellInfo* morph;
-        SpellInfo* plague;
+        SpellInfo const* morph;
+        SpellInfo const* plague;
 };
 
 
@@ -395,7 +395,7 @@ class AntusulAI : public CreatureAIScript
         Creature* add6;
         Creature* trigger;
 
-        SpellInfo* servant;
+        SpellInfo const* servant;
         //SpellEntry* healing_ward;
         //SpellEntry* earthgrab_ward;
 };

--- a/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
@@ -1899,7 +1899,7 @@ class SupremusAI : public CreatureAIScript
         uint32 timer;
         uint32 m_phase;
         bool m_MoltenFlame, m_HurtfulStrike, m_MoltenPunch, m_VolcanicGazer;
-        SpellInfo* infoMoltenFlame, *infoHurtfulStrike, *infoMoltenPunch, *infoVolcanicGazer;
+        SpellInfo const* infoMoltenFlame, *infoHurtfulStrike, *infoMoltenPunch, *infoVolcanicGazer;
 };
 
 //------------------------------------

--- a/src/scripts/InstanceScripts/Raid_Karazhan.cpp
+++ b/src/scripts/InstanceScripts/Raid_Karazhan.cpp
@@ -1937,19 +1937,19 @@ class ShadeofAranAI : public CreatureAIScript
         uint32 m_time_conjure;
         uint32 FlameWreathTimer;
         uint64 FlameWreathTarget[3];
-        SpellInfo* info_flame_wreath;
-        SpellInfo* info_aexplosion;
-        SpellInfo* info_blizzard;
-        SpellInfo* info_magnetic_pull;
-        SpellInfo* info_blink_center;
-        SpellInfo* info_massslow;
-        SpellInfo* info_mass_polymorph;
-        SpellInfo* info_conjure;
-        SpellInfo* info_drink;
-        SpellInfo* info_pyroblast;
-        SpellInfo* info_summon_elemental_1;
-        SpellInfo* info_summon_elemental_2;
-        SpellInfo* info_summon_elemental_3;
+        SpellInfo const* info_flame_wreath;
+        SpellInfo const* info_aexplosion;
+        SpellInfo const* info_blizzard;
+        SpellInfo const* info_magnetic_pull;
+        SpellInfo const* info_blink_center;
+        SpellInfo const* info_massslow;
+        SpellInfo const* info_mass_polymorph;
+        SpellInfo const* info_conjure;
+        SpellInfo const* info_drink;
+        SpellInfo const* info_pyroblast;
+        SpellInfo const* info_summon_elemental_1;
+        SpellInfo const* info_summon_elemental_2;
+        SpellInfo const* info_summon_elemental_3;
 };
 
 class WaterEleAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Raid_MoltenCore.cpp
+++ b/src/scripts/InstanceScripts/Raid_MoltenCore.cpp
@@ -86,7 +86,7 @@ class CoreRagerAI : public CreatureAIScript
     protected:
 
         bool m_mangle;
-        SpellInfo* info_mangle;
+        SpellInfo const* info_mangle;
 };
 
 #define CN_SULFURON_HARBRINGER 12098
@@ -183,7 +183,7 @@ class SulfuronAI : public CreatureAIScript
     protected:
 
         bool m_demoralizingshout, m_inspire, m_flamespear;
-        SpellInfo* info_demoralizingshout, *info_inspire, *info_flamespear;
+        SpellInfo const* info_demoralizingshout, *info_inspire, *info_flamespear;
 };
 
 
@@ -325,7 +325,7 @@ class RagnarosAI : public CreatureAIScript
     protected:
 
         bool m_elementalfire, m_wrath, m_hammer, m_meltweapon, m_summonsons;
-        SpellInfo* info_elementalfire, *info_wrath, *info_hammer, *info_meltweapon, *info_summonsons;
+        SpellInfo const* info_elementalfire, *info_wrath, *info_hammer, *info_meltweapon, *info_summonsons;
 };
 
 /*

--- a/src/scripts/InstanceScripts/Raid_OnyxiasLair.cpp
+++ b/src/scripts/InstanceScripts/Raid_OnyxiasLair.cpp
@@ -474,7 +474,7 @@ class OnyxiaAI : public CreatureAIScript
         uint32 m_aoeFearCooldown;
         uint32 m_fCastCount;
         uint32 m_currentWP;
-        SpellInfo* infoFear, *infoWBuffet, *infoCleave, *infoFBreath, *infoKAway, *infoSFireball, *infoDeepBreath;
+        SpellInfo const* infoFear, *infoWBuffet, *infoCleave, *infoFBreath, *infoKAway, *infoSFireball, *infoDeepBreath;
 };
 
 void SetupOnyxiasLair(ScriptMgr* mgr)

--- a/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
@@ -949,8 +949,8 @@ class LeotherasAI : public CreatureAIScript
         bool mInWhirlwind;
         bool IsMorphing;
         uint32 Phase;
-        SpellInfo* info_whirlwind;
-        SpellInfo* info_chaos_blast;
+        SpellInfo const* info_whirlwind;
+        SpellInfo const* info_chaos_blast;
         uint32 FinalPhaseSubphase;
         uint32 FinalPhaseTimer;
 };
@@ -1179,7 +1179,7 @@ class ShadowofLeotherasAI : public CreatureAIScript
         }
 
     protected:
-        SpellInfo* info_chaos_blast;
+        SpellInfo const* info_chaos_blast;
 };
 
 
@@ -1270,7 +1270,8 @@ class KarathressAI : public CreatureAIScript
                 if (random_target == nullptr)
                     return;
                 //let's force this effect
-                info_cataclysmic_bolt->EffectBasePoints[0] = random_target->getUInt32Value(UNIT_FIELD_MAXHEALTH) / 2;
+                // TODO: fix this
+                //info_cataclysmic_bolt->EffectBasePoints[0] = random_target->getUInt32Value(UNIT_FIELD_MAXHEALTH) / 2;
                 _unit->CastSpell(random_target, info_cataclysmic_bolt, true);
                 TargetTable.clear();
             }
@@ -1301,7 +1302,7 @@ class KarathressAI : public CreatureAIScript
         uint32 AdvisorsLeft;
 
     private:
-        SpellInfo* info_cataclysmic_bolt;
+        SpellInfo const* info_cataclysmic_bolt;
         uint32 CataclysmicBoltTimer;
         uint32 EnrageTimer;
         uint32 BlessingOfTidesCounter;
@@ -2253,8 +2254,8 @@ class VashjAI : public CreatureAIScript
         uint32 CoilfangEliteTimer;
         uint32 SporebatTimer;
         uint32 ForkedLightningTimer;
-        SpellInfo* info_multishot;
-        SpellInfo* info_shot;
+        SpellInfo const* info_multishot;
+        SpellInfo const* info_shot;
 };
 
 class TaintedElementalAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Raid_TheEye.cpp
+++ b/src/scripts/InstanceScripts/Raid_TheEye.cpp
@@ -1808,7 +1808,7 @@ bool Dummy_Solarian_WrathOfTheAstromancer(uint32 pEffectIndex, Spell* pSpell)
     Unit* Target = Caster->GetAIInterface()->getNextTarget();
     if (!Target) return true;
 
-    SpellInfo* SpellInfo = sSpellCustomizations.GetSpellInfo(SOLARIAN_WRATH_OF_THE_ASTROMANCER_BOMB);
+    SpellInfo const* SpellInfo = sSpellCustomizations.GetSpellInfo(SOLARIAN_WRATH_OF_THE_ASTROMANCER_BOMB);
     if (!SpellInfo) return true;
 
     //Explode bomb after 6sec

--- a/src/scripts/InstanceScripts/Setup.h
+++ b/src/scripts/InstanceScripts/Setup.h
@@ -116,7 +116,7 @@ enum SPELL_TARGETS
 struct SP_AI_Spell
 {
     SP_AI_Spell();
-    SpellInfo* info;        // spell info
+    SpellInfo const* info;        // spell info
     char targettype;        // 0-self , 1-attaking target, ....
     bool instant;           // does it is instant or not?
     float perctrigger;      // % of the cast of this spell in a total of 100% of the attacks

--- a/src/scripts/LuaEngine/AuraFunctions.h
+++ b/src/scripts/LuaEngine/AuraFunctions.h
@@ -142,7 +142,7 @@ namespace LuaAura
         int valindex = 2;
         if (subindex)
             valindex++;
-        SpellInfo* proto = aura->m_spellInfo;
+        SpellInfo const* proto = aura->m_spellInfo;
         LuaSpellEntry l = GetLuaSpellEntryByName(var);
         if (!l.name)
             RET_BOOL(false);
@@ -177,7 +177,7 @@ namespace LuaAura
             lua_pushnil(L);
             return 1;
         }
-        SpellInfo* proto = aura->m_spellInfo;
+        SpellInfo const* proto = aura->m_spellInfo;
         LuaSpellEntry l = GetLuaSpellEntryByName(var);
         if (!l.name)
             RET_NIL();

--- a/src/scripts/LuaEngine/GlobalFunctions.h
+++ b/src/scripts/LuaEngine/GlobalFunctions.h
@@ -417,7 +417,7 @@ namespace luaGlobalFunctions
             subindex = static_cast<int>(luaL_optinteger(L, 3, 0));
             valindex++;
         }
-        SpellInfo* proto = sSpellCustomizations.GetSpellInfo(entry);
+        SpellInfo const* proto = sSpellCustomizations.GetSpellInfo(entry);
         if (!entry || !var || subindex < 0 || !proto)
         {
             lua_pushboolean(L, 0);
@@ -453,7 +453,7 @@ namespace luaGlobalFunctions
         uint32 entry = static_cast<uint32>(luaL_checkinteger(L, 1));
         const char* var = luaL_checkstring(L, 2);
         int subindex = static_cast<int>(luaL_optinteger(L, 3, 0));
-        SpellInfo* proto = sSpellCustomizations.GetSpellInfo(entry);
+        SpellInfo const* proto = sSpellCustomizations.GetSpellInfo(entry);
         if (!entry || !var || subindex < 0 || !proto)
         {
             lua_pushnil(L);

--- a/src/scripts/LuaEngine/LUAEngine.cpp
+++ b/src/scripts/LuaEngine/LUAEngine.cpp
@@ -1120,7 +1120,7 @@ void LuaHookOnEnterCombat(Player* pPlayer, Unit* pTarget)
     RELEASE_LOCK
 }
 
-bool LuaHookOnCastSpell(Player* pPlayer, SpellInfo* pSpell, Spell* spell)
+bool LuaHookOnCastSpell(Player* pPlayer, SpellInfo const* pSpell, Spell* spell)
 {
     GET_LOCK
     bool result = true;

--- a/src/scripts/LuaEngine/SpellFunctions.h
+++ b/src/scripts/LuaEngine/SpellFunctions.h
@@ -380,7 +380,7 @@ namespace LuaSpell
             return 1;
         }
         sp->InitProtoOverride();
-        SpellInfo* proto = sp->GetSpellInfo();
+        SpellInfo const* proto = sp->GetSpellInfo();
         LuaSpellEntry l = GetLuaSpellEntryByName(var);
         if (!l.name)
             RET_BOOL(false);
@@ -415,7 +415,7 @@ namespace LuaSpell
             lua_pushnil(L);
             return 1;
         }
-        SpellInfo* proto = sp->GetSpellInfo();
+        SpellInfo const* proto = sp->GetSpellInfo();
         LuaSpellEntry l = GetLuaSpellEntryByName(var);
         if (!l.name)
             RET_NIL();

--- a/src/scripts/SpellHandlers/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/DeathKnightSpells.cpp
@@ -125,7 +125,7 @@ bool RaiseDead(uint32 i, Spell* s)
     float y = s->p_caster->GetPositionY() - 1;
     float z = s->p_caster->GetPositionZ();
 
-    SpellInfo* sp = nullptr;
+    SpellInfo const* sp = nullptr;
 
     // Master of Ghouls
     if (s->p_caster->HasAura(52143) == false)

--- a/src/scripts/SpellHandlers/ItemSpells_1.cpp
+++ b/src/scripts/SpellHandlers/ItemSpells_1.cpp
@@ -83,7 +83,7 @@ bool HallowsEndCandy(uint32 i, Spell* pSpell)
 
     int newspell = 24924 + RandomUInt(3);
 
-    SpellInfo* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
+    SpellInfo const* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
     if (!spInfo) return true;
 
     pSpell->p_caster->CastSpell(pSpell->p_caster, spInfo, true);
@@ -97,7 +97,7 @@ bool DeviateFish(uint32 i, Spell* pSpell)
 
     int newspell = 8064 + RandomUInt(4);
 
-    SpellInfo* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
+    SpellInfo const* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
     if (!spInfo) return true;
 
     pSpell->p_caster->CastSpell(pSpell->p_caster, spInfo, true);
@@ -126,7 +126,7 @@ bool CookedDeviateFish(uint32 i, Spell* pSpell)
 
     if (newspell)
     {
-        SpellInfo* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
+        SpellInfo const* spInfo = sSpellCustomizations.GetSpellInfo(newspell);
         if (!spInfo) return true;
 
         pSpell->p_caster->CastSpell(pSpell->p_caster, spInfo, true);
@@ -163,7 +163,7 @@ bool NetOMatic(uint32 i, Spell* pSpell)
     if (!pSpell->p_caster || !target)
         return true;
 
-    SpellInfo* spInfo = sSpellCustomizations.GetSpellInfo(13099);
+    SpellInfo const* spInfo = sSpellCustomizations.GetSpellInfo(13099);
     if (!spInfo)
         return true;
 
@@ -221,7 +221,7 @@ bool ForemansBlackjack(uint32 i, Spell* pSpell)
     c_target->Emote(EMOTE_STATE_WORK_CHOPWOOD);
 
     // Add timed event to return lazy peon to Zzz after 5-10 minutes (spell 17743)
-    SpellInfo* pSpellEntry = sSpellCustomizations.GetSpellInfo(17743);
+    SpellInfo const* pSpellEntry = sSpellCustomizations.GetSpellInfo(17743);
     sEventMgr.AddEvent(target, &Unit::EventCastSpell, target, pSpellEntry, EVENT_UNK, 300000 + RandomUInt(300000), 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
 
     return true;

--- a/src/scripts/SpellHandlers/MiscSpells.cpp
+++ b/src/scripts/SpellHandlers/MiscSpells.cpp
@@ -151,7 +151,7 @@ bool GiftOfLife(uint32 i, Spell* s)
 
     SpellCastTargets tgt;
     tgt.m_unitTarget = playerTarget->GetGUID();
-    SpellInfo* inf = sSpellCustomizations.GetSpellInfo(23782);
+    SpellInfo const* inf = sSpellCustomizations.GetSpellInfo(23782);
     Spell* spe = sSpellFactoryMgr.NewSpell(s->u_caster, inf, true, NULL);
     spe->prepare(&tgt);
 
@@ -204,13 +204,13 @@ bool NorthRendInscriptionResearch(uint32 i, Spell* s)
 
             if (skill_line_ability->skilline == SKILL_INSCRIPTION && skill_line_ability->next == 0)
             {
-                SpellInfo* se1 = sSpellCustomizations.GetSpellInfo(skill_line_ability->spell);
+                SpellInfo const* se1 = sSpellCustomizations.GetSpellInfo(skill_line_ability->spell);
                 if (se1 && se1->Effect[0] == SPELL_EFFECT_CREATE_ITEM)
                 {
                     ItemProperties const* itm = sMySQLStore.getItemProperties(se1->EffectItemType[0]);
                     if (itm && (itm->Spells[0].Id != 0))
                     {
-                        SpellInfo* se2 = sSpellCustomizations.GetSpellInfo(itm->Spells[0].Id);
+                        SpellInfo const* se2 = sSpellCustomizations.GetSpellInfo(itm->Spells[0].Id);
                         if (se2 && se2->Effect[0] == SPELL_EFFECT_USE_GLYPH)
                         {
 #if VERSION_STRING > TBC
@@ -382,7 +382,7 @@ bool Dummy_Solarian_WrathOfTheAstromancer(uint32 pEffectIndex, Spell* pSpell)
     if (!Target)
         return true;
 
-    SpellInfo* SpellInfo = sSpellCustomizations.GetSpellInfo(42787);
+    SpellInfo const* SpellInfo = sSpellCustomizations.GetSpellInfo(42787);
     if (!SpellInfo)
         return true;
 

--- a/src/scripts/SpellHandlers/PaladinSpells.cpp
+++ b/src/scripts/SpellHandlers/PaladinSpells.cpp
@@ -388,7 +388,7 @@ bool Illumination(uint32 i, Spell* s)
     {
                   if (s->p_caster == NULL)
                       return false;
-                  SpellInfo* sp = s->p_caster->last_heal_spell ? s->p_caster->last_heal_spell : s->GetSpellInfo();
+                  SpellInfo const* sp = s->p_caster->last_heal_spell ? s->p_caster->last_heal_spell : s->GetSpellInfo();
                   s->p_caster->Energize(s->p_caster, 20272, 60 * s->u_caster->GetBaseMana() * sp->ManaCostPercentage / 10000, POWER_TYPE_MANA);
     }
         break;

--- a/src/scripts/SpellHandlers/PetAISpells.cpp
+++ b/src/scripts/SpellHandlers/PetAISpells.cpp
@@ -275,7 +275,7 @@ class DancingRuneWeaponAI : public CreatureAIScript
                 if (dpsCycle > 11)
                     dpsCycle = 0;
 
-                SpellInfo* MyNextSpell = sSpellCustomizations.GetSpellInfo(dpsSpell);
+                SpellInfo const* MyNextSpell = sSpellCustomizations.GetSpellInfo(dpsSpell);
                 if (MyNextSpell != NULL)
                     _unit->CastSpell(curtarget, MyNextSpell, true);
 
@@ -288,7 +288,7 @@ class DancingRuneWeaponAI : public CreatureAIScript
             {
                 if (procSpell[p] != 0)
                 {
-                    SpellInfo* mProc = sSpellCustomizations.GetSpellInfo(procSpell[p]);
+                    SpellInfo const* mProc = sSpellCustomizations.GetSpellInfo(procSpell[p]);
                     if (!mProc)
                         return;
                     int x = RandomUInt(99);

--- a/src/scripts/SpellHandlers/QIspells.cpp
+++ b/src/scripts/SpellHandlers/QIspells.cpp
@@ -1677,7 +1677,7 @@ bool HunterTamingQuest(uint32 i, Aura* a, bool apply)
     {
         uint32 TamingSpellid = a->GetSpellInfo()->EffectMiscValue[1];
 
-        SpellInfo* triggerspell = sSpellCustomizations.GetSpellInfo(TamingSpellid);
+        SpellInfo const* triggerspell = sSpellCustomizations.GetSpellInfo(TamingSpellid);
         if (triggerspell == NULL)
         {
             LogError("An Aura with spellid %u is calling HunterTamingQuest() with an invalid TamingSpellid: %u", a->GetSpellId(), TamingSpellid);

--- a/src/scripts/SpellHandlers/RogueSpells.cpp
+++ b/src/scripts/SpellHandlers/RogueSpells.cpp
@@ -72,7 +72,7 @@ bool Shiv(uint32 i, Spell* pSpell)
         {
             if(Entry->type[c] && Entry->spell[c])
             {
-                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
+                SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
                 if(!sp) return true;
 
                 if(sp->custom_c_is_flags & SPELL_FLAG_IS_POISON)

--- a/src/scripts/SpellHandlers/WarlockSpells.cpp
+++ b/src/scripts/SpellHandlers/WarlockSpells.cpp
@@ -653,7 +653,7 @@ bool DemonicCircleSummon(uint32 i, Aura* a, bool apply)
     {
 
         GameObject* circle = m_target->GetMapMgr()->GetGameObject(a->GetTarget()->m_ObjectSlots[0]);
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(48020);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(48020);
 
         if (circle != NULL && sp != NULL && m_target->CalcDistance(circle) <= GetMaxRange(sSpellRangeStore.LookupEntry(sp->rangeIndex)))
         {

--- a/src/scripts/SpellHandlers/WarriorSpells.cpp
+++ b/src/scripts/SpellHandlers/WarriorSpells.cpp
@@ -172,7 +172,7 @@ bool LastStand(uint32 i, Spell* s)
     SpellCastTargets tgt;
     tgt.m_unitTarget = playerTarget->GetGUID();
 
-    SpellInfo* inf = sSpellCustomizations.GetSpellInfo(12976);
+    SpellInfo const* inf = sSpellCustomizations.GetSpellInfo(12976);
     Spell* spe = sSpellFactoryMgr.NewSpell(s->u_caster, inf, true, NULL);
     spe->prepare(&tgt);
 

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -393,7 +393,7 @@ bool ChatHandler::HandleCharLearnCommand(const char* args, WorldSession* m_sessi
     if (!*args)
         return false;
 
-    SpellInfo* spell_entry = nullptr;
+    SpellInfo const* spell_entry = nullptr;
 
     if (stricmp(args, "all") == 0)
     {

--- a/src/world/Chat/Commands/LookupCommands.cpp
+++ b/src/world/Chat/Commands/LookupCommands.cpp
@@ -573,7 +573,7 @@ bool ChatHandler::HandleLookupSpellCommand(const char* args, WorldSession* m_ses
     char itoabuf[12];
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        SpellInfo* spell = sSpellCustomizations.GetSpellInfo(it->first);
+        SpellInfo const* spell = sSpellCustomizations.GetSpellInfo(it->first);
         std::string y = std::string(spell->Name);
         Util::StringToLowerCase(y);
         if (Util::findXinYString(x, y))

--- a/src/world/Chat/Commands/PetCommands.cpp
+++ b/src/world/Chat/Commands/PetCommands.cpp
@@ -158,7 +158,7 @@ bool ChatHandler::HandlePetAddSpellCommand(const char* args, WorldSession* m_ses
         return false;
 
     uint32 SpellId = atol(args);
-    SpellInfo* spell_entry = sSpellCustomizations.GetSpellInfo(SpellId);
+    SpellInfo const* spell_entry = sSpellCustomizations.GetSpellInfo(SpellId);
     if (spell_entry == nullptr)
     {
         RedSystemMessage(m_session, "Invalid spell id %u.", SpellId);
@@ -193,7 +193,7 @@ bool ChatHandler::HandlePetRemoveSpellCommand(const char* args, WorldSession* m_
         return false;
 
     uint32 SpellId = atol(args);
-    SpellInfo* spell_entry = sSpellCustomizations.GetSpellInfo(SpellId);
+    SpellInfo const* spell_entry = sSpellCustomizations.GetSpellInfo(SpellId);
     if (spell_entry == nullptr)
     {
         RedSystemMessage(m_session, "Invalid spell id requested.");

--- a/src/world/Chat/Commands/debugcmds.cpp
+++ b/src/world/Chat/Commands/debugcmds.cpp
@@ -977,7 +977,7 @@ bool ChatHandler::HandleAuraUpdateAdd(const char* args, WorldSession* m_session)
     }
     else
     {
-        SpellInfo* Sp = sSpellCustomizations.GetSpellInfo(SpellID);
+        SpellInfo const* Sp = sSpellCustomizations.GetSpellInfo(SpellID);
         if (!Sp)
         {
             SystemMessage(m_session, "SpellID %u is invalid.", SpellID);
@@ -1149,10 +1149,10 @@ struct spell_thingo
     uint32 target;
 };
 
-std::list<SpellInfo*> aiagent_spells;
+std::list<SpellInfo const*> aiagent_spells;
 std::map<uint32, spell_thingo> aiagent_extra;
 
-SpellCastTargets SetTargets(SpellInfo* sp, uint32 type, uint32 targettype, Unit* dst, Creature* src)
+SpellCastTargets SetTargets(SpellInfo const* sp, uint32 type, uint32 targettype, Unit* dst, Creature* src)
 {
     SpellCastTargets targets;
     targets.m_unitTarget = 0;
@@ -1212,7 +1212,7 @@ bool ChatHandler::HandleAIAgentDebugContinue(const char* args, WorldSession* m_s
         if (!aiagent_spells.size())
             break;
 
-        SpellInfo* sp = *aiagent_spells.begin();
+        SpellInfo const* sp = *aiagent_spells.begin();
         aiagent_spells.erase(aiagent_spells.begin());
         BlueSystemMessage(m_session, "Casting %u, " MSG_COLOR_SUBWHITE "%u remaining.", sp->Id, aiagent_spells.size());
 
@@ -1242,13 +1242,13 @@ bool ChatHandler::HandleAIAgentDebugBegin(const char* args, WorldSession* m_sess
 
     do
     {
-        SpellInfo* se = sSpellCustomizations.GetSpellInfo(result->Fetch()[0].GetUInt32());
+        SpellInfo const* se = sSpellCustomizations.GetSpellInfo(result->Fetch()[0].GetUInt32());
         if (se)
             aiagent_spells.push_back(se);
     } while (result->NextRow());
     delete result;
 
-    for (std::list<SpellInfo*>::iterator itr = aiagent_spells.begin(); itr != aiagent_spells.end(); ++itr)
+    for (std::list<SpellInfo const*>::iterator itr = aiagent_spells.begin(); itr != aiagent_spells.end(); ++itr)
     {
         result = WorldDatabase.Query("SELECT * FROM ai_agents WHERE spell = %u", (*itr)->Id);
         ARCEMU_ASSERT(result != NULL);
@@ -1276,7 +1276,7 @@ bool ChatHandler::HandleCastSpellCommand(const char* args, WorldSession* m_sessi
     }
 
     uint32 spellid = atol(args);
-    SpellInfo* spellentry = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* spellentry = sSpellCustomizations.GetSpellInfo(spellid);
     if (!spellentry)
     {
         RedSystemMessage(m_session, "Invalid spell id!");
@@ -1317,7 +1317,7 @@ bool ChatHandler::HandleCastSpellNECommand(const char* args, WorldSession* m_ses
     }
 
     uint32 spellId = atol(args);
-    SpellInfo* spellentry = sSpellCustomizations.GetSpellInfo(spellId);
+    SpellInfo const* spellentry = sSpellCustomizations.GetSpellInfo(spellId);
     if (!spellentry)
     {
         RedSystemMessage(m_session, "Invalid spell id!");
@@ -1377,7 +1377,7 @@ bool ChatHandler::HandleCastSelfCommand(const char* args, WorldSession* m_sessio
     }
 
     uint32 spellid = atol(args);
-    SpellInfo* spellentry = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* spellentry = sSpellCustomizations.GetSpellInfo(spellid);
     if (!spellentry)
     {
         RedSystemMessage(m_session, "Invalid spell id!");

--- a/src/world/GameCata/Handlers/NPCHandler.cpp
+++ b/src/world/GameCata/Handlers/NPCHandler.cpp
@@ -61,7 +61,7 @@ void WorldSession::SendTrainerList(Creature* pCreature)
                     break;
                 }
 
-                SpellInfo* learnedSpellInfo = sSpellCustomizations.GetSpellInfo(pSpell->learnedSpell[i]);
+                SpellInfo const* learnedSpellInfo = sSpellCustomizations.GetSpellInfo(pSpell->learnedSpell[i]);
                 if (learnedSpellInfo && learnedSpellInfo->IsPrimaryProfession())
                     primary_prof_first_rank = true;
             }
@@ -107,7 +107,7 @@ void WorldSession::SendTrainerList(Creature* pCreature)
                 ++maxReq;
             }
 
-            SpellInfo* spell = sSpellCustomizations.GetSpellInfo(pSpell->spell);
+            SpellInfo const* spell = sSpellCustomizations.GetSpellInfo(pSpell->spell);
             if (spell && spell->IsPrimaryProfession())
                 data << uint32_t(primary_prof_first_rank && can_learn_primary_prof ? 1 : 0);
             else

--- a/src/world/GameCata/Handlers/SkillHandler.cpp
+++ b/src/world/GameCata/Handlers/SkillHandler.cpp
@@ -135,7 +135,7 @@ void WorldSession::HandlePetLearnTalent(WorldPacket& recvPacket)
     if (talent_rank > 0 && talent_entry->RankID[talent_rank - 1] != 0)
         player_pet->RemoveSpell(talent_entry->RankID[talent_rank - 1]);
 
-    SpellInfo* spell_info = sSpellCustomizations.GetSpellInfo(talent_entry->RankID[talent_rank]);
+    SpellInfo const* spell_info = sSpellCustomizations.GetSpellInfo(talent_entry->RankID[talent_rank]);
     if (spell_info != nullptr)
     {
         player_pet->AddSpell(spell_info, true);

--- a/src/world/GameCata/Handlers/SpellHandler.cpp
+++ b/src/world/GameCata/Handlers/SpellHandler.cpp
@@ -32,7 +32,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     recvPacket >> missileflag;
 
     // check for spell id
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
     if (!spellInfo)
     {
         LogError("WORLD: unknown spell id %i", spellId);
@@ -103,7 +103,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
                     LogDebugFlag(LF_SPELL, "HandleCastSpellOpcode : Cancelling auto-shot cast because targets.m_unitTarget is null!");
                     return;
                 }
-                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+                SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
 
                 _player->m_AutoShotSpell = sp;
                 _player->m_AutoShotDuration = duration;

--- a/src/world/Management/AchievementMgr.cpp
+++ b/src/world/Management/AchievementMgr.cpp
@@ -1324,7 +1324,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type)
                 uint32 nm = 0;
                 while (sl != GetPlayer()->mSpells.end())
                 {
-                    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(*sl);
+                    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(*sl);
                     if (achievementCriteria->number_of_mounts.unknown == 777 && sp && sp->MechanicsType == MECHANIC_MOUNTED)
                     {
                         // mount spell

--- a/src/world/Management/Arenas.cpp
+++ b/src/world/Management/Arenas.cpp
@@ -441,7 +441,7 @@ void Arena::HookOnAreaTrigger(Player* plr, uint32 id)
         if (m_buffs[buffslot] != NULL && m_buffs[buffslot]->IsInWorld())
         {
             // apply the buff
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(m_buffs[buffslot]->GetGameObjectProperties()->raw.parameter_3);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(m_buffs[buffslot]->GetGameObjectProperties()->raw.parameter_3);
             ARCEMU_ASSERT(sp != NULL);
 
             Spell* s = sSpellFactoryMgr.NewSpell(plr, sp, true, 0);

--- a/src/world/Management/Item.cpp
+++ b/src/world/Management/Item.cpp
@@ -804,7 +804,7 @@ void Item::ApplyEnchantmentBonus(uint32 Slot, bool Apply)
                     if (Apply)
                     {
                         SpellCastTargets targets(m_owner->GetGUID());
-                        SpellInfo* sp;
+                        SpellInfo const* sp;
                         Spell* spell;
 
                         if (Entry->spell[c] != 0)

--- a/src/world/Management/QuestMgr.cpp
+++ b/src/world/Management/QuestMgr.cpp
@@ -1260,7 +1260,7 @@ void QuestMgr::OnQuestFinished(Player* plr, QuestProperties const* qst, Object* 
         // cast Effect Spell
         if (qst->effect_on_player)
         {
-            SpellInfo* spell_entry = sSpellCustomizations.GetSpellInfo(qst->effect_on_player);
+            SpellInfo const* spell_entry = sSpellCustomizations.GetSpellInfo(qst->effect_on_player);
             if (spell_entry)
             {
                 Spell* spe = sSpellFactoryMgr.NewSpell(plr, spell_entry, true, NULL);
@@ -1407,7 +1407,7 @@ void QuestMgr::OnQuestFinished(Player* plr, QuestProperties const* qst, Object* 
         // cast Effect Spell
         if (qst->effect_on_player)
         {
-            SpellInfo* spell_entry = sSpellCustomizations.GetSpellInfo(qst->effect_on_player);
+            SpellInfo const* spell_entry = sSpellCustomizations.GetSpellInfo(qst->effect_on_player);
             if (spell_entry)
             {
                 Spell* spe = sSpellFactoryMgr.NewSpell(plr, spell_entry, true, NULL);

--- a/src/world/Objects/DynamicObject.h
+++ b/src/world/Objects/DynamicObject.h
@@ -55,7 +55,7 @@ public:
 
     protected:
 
-        SpellInfo* m_spellProto;
+        SpellInfo const* m_spellProto;
         Unit* u_caster;
         Player* p_caster;
         Spell* m_parentSpell;

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -454,7 +454,7 @@ void GameObject::SetRotationAngles(float z_rot, float y_rot, float x_rot)
     SetRotationQuat(quat.x, quat.y, quat.z, quat.w);
 }
 
-void GameObject::CastSpell(uint64 TargetGUID, SpellInfo* sp)
+void GameObject::CastSpell(uint64 TargetGUID, SpellInfo const* sp)
 {
     Spell* s = new Spell(this, sp, true, NULL);
 
@@ -468,7 +468,7 @@ void GameObject::CastSpell(uint64 TargetGUID, SpellInfo* sp)
 
 void GameObject::CastSpell(uint64 TargetGUID, uint32 SpellID)
 {
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
     if (sp == nullptr)
     {
         LogError("GameObject %u tried to cast a non-existing Spell %u.", gameobject_properties->entry, SpellID);

--- a/src/world/Objects/GameObject.h
+++ b/src/world/Objects/GameObject.h
@@ -393,7 +393,7 @@ class SERVER_DECL GameObject : public Object
         virtual bool IsLootable() { return false; }
 
         virtual void Use(uint64 GUID) {}
-        void CastSpell(uint64 TargetGUID, SpellInfo* sp);
+        void CastSpell(uint64 TargetGUID, SpellInfo const* sp);
         void CastSpell(uint64 TargetGUID, uint32 SpellID);
 
         void Update(unsigned long time_passed);
@@ -584,7 +584,7 @@ class GameObject_Button : public GameObject
 
     private:
 
-        SpellInfo* spell;
+        SpellInfo const* spell;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -692,7 +692,7 @@ class GameObject_Chest : public GameObject_Lootable
 
     private:
 
-        SpellInfo* spell;
+        SpellInfo const* spell;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -710,7 +710,7 @@ class GameObject_Trap : public GameObject
 
     private:
 
-        SpellInfo* spell;
+        SpellInfo const* spell;
         uint32 targetupdatetimer;
         float maxdistance;
         uint32 cooldown;
@@ -751,7 +751,7 @@ class GameObject_Goober : public GameObject
         void Close();
 
     private:
-        SpellInfo* spell;
+        SpellInfo const* spell;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -821,7 +821,7 @@ class GameObject_SpellCaster : public GameObject
 
     private:
 
-        SpellInfo* spell;
+        SpellInfo const* spell;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -2392,7 +2392,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
     if (pVictim == NULL || !pVictim->isAlive())
         return;
 
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellID);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellID);
     if (spellInfo == NULL)
         return;
 
@@ -2509,7 +2509,8 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
         vproc |= PROC_ON_ABSORB;
 
     // Incanter's Absorption
-    if (pVictim->IsPlayer() && pVictim->HasAurasWithNameHash(SPELL_HASH_INCANTER_S_ABSORPTION))
+    // Appled: needs rework
+    /*if (pVictim->IsPlayer() && pVictim->HasAurasWithNameHash(SPELL_HASH_INCANTER_S_ABSORPTION))
     {
         float pctmod = 0.0f;
         Player* pl = static_cast< Player* >(pVictim);
@@ -2526,7 +2527,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
         if (spellpower > hp)
             spellpower = hp;
 
-        SpellInfo* entry = sSpellCustomizations.GetSpellInfo(44413);
+        SpellInfo const* entry = sSpellCustomizations.GetSpellInfo(44413);
         if (!entry)
             return;
 
@@ -2535,7 +2536,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
         SpellCastTargets targets;
         targets.m_unitTarget = pl->GetGUID();
         sp->prepare(&targets);
-    }
+    }*/
 
     res = static_cast< float >(ress);
     dealdamage dmg;

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -809,10 +809,10 @@ public:
 
         void EventSpellDamage(uint64 Victim, uint32 SpellID, uint32 Damage);
         void SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage, bool allowProc, bool static_damage = false, bool no_remove_auras = false);
-        virtual bool IsCriticalDamageForSpell(Object* victim, SpellInfo* spell) { return false; }
-        virtual float GetCriticalDamageBonusForSpell(Object* victim, SpellInfo* spell, float amount) { return 0; }
-        virtual bool IsCriticalHealForSpell(Object* victim, SpellInfo* spell) { return false; }
-        virtual float GetCriticalHealBonusForSpell(Object* victim, SpellInfo* spell, float amount) { return 0; }
+        virtual bool IsCriticalDamageForSpell(Object* victim, SpellInfo const* spell) { return false; }
+        virtual float GetCriticalDamageBonusForSpell(Object* victim, SpellInfo const* spell, float amount) { return 0; }
+        virtual bool IsCriticalHealForSpell(Object* victim, SpellInfo const* spell) { return false; }
+        virtual float GetCriticalHealBonusForSpell(Object* victim, SpellInfo const* spell, float amount) { return 0; }
 
         /// SpellLog packets just to keep the code cleaner and better to read
         void SendSpellLog(Object* Caster, Object* Target, uint32 Ability, uint8 SpellLogType);

--- a/src/world/Objects/ObjectMgr.cpp
+++ b/src/world/Objects/ObjectMgr.cpp
@@ -392,7 +392,7 @@ DBC::Structures::SkillLineAbilityEntry const* ObjectMgr::GetSpellSkill(uint32 id
     return mSpellSkills[id];
 }
 
-SpellInfo* ObjectMgr::GetNextSpellRank(SpellInfo* sp, uint32 level)
+SpellInfo const* ObjectMgr::GetNextSpellRank(SpellInfo const* sp, uint32 level)
 {
     // Looks for next spell rank
     if (sp == nullptr)
@@ -403,7 +403,7 @@ SpellInfo* ObjectMgr::GetNextSpellRank(SpellInfo* sp, uint32 level)
     auto skill_line_ability = GetSpellSkill(sp->Id);
     if (skill_line_ability != nullptr && skill_line_ability->next > 0)
     {
-        SpellInfo* sp1 = sSpellCustomizations.GetSpellInfo(skill_line_ability->next);
+        SpellInfo const* sp1 = sSpellCustomizations.GetSpellInfo(skill_line_ability->next);
         if (sp1 && sp1->baseLevel <= level)   // check level
         {
             return GetNextSpellRank(sp1, level);   // recursive for higher ranks
@@ -1374,7 +1374,7 @@ void ObjectMgr::LoadAIThreatToSpellId()
     do
     {
         Field* fields = result->Fetch();
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(fields[0].GetUInt32());
+        SpellInfo* sp = sSpellCustomizations.getSpellInfoUnsafe(fields[0].GetUInt32());
         if (sp != NULL)
         {
             sp->custom_ThreatForSpell = fields[1].GetUInt32();
@@ -1412,7 +1412,7 @@ void ObjectMgr::LoadSpellEffectsOverride()
 
             if (seo_SpellId)
             {
-                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(seo_SpellId);
+                SpellInfo* sp = sSpellCustomizations.getSpellInfoUnsafe(seo_SpellId);
                 if (sp != NULL)
                 {
                     if (seo_Disable)
@@ -2340,7 +2340,7 @@ uint32 ObjectMgr::GetPetSpellCooldown(uint32 SpellId)
     if (itr != mPetSpellCooldowns.end())
         return itr->second;
 
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellId);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellId);
     if (sp->RecoveryTime > sp->CategoryRecoveryTime)
         return sp->RecoveryTime;
     else
@@ -3739,7 +3739,7 @@ void ObjectMgr::LoadCreatureAIAgents()
                 Field* fields = result->Fetch();
                 uint32 entry = fields[0].GetUInt32();
                 CreatureProperties const* cn = sMySQLStore.getCreatureProperties(entry);
-                SpellInfo* spe = sSpellCustomizations.GetSpellInfo(fields[6].GetUInt32());
+                SpellInfo const* spe = sSpellCustomizations.GetSpellInfo(fields[6].GetUInt32());
 
                 if (spe == nullptr)
                 {

--- a/src/world/Objects/ObjectMgr.h
+++ b/src/world/Objects/ObjectMgr.h
@@ -132,9 +132,9 @@ struct TrainerSpell
 #else
 struct TrainerSpell
 {
-    SpellInfo* pCastSpell;
-    SpellInfo* pLearnSpell;
-    SpellInfo* pCastRealSpell;
+    SpellInfo const* pCastSpell;
+    SpellInfo const* pLearnSpell;
+    SpellInfo const* pCastRealSpell;
     uint32 DeleteSpell;
     uint32 RequiredSpell;
     uint32 RequiredSkillLine;
@@ -504,7 +504,7 @@ class SERVER_DECL ObjectMgr : public Singleton < ObjectMgr >, public EventableOb
         GM_Ticket* GetGMTicketByPlayer(uint64 playerGuid);
 
         DBC::Structures::SkillLineAbilityEntry const* GetSpellSkill(uint32 id);
-        SpellInfo* GetNextSpellRank(SpellInfo* sp, uint32 level);
+        SpellInfo const* GetNextSpellRank(SpellInfo const* sp, uint32 level);
 
         //Vendors
         std::vector<CreatureItem> *GetVendorList(uint32 entry);

--- a/src/world/Server/Packets/Handlers/HonorHandler.cpp
+++ b/src/world/Server/Packets/Handlers/HonorHandler.cpp
@@ -225,7 +225,7 @@ void HonorHandler::OnPlayerKilled(Player* pPlayer, Player* pVictim)
                 if (pAffectedPlayer->GetZoneId() == 3518)
                 {
                     // Add Halaa Battle Token
-                    SpellInfo* pvp_token_spell = sSpellCustomizations.GetSpellInfo(pAffectedPlayer->IsTeamHorde() ? 33004 : 33005);
+                    SpellInfo const* pvp_token_spell = sSpellCustomizations.GetSpellInfo(pAffectedPlayer->IsTeamHorde() ? 33004 : 33005);
                     pAffectedPlayer->CastSpell(pAffectedPlayer, pvp_token_spell, true);
                 }
                 // If we are in Hellfire Peninsula <http://www.wowwiki.com/Hellfire_Peninsula#World_PvP_-_Hellfire_Fortifications>
@@ -241,7 +241,7 @@ void HonorHandler::OnPlayerKilled(Player* pPlayer, Player* pVictim)
                         */
 
                     // Add Mark of Thrallmar/Honor Hold
-                    SpellInfo* pvp_token_spell = sSpellCustomizations.GetSpellInfo(pAffectedPlayer->IsTeamHorde() ? 32158 : 32155);
+                    SpellInfo const* pvp_token_spell = sSpellCustomizations.GetSpellInfo(pAffectedPlayer->IsTeamHorde() ? 32158 : 32155);
                     pAffectedPlayer->CastSpell(pAffectedPlayer, pvp_token_spell, true);
                 }
             }

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -1628,7 +1628,7 @@ void WorldSession::HandleGameObjectUse(WorldPacket& recv_data)
     recv_data >> guid;
     SpellCastTargets targets;
     Spell* spell = NULL;
-    SpellInfo* spellInfo = NULL;
+    SpellInfo const* spellInfo = NULL;
     LOG_DEBUG("WORLD: CMSG_GAMEOBJ_USE: [GUID %d]", guid);
 
     GameObject* obj = _player->GetMapMgr()->GetGameObject((uint32)guid);
@@ -1866,7 +1866,7 @@ void WorldSession::HandleGameObjectUse(WorldPacket& recv_data)
                     }
                 }
 
-                SpellInfo* info = nullptr;
+                SpellInfo const* info = nullptr;
                 if (gameobject_info->entry == 36727 || gameobject_info->entry == 194108)   // summon portal
                 {
                     if (!ritual_obj->GetRitual()->GetTargetGUID() == 0)
@@ -2303,7 +2303,7 @@ void WorldSession::HandleSelfResurrectOpcode(WorldPacket& recv_data)
     uint32 self_res_spell = _player->getUInt32Value(PLAYER_SELF_RES_SPELL);
     if (self_res_spell)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(self_res_spell);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(self_res_spell);
         Spell* s = sSpellFactoryMgr.NewSpell(_player, sp, true, NULL);
         SpellCastTargets tgt;
         tgt.m_unitTarget = _player->GetGUID();

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -488,7 +488,7 @@ void WorldSession::HandleSpiritHealerActivateOpcode(WorldPacket& recv_data)
 
         if (aur == NULL)        // If the player already have the aura, just extend it.
         {
-            SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(15007);    //resurrection sickness
+            SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(15007);    //resurrection sickness
             SpellCastTargets targets;
             targets.m_unitTarget = GetPlayer()->GetGUID();
             Spell* sp = sSpellFactoryMgr.NewSpell(_player, spellInfo, true, NULL);

--- a/src/world/Server/Packets/Handlers/PetHandler.cpp
+++ b/src/world/Server/Packets/Handlers/PetHandler.cpp
@@ -164,7 +164,7 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
             case PET_ACTION_SPELL:
             {
                 // misc == spellid
-                SpellInfo* entry = sSpellCustomizations.GetSpellInfo(misc);
+                SpellInfo const* entry = sSpellCustomizations.GetSpellInfo(misc);
                 if (entry == NULL)
                     return;
 
@@ -430,7 +430,7 @@ void WorldSession::HandlePetSetActionOpcode(WorldPacket& recv_data)
         return;
 
     Pet* pet = _player->GetSummon();
-    SpellInfo* spe = sSpellCustomizations.GetSpellInfo(spell);
+    SpellInfo const* spe = sSpellCustomizations.GetSpellInfo(spell);
     if (spe == NULL)
         return;
 
@@ -545,7 +545,7 @@ void WorldSession::HandlePetSpellAutocast(WorldPacket& recvPacket)
     uint8  state;
     recvPacket >> guid >> spellid >> unk >> state;
 
-    SpellInfo* spe = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* spe = sSpellCustomizations.GetSpellInfo(spellid);
     if (spe == NULL)
         return;
 
@@ -569,7 +569,7 @@ void WorldSession::HandlePetCancelAura(WorldPacket& recvPacket)
 
     recvPacket >> guid >> spellid;
 
-    SpellInfo* info = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* info = sSpellCustomizations.GetSpellInfo(spellid);
     if (info != NULL && info->Attributes & static_cast<uint32>(ATTRIBUTES_CANT_CANCEL))
         return;
     Creature* pet = _player->GetMapMgr()->GetCreature(static_cast<uint32>(guid));
@@ -634,7 +634,7 @@ void WorldSession::HandlePetLearnTalent(WorldPacket& recvPacket)
 
 #if VERSION_STRING > TBC
     // add spell, discount talent point
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(talent->RankID[talentcol]);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(talent->RankID[talentcol]);
     if (sp != NULL)
     {
         pPet->AddSpell(sp, true);

--- a/src/world/Server/Packets/Handlers/SpellHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SpellHandler.cpp
@@ -143,7 +143,7 @@ void WorldSession::HandleUseItemOpcode(WorldPacket& recvPacket)
 
     SpellCastTargets targets(recvPacket, _player->GetGUID());
 
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
     if (spellInfo == NULL)
     {
         LOG_ERROR("WORLD: unknown spell id %i", spellId);
@@ -334,7 +334,7 @@ void WorldSession::HandleSpellClick(WorldPacket& recvPacket)
     {
         cast_spell_id = sp->SpellID;
 
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(cast_spell_id);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(cast_spell_id);
         if (spellInfo == nullptr)
             return;
 
@@ -354,7 +354,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
 
     recvPacket >> cn >> spellId >> unk;
     // check for spell id
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
 
     if (!spellInfo)
     {
@@ -426,7 +426,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
                     LogDebugFlag(LF_SPELL, "HandleCastSpellOpcode : Cancelling auto-shot cast because targets.m_unitTarget is null!");
                     return;
                 }
-                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+                SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
 
                 _player->m_AutoShotSpell = sp;
                 _player->m_AutoShotDuration = duration;
@@ -503,7 +503,7 @@ void WorldSession::HandleCancelAuraOpcode(WorldPacket& recvPacket)
         _player->m_currentSpell->cancel();
     else
     {
-        SpellInfo* info = sSpellCustomizations.GetSpellInfo(spellId);
+        SpellInfo const* info = sSpellCustomizations.GetSpellInfo(spellId);
         if (info == nullptr)
             return;
 
@@ -564,7 +564,7 @@ void WorldSession::HandlePetCastSpell(WorldPacket& recvPacket)
     recvPacket >> spellid;
     recvPacket >> castflags;
 
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
     if (sp == NULL)
         return;
     // Summoned Elemental's Freeze
@@ -701,7 +701,7 @@ void WorldSession::HandleUpdateProjectilePosition(WorldPacket& recv_data)
 
     LogDebugFlag(LF_OPCODE, "Recieved spell: %u, count: %i, position: x(%f) y(%f) z(%f)", spellId, castCount, x, y, z);
 
-    SpellInfo* spell = Spell::checkAndReturnSpellEntry(spellId);
+    SpellInfo const* spell = Spell::checkAndReturnSpellEntry(spellId);
     if (!spell || spell->ai_target_type == TARGET_FLAG_DEST_LOCATION)
         return;
 

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -220,7 +220,7 @@ void ScriptMgr::DumpUnimplementedSpells()
 
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(it->first);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(it->first);
         if (!sp)
             continue;
 
@@ -257,7 +257,7 @@ void ScriptMgr::DumpUnimplementedSpells()
 
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(it->first);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(it->first);
         if (!sp)
             continue;
 
@@ -309,7 +309,7 @@ void ScriptMgr::register_dummy_aura(uint32 entry, exp_handle_dummy_aura callback
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr tried to register a script for Aura ID: %u but this aura has already one.", entry);
     }
 
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(entry);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(entry);
     if (sp == NULL)
     {
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr tried to register a dummy aura handler for invalid Spell ID: %u.", entry);
@@ -330,7 +330,7 @@ void ScriptMgr::register_dummy_spell(uint32 entry, exp_handle_dummy_spell callba
         return;
     }
 
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(entry);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(entry);
     if (sp == NULL)
     {
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr tried to register a dummy handler for invalid Spell ID: %u.", entry);
@@ -442,7 +442,7 @@ void ScriptMgr::register_script_effect(uint32 entry, exp_handle_script_effect ca
         return;
     }
 
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(entry);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(entry);
     if (sp == NULL)
     {
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr tried to register a script effect handler for invalid Spell %u.", entry);
@@ -900,7 +900,7 @@ void HookInterface::OnEnterCombat(Player* pPlayer, Unit* pTarget)
         ((tOnEnterCombat)*itr)(pPlayer, pTarget);
 }
 
-bool HookInterface::OnCastSpell(Player* pPlayer, SpellInfo* pSpell, Spell* spell)
+bool HookInterface::OnCastSpell(Player* pPlayer, SpellInfo const* pSpell, Spell* spell)
 {
     ServerHookList hookList = sScriptMgr._hooks[SERVER_HOOK_EVENT_ON_CAST_SPELL];
     bool ret_val = true;

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -95,7 +95,7 @@ typedef void(*tOnDeath)(Player* pPlayer);
 typedef bool(*tOnRepop)(Player* pPlayer);
 typedef void(*tOnEmote)(Player* pPlayer, uint32 Emote, Unit* pUnit);
 typedef void(*tOnEnterCombat)(Player* pPlayer, Unit* pTarget);
-typedef bool(*tOnCastSpell)(Player* pPlayer, SpellInfo* pSpell, Spell* spell);
+typedef bool(*tOnCastSpell)(Player* pPlayer, SpellInfo const* pSpell, Spell* spell);
 typedef void(*tOnTick)();
 typedef bool(*tOnLogoutRequest)(Player* pPlayer);
 typedef void(*tOnLogout)(Player* pPlayer);
@@ -516,7 +516,7 @@ class SERVER_DECL InstanceScript
         virtual ~InstanceScript() {};
 
         // Procedures that had been here before
-        virtual GameObject* GetObjectForOpenLock(Player* /*pCaster*/, Spell* /*pSpell*/, SpellInfo* /*pSpellEntry*/) { return NULL; };
+        virtual GameObject* GetObjectForOpenLock(Player* /*pCaster*/, Spell* /*pSpell*/, SpellInfo const* /*pSpellEntry*/) { return NULL; };
         virtual void SetLockOptions(uint32 /*pEntryId*/, GameObject* /*pGameObject*/) {};
         virtual uint32 GetRespawnTimeForCreature(uint32 /*pEntryId*/, Creature* /*pCreature*/) { return 240000; };
 
@@ -573,7 +573,7 @@ class SERVER_DECL HookInterface : public Singleton<HookInterface>
         bool OnRepop(Player* pPlayer);
         void OnEmote(Player* pPlayer, uint32 Emote, Unit* pUnit);
         void OnEnterCombat(Player* pPlayer, Unit* pTarget);
-        bool OnCastSpell(Player* pPlayer, SpellInfo* pSpell, Spell* spell);
+        bool OnCastSpell(Player* pPlayer, SpellInfo const* pSpell, Spell* spell);
         bool OnLogoutRequest(Player* pPlayer);
         void OnLogout(Player* pPlayer);
         void OnQuestAccept(Player* pPlayer, QuestProperties const* pQuest, Object* pQuestGiver);

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -138,7 +138,7 @@ World::~World()
 
     delete mEventableObjectHolder;
 
-    for (std::list<SpellInfo*>::iterator itr = dummySpellList.begin(); itr != dummySpellList.end(); ++itr)
+    for (std::list<SpellInfo const*>::iterator itr = dummySpellList.begin(); itr != dummySpellList.end(); ++itr)
         delete *itr;
 }
 

--- a/src/world/Server/World.h
+++ b/src/world/Server/World.h
@@ -177,7 +177,7 @@ class SERVER_DECL World : public Singleton<World>, public EventableObject, publi
 
     public:
 
-        std::list<SpellInfo*> dummySpellList;
+        std::list<SpellInfo const*> dummySpellList;
 
         bool setInitialWorldSettings();
         void resetCharacterLoginBannState();

--- a/src/world/Spell/Customization/HackFixes.cpp
+++ b/src/world/Spell/Customization/HackFixes.cpp
@@ -439,7 +439,7 @@ void Set_missing_spellLevel(SpellInfo* sp)
 
             if (teachspell)
             {
-                SpellInfo* spellInfo = Spell::checkAndReturnSpellEntry(teachspell);
+                SpellInfo* spellInfo = Spell::checkAndReturnSpellEntryUnsafe(teachspell);
                 if (spellInfo != nullptr)
                 {
                     spellInfo->spellLevel = new_level;
@@ -6483,7 +6483,7 @@ void ApplyNormalFixes()
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
         // Read every SpellEntry row
-        sp = sSpellCustomizations.GetSpellInfo(it->first);
+        sp = sSpellCustomizations.getSpellInfoUnsafe(it->first);
         if (sp == nullptr)
             continue;
 
@@ -6907,7 +6907,7 @@ void ApplyNormalFixes()
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
         // get spellentry
-        sp = sSpellCustomizations.GetSpellInfo(it->first);
+        sp = sSpellCustomizations.getSpellInfoUnsafe(it->first);
         if (sp == nullptr)
             continue;
 
@@ -7330,7 +7330,7 @@ void ApplyNormalFixes()
         {
             Field* f;
             f = resultx->Fetch();
-            sp = sSpellCustomizations.GetSpellInfo(f[0].GetUInt32());
+            sp = sSpellCustomizations.getSpellInfoUnsafe(f[0].GetUInt32());
             if (sp != nullptr)
             {
                 sp->Dspell_coef_override = f[2].GetFloat();
@@ -7347,7 +7347,7 @@ void ApplyNormalFixes()
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
         // get spellentry
-        sp = sSpellCustomizations.GetSpellInfo(it->first);
+        sp = sSpellCustomizations.getSpellInfoUnsafe(it->first);
         if (sp == nullptr)
             continue;
 
@@ -7358,7 +7358,7 @@ void ApplyNormalFixes()
         {
             if (sp->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_TRIGGER_SPELL)
             {
-                spz = Spell::checkAndReturnSpellEntry(sp->EffectTriggerSpell[i]);
+                spz = Spell::checkAndReturnSpellEntryUnsafe(sp->EffectTriggerSpell[i]);
                 if (spz != NULL)
                 {
                     if (sp->Dspell_coef_override >= 0)
@@ -7403,7 +7403,7 @@ void ApplyNormalFixes()
     const static uint32 thrown_spells[] = { SPELL_RANGED_GENERAL, SPELL_RANGED_THROW, SPELL_RANGED_WAND, 26679, 29436, 37074, 41182, 41346, 0 };
     for (uint32 i = 0; thrown_spells[i] != 0; ++i)
     {
-        sp = Spell::checkAndReturnSpellEntry(thrown_spells[i]);
+        sp = Spell::checkAndReturnSpellEntryUnsafe(thrown_spells[i]);
         if (sp != nullptr && sp->RecoveryTime == 0 && sp->StartRecoveryTime == 0)
         {
             if (sp->Id == SPELL_RANGED_GENERAL)
@@ -7415,7 +7415,7 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Wands
-    sp = Spell::checkAndReturnSpellEntry(SPELL_RANGED_WAND);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(SPELL_RANGED_WAND);
     if (sp != nullptr)
         sp->Spell_Dmg_Type = SPELL_DMG_TYPE_RANGED;
 
@@ -7436,70 +7436,70 @@ void ApplyNormalFixes()
     // Arms
 
     // Juggernaut
-    sp = Spell::checkAndReturnSpellEntry(65156);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(65156);
     if (sp != nullptr)
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
 
     // Warrior - Overpower Rank 1
-    sp = Spell::checkAndReturnSpellEntry(7384);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(7384);
     if (sp != nullptr)
         sp->Attributes |= ATTRIBUTES_CANT_BE_DPB;
     // Warrior - Overpower Rank 2
-    sp = Spell::checkAndReturnSpellEntry(7887);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(7887);
     if (sp != nullptr)
         sp->Attributes |= ATTRIBUTES_CANT_BE_DPB;
     // Warrior - Overpower Rank 3
-    sp = Spell::checkAndReturnSpellEntry(11584);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11584);
     if (sp != nullptr)
         sp->Attributes |= ATTRIBUTES_CANT_BE_DPB;
     // Warrior - Overpower Rank 4
-    sp = Spell::checkAndReturnSpellEntry(11585);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11585);
     if (sp != nullptr)
         sp->Attributes |= ATTRIBUTES_CANT_BE_DPB;
 
     // Warrior - Tactical Mastery Rank 1
-    sp = Spell::checkAndReturnSpellEntry(12295);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12295);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0x00070000;
     // Warrior - Tactical Mastery Rank 2
-    sp = Spell::checkAndReturnSpellEntry(12676);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12676);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0x00070000;
     // Warrior - Tactical Mastery Rank 3
-    sp = Spell::checkAndReturnSpellEntry(12677);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12677);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0x00070000;
 
     // Warrior - Heroic Throw
-    sp = Spell::checkAndReturnSpellEntry(57755);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(57755);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
     }
 
     // Warrior - Rend
-    sp = Spell::checkAndReturnSpellEntry(772);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(772);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(6546);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6546);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(6547);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6547);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(6548);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6548);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11572);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11572);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11573);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11573);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11574);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11574);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(25208);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25208);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
 
@@ -7507,70 +7507,70 @@ void ApplyNormalFixes()
     // Fury
 
     // Warrior - Slam
-    sp = Spell::checkAndReturnSpellEntry(1464);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(1464);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(8820);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8820);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(11604);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11604);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(11605);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11605);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(25241);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25241);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(25242);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25242);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(47474);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47474);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
-    sp = Spell::checkAndReturnSpellEntry(47475);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47475);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_SCHOOL_DAMAGE;
 
     // Warrior - Bloodthirst new version is ok but old version is wrong from now on :(
-    sp = Spell::checkAndReturnSpellEntry(23881);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23881);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL; //cast on us, it is good
         sp->EffectTriggerSpell[1] = 23885; //evil , but this is good for us :D
     }
-    sp = Spell::checkAndReturnSpellEntry(23892);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23892);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 23886; //evil , but this is good for us :D  // DankoDJ: Is there a reason to trigger an non existing spell?
     }
-    sp = Spell::checkAndReturnSpellEntry(23893);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23893);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL; //
         sp->EffectTriggerSpell[1] = 23887; //evil , but this is good for us :D // DankoDJ: Is there a reason to trigger an non existing spell?
     }
-    sp = Spell::checkAndReturnSpellEntry(23894);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23894);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL; //
         sp->EffectTriggerSpell[1] = 23888; //evil , but this is good for us :D // DankoDJ: Is there a reason to trigger an non existing spell?
     }
-    sp = Spell::checkAndReturnSpellEntry(25251);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25251);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL; //aura
         sp->EffectTriggerSpell[1] = 25252; //evil , but this is good for us :D // DankoDJ: Is there a reason to trigger an non existing spell?
     }
-    sp = Spell::checkAndReturnSpellEntry(30335);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30335);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL; //aura
@@ -7578,7 +7578,7 @@ void ApplyNormalFixes()
     }
 
     // Warrior - Berserker Rage
-    sp = Spell::checkAndReturnSpellEntry(18499);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18499);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;//Forcing a dummy aura, so we can add the missing 4th effect.
@@ -7587,7 +7587,7 @@ void ApplyNormalFixes()
     }
 
     // Warrior - Heroic Fury
-    sp = Spell::checkAndReturnSpellEntry(60970);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60970);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_DUMMY;
@@ -7597,7 +7597,7 @@ void ApplyNormalFixes()
     // Protection
 
     // Intervene  Ranger: stop attack
-    sp = Spell::checkAndReturnSpellEntry(3411);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(3411);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_STOP_ATTACK;
@@ -7610,36 +7610,36 @@ void ApplyNormalFixes()
     // Insert paladin spell fixes here
 
     //Paladin - Seal of Command - Holy damage, but melee mechanics (crit damage, chance, etc)
-    sp = Spell::checkAndReturnSpellEntry(20424);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20424);
     if (sp != nullptr)
         sp->custom_is_melee_spell = true;
 
     //Paladin - Hammer of the Righteous
-    sp = Spell::checkAndReturnSpellEntry(53595);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53595);
     if (sp != nullptr)
     {
         sp->speed = 0;    //without, no damage is done
     }
 
     //Paladin - Seal of Martyr
-    sp = Spell::checkAndReturnSpellEntry(53720);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53720);
     if (sp != nullptr)
     {
         sp->School = SCHOOL_HOLY;
     }
     //Paladin - seal of blood
-    sp = Spell::checkAndReturnSpellEntry(31892);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31892);
     if (sp != nullptr)
     {
         sp->School = SCHOOL_HOLY;
     }
-    sp = Spell::checkAndReturnSpellEntry(53719);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53719);
     if (sp != nullptr)
     {
         sp->School = SCHOOL_HOLY;
         sp->Spell_Dmg_Type = SPELL_DMG_TYPE_MAGIC;
     }
-    sp = Spell::checkAndReturnSpellEntry(31893);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31893);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_PHYSICAL_ATTACK;
@@ -7648,7 +7648,7 @@ void ApplyNormalFixes()
     }
 
     //Paladin - Divine Storm
-    sp = Spell::checkAndReturnSpellEntry(53385);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53385);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -7661,7 +7661,7 @@ void ApplyNormalFixes()
     }
 
     //Paladin - Judgements of the Wise
-    sp = Spell::checkAndReturnSpellEntry(31930);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31930);
     if (sp != nullptr)
     {
         sp->SpellFamilyName = 0;
@@ -7670,7 +7670,7 @@ void ApplyNormalFixes()
         sp->SpellGroupType[2] = 0;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(54180);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(54180);
     if (sp != nullptr)
     {
         sp->SpellFamilyName = 0;
@@ -7680,83 +7680,83 @@ void ApplyNormalFixes()
     }
 
     //Paladin - Avenging Wrath marker - Is forced debuff
-    sp = Spell::checkAndReturnSpellEntry(61987);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(61987);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
     }
 
     //Paladin - Forbearance - Is forced debuff
-    sp = Spell::checkAndReturnSpellEntry(25771);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25771);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
     }
 
     //Divine Protection
-    sp = Spell::checkAndReturnSpellEntry(498);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(498);
     if (sp != nullptr)
         sp->targetAuraSpellNot = 25771;
 
     //Divine Shield
-    sp = Spell::checkAndReturnSpellEntry(642);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(642);
     if (sp != nullptr)
         sp->targetAuraSpellNot = 25771;
 
     //Hand of Protection Rank 1
-    sp = Spell::checkAndReturnSpellEntry(1022);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(1022);
     if (sp != nullptr)
         sp->targetAuraSpellNot = 25771;
 
     //Hand of Protection Rank 2
-    sp = Spell::checkAndReturnSpellEntry(5599);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(5599);
     if (sp != nullptr)
         sp->targetAuraSpellNot = 25771;
 
     //Hand of Protection Rank 3
-    sp = Spell::checkAndReturnSpellEntry(10278);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(10278);
     if (sp != nullptr)
         sp->targetAuraSpellNot = 25771;
 
     //Paladin - Art of War
-    sp = Spell::checkAndReturnSpellEntry(53486);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53486);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_DONE;
     }
-    sp = Spell::checkAndReturnSpellEntry(53489);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53489);
     if (sp != nullptr)
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
 
-    sp = Spell::checkAndReturnSpellEntry(53488);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53488);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_DONE;
     }
-    sp = Spell::checkAndReturnSpellEntry(59578);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(59578);
     if (sp != nullptr)
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
 
     //Paladin - Hammer of Justice - Interrupt effect
-    sp = Spell::checkAndReturnSpellEntry(853);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(853);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 32747;
     }
-    sp = Spell::checkAndReturnSpellEntry(5588);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(5588);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 32747;
     }
-    sp = Spell::checkAndReturnSpellEntry(5589);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(5589);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 32747;
     }
-    sp = Spell::checkAndReturnSpellEntry(10308);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(10308);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -7770,37 +7770,37 @@ void ApplyNormalFixes()
     // Insert hunter spell fixes here
 
     //Hunter - Bestial Wrath
-    sp = Spell::checkAndReturnSpellEntry(19574);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19574);
     if (sp != nullptr)
         sp->EffectApplyAuraName[2] = SPELL_AURA_DUMMY;
 
     //Hunter - The Beast Within
-    sp = Spell::checkAndReturnSpellEntry(34471);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34471);
     if (sp != nullptr)
         sp->EffectApplyAuraName[2] = SPELL_AURA_DUMMY;
 
     //Hunter - Go for the Throat
-    sp = Spell::checkAndReturnSpellEntry(34952);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34952);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(34953);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34953);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
 
     // Hunter - Spirit Bond
-    sp = Spell::checkAndReturnSpellEntry(19578);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19578);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 19579;
     }
-    sp = Spell::checkAndReturnSpellEntry(20895);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20895);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 24529;
     }
-    sp = Spell::checkAndReturnSpellEntry(19579);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19579);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA; //we should do the same for player too as we did for pet
@@ -7810,7 +7810,7 @@ void ApplyNormalFixes()
         sp->EffectAmplitude[1] = sp->EffectAmplitude[0];
         sp->EffectDieSides[1] = sp->EffectDieSides[0];
     }
-    sp = Spell::checkAndReturnSpellEntry(24529);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(24529);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA; //we should do the same for player too as we did for pet
@@ -7822,14 +7822,14 @@ void ApplyNormalFixes()
     }
 
     //Hunter Silencing Shot
-    sp = Spell::checkAndReturnSpellEntry(34490);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34490);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_MOD_SILENCE;
     }
 
     // Hunter - Ferocious Inspiration
-    sp = Spell::checkAndReturnSpellEntry(34455);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34455);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7838,7 +7838,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CRIT_ATTACK | PROC_ON_SPELL_CRIT_HIT | static_cast<uint32>(PROC_TARGET_SELF); //maybe target master ?
         sp->Effect[1] = SPELL_EFFECT_NULL; //remove this
     }
-    sp = Spell::checkAndReturnSpellEntry(34459);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34459);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7847,7 +7847,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CRIT_ATTACK | PROC_ON_SPELL_CRIT_HIT | static_cast<uint32>(PROC_TARGET_SELF);
         sp->Effect[1] = SPELL_EFFECT_NULL; //remove this
     }
-    sp = Spell::checkAndReturnSpellEntry(34460);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34460);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7858,13 +7858,13 @@ void ApplyNormalFixes()
     }
 
     // Hunter - Focused Fire
-    sp = Spell::checkAndReturnSpellEntry(35029);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35029);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 35060;
     }
-    sp = Spell::checkAndReturnSpellEntry(35030);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35030);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -7872,7 +7872,7 @@ void ApplyNormalFixes()
     }
 
     // Hunter - Thrill of the Hunt
-    sp = Spell::checkAndReturnSpellEntry(34497);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34497);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_SPELL_CRIT_HIT | static_cast<uint32>(PROC_TARGET_SELF);
@@ -7880,7 +7880,7 @@ void ApplyNormalFixes()
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 34720;
     }
-    sp = Spell::checkAndReturnSpellEntry(34498);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34498);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_SPELL_CRIT_HIT | static_cast<uint32>(PROC_TARGET_SELF);
@@ -7888,7 +7888,7 @@ void ApplyNormalFixes()
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 34720;
     }
-    sp = Spell::checkAndReturnSpellEntry(34499);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34499);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_SPELL_CRIT_HIT | static_cast<uint32>(PROC_TARGET_SELF);
@@ -7898,7 +7898,7 @@ void ApplyNormalFixes()
     }
 
     //Hunter - Frenzy
-    sp = Spell::checkAndReturnSpellEntry(19621);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19621);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7907,7 +7907,7 @@ void ApplyNormalFixes()
         sp->procChance = sp->EffectBasePoints[0];
         sp->procFlags = PROC_ON_CRIT_ATTACK | static_cast<uint32>(PROC_TARGET_SELF);        //Zyres: moved from custom_c_is_flag
     }
-    sp = Spell::checkAndReturnSpellEntry(19622);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19622);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7916,7 +7916,7 @@ void ApplyNormalFixes()
         sp->procChance = sp->EffectBasePoints[0];
         sp->procFlags = PROC_ON_CRIT_ATTACK | static_cast<uint32>(PROC_TARGET_SELF);        //Zyres: moved from custom_c_is_flag
     }
-    sp = Spell::checkAndReturnSpellEntry(19623);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19623);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7925,7 +7925,7 @@ void ApplyNormalFixes()
         sp->procChance = sp->EffectBasePoints[0];
         sp->procFlags = PROC_ON_CRIT_ATTACK | static_cast<uint32>(PROC_TARGET_SELF);        //Zyres: moved from custom_c_is_flag
     }
-    sp = Spell::checkAndReturnSpellEntry(19624);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19624);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7934,7 +7934,7 @@ void ApplyNormalFixes()
         sp->procChance = sp->EffectBasePoints[0];
         sp->procFlags = PROC_ON_CRIT_ATTACK | static_cast<uint32>(PROC_TARGET_SELF);        //Zyres: moved from custom_c_is_flag
     }
-    sp = Spell::checkAndReturnSpellEntry(19625);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19625);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -7945,24 +7945,24 @@ void ApplyNormalFixes()
     }
 
     //Hunter : Pathfinding
-    sp = Spell::checkAndReturnSpellEntry(19559);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19559);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(19560);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19560);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
 
     //Hunter : Rapid Killing - might need to add honor trigger too here. I'm guessing you receive Xp too so I'm avoiding double proc
-    sp = Spell::checkAndReturnSpellEntry(34948);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34948);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_GAIN_EXPIERIENCE | static_cast<uint32>(PROC_TARGET_SELF);
     }
-    sp = Spell::checkAndReturnSpellEntry(34949);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34949);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_GAIN_EXPIERIENCE | static_cast<uint32>(PROC_TARGET_SELF);
@@ -7970,18 +7970,18 @@ void ApplyNormalFixes()
 
     /* Zyres: Same procFlags are already in the dbcs!
     //Hunter : Entrapment
-    sp = checkAndReturnSpellEntry(19184);
+    sp = checkAndReturnSpellEntryUnsafe(19184);
     if (sp != nullptr)
         sp->procFlags = PROC_ON_TRAP_TRIGGER;
-    sp = checkAndReturnSpellEntry(19387);
+    sp = checkAndReturnSpellEntryUnsafe(19387);
     if (sp != nullptr)
         sp->procFlags = PROC_ON_TRAP_TRIGGER;
-    sp = checkAndReturnSpellEntry(19388);
+    sp = checkAndReturnSpellEntryUnsafe(19388);
     if (sp != nullptr)
         sp->procFlags = PROC_ON_TRAP_TRIGGER;*/
 
     // Feed pet
-    sp = Spell::checkAndReturnSpellEntry(6991);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6991);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = 0;
@@ -7989,21 +7989,21 @@ void ApplyNormalFixes()
 
     //\todo 16/03/08 Zyres: sql
     // MesoX: Serendipity http://www.wowhead.com/?spell=63730
-    sp = Spell::checkAndReturnSpellEntry(63730);   // Rank 1
+    sp = Spell::checkAndReturnSpellEntryUnsafe(63730);   // Rank 1
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->custom_ProcOnNameHash[0] = SPELL_HASH_BINDING_HEAL;
         sp->custom_ProcOnNameHash[1] = SPELL_HASH_FLASH_HEAL;
     }
-    sp = Spell::checkAndReturnSpellEntry(63733);   // Rank 2
+    sp = Spell::checkAndReturnSpellEntryUnsafe(63733);   // Rank 2
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->custom_ProcOnNameHash[0] = SPELL_HASH_BINDING_HEAL;
         sp->custom_ProcOnNameHash[1] = SPELL_HASH_FLASH_HEAL;
     }
-    sp = Spell::checkAndReturnSpellEntry(63737);   // Rank 3
+    sp = Spell::checkAndReturnSpellEntryUnsafe(63737);   // Rank 3
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -8019,7 +8019,7 @@ void ApplyNormalFixes()
     // Insert rogue spell fixes here
 
     // Garrote - this is used?
-    sp = Spell::checkAndReturnSpellEntry(37066);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(37066);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_ENEMY;
@@ -8027,29 +8027,29 @@ void ApplyNormalFixes()
     }
 
     //rogue - Camouflage.
-    sp = Spell::checkAndReturnSpellEntry(13975);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(13975);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14062);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14062);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14063);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14063);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
 
     //rogue - Vanish : Second Trigger Spell
-    sp = Spell::checkAndReturnSpellEntry(18461);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18461);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
 
     // rogue - Blind (Make it able to miss!)
-    sp = Spell::checkAndReturnSpellEntry(2094);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(2094);
     if (sp != nullptr)
     {
         sp->Spell_Dmg_Type = SPELL_DMG_TYPE_RANGED;
@@ -8057,73 +8057,73 @@ void ApplyNormalFixes()
     }
 
     //rogue - Shadowstep
-    sp = Spell::checkAndReturnSpellEntry(36563);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(36563);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[2] = SMT_MISC_EFFECT;
     }
     // Still related to shadowstep - prevent the trigger spells from breaking stealth.
-    sp = Spell::checkAndReturnSpellEntry(44373);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44373);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
-    sp = Spell::checkAndReturnSpellEntry(36563);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(36563);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
-    sp = Spell::checkAndReturnSpellEntry(36554);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(36554);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
 
     //garrot
-    sp = Spell::checkAndReturnSpellEntry(703);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(703);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(8631);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8631);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(8632);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8632);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(8633);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8633);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11289);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11289);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11290);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11290);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(26839);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(26839);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(26884);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(26884);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
 
     //rupture
-    sp = Spell::checkAndReturnSpellEntry(1943);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(1943);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(8639);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8639);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(8640);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8640);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11273);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11273);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11274);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11274);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(11275);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11275);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
-    sp = Spell::checkAndReturnSpellEntry(26867);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(26867);
     if (sp != nullptr)
         sp->MechanicsType = MECHANIC_BLEEDING;
 
     //Rogue - Killing Spree Stealth fix
-    sp = Spell::checkAndReturnSpellEntry(51690);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51690);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
 
@@ -8135,30 +8135,30 @@ void ApplyNormalFixes()
     // Insert priest spell fixes here
 
     // Prayer of mending
-    sp = Spell::checkAndReturnSpellEntry(41635);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(41635);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
-    sp = Spell::checkAndReturnSpellEntry(48110);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48110);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
-    sp = Spell::checkAndReturnSpellEntry(48111);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48111);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
-    sp = Spell::checkAndReturnSpellEntry(33110);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33110);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
 
     // Vampiric Embrace heal spell
-    sp = Spell::checkAndReturnSpellEntry(15290);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15290);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] = 2;
@@ -8166,31 +8166,31 @@ void ApplyNormalFixes()
     }
 
     // Improved Mind Blast
-    sp = Spell::checkAndReturnSpellEntry(15273);   //rank 1
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15273);   //rank 1
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA;
         sp->EffectApplyAuraName[1] = SPELL_AURA_DUMMY;
     }
-    sp = Spell::checkAndReturnSpellEntry(15312);   //rank 2
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15312);   //rank 2
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA;
         sp->EffectApplyAuraName[1] = SPELL_AURA_DUMMY;
     }
-    sp = Spell::checkAndReturnSpellEntry(15313);   //rank 3
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15313);   //rank 3
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA;
         sp->EffectApplyAuraName[1] = SPELL_AURA_DUMMY;
     }
-    sp = Spell::checkAndReturnSpellEntry(15314);   //rank 4
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15314);   //rank 4
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA;
         sp->EffectApplyAuraName[1] = SPELL_AURA_DUMMY;
     }
-    sp = Spell::checkAndReturnSpellEntry(15316);   //rank 5
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15316);   //rank 5
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_APPLY_AURA;
@@ -8198,44 +8198,44 @@ void ApplyNormalFixes()
     }
 
     // Body and soul - fix duration of cleanse poison
-    sp = Spell::checkAndReturnSpellEntry(64134);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(64134);
     if (sp != nullptr)
         sp->DurationIndex = 29;
 
     // Spirit of Redemption - required spells can be casted while dead
-    sp = Spell::checkAndReturnSpellEntry(27795);   // This is casted by shape shift
+    sp = Spell::checkAndReturnSpellEntryUnsafe(27795);   // This is casted by shape shift
     if (sp != nullptr)
         sp->AttributesExC |= ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD;
-    sp = Spell::checkAndReturnSpellEntry(27792);   // This is casted by Apply Aura: Spirit of Redemption
+    sp = Spell::checkAndReturnSpellEntryUnsafe(27792);   // This is casted by Apply Aura: Spirit of Redemption
     if (sp != nullptr)
         sp->AttributesExC |= ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD;
 
     //Priest - Wand Specialization
-    sp = Spell::checkAndReturnSpellEntry(14524);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14524);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14525);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14525);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14526);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14526);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14527);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14527);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(14528);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14528);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -8243,31 +8243,31 @@ void ApplyNormalFixes()
     }
 
     //Priest - Inspiration proc spell
-    sp = Spell::checkAndReturnSpellEntry(14893);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(14893);
     if (sp != nullptr)
         sp->rangeIndex = 4;
-    sp = Spell::checkAndReturnSpellEntry(15357);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15357);
     if (sp != nullptr)
         sp->rangeIndex = 4;
-    sp = Spell::checkAndReturnSpellEntry(15359);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(15359);
     if (sp != nullptr)
         sp->rangeIndex = 4;
 
     //priest - surge of light
-    sp = Spell::checkAndReturnSpellEntry(33151);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33151);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
     }
     // priest - Reflective Shield
-    sp = Spell::checkAndReturnSpellEntry(33201);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33201);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_ABSORB;
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 33619; //!! WRONG spell, we will make direct dmg here
     }
-    sp = Spell::checkAndReturnSpellEntry(33202);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33202);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_ABSORB;
@@ -8275,35 +8275,35 @@ void ApplyNormalFixes()
         sp->EffectTriggerSpell[0] = 33619; //!! WRONG spell, we will make direct dmg here
     }
     // Weakened Soul - Is debuff
-    sp = Spell::checkAndReturnSpellEntry(6788);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6788);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
     }
 
     // Penance
-    sp = Spell::checkAndReturnSpellEntry(47540);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47540);
     if (sp != nullptr)
     {
         sp->DurationIndex = 566; // Change to instant cast as script will cast the real channeled spell.
         sp->ChannelInterruptFlags = 0; // Remove channeling behavior.
     }
 
-    sp = Spell::checkAndReturnSpellEntry(53005);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53005);
     if (sp != nullptr)
     {
         sp->DurationIndex = 566;
         sp->ChannelInterruptFlags = 0;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(53006);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53006);
     if (sp != nullptr)
     {
         sp->DurationIndex = 566;
         sp->ChannelInterruptFlags = 0;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(53007);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(53007);
     if (sp != nullptr)
     {
         sp->DurationIndex = 566;
@@ -8311,25 +8311,25 @@ void ApplyNormalFixes()
     }
 
     // Penance triggered healing spells have wrong targets.
-    sp = Spell::checkAndReturnSpellEntry(47750);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47750);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(52983);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(52983);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(52984);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(52984);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(52985);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(52985);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
@@ -8342,19 +8342,19 @@ void ApplyNormalFixes()
 
     // Insert shaman spell fixes here
     //shaman - Healing Way
-    sp = Spell::checkAndReturnSpellEntry(29202);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29202);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;     // DankoDJ: No triggered Spell! We override SPELL_AURA_ADD_PCT_MODIFIER with this crap?
     }
-    sp = Spell::checkAndReturnSpellEntry(29205);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29205);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectApplyAuraName[0] = SPELL_AURA_PROC_TRIGGER_SPELL;     // DankoDJ: No triggered Spell! We override SPELL_AURA_ADD_PCT_MODIFIER with this crap?
     }
-    sp = Spell::checkAndReturnSpellEntry(29206);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29206);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -8362,7 +8362,7 @@ void ApplyNormalFixes()
     }
 
     // Elemental Mastery
-    sp = Spell::checkAndReturnSpellEntry(16166);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16166);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_CRITICAL;
@@ -8372,18 +8372,18 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Shamanistic Rage
-    SpellInfo*  parentsp = Spell::checkAndReturnSpellEntry(30823);
-    SpellInfo* triggersp = Spell::checkAndReturnSpellEntry(30824);
+    SpellInfo const*  parentsp = Spell::checkAndReturnSpellEntry(30823);
+    SpellInfo* triggersp = Spell::checkAndReturnSpellEntryUnsafe(30824);
     if (parentsp != nullptr && triggersp != nullptr)
         triggersp->EffectBasePoints[0] = parentsp->EffectBasePoints[0];
 
     //summon only 1 elemental totem
-    sp = Spell::checkAndReturnSpellEntry(2894);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(2894);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_TOTEM_FIRE; //remove this targeting. it is enough to get 1 target
 
     //summon only 1 elemental totem
-    sp = Spell::checkAndReturnSpellEntry(2062);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(2062);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_TOTEM_EARTH; //remove this targeting. it is enough to get 1 target
 
@@ -8391,12 +8391,12 @@ void ApplyNormalFixes()
     ////////////////////////////////////////////////////////////
     // Bloodlust
     //Bloodlust
-    sp = Spell::checkAndReturnSpellEntry(2825);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(2825);
     if (sp != nullptr)
         sp->casterAuraSpellNot = 57724; //sated debuff
 
     // Sated - is debuff
-    sp = Spell::checkAndReturnSpellEntry(57724);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(57724);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
@@ -8405,12 +8405,12 @@ void ApplyNormalFixes()
     ////////////////////////////////////////////////////////////
     // Heroism
     //Heroism
-    sp = Spell::checkAndReturnSpellEntry(32182);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32182);
     if (sp != nullptr)
         sp->casterAuraSpellNot = 57723; //sated debuff
 
     // Sated - is debuff
-    sp = Spell::checkAndReturnSpellEntry(57723);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(57723);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
@@ -8418,47 +8418,47 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Purge
-    sp = Spell::checkAndReturnSpellEntry(370);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(370);
     if (sp != nullptr)
         sp->DispelType = DISPEL_MAGIC;
-    sp = Spell::checkAndReturnSpellEntry(8012);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8012);
     if (sp != nullptr)
         sp->DispelType = DISPEL_MAGIC;
-    sp = Spell::checkAndReturnSpellEntry(27626);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(27626);
     if (sp != nullptr)
         sp->DispelType = DISPEL_MAGIC;
-    sp = Spell::checkAndReturnSpellEntry(33625);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33625);
     if (sp != nullptr)
         sp->DispelType = DISPEL_MAGIC;
 
     //Shaman - Shamanistic Focus
     // needs to be fixed (doesn't need to proc, it now just reduces mana cost always by %)
-    sp = Spell::checkAndReturnSpellEntry(43338);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43338);
     if (sp != nullptr)
     {
         sp->EffectTriggerSpell[0] = 43339;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(43339);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43339);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_COST;
     }
 
     //shaman - Improved Chain Heal
-    sp = Spell::checkAndReturnSpellEntry(30873);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30873);
     if (sp != nullptr)
     {
         sp->EffectDieSides[0] = 0;
     }
-    sp = Spell::checkAndReturnSpellEntry(30872);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30872);
     if (sp != nullptr)
     {
         sp->EffectDieSides[0] = 0;
     }
 
     //shaman - Improved Weapon Totems
-    sp = Spell::checkAndReturnSpellEntry(29193);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29193);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -8466,7 +8466,7 @@ void ApplyNormalFixes()
         sp->EffectMiscValue[0] = SMT_MISC_EFFECT;
         sp->EffectMiscValue[1] = SMT_MISC_EFFECT;
     }
-    sp = Spell::checkAndReturnSpellEntry(29192);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29192);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -8476,31 +8476,31 @@ void ApplyNormalFixes()
     }
 
     // Shaman - Improved Fire Totems
-    sp = Spell::checkAndReturnSpellEntry(16544);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16544);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_DURATION;
     }
-    sp = Spell::checkAndReturnSpellEntry(16086);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16086);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_DURATION;
     }
 
     //shaman - Elemental Weapons
-    sp = Spell::checkAndReturnSpellEntry(29080);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29080);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_DAMAGE_DONE;
         sp->EffectMiscValue[2] = SMT_DAMAGE_DONE;
     }
-    sp = Spell::checkAndReturnSpellEntry(29079);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29079);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_DAMAGE_DONE;
         sp->EffectMiscValue[2] = SMT_DAMAGE_DONE;
     }
-    sp = Spell::checkAndReturnSpellEntry(16266);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16266);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_DAMAGE_DONE;
@@ -8508,37 +8508,37 @@ void ApplyNormalFixes()
     }
 
     // Magma Totem - 0% spd coefficient
-    sp = Spell::checkAndReturnSpellEntry(25550);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25550);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.0f;
-    sp = Spell::checkAndReturnSpellEntry(10581);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(10581);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.0f;
-    sp = Spell::checkAndReturnSpellEntry(10580);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(10580);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.0f;
-    sp = Spell::checkAndReturnSpellEntry(10579);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(10579);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.0f;
-    sp = Spell::checkAndReturnSpellEntry(8187);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8187);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.0f;
 
     ////////////////////////////////////////////////////////////
     //  Unleashed Rage - LordLeeCH
-    sp = Spell::checkAndReturnSpellEntry(30802);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30802);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CRIT_ATTACK;
         sp->Effect[0] = SPELL_EFFECT_APPLY_GROUP_AREA_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(30808);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30808);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CRIT_ATTACK;
         sp->Effect[0] = SPELL_EFFECT_APPLY_GROUP_AREA_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(30809);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30809);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CRIT_ATTACK;
@@ -8547,17 +8547,17 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Ancestral healing proc spell
-    sp = Spell::checkAndReturnSpellEntry(16177);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16177);
     if (sp != nullptr)
         sp->rangeIndex = 4;
-    sp = Spell::checkAndReturnSpellEntry(16236);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16236);
     if (sp != nullptr)
         sp->rangeIndex = 4;
-    sp = Spell::checkAndReturnSpellEntry(16237);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16237);
     if (sp != nullptr)
         sp->rangeIndex = 4;
 
-    sp = Spell::checkAndReturnSpellEntry(20608);   //Reincarnation
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20608);   //Reincarnation
     if (sp != nullptr)
     {
         for (uint8 i = 0; i < 8; ++i)
@@ -8573,7 +8573,7 @@ void ApplyNormalFixes()
     //////////////////////////////////////////
     // SHAMAN WRATH OF AIR TOTEM            //
     //////////////////////////////////////////
-    sp = Spell::checkAndReturnSpellEntry(2895);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(2895);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SELF;
@@ -8585,7 +8585,7 @@ void ApplyNormalFixes()
     }
 
     // Rogue - Master of Subtlety
-    sp = Spell::checkAndReturnSpellEntry(31665);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31665);
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
 
@@ -8596,40 +8596,40 @@ void ApplyNormalFixes()
     // Insert mage spell fixes here
 
     // Brain Freeze rank 1
-    sp = Spell::checkAndReturnSpellEntry(44546);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44546);
     if (sp != nullptr)
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
 
     // Brain Freeze rank 2
-    sp = Spell::checkAndReturnSpellEntry(44548);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44548);
     if (sp != nullptr)
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
 
     // Brain Freeze rank 3
-    sp = Spell::checkAndReturnSpellEntry(44549);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44549);
     if (sp != nullptr)
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
 
     // Fingers of Frost rank 1
-    sp = Spell::checkAndReturnSpellEntry(44543);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44543);
     if (sp != nullptr)
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
 
 
     // Fingers of Frost rank 2
-    sp = Spell::checkAndReturnSpellEntry(44545);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44545);
     if (sp != nullptr)
         sp->EffectApplyAuraName[0] = SPELL_AURA_DUMMY;
 
 
     //Mage - Spell Power
-    sp = Spell::checkAndReturnSpellEntry(35578);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35578);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_CRITICAL_DAMAGE;
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
     }
-    sp = Spell::checkAndReturnSpellEntry(35581);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35581);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[0] = SMT_CRITICAL_DAMAGE;
@@ -8637,19 +8637,19 @@ void ApplyNormalFixes()
     }
 
     //Mage - Elemental Precision
-    sp = Spell::checkAndReturnSpellEntry(29438);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29438);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_COST;
     }
-    sp = Spell::checkAndReturnSpellEntry(29439);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29439);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
         sp->EffectMiscValue[0] = SMT_COST;
     }
-    sp = Spell::checkAndReturnSpellEntry(29440);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29440);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -8657,7 +8657,7 @@ void ApplyNormalFixes()
     }
 
     //Mage - Arcane Blast
-    sp = Spell::checkAndReturnSpellEntry(30451);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30451);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -8666,7 +8666,7 @@ void ApplyNormalFixes()
     }
 
     // Arcane Blast
-    sp = Spell::checkAndReturnSpellEntry(42894);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42894);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -8674,14 +8674,14 @@ void ApplyNormalFixes()
         sp->custom_ProcOnNameHash[1] = SPELL_HASH_ARCANE_BLAST;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(42896);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42896);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_PROC_TRIGGER_SPELL;
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(42897);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42897);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_PROC_TRIGGER_SPELL;
@@ -8690,17 +8690,17 @@ void ApplyNormalFixes()
 
     //mage : Empowered Arcane Missiles
     //heh B thinks he is smart by adding this to description ? If it doesn't work std then it still needs to made by hand
-    sp = Spell::checkAndReturnSpellEntry(31579);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31579);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] = 5 * (sp->EffectBasePoints[0] + 1);
     }
-    sp = Spell::checkAndReturnSpellEntry(31582);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31582);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] = 5 * (sp->EffectBasePoints[0] + 1);
     }
-    sp = Spell::checkAndReturnSpellEntry(31583);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31583);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] = 5 * (sp->EffectBasePoints[0] + 1);
@@ -8708,7 +8708,7 @@ void ApplyNormalFixes()
 
     // cebernic: not for self?
     // impact
-    sp = Spell::checkAndReturnSpellEntry(12355);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12355);
     if (sp != nullptr)
     {
         // passive rank: 11103, 12357, 12358 ,12359,12360 :D
@@ -8722,7 +8722,7 @@ void ApplyNormalFixes()
     }
 
     //Mage - Invisibility
-    sp = Spell::checkAndReturnSpellEntry(66);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(66);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags |= AURA_INTERRUPT_ON_CAST_SPELL;
@@ -8738,14 +8738,14 @@ void ApplyNormalFixes()
     }
 
     //Invisibility triggered spell, should be removed on cast
-    sp = Spell::checkAndReturnSpellEntry(32612);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32612);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags |= AURA_INTERRUPT_ON_CAST_SPELL;
     }
 
     //Arcane Potency procs
-    sp = Spell::checkAndReturnSpellEntry(57529);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(57529);
     if (sp != nullptr)
     {
         sp->procFlags = 0;
@@ -8753,7 +8753,7 @@ void ApplyNormalFixes()
         sp->AuraInterruptFlags = 0;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(57531);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(57531);
     if (sp != nullptr)
     {
         sp->procFlags = 0;
@@ -8762,37 +8762,37 @@ void ApplyNormalFixes()
     }
 
     //Hot Streak proc
-    sp = Spell::checkAndReturnSpellEntry(48108);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48108);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags |= AURA_INTERRUPT_ON_CAST_SPELL;
     }
 
     //Ice Lances
-    sp = Spell::checkAndReturnSpellEntry(42914);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42914);
     if (sp != nullptr)
         sp->Dspell_coef_override = 0.1429f;
 
-    sp = Spell::checkAndReturnSpellEntry(42913);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42913);
     if (sp != nullptr)
         sp->Dspell_coef_override = 0.1429f;
 
-    sp = Spell::checkAndReturnSpellEntry(30455);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30455);
     if (sp != nullptr)
         sp->Dspell_coef_override = 0.1429f;
 
     // Frostfire Bolts
-    sp = Spell::checkAndReturnSpellEntry(47610);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47610);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.8571f;
 
-    sp = Spell::checkAndReturnSpellEntry(44614);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44614);
     if (sp != nullptr)
         sp->fixed_dddhcoef = 0.8571f;
 
 
     //mage - Combustion
-    sp = Spell::checkAndReturnSpellEntry(11129);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11129);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL;
@@ -8804,40 +8804,40 @@ void ApplyNormalFixes()
     }
 
     // mage - Conjure Refreshment Table
-    sp = Spell::checkAndReturnSpellEntry(43985);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43985);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_DYNAMIC_OBJECT;
 
     // Hypothermia - forced debuff
-    sp = Spell::checkAndReturnSpellEntry(41425);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(41425);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
     }
 
     // Mage - Permafrost Rank 1
-    sp = Spell::checkAndReturnSpellEntry(11175);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11175);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_MISC_EFFECT;
     }
 
     // Mage - Permafrost Rank 2
-    sp = Spell::checkAndReturnSpellEntry(12569);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12569);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_MISC_EFFECT;
     }
 
     // Mage - Permafrost Rank 3
-    sp = Spell::checkAndReturnSpellEntry(12571);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12571);
     if (sp != nullptr)
     {
         sp->EffectMiscValue[1] = SMT_MISC_EFFECT;
     }
 
     //Improved Counterspell rank 1
-    sp = Spell::checkAndReturnSpellEntry(11255);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11255);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -8845,7 +8845,7 @@ void ApplyNormalFixes()
     }
 
     //Improved Counterspell rank 2
-    sp = Spell::checkAndReturnSpellEntry(12598);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(12598);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -8858,13 +8858,13 @@ void ApplyNormalFixes()
     // Insert warlock spell fixes here
 
     //Dummy for Demonic Circle
-    sp = Spell::checkAndReturnSpellEntry(48018);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48018);
     if (sp != nullptr)
     {
 
         sp->EffectImplicitTargetA[1] = 1;
         CreateDummySpell(62388);
-        sp = Spell::checkAndReturnSpellEntry(62388);
+        sp = Spell::checkAndReturnSpellEntryUnsafe(62388);
         if (sp != nullptr)
         {
             sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -8873,7 +8873,7 @@ void ApplyNormalFixes()
     }
 
     //megai2: Immolation Aura
-    sp = Spell::checkAndReturnSpellEntry(50589);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(50589);
     if (sp != nullptr)
     {
         sp->ChannelInterruptFlags = 0; // Remove channeling behaviour.
@@ -8881,7 +8881,7 @@ void ApplyNormalFixes()
 
 #if VERSION_STRING != Cata
     //megai2: Everlasting Affliction
-    sp = Spell::checkAndReturnSpellEntry(47205);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47205);
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[1][0] = 0x111;
@@ -8889,7 +8889,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_ANY_HOSTILE_ACTION;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(47204);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47204);
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[1][0] = 0x111;
@@ -8897,7 +8897,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_ANY_HOSTILE_ACTION;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(47203);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47203);
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[1][0] = 0x111;
@@ -8905,7 +8905,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_ANY_HOSTILE_ACTION;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(47202);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47202);
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[1][0] = 0x111;
@@ -8913,7 +8913,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_ANY_HOSTILE_ACTION;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(47201);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47201);
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[1][0] = 0x111;
@@ -8923,7 +8923,7 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Backlash
-    sp = Spell::checkAndReturnSpellEntry(34936);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34936);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
@@ -8931,7 +8931,7 @@ void ApplyNormalFixes()
 
     ////////////////////////////////////////////////////////////
     // Demonic Knowledge
-    sp = Spell::checkAndReturnSpellEntry(35691);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35691);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_DONE;
@@ -8944,7 +8944,7 @@ void ApplyNormalFixes()
         sp->EffectTriggerSpell[2] = 35696;
         sp->EffectImplicitTargetA[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(35692);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35692);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_DONE;
@@ -8957,7 +8957,7 @@ void ApplyNormalFixes()
         sp->EffectTriggerSpell[2] = 35696;
         sp->EffectImplicitTargetA[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(35693);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35693);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_DONE;
@@ -8970,7 +8970,7 @@ void ApplyNormalFixes()
         sp->EffectTriggerSpell[2] = 35696;
         sp->EffectImplicitTargetA[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(35696);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35696);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA; //making this only for the visible effect
@@ -8979,31 +8979,31 @@ void ApplyNormalFixes()
     }
 
     //Shadow Trance should be removed on the first SB
-    sp = Spell::checkAndReturnSpellEntry(17941);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(17941);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_CAST_SPELL;
     }
 
     //warlock: Empowered Corruption
-    sp = Spell::checkAndReturnSpellEntry(32381);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32381);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] *= 6;
     }
-    sp = Spell::checkAndReturnSpellEntry(32382);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32382);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] *= 6;
     }
-    sp = Spell::checkAndReturnSpellEntry(32383);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32383);
     if (sp != nullptr)
     {
         sp->EffectBasePoints[0] *= 6;
     }
 
     //warlock - Demonic Tactics
-    sp = Spell::checkAndReturnSpellEntry(30242);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30242);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL; //disable this. This is just blizz crap. Pure proof that they suck :P
@@ -9012,28 +9012,28 @@ void ApplyNormalFixes()
                                                                         // Zyres: No you fukced it up. This spell was defined few lines below.
         sp->EffectImplicitTargetB[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30245);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30245);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL; //disable this. This is just blizz crap. Pure proof that they suck :P
         sp->EffectImplicitTargetB[1] = EFF_TARGET_PET;
         sp->EffectImplicitTargetB[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30246);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30246);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL; //disable this. This is just blizz crap. Pure proof that they suck :P
         sp->EffectImplicitTargetB[1] = EFF_TARGET_PET;
         sp->EffectImplicitTargetB[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30247);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30247);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL; //disable this. This is just blizz crap. Pure proof that they suck :P
         sp->EffectImplicitTargetB[1] = EFF_TARGET_PET;
         sp->EffectImplicitTargetB[2] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30248);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30248);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_NULL; //disable this. This is just blizz crap. Pure proof that they suck :P
@@ -9042,19 +9042,19 @@ void ApplyNormalFixes()
     }
 
     //warlock - Demonic Resilience
-    sp = Spell::checkAndReturnSpellEntry(30319);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30319);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30320);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30320);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(30321);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30321);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[1] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
@@ -9062,53 +9062,53 @@ void ApplyNormalFixes()
     }
 
     //warlock - Improved Imp
-    sp = Spell::checkAndReturnSpellEntry(18694);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18694);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18695);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18695);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18696);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18696);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
 
     //warlock - Demonic Brutality
-    sp = Spell::checkAndReturnSpellEntry(18705);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18705);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18706);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18706);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18707);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18707);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
 
     //warlock - Improved Succubus
-    sp = Spell::checkAndReturnSpellEntry(18754);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18754);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18755);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18755);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18756);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18756);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
@@ -9116,21 +9116,21 @@ void ApplyNormalFixes()
     }
 
     //warlock - Fel Vitality
-    sp = Spell::checkAndReturnSpellEntry(18731);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18731);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_PERCENT_STAT;
         sp->EffectMiscValue[0] = 3;
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18743);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18743);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_PERCENT_STAT;
         sp->EffectMiscValue[0] = 3;
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
     }
-    sp = Spell::checkAndReturnSpellEntry(18744);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18744);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_PERCENT_STAT;
@@ -9140,7 +9140,7 @@ void ApplyNormalFixes()
 
     //warlock - Demonic Tactics
     /* Zyres: Disabled this spell has already some changes few lines above!
-    sp = checkAndReturnSpellEntry(30242);
+    sp = checkAndReturnSpellEntryUnsafe(30242);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9154,7 +9154,7 @@ void ApplyNormalFixes()
     }*/
 
     //warlock - Unholy Power
-    sp = Spell::checkAndReturnSpellEntry(18769);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18769);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9166,7 +9166,7 @@ void ApplyNormalFixes()
         sp->EffectMiscValue[1] = SCHOOL_NORMAL;
         sp->EffectBasePoints[1] = sp->EffectBasePoints[0];
     }
-    sp = Spell::checkAndReturnSpellEntry(18770);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18770);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9178,7 +9178,7 @@ void ApplyNormalFixes()
         sp->EffectMiscValue[1] = SCHOOL_NORMAL;
         sp->EffectBasePoints[1] = sp->EffectBasePoints[0];
     }
-    sp = Spell::checkAndReturnSpellEntry(18771);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18771);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9190,7 +9190,7 @@ void ApplyNormalFixes()
         sp->EffectMiscValue[1] = SCHOOL_NORMAL;
         sp->EffectBasePoints[1] = sp->EffectBasePoints[0];
     }
-    sp = Spell::checkAndReturnSpellEntry(18772);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18772);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9202,7 +9202,7 @@ void ApplyNormalFixes()
         sp->EffectMiscValue[1] = SCHOOL_NORMAL;
         sp->EffectBasePoints[1] = sp->EffectBasePoints[0];
     }
-    sp = Spell::checkAndReturnSpellEntry(18773);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18773);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -9216,88 +9216,88 @@ void ApplyNormalFixes()
     }
 
     //warlock - Master Demonologist - 25 spells here
-    sp = Spell::checkAndReturnSpellEntry(23785);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23785);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 23784;
     }
-    sp = Spell::checkAndReturnSpellEntry(23822);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23822);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 23830;
     }
-    sp = Spell::checkAndReturnSpellEntry(23823);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23823);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 23831;
     }
-    sp = Spell::checkAndReturnSpellEntry(23824);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23824);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 23832;
     }
-    sp = Spell::checkAndReturnSpellEntry(23825);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23825);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 35708;
     }
     //and the rest
-    sp = Spell::checkAndReturnSpellEntry(23784);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23784);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(23830);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23830);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(23831);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23831);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(23832);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23832);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(35708);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35708);
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_PET;
-    sp = Spell::checkAndReturnSpellEntry(23759);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23759);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23760);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23760);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23761);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23761);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23762);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23762);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23826);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23826);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23827);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23827);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23828);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23828);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
     }
-    sp = Spell::checkAndReturnSpellEntry(23829);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23829);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -9305,37 +9305,37 @@ void ApplyNormalFixes()
     // Zyres: eeek
     for (uint32 i = 23833; i <= 23844; ++i)
     {
-        sp = Spell::checkAndReturnSpellEntry(i);
+        sp = Spell::checkAndReturnSpellEntryUnsafe(i);
         if (sp != nullptr)
         {
             sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
         }
     }
-    sp = Spell::checkAndReturnSpellEntry(35702);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35702);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
         sp->Effect[1] = SPELL_EFFECT_NULL; //hacks, we are handling this in another way
     }
-    sp = Spell::checkAndReturnSpellEntry(35703);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35703);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
         sp->Effect[1] = SPELL_EFFECT_NULL; //hacks, we are handling this in another way
     }
-    sp = Spell::checkAndReturnSpellEntry(35704);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35704);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
         sp->Effect[1] = SPELL_EFFECT_NULL; //hacks, we are handling this in another way
     }
-    sp = Spell::checkAndReturnSpellEntry(35705);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35705);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
         sp->Effect[1] = SPELL_EFFECT_NULL; //hacks, we are handling this in another way
     }
-    sp = Spell::checkAndReturnSpellEntry(35706);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35706);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -9343,7 +9343,7 @@ void ApplyNormalFixes()
     }
 
     //warlock - Improved Drain Soul
-    sp = Spell::checkAndReturnSpellEntry(18213);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18213);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_TARGET_DIE | static_cast<uint32>(PROC_TARGET_SELF);
@@ -9354,7 +9354,7 @@ void ApplyNormalFixes()
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SELF;
         sp->Effect[2] = SPELL_EFFECT_NULL; //remove this effect
     }
-    sp = Spell::checkAndReturnSpellEntry(18372);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(18372);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_TARGET_DIE | static_cast<uint32>(PROC_TARGET_SELF);
@@ -9367,28 +9367,28 @@ void ApplyNormalFixes()
     }
 
     //Warlock Chaos bolt
-    sp = Spell::checkAndReturnSpellEntry(50796);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(50796);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_IGNORE_INVULNERABILITY;
         sp->School = SCHOOL_FIRE;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(59170);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(59170);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_IGNORE_INVULNERABILITY;
         sp->School = SCHOOL_FIRE;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(59171);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(59171);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_IGNORE_INVULNERABILITY;
         sp->School = SCHOOL_FIRE;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(59172);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(59172);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_IGNORE_INVULNERABILITY;
@@ -9400,7 +9400,7 @@ void ApplyNormalFixes()
     int HealthStoneID[8] = { 6201, 6202, 5699, 11729, 11730, 27230, 47871, 47878 };
     for (uint8 i = 0; i < 8; i++)
     {
-        sp = Spell::checkAndReturnSpellEntry(HealthStoneID[i]);
+        sp = Spell::checkAndReturnSpellEntryUnsafe(HealthStoneID[i]);
         if (sp != nullptr)
         {
             sp->Reagent[1] = 0;
@@ -9418,7 +9418,7 @@ void ApplyNormalFixes()
     ////////////////////////////////////////////////////////////
 
     // Druid - Force of Nature
-    sp = Spell::checkAndReturnSpellEntry(33831);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(33831);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SELF; //some land under target is used that gathers multiple targets ...
@@ -9430,7 +9430,7 @@ void ApplyNormalFixes()
     ////////////////////////////////////////////////////////////
 
     // Druid - Infected Wounds
-    sp = Spell::checkAndReturnSpellEntry(48483);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48483);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -9439,7 +9439,7 @@ void ApplyNormalFixes()
         sp->custom_ProcOnNameHash[2] = SPELL_HASH_MANGLE;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(48484);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48484);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -9448,7 +9448,7 @@ void ApplyNormalFixes()
         sp->custom_ProcOnNameHash[2] = SPELL_HASH_MANGLE;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(48485);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48485);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -9458,19 +9458,19 @@ void ApplyNormalFixes()
     }
 
     // Druid - Bash - Interrupt effect
-    sp = Spell::checkAndReturnSpellEntry(5211);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(5211);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 32747;
     }
-    sp = Spell::checkAndReturnSpellEntry(6798);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(6798);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 32747;
     }
-    sp = Spell::checkAndReturnSpellEntry(8983);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(8983);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -9478,13 +9478,13 @@ void ApplyNormalFixes()
     }
 
     //Druid - Feral Swiftness
-    sp = Spell::checkAndReturnSpellEntry(17002);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(17002);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 24867;
     }
-    sp = Spell::checkAndReturnSpellEntry(24866);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(24866);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -9492,31 +9492,31 @@ void ApplyNormalFixes()
     }
 
     // Druid - Maim
-    sp = Spell::checkAndReturnSpellEntry(22570);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(22570);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_UNUSED2;
         sp->custom_is_melee_spell = true;
     }
-    sp = Spell::checkAndReturnSpellEntry(49802);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(49802);
     if (sp != nullptr)
     {
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_UNUSED2;
         sp->custom_is_melee_spell = true;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(20719); //feline grace
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20719); //feline grace
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_NULL;
 
     // Druid - Feral Swiftness
-    sp = Spell::checkAndReturnSpellEntry(17002);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(17002);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 24867;
     }
-    sp = Spell::checkAndReturnSpellEntry(24866);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(24866);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -9524,7 +9524,7 @@ void ApplyNormalFixes()
     }
 
     // Druid - Frenzied Regeneration
-    sp = Spell::checkAndReturnSpellEntry(22842);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(22842);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -9533,24 +9533,24 @@ void ApplyNormalFixes()
     }
 
     // Druid - Primal Fury (talent)
-    sp = Spell::checkAndReturnSpellEntry(37116);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(37116);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
 
-    sp = Spell::checkAndReturnSpellEntry(37117);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(37117);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
 
     // Druid - Predatory Strikes
     uint32 mm = decimalToMask(FORM_BEAR) | decimalToMask(FORM_DIREBEAR) | decimalToMask(FORM_MOONKIN) | decimalToMask(FORM_CAT);
 
-    sp = Spell::checkAndReturnSpellEntry(16972);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16972);
     if (sp != nullptr)
         sp->RequiredShapeShift = mm;
-    sp = Spell::checkAndReturnSpellEntry(16974);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16974);
     if (sp != nullptr)
         sp->RequiredShapeShift = mm;
-    sp = Spell::checkAndReturnSpellEntry(16975);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16975);
     if (sp != nullptr)
         sp->RequiredShapeShift = mm;
 
@@ -9560,22 +9560,22 @@ void ApplyNormalFixes()
 
     // Druid - Tree Form Aura
     /* Zyres: Genius... Delete this! I'm not familiar with this technique, looks awesome. Unfortunately I don't understand the effect of this. SPELL_HASH_TREE_OF_LIFE is not used in any statement...
-    sp = checkAndReturnSpellEntry(34123);
+    sp = checkAndReturnSpellEntryUnsafe(34123);
     if (sp != nullptr)
         sp->custom_NameHash = 0;*/
 
     // Druid - Natural Shapeshifter
-    sp = Spell::checkAndReturnSpellEntry(16833);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16833);
     if (sp != nullptr)
         sp->DurationIndex = 0;
-    sp = Spell::checkAndReturnSpellEntry(16834);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16834);
     if (sp != nullptr)
         sp->DurationIndex = 0;
-    sp = Spell::checkAndReturnSpellEntry(16835);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16835);
     if (sp != nullptr)
         sp->DurationIndex = 0;
 
-    sp = Spell::checkAndReturnSpellEntry(61177); // Northrend Inscription Research
+    sp = Spell::checkAndReturnSpellEntryUnsafe(61177); // Northrend Inscription Research
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_NULL;
@@ -9584,7 +9584,7 @@ void ApplyNormalFixes()
         sp->EffectImplicitTargetA[1] = 0;
         sp->EffectDieSides[1] = 0;
     }
-    sp = Spell::checkAndReturnSpellEntry(61288); // Minor Inscription Research
+    sp = Spell::checkAndReturnSpellEntryUnsafe(61288); // Minor Inscription Research
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_NULL;
@@ -9593,7 +9593,7 @@ void ApplyNormalFixes()
         sp->EffectImplicitTargetA[1] = 0;
         sp->EffectDieSides[1] = 0;
     }
-    sp = Spell::checkAndReturnSpellEntry(60893); // Northrend Alchemy Research
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60893); // Northrend Alchemy Research
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_NULL;
@@ -9603,7 +9603,7 @@ void ApplyNormalFixes()
         sp->EffectDieSides[1] = 0;
     }
 #if VERSION_STRING != Cata
-    sp = Spell::checkAndReturnSpellEntry(46097); // Brutal Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(46097); // Brutal Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9611,7 +9611,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
     }
-    sp = Spell::checkAndReturnSpellEntry(43860); // Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43860); // Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9619,7 +9619,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
     }
-    sp = Spell::checkAndReturnSpellEntry(43861); // Merciless Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43861); // Merciless Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9627,7 +9627,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
     }
-    sp = Spell::checkAndReturnSpellEntry(43862); // Vengeful Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43862); // Vengeful Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9635,7 +9635,7 @@ void ApplyNormalFixes()
         sp->procFlags = PROC_ON_CAST_SPELL;
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
     }
-    sp = Spell::checkAndReturnSpellEntry(60564); // Savage Gladiator's Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60564); // Savage Gladiator's Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9645,7 +9645,7 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 60565; // Savage Magic
     }
-    sp = Spell::checkAndReturnSpellEntry(60571); // Hateful Gladiator's Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60571); // Hateful Gladiator's Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9655,7 +9655,7 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 60566; // Hateful Magic
     }
-    sp = Spell::checkAndReturnSpellEntry(60572); // Deadly Gladiator's Totem of Survival
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60572); // Deadly Gladiator's Totem of Survival
     if (sp != nullptr)
     {
         sp->EffectSpellClassMask[0][0] = 0x00100000 | 0x10000000 | 0x80000000;
@@ -9665,10 +9665,10 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 60567; // Deadly Magic
     }
-    sp = Spell::checkAndReturnSpellEntry(60567); // Deadly Magic
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60567); // Deadly Magic
     if (sp != nullptr)
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
-    sp = Spell::checkAndReturnSpellEntry(46098); // Brutal Totem of Third WInd
+    sp = Spell::checkAndReturnSpellEntryUnsafe(46098); // Brutal Totem of Third WInd
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -9676,7 +9676,7 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 46099; // Brutal Gladiator's Totem of the Third Wind
     }
-    sp = Spell::checkAndReturnSpellEntry(34138); // Totem of the Third Wind
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34138); // Totem of the Third Wind
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -9684,7 +9684,7 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 34132; // Gladiator's Totem of the Third Wind
     }
-    sp = Spell::checkAndReturnSpellEntry(42370); // Merciless Totem of the Third WInd
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42370); // Merciless Totem of the Third WInd
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -9692,7 +9692,7 @@ void ApplyNormalFixes()
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 42371; // Merciless Gladiator's Totem of the Third Wind
     }
-    sp = Spell::checkAndReturnSpellEntry(43728); // Vengeful Totem of Third WInd
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43728); // Vengeful Totem of Third WInd
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -9708,42 +9708,42 @@ void ApplyNormalFixes()
     // Insert items spell fixes here
 
     //Compact Harvest Reaper
-    sp = Spell::checkAndReturnSpellEntry(4078);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(4078);
     if (sp != nullptr)
     {
         sp->DurationIndex = 6;
     }
 
     //Graccu's Mince Meat Fruitcake
-    sp = Spell::checkAndReturnSpellEntry(25990);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25990);
     if (sp != nullptr)
     {
         sp->EffectAmplitude[1] = 1000;
     }
 
     //Extract Gas
-    sp = Spell::checkAndReturnSpellEntry(30427);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30427);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_DUMMY;
     }
 
     //Relic - Idol of the Unseen Moon
-    sp = Spell::checkAndReturnSpellEntry(43739);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43739);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
     }
 
     //Lunar Grace - Idol of the Unseen Moon proc
-    sp = Spell::checkAndReturnSpellEntry(43740);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43740);
     if (sp != nullptr)
     {
         sp->custom_ProcOnNameHash[0] = SPELL_HASH_MOONFIRE;
     }
 
     //Primal Instinct - Idol of Terror proc
-    sp = Spell::checkAndReturnSpellEntry(43738);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43738);
     if (sp != nullptr)
     {
         sp->custom_self_cast_only = true;
@@ -9752,14 +9752,14 @@ void ApplyNormalFixes()
     }
 
     //Thunderfury
-    sp = Spell::checkAndReturnSpellEntry(21992);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(21992);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[2] = EFF_TARGET_ALL_ENEMIES_AROUND_CASTER; // cebernic: for enemies not self
     }
 
     // Sigil of the Unfaltering Knight
-    sp = Spell::checkAndReturnSpellEntry(62147);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(62147);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -9768,7 +9768,7 @@ void ApplyNormalFixes()
     }
 
     // Deadly Aggression - triggered by Deadly Gladiator's Relic/Idol/Libram/Totem
-    sp = Spell::checkAndReturnSpellEntry(60549);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60549);
     if (sp != nullptr)
     {
         // effect 1 and 2 are the same... dunno why
@@ -9776,7 +9776,7 @@ void ApplyNormalFixes()
     }
 
     // Furious Gladiator's Libram of Fortitude - triggered by LK Arena 4 Gladiator's Relic/Idol/Libram/Totem
-    sp = Spell::checkAndReturnSpellEntry(60551);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60551);
     if (sp != nullptr)
     {
         // effect 1 and 2 are the same... dunno why
@@ -9784,7 +9784,7 @@ void ApplyNormalFixes()
     }
 
     // Relentless Aggression - triggered by LK Arena 5 Gladiator's Relic/Idol/Libram/Totem
-    sp = Spell::checkAndReturnSpellEntry(60553);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60553);
     if (sp != nullptr)
     {
         // effect 1 and 2 are the same... dunno why
@@ -9792,7 +9792,7 @@ void ApplyNormalFixes()
     }
 
     // Savage Aggression - triggered by Savage Gladiator's Relic/Idol/Libram/Totem
-    sp = Spell::checkAndReturnSpellEntry(60544);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60544);
     if (sp != nullptr)
     {
         // effect 1 and 2 are the same... dunno why
@@ -9800,7 +9800,7 @@ void ApplyNormalFixes()
     }
 
     // Sigil of Haunted Dreams
-    sp = Spell::checkAndReturnSpellEntry(60826);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60826);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPECIFIC_SPELL;
@@ -9810,36 +9810,36 @@ void ApplyNormalFixes()
     }
 
     //Totem of the Third Wind - bad range
-    sp = Spell::checkAndReturnSpellEntry(34132);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34132);
     if (sp != nullptr)
     {
         sp->rangeIndex = 5;
     }
-    sp = Spell::checkAndReturnSpellEntry(42371);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42371);
     if (sp != nullptr)
     {
         sp->rangeIndex = 5;
     }
-    sp = Spell::checkAndReturnSpellEntry(43729);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43729);
     if (sp != nullptr)
     {
         sp->rangeIndex = 5;
     }
-    sp = Spell::checkAndReturnSpellEntry(46099);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(46099);
     if (sp != nullptr)
     {
         sp->rangeIndex = 5;
     }
 
     // Eye of Acherus, our phase shift mode messes up the control :/
-    sp = Spell::checkAndReturnSpellEntry(51852);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51852);
     if (sp != nullptr)
         sp->Effect[0] = SPELL_EFFECT_NULL;
 
 
     //Ashtongue Talisman of Equilibrium
     // DankoDJ: To set the same value several times makes no sense!
-    sp = Spell::checkAndReturnSpellEntry(40442);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(40442);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -9864,7 +9864,7 @@ void ApplyNormalFixes()
 
     //Ashtongue Talisman of Acumen
     // DankoDJ: To set the same value several times makes no sense!
-    sp = Spell::checkAndReturnSpellEntry(40438);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(40438);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_APPLY_AURA;
@@ -9881,7 +9881,7 @@ void ApplyNormalFixes()
         sp->maxstack = 1;
     }
     // Drums of war targets surrounding party members instead of us
-    sp = Spell::checkAndReturnSpellEntry(35475);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35475);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_ALL_PARTY;
@@ -9893,7 +9893,7 @@ void ApplyNormalFixes()
     }
 
     // Drums of Battle targets surrounding party members instead of us
-    sp = Spell::checkAndReturnSpellEntry(35476);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35476);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_ALL_PARTY;
@@ -9905,7 +9905,7 @@ void ApplyNormalFixes()
     }
 
     // Drums of Panic targets surrounding creatures instead of us
-    sp = Spell::checkAndReturnSpellEntry(35474);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35474);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_ALL_ENEMIES_AROUND_CASTER;
@@ -9917,7 +9917,7 @@ void ApplyNormalFixes()
     }
 
     // Drums of Restoration targets surrounding party members instead of us
-    sp = Spell::checkAndReturnSpellEntry(35478);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35478);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_ALL_PARTY;
@@ -9928,7 +9928,7 @@ void ApplyNormalFixes()
         sp->EffectImplicitTargetB[2] = 0;
     }
     // Drums of Speed targets surrounding party members instead of us
-    sp = Spell::checkAndReturnSpellEntry(35477);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35477);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_ALL_PARTY;
@@ -9940,24 +9940,24 @@ void ApplyNormalFixes()
     }
 
     //all Drums
-    sp = Spell::checkAndReturnSpellEntry(35474);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35474);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
-    sp = Spell::checkAndReturnSpellEntry(35475);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35475);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
-    sp = Spell::checkAndReturnSpellEntry(35476);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35476);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
-    sp = Spell::checkAndReturnSpellEntry(35477);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35477);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
-    sp = Spell::checkAndReturnSpellEntry(35478);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35478);
     if (sp != nullptr)
         sp->RequiredShapeShift = 0;
 
     //Purify helboar meat
-    sp = Spell::checkAndReturnSpellEntry(29200);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(29200);
     if (sp != nullptr)
     {
         sp->Reagent[1] = 0;
@@ -9965,35 +9965,35 @@ void ApplyNormalFixes()
     }
 
     //Thorium Grenade
-    sp = Spell::checkAndReturnSpellEntry(19769);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(19769);
     if (sp != nullptr)
     {
         sp->InterruptFlags |= ~(CAST_INTERRUPT_ON_MOVEMENT);
     }
 
     //M73 Frag Grenade
-    sp = Spell::checkAndReturnSpellEntry(13808);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(13808);
     if (sp != nullptr)
     {
         sp->InterruptFlags |= ~(CAST_INTERRUPT_ON_MOVEMENT);
     }
 
     //Iron Grenade
-    sp = Spell::checkAndReturnSpellEntry(4068);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(4068);
     if (sp != nullptr)
     {
         sp->InterruptFlags |= ~(CAST_INTERRUPT_ON_MOVEMENT);
     }
 
     //Frost Grenade
-    sp = Spell::checkAndReturnSpellEntry(39965);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(39965);
     if (sp != nullptr)
     {
         sp->InterruptFlags |= ~(CAST_INTERRUPT_ON_MOVEMENT);
     }
 
     //Adamantine Grenade
-    sp = Spell::checkAndReturnSpellEntry(30217);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(30217);
     if (sp != nullptr)
     {
         sp->InterruptFlags |= ~(CAST_INTERRUPT_ON_MOVEMENT);
@@ -10004,7 +10004,7 @@ void ApplyNormalFixes()
     ///////////////////////////////////////////////////////////////
 
     // Citrine Pendant of Golden Healing
-    sp = Spell::checkAndReturnSpellEntry(25608);        //    http://www.wowhead.com/?item=20976
+    sp = Spell::checkAndReturnSpellEntryUnsafe(25608);        //    http://www.wowhead.com/?item=20976
     if (sp != nullptr)
     {
         //Overrides any spell coefficient calculation - DBCStores.h
@@ -10013,25 +10013,25 @@ void ApplyNormalFixes()
     }
 
     //Figurine - Shadowsong Panther
-    sp = Spell::checkAndReturnSpellEntry(46784);        //    http://www.wowhead.com/?item=35702
+    sp = Spell::checkAndReturnSpellEntryUnsafe(46784);        //    http://www.wowhead.com/?item=35702
     if (sp != nullptr)
         sp->AttributesEx |= ATTRIBUTESEX_NOT_BREAK_STEALTH;
 
     // Infernal Protection
-    sp = Spell::checkAndReturnSpellEntry(36488);            //    http://www.wowhead.com/?spell=36488
+    sp = Spell::checkAndReturnSpellEntryUnsafe(36488);            //    http://www.wowhead.com/?spell=36488
     if (sp != nullptr)
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SINGLE_FRIEND;
 
 
     //Fury of the Five Flights
-    sp = Spell::checkAndReturnSpellEntry(60313);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(60313);
     if (sp != nullptr)
     {
         sp->maxstack = 20;
     }
 
     //Pendant of the Violet Eye
-    sp = Spell::checkAndReturnSpellEntry(35095);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(35095);
     if (sp != nullptr)
     {
         sp->custom_self_cast_only = true;
@@ -10044,7 +10044,7 @@ void ApplyNormalFixes()
     // Insert boss spell fixes here
 
     // Major Domo - Magic Reflection
-    sp = Spell::checkAndReturnSpellEntry(20619);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20619);
     if (sp != nullptr)
     {
         for (uint8 i = 0; i < 3; ++i)
@@ -10057,7 +10057,7 @@ void ApplyNormalFixes()
     }
 
     // Major Domo - Damage Shield
-    sp = Spell::checkAndReturnSpellEntry(21075);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(21075);
     if (sp != nullptr)
     {
         for (uint8 i = 0; i < 3; ++i)
@@ -10070,20 +10070,20 @@ void ApplyNormalFixes()
     }
 
     // Dark Glare
-    sp = Spell::checkAndReturnSpellEntry(26029);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(26029);
     if (sp != nullptr)
         sp->cone_width = 15.0f; // 15 degree cone
 
     // Drain Power (Malacrass) // bugged - the charges fade even when refreshed with new ones. This makes them everlasting.
-    sp = Spell::checkAndReturnSpellEntry(44131);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44131);
     if (sp != nullptr)
         sp->DurationIndex = 21;
-    sp = Spell::checkAndReturnSpellEntry(44132);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44132);
     if (sp != nullptr)
         sp->DurationIndex = 21;
 
     // Zul'jin spell, proc from Creeping Paralysis
-    sp = Spell::checkAndReturnSpellEntry(43437);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43437);
     if (sp != nullptr)
     {
         sp->EffectImplicitTargetA[0] = 0;
@@ -10091,46 +10091,46 @@ void ApplyNormalFixes()
     }
 
     //Bloodboil
-    sp = Spell::checkAndReturnSpellEntry(42005);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(42005);
     if (sp != nullptr)
     {
         sp->MaxTargets = 5;
     }
 
     //Doom
-    sp = Spell::checkAndReturnSpellEntry(31347);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(31347);
     if (sp != nullptr)
     {
         sp->MaxTargets = 1;
     }
     //Shadow of Death
-    sp = Spell::checkAndReturnSpellEntry(40251);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(40251);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
         sp->EffectTriggerSpell[0] = 0;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(9036);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(9036);
     if (sp != nullptr)
     {
         sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
         sp->EffectTriggerSpell[1] = 20584;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(24379);   //bg Restoration
+    sp = Spell::checkAndReturnSpellEntryUnsafe(24379);   //bg Restoration
     if (sp != nullptr)
     {
         sp->EffectTriggerSpell[0] = 23493;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(23493);   //bg Restoration
+    sp = Spell::checkAndReturnSpellEntryUnsafe(23493);   //bg Restoration
     if (sp != nullptr)
     {
         sp->EffectTriggerSpell[0] = 24379;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(5246);    // why self?
+    sp = Spell::checkAndReturnSpellEntryUnsafe(5246);    // why self?
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -10147,7 +10147,7 @@ void ApplyNormalFixes()
     // Insert Death Knight spells here
 
     // Unholy Aura - Ranks 1
-    sp = Spell::checkAndReturnSpellEntry(50391);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(50391);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_INCREASE_SPEED_ALWAYS;
@@ -10158,7 +10158,7 @@ void ApplyNormalFixes()
         sp->EffectImplicitTargetA[1] = EFF_TARGET_SELF;
     }
     // Unholy Aura - Ranks 2
-    sp = Spell::checkAndReturnSpellEntry(50392);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(50392);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_INCREASE_SPEED_ALWAYS;
@@ -10170,7 +10170,7 @@ void ApplyNormalFixes()
     }
 
     //    Empower Rune Weapon
-    sp = Spell::checkAndReturnSpellEntry(47568);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(47568);
     if (sp != nullptr)
     {
         sp->Effect[2] = SPELL_EFFECT_ACTIVATE_RUNES;
@@ -10179,7 +10179,7 @@ void ApplyNormalFixes()
     }
 
     // Frost Presence
-    sp = Spell::checkAndReturnSpellEntry(48263);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48263);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_BASE_RESISTANCE_PCT;
@@ -10190,7 +10190,7 @@ void ApplyNormalFixes()
     }
 
     //    Unholy Presence
-    sp = Spell::checkAndReturnSpellEntry(48265);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(48265);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_HASTE;
@@ -10201,28 +10201,28 @@ void ApplyNormalFixes()
     }
 
     // DEATH AND DECAY
-    sp = sSpellCustomizations.GetSpellInfo(49937);
+    sp = sSpellCustomizations.getSpellInfoUnsafe(49937);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PERIODIC_DAMAGE;
         sp->Effect[0] = SPELL_EFFECT_PERSISTENT_AREA_AURA;
     }
 
-    sp = sSpellCustomizations.GetSpellInfo(49936);
+    sp = sSpellCustomizations.getSpellInfoUnsafe(49936);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PERIODIC_DAMAGE;
         sp->Effect[0] = SPELL_EFFECT_PERSISTENT_AREA_AURA;
     }
 
-    sp = sSpellCustomizations.GetSpellInfo(49938);
+    sp = sSpellCustomizations.getSpellInfoUnsafe(49938);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PERIODIC_DAMAGE;
         sp->Effect[0] = SPELL_EFFECT_PERSISTENT_AREA_AURA;
     }
 
-    sp = sSpellCustomizations.GetSpellInfo(43265);
+    sp = sSpellCustomizations.getSpellInfoUnsafe(43265);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_PERIODIC_DAMAGE;
@@ -10243,7 +10243,7 @@ void ApplyNormalFixes()
     }*/
 
     // Vengeance
-    sp = sSpellCustomizations.GetSpellInfo(93099);
+    sp = sSpellCustomizations.getSpellInfoUnsafe(93099);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_ANY_DAMAGE_VICTIM;
@@ -10254,7 +10254,7 @@ void ApplyNormalFixes()
     ///////////////////////////////////////////////////////////
     //    Path of Frost
     ///////////////////////////////////////////////////////////
-    sp = Spell::checkAndReturnSpellEntry(3714);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(3714);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_WATER_WALK;
@@ -10262,14 +10262,14 @@ void ApplyNormalFixes()
     }
 
     // Rune Strike
-    sp = Spell::checkAndReturnSpellEntry(56815);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(56815);
     if (sp != nullptr)
     {
         sp->Attributes |= ATTRIBUTES_CANT_BE_DPB;
     }
 
     CreateDummySpell(56817);
-    sp = Spell::checkAndReturnSpellEntry(56817);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(56817);
     if (sp != nullptr)
     {
         sp->DurationIndex = 28;
@@ -10278,39 +10278,39 @@ void ApplyNormalFixes()
     }
 
     //Frost Strike
-    sp = Spell::checkAndReturnSpellEntry(49143);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(49143);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
-    sp = Spell::checkAndReturnSpellEntry(51416);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51416);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
-    sp = Spell::checkAndReturnSpellEntry(51417);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51417);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
-    sp = Spell::checkAndReturnSpellEntry(51418);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51418);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
-    sp = Spell::checkAndReturnSpellEntry(51419);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51419);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
-    sp = Spell::checkAndReturnSpellEntry(55268);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(55268);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_CANT_BE_DPB;
     }
 
     // Noggenfogger elixir - reduce size effect
-    sp = Spell::checkAndReturnSpellEntry(16595);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(16595);
     if (sp != nullptr)
     {
         sp->EffectApplyAuraName[0] = SPELL_AURA_MOD_SCALE;
@@ -10318,7 +10318,7 @@ void ApplyNormalFixes()
         sp->maxstack = 1;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(46584);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(46584);
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_DUMMY;
@@ -10328,7 +10328,7 @@ void ApplyNormalFixes()
 
     //Other Librams
     //Libram of Saints Departed and Libram of Zeal
-    sp = Spell::checkAndReturnSpellEntry(34263);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34263);
     if (sp != nullptr)
     {
         sp->custom_self_cast_only = true;
@@ -10337,7 +10337,7 @@ void ApplyNormalFixes()
     }
 
     //Libram of Avengement
-    sp = Spell::checkAndReturnSpellEntry(34260);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(34260);
     if (sp != nullptr)
     {
         sp->custom_self_cast_only = true;
@@ -10346,7 +10346,7 @@ void ApplyNormalFixes()
     }
 
     //Libram of Mending
-    sp = Spell::checkAndReturnSpellEntry(43742);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(43742);
     if (sp != nullptr)
     {
         sp->custom_self_cast_only = true;
@@ -10355,18 +10355,18 @@ void ApplyNormalFixes()
     }
 
     // Recently Bandaged - is debuff
-    sp = Spell::checkAndReturnSpellEntry(11196);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(11196);
     if (sp != nullptr)
     {
         sp->Attributes = ATTRIBUTES_IGNORE_INVULNERABILITY;
     }
 
-    sp = Spell::checkAndReturnSpellEntry(44856);        // Bash'ir Phasing Device
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44856);        // Bash'ir Phasing Device
     if (sp != nullptr)
         sp->AuraInterruptFlags = AURA_INTERRUPT_ON_LEAVE_AREA;
 
 
-    sp = Spell::checkAndReturnSpellEntry(24574);        // Zandalarian Hero Badge 24590 24575
+    sp = Spell::checkAndReturnSpellEntryUnsafe(24574);        // Zandalarian Hero Badge 24590 24575
     if (sp != nullptr)
     {
         sp->Effect[0] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -10375,19 +10375,19 @@ void ApplyNormalFixes()
     }
 
     //Tempfix for Stone Statues
-    sp = Spell::checkAndReturnSpellEntry(32253);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32253);
     if (sp != nullptr)
         sp->DurationIndex = 64;
-    sp = Spell::checkAndReturnSpellEntry(32787);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32787);
     if (sp != nullptr)
         sp->DurationIndex = 64;
-    sp = Spell::checkAndReturnSpellEntry(32788);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32788);
     if (sp != nullptr)
         sp->DurationIndex = 64;
-    sp = Spell::checkAndReturnSpellEntry(32790);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32790);
     if (sp != nullptr)
         sp->DurationIndex = 64;
-    sp = Spell::checkAndReturnSpellEntry(32791);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(32791);
     if (sp != nullptr)
         sp->DurationIndex = 64;
 
@@ -10396,21 +10396,21 @@ void ApplyNormalFixes()
     //////////////////////////////////////////////////////
 
     // Blessing of Zim'Torga
-    sp = Spell::checkAndReturnSpellEntry(51729);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51729);
     if (sp)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SCRIPTED_OR_SINGLE_TARGET;
     }
 
     // Blessing of Zim'Abwa
-    sp = Spell::checkAndReturnSpellEntry(51265);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51265);
     if (sp)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SCRIPTED_OR_SINGLE_TARGET;
     }
 
     // Blessing of Zim'Rhuk
-    sp = Spell::checkAndReturnSpellEntry(52051);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(52051);
     if (sp)
     {
         sp->EffectImplicitTargetA[0] = EFF_TARGET_SCRIPTED_OR_SINGLE_TARGET;
@@ -10419,12 +10419,12 @@ void ApplyNormalFixes()
     // Ritual of Summoning summons a GameObject that triggers an inexistant spell.
     // This will copy an existant Summon Player spell used for another Ritual Of Summoning
     // to the one taught by Warlock trainers.
-    sp = Spell::checkAndReturnSpellEntry(7720);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(7720);
     if (sp)
     {
         const uint32 ritOfSummId = 62330;
         CreateDummySpell(ritOfSummId);
-        SpellInfo * ritOfSumm = sSpellCustomizations.GetSpellInfo(ritOfSummId);
+        SpellInfo* ritOfSumm = sSpellCustomizations.getSpellInfoUnsafe(ritOfSummId);
         if (ritOfSumm != NULL)
         {
             memcpy(ritOfSumm, sp, sizeof(SpellInfo));
@@ -10432,7 +10432,7 @@ void ApplyNormalFixes()
         }
     }
     //Persistent Shield
-    sp = Spell::checkAndReturnSpellEntry(26467);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(26467);
 	if (sp)
 	{
 		sp->EffectTriggerSpell[0] = 26470;
@@ -10441,7 +10441,7 @@ void ApplyNormalFixes()
 		sp->procFlags = PROC_ON_CAST_SPELL;
 	}
     //Gravity Bomb
-    sp = Spell::checkAndReturnSpellEntry(63024);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(63024);
 	if (sp)
 	{
 		sp->EffectBasePoints[0] = 0;
@@ -10458,7 +10458,7 @@ void ApplyNormalFixes()
 		sp->Attributes |= ATTRIBUTES_NEGATIVE;
 	}
     // War Stomp
-    sp = Spell::checkAndReturnSpellEntry(20549);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(20549);
     if (sp)
     {
         sp->EffectMechanic[0] = MECHANIC_STUNNED;
@@ -10467,7 +10467,7 @@ void ApplyNormalFixes()
     }
 
     // Fan of knives
-    sp = Spell::checkAndReturnSpellEntry(51723);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(51723);
     if (sp != nullptr)
     {
         //sp->Effect[1] = SPELL_EFFECT_TRIGGER_SPELL;
@@ -10479,7 +10479,7 @@ void ApplyNormalFixes()
 
     //Mage - firestarter talent ranks 1 & 2
     // overwrite procs, should only proc on these 2 spellgroups.
-    sp = Spell::checkAndReturnSpellEntry(44442);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44442);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;
@@ -10487,7 +10487,7 @@ void ApplyNormalFixes()
         sp->custom_ProcOnNameHash[0] = SPELL_HASH_DRAGON_S_BREATH;
         sp->custom_ProcOnNameHash[1] = SPELL_HASH_BLAST_WAVE;
     }
-    sp = Spell::checkAndReturnSpellEntry(44443);
+    sp = Spell::checkAndReturnSpellEntryUnsafe(44443);
     if (sp != nullptr)
     {
         sp->procFlags = PROC_ON_CAST_SPELL;

--- a/src/world/Spell/Customization/SpellCustomizations.cpp
+++ b/src/world/Spell/Customization/SpellCustomizations.cpp
@@ -436,13 +436,22 @@ void SpellCustomizations::LoadSpellInfoData()
 #endif
 }
 
-SpellInfo* SpellCustomizations::GetSpellInfo(uint32 spell_id)
+SpellInfo const* SpellCustomizations::GetSpellInfo(uint32 spell_id) const
 {
     SpellInfoContainer::const_iterator itr = _spellInfoContainerStore.find(spell_id);
     if (itr != _spellInfoContainerStore.end())
-        return const_cast<SpellInfo*>(&itr->second);
+        return &itr->second;
 
     return nullptr;
+}
+
+SpellInfo* SpellCustomizations::getSpellInfoUnsafe(uint32_t spell_id)
+{
+	SpellInfoContainer::iterator itr = _spellInfoContainerStore.find(spell_id);
+	if (itr != _spellInfoContainerStore.end())
+		return &itr->second;
+
+	return nullptr;
 }
 
 SpellCustomizations::SpellInfoContainer* SpellCustomizations::GetSpellInfoStore()
@@ -463,7 +472,7 @@ void SpellCustomizations::StartSpellCustomization()
 
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        auto spellentry = GetSpellInfo(it->first);
+        auto spellentry = getSpellInfoUnsafe(it->first);
         if (spellentry != nullptr)
         {
             //Set spell overwrites (effect based)
@@ -494,7 +503,7 @@ void SpellCustomizations::LoadSpellRanks()
             uint32 spell_id = result->Fetch()[0].GetUInt32();
             uint32 pRank = result->Fetch()[1].GetUInt32();
 
-            SpellInfo* spell_entry = GetSpellInfo(spell_id);
+            SpellInfo* spell_entry = getSpellInfoUnsafe(spell_id);
             if (spell_entry != nullptr)
             {
                 spell_entry->custom_RankNumber = pRank;
@@ -535,7 +544,7 @@ void SpellCustomizations::LoadSpellCustomAssign()
             bool self_cast_only = result->Fetch()[3].GetBool();
             uint32 c_is_flag = result->Fetch()[4].GetUInt32();
 
-            SpellInfo* spell_entry = GetSpellInfo(spell_id);
+            SpellInfo* spell_entry = getSpellInfoUnsafe(spell_id);
             if (spell_entry != nullptr)
             {
                 spell_entry->custom_BGR_one_buff_on_target = on_target;
@@ -576,7 +585,7 @@ void SpellCustomizations::LoadSpellCustomCoefFlags()
             uint32 spell_id = result->Fetch()[0].GetUInt32();
             uint32 coef_flags = result->Fetch()[1].GetUInt32();
 
-            SpellInfo* spell_entry = GetSpellInfo(spell_id);
+            SpellInfo* spell_entry = getSpellInfoUnsafe(spell_id);
             if (spell_entry != nullptr)
             {
                 spell_entry->custom_spell_coef_flags = coef_flags;
@@ -614,7 +623,7 @@ void SpellCustomizations::LoadSpellProcs()
             uint32 spell_id = f[0].GetUInt32();
             uint32 name_hash = f[1].GetUInt32();
 
-            auto spell_entry = GetSpellInfo(spell_id);
+            auto spell_entry = getSpellInfoUnsafe(spell_id);
             if (spell_entry != nullptr)
             {
                 for (uint8 x = 0; x < 3; ++x)
@@ -673,7 +682,7 @@ void SpellCustomizations::LoadSpellProcs()
 }
 
 ///Fix if it is a periodic trigger with amplitude = 0, to avoid division by zero
-void SpellCustomizations::SetEffectAmplitude(SpellInfo* spell_entry)
+void SpellCustomizations::SetEffectAmplitude(SpellInfo * spell_entry)
 {
     for (uint8 y = 0; y < 3; y++)
     {

--- a/src/world/Spell/Customization/SpellCustomizations.hpp
+++ b/src/world/Spell/Customization/SpellCustomizations.hpp
@@ -24,13 +24,22 @@
 class SERVER_DECL SpellCustomizations : public Singleton<SpellCustomizations>
 {
 public:
+	// APGL End
+    // MIT Start
+    /// TODO: this class should be reworked to only load spell dbcs into source (GetSpellInfo), remove all customizations and rename the class
+
+    // This function is only used to load scripts into spells, do not use this elsewhere! -Appled
+    SpellInfo* getSpellInfoUnsafe(uint32_t spell_id);
+
+    // MIT End
+    // APGL Start
     SpellCustomizations();
     ~SpellCustomizations();
 
     typedef std::unordered_map<uint32, SpellInfo> SpellInfoContainer;
 
     void LoadSpellInfoData();
-    SpellInfo* GetSpellInfo(uint32 spell_id);
+    SpellInfo const* GetSpellInfo(uint32 spell_id) const;
     SpellInfoContainer* GetSpellInfoStore();
 
     void StartSpellCustomization();

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -92,7 +92,7 @@ bool CanAttackCreatureType(uint32 TargetTypeMask, uint32 type)
         return true;
 }
 
-Spell::Spell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur)
+Spell::Spell(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur)
 {
     ARCEMU_ASSERT(Caster != NULL && info != NULL);
 
@@ -111,7 +111,7 @@ Spell::Spell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur)
 
     if ((info->SpellDifficultyID != 0) && (Caster->GetTypeId() != TYPEID_PLAYER) && (Caster->GetMapMgr() != NULL) && (Caster->GetMapMgr()->pInstance != NULL))
     {
-        SpellInfo* SpellDiffEntry = sSpellFactoryMgr.GetSpellEntryByDifficulty(info->SpellDifficultyID, Caster->GetMapMgr()->iInstanceMode);
+        SpellInfo const* SpellDiffEntry = sSpellFactoryMgr.GetSpellEntryByDifficulty(info->SpellDifficultyID, Caster->GetMapMgr()->iInstanceMode);
         if (SpellDiffEntry != NULL)
             m_spellInfo = SpellDiffEntry;
         else
@@ -2997,7 +2997,7 @@ void Spell::HandleAddAura(uint64 guid)
         p_caster->GetShapeShift() == FORM_DIREBEAR) &&
         p_caster->HasAurasWithNameHash(SPELL_HASH_KING_OF_THE_JUNGLE))
     {
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(51185);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(51185);
         if (!spellInfo)
         {
             delete aur;
@@ -3040,7 +3040,7 @@ void Spell::HandleAddAura(uint64 guid)
 
     if (spellid && Target)
     {
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
         if (!spellInfo)
         {
             delete aur;
@@ -3167,7 +3167,7 @@ bool Spell::IsSeal()
         (GetSpellInfo()->Id == 31801) || (GetSpellInfo()->Id == 31892) || (GetSpellInfo()->Id == 53720) || (GetSpellInfo()->Id == 53736));
 }
 
-SpellInfo* Spell::GetSpellInfo()
+SpellInfo const* Spell::GetSpellInfo()
 {
     return (m_spellInfo_override == NULL) ? m_spellInfo : m_spellInfo_override;
 }
@@ -3288,7 +3288,7 @@ uint32 Spell::GetBaseThreat(uint32 dmg)
     return dmg;
 }
 
-uint32 Spell::GetMechanic(SpellInfo* sp)
+uint32 Spell::GetMechanic(SpellInfo const* sp)
 {
     if (sp->MechanicsType)
         return sp->MechanicsType;
@@ -4175,7 +4175,7 @@ uint8 Spell::CanCast(bool tolerate)
                         return SPELL_FAILED_NO_PET;
 
                     // other checks
-                    SpellInfo* trig = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[0]);
+                    SpellInfo const* trig = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[0]);
                     if (trig == NULL)
                         return SPELL_FAILED_SPELL_UNAVAILABLE;
 
@@ -4641,7 +4641,7 @@ uint8 Spell::CanCast(bool tolerate)
 
         if (u_caster->GetChannelSpellTargetGUID() != 0)
         {
-            SpellInfo* t_spellInfo = (u_caster->GetCurrentSpell() ? u_caster->GetCurrentSpell()->GetSpellInfo() : NULL);
+            SpellInfo const* t_spellInfo = (u_caster->GetCurrentSpell() ? u_caster->GetCurrentSpell()->GetSpellInfo() : NULL);
 
             if (!t_spellInfo || !m_triggeredSpell)
                 return SPELL_FAILED_SPELL_IN_PROGRESS;
@@ -5841,7 +5841,7 @@ void Spell::SafeAddModeratedTarget(uint64 guid, uint16 type)
 
 bool Spell::Reflect(Unit* refunit)
 {
-    SpellInfo* refspell = NULL;
+    SpellInfo const* refspell = NULL;
     bool canreflect = false;
 
     if (m_reflectedParent != NULL || refunit == NULL || m_caster == refunit)
@@ -6157,7 +6157,7 @@ void Spell::SetCanReflect(bool reflect)
     m_CanRelect = reflect;
 }
 
-uint8 Spell::GetErrorAtShapeshiftedCast(SpellInfo* spellInfo, uint32 form)
+uint8 Spell::GetErrorAtShapeshiftedCast(SpellInfo const* spellInfo, uint32 form)
 {
     uint32 stanceMask = (form ? decimalToMask(form) : 0);
 
@@ -6526,7 +6526,7 @@ void Spell::HandleTargetNoObject()
     m_targets.setDestination(LocationVector(newx, newy, newz));
 }
 
-SpellInfo* Spell::checkAndReturnSpellEntry(uint32_t spellid)
+SpellInfo const* Spell::checkAndReturnSpellEntry(uint32_t spellid)
 {
     //Logging that spellid 0 or -1 don't exist is not needed.
     if (spellid == 0 || spellid == uint32_t(-1))
@@ -6539,5 +6539,17 @@ SpellInfo* Spell::checkAndReturnSpellEntry(uint32_t spellid)
     }
 
     return spell_info;
+}
+
+SpellInfo* Spell::checkAndReturnSpellEntryUnsafe(uint32_t spellId)
+{
+    if (spellId == 0 || spellId == uint32_t(-1))
+        return nullptr;
+
+    auto spellInfo = sSpellCustomizations.getSpellInfoUnsafe(spellId);
+    if (spellInfo == nullptr)
+        LogDebugFlag(LF_SPELL, "Something tried to access nonexistent spell %u", spellId);
+
+    return spellInfo;
 }
 #endif

--- a/src/world/Spell/Spell.Legacy.h
+++ b/src/world/Spell/Spell.Legacy.h
@@ -50,7 +50,7 @@ class SERVER_DECL Spell : public EventableObject
     public:
 
         friend class DummySpellHandler;
-        Spell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur);
+        Spell(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur);
         ~Spell();
 
     int32 event_GetInstanceID() override;
@@ -135,7 +135,7 @@ class SERVER_DECL Spell : public EventableObject
         void AddCooldown();
         void AddStartCooldown();
         //
-        uint8 GetErrorAtShapeshiftedCast(SpellInfo* spellInfo, uint32 form);
+        uint8 GetErrorAtShapeshiftedCast(SpellInfo const* spellInfo, uint32 form);
 
 
         bool Reflect(Unit* refunit);
@@ -168,7 +168,7 @@ class SERVER_DECL Spell : public EventableObject
         void writeSpellGoTargets(WorldPacket* data);
         void writeSpellMissedTargets(WorldPacket* data);
         uint32 pSpellId;
-        SpellInfo* ProcedOnSpell;
+        SpellInfo const* ProcedOnSpell;
         SpellCastTargets m_targets;
         SpellExtraError m_extraError;
 
@@ -340,7 +340,7 @@ class SERVER_DECL Spell : public EventableObject
         bool IsAspect();
         bool IsSeal();
 
-    SpellInfo* GetSpellInfo();
+    SpellInfo const* GetSpellInfo();
 
     void InitProtoOverride();
 
@@ -350,7 +350,7 @@ class SERVER_DECL Spell : public EventableObject
 
     static uint32 GetBaseThreat(uint32 dmg);
 
-    static uint32 GetMechanic(SpellInfo* sp);
+    static uint32 GetMechanic(SpellInfo const* sp);
 
         bool IsStealthSpell();
         bool IsInvisibilitySpell();
@@ -479,10 +479,18 @@ class SERVER_DECL Spell : public EventableObject
 
     public:
 
-        SpellInfo* m_spellInfo;
-        SpellInfo* m_spellInfo_override;   //used by spells that should have dynamic variables in spellentry.
+        SpellInfo const* m_spellInfo;
+        SpellInfo const* m_spellInfo_override;   //used by spells that should have dynamic variables in spellentry.
         static uint32_t getDiminishingGroup(uint32_t nameHash);
-        static SpellInfo* checkAndReturnSpellEntry(uint32_t spellid);
+        static SpellInfo const* checkAndReturnSpellEntry(uint32_t spellid);
+        // APGL End
+        // MIT Start
+
+        // Used in Hackfixes.cpp, avoid using it elsewhere. Will be removed when it's time to get rid of Hackfixes.cpp -Appled
+        static SpellInfo* checkAndReturnSpellEntryUnsafe(uint32_t spellid);
+
+        // MIT End
+        // APGL Start
 };
 
 #endif // USE_EXPERIMENTAL_SPELL_SYSTEM

--- a/src/world/Spell/SpellAuras.cpp
+++ b/src/world/Spell/SpellAuras.cpp
@@ -743,7 +743,7 @@ Object* Aura::GetCaster()
         return nullptr;
 }
 
-Aura::Aura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster)
+Aura::Aura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster)
 {
     m_castInDuel = false;
     m_spellInfo = proto;
@@ -1745,7 +1745,7 @@ void Aura::SpellAuraPeriodicDamage(bool apply)
             {
                 if (!pSpellId) //we need a parent spell and should always have one since it procs on it
                     break;
-                SpellInfo* parentsp = sSpellCustomizations.GetSpellInfo(pSpellId);
+                SpellInfo const* parentsp = sSpellCustomizations.GetSpellInfo(pSpellId);
                 if (!parentsp)
                     return;
                 if (c != nullptr && c->IsPlayer())
@@ -1796,7 +1796,7 @@ void Aura::SpellAuraPeriodicDamage(bool apply)
                 }
             }
         }
-        uint32* gr = GetSpellInfo()->SpellGroupType;
+        const uint32* gr = GetSpellInfo()->SpellGroupType;
         if (gr)
         {
             if (c != nullptr)
@@ -1944,7 +1944,7 @@ void Aura::EventPeriodicDamage(uint32 amount)
     }
 
     // grep: this is hack.. some auras seem to delete this shit.
-    SpellInfo* sp = m_spellInfo;
+    SpellInfo const* sp = m_spellInfo;
 
     if (m_target->m_damageSplitTarget)
         res = static_cast<float>(m_target->DoDamageSplitTarget(static_cast<uint32>(res), GetSpellInfo()->School, false));
@@ -3087,7 +3087,7 @@ void Aura::SpellAuraPeriodicTriggerSpellWithValue(bool apply)
 {
     if (apply)
     {
-        SpellInfo* spe = sSpellCustomizations.GetSpellInfo(m_spellInfo->EffectTriggerSpell[mod->i]);
+        SpellInfo const* spe = sSpellCustomizations.GetSpellInfo(m_spellInfo->EffectTriggerSpell[mod->i]);
         if (spe == NULL)
             return;
 
@@ -3163,7 +3163,7 @@ void Aura::SpellAuraPeriodicTriggerSpell(bool apply)
 
     if (apply)
     {
-        SpellInfo* trigger = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[mod->i]);
+        SpellInfo const* trigger = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[mod->i]);
 
         if (trigger == NULL)
             return;
@@ -3185,7 +3185,7 @@ void Aura::SpellAuraPeriodicTriggerSpell(bool apply)
     }
 }
 
-void Aura::EventPeriodicTriggerSpell(SpellInfo* spellInfo, bool overridevalues, int32 overridevalue)
+void Aura::EventPeriodicTriggerSpell(SpellInfo const* spellInfo, bool overridevalues, int32 overridevalue)
 {
     Spell* spell = sSpellFactoryMgr.NewSpell(m_target, spellInfo, true, this);
     if (overridevalues)
@@ -3727,7 +3727,7 @@ void Aura::SpellAuraModShapeshift(bool apply)
                     modelId = 2289;
 
                 //some say there is a second effect
-                SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(21178);
+                SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(21178);
 
                 Spell* sp = sSpellFactoryMgr.NewSpell(m_target, spellInfo, true, NULL);
                 SpellCastTargets tgt;
@@ -3869,7 +3869,7 @@ void Aura::SpellAuraModShapeshift(bool apply)
 
                     if (furorSpell != 0)
                     {
-                        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(furorSpell);
+                        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(furorSpell);
 
                         Spell* sp = sSpellFactoryMgr.NewSpell(m_target, spellInfo, true, NULL);
                         SpellCastTargets tgt;
@@ -3900,7 +3900,7 @@ void Aura::SpellAuraModShapeshift(bool apply)
         if (spellId == 0)
             return;
 
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
 
         Spell* sp = sSpellFactoryMgr.NewSpell(m_target, spellInfo, true, NULL);
         SpellCastTargets tgt;
@@ -4330,7 +4330,7 @@ void Aura::EventPeriodicLeech(uint32 amount)
     if (!(m_target->isAlive() && m_caster->isAlive()))
         return;
 
-    SpellInfo* sp = GetSpellInfo();
+    SpellInfo const* sp = GetSpellInfo();
 
     if (m_target->SchoolImmunityList[sp->School])
     {
@@ -6076,9 +6076,9 @@ void Aura::SpellAuraAddPctMod(bool apply)
 {
     int32 val = apply ? mod->m_amount : -mod->m_amount;
 #if VERSION_STRING != Cata
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask[mod->i];
+    const uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask[mod->i];
 #else
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
+    const uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
 #endif
 
     switch (mod->m_miscValue)  //let's generate warnings for unknown types of modifiers
@@ -6186,7 +6186,7 @@ void Aura::SpellAuraAddPctMod(bool apply)
     }
 }
 
-void Aura::SendModifierLog(int32** m, int32 v, uint32* mask, uint8 type, bool pct)
+void Aura::SendModifierLog(int32** m, int32 v, const uint32* mask, uint8 type, bool pct)
 {
     uint32 intbit = 0, groupnum = 0;
 
@@ -6237,13 +6237,13 @@ void Aura::SendModifierLog(int32** m, int32 v, uint32* mask, uint8 type, bool pc
     }
 }
 
-void Aura::SendDummyModifierLog(std::map< SpellInfo*, uint32 >* m, SpellInfo* spellInfo, uint32 i, bool apply, bool pct)
+void Aura::SendDummyModifierLog(std::map< SpellInfo const*, uint32 >* m, SpellInfo const* spellInfo, uint32 i, bool apply, bool pct)
 {
     int32 v = spellInfo->EffectBasePoints[i] + 1;
 #if VERSION_STRING != Cata
-    uint32* mask = spellInfo->EffectSpellClassMask[i];
+    const uint32* mask = spellInfo->EffectSpellClassMask[i];
 #else
-    uint32* mask = spellInfo->EffectSpellClassMask;
+    const uint32* mask = spellInfo->EffectSpellClassMask;
 #endif
     uint8 type = static_cast<uint8>(spellInfo->EffectMiscValue[i]);
 
@@ -6254,7 +6254,7 @@ void Aura::SendDummyModifierLog(std::map< SpellInfo*, uint32 >* m, SpellInfo* sp
     else
     {
         v = -v;
-        std::map<SpellInfo*, uint32>::iterator itr = m->find(spellInfo);
+        std::map<SpellInfo const*, uint32>::iterator itr = m->find(spellInfo);
         if (itr != m->end())
             m->erase(itr);
     }
@@ -6283,7 +6283,7 @@ void Aura::SpellAuraAddClassTargetTrigger(bool apply)
     {
         uint32 groupRelation[3], procClassMask[3];
         int charges;
-        SpellInfo* sp;
+        SpellInfo const* sp;
 
         // Find spell of effect to be triggered
         sp = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[mod->i]);
@@ -6400,7 +6400,7 @@ void Aura::SpellAuraOverrideClassScripts(bool apply)
                     break;
                 }
 
-                std::list<SpellInfo*>::iterator itrSE = itermap->second->begin();
+                std::list<SpellInfo const*>::iterator itrSE = itermap->second->begin();
 
                 SpellOverrideMap::iterator itr = plr->mSpellOverrideMap.find((*itrSE)->Id);
 
@@ -6449,7 +6449,7 @@ void Aura::SpellAuraOverrideClassScripts(bool apply)
                 SpellOverrideMap::iterator itr = plr->mSpellOverrideMap.begin(), itr2;
                 while (itr != plr->mSpellOverrideMap.end())
                 {
-                    std::list<SpellInfo*>::iterator itrSE = itermap->second->begin();
+                    std::list<SpellInfo const*>::iterator itrSE = itermap->second->begin();
                     for (; itrSE != itermap->second->end(); ++itrSE)
                     {
                         if (itr->first == (*itrSE)->Id)
@@ -7444,9 +7444,9 @@ void Aura::SpellAuraAddFlatModifier(bool apply)
 {
     int32 val = apply ? mod->m_amount : -mod->m_amount;
 #if VERSION_STRING != Cata
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask[mod->i];
+    const uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask[mod->i];
 #else
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
+    const uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
 #endif
 
     switch (mod->m_miscValue) //let's generate warnings for unknown types of modifiers
@@ -8280,7 +8280,7 @@ void Aura::SpellAuraSpiritOfRedemption(bool apply)
     {
         m_target->SetScale(0.5);
         m_target->SetHealth(1);
-        SpellInfo* sorInfo = sSpellCustomizations.GetSpellInfo(27792);
+        SpellInfo const* sorInfo = sSpellCustomizations.GetSpellInfo(27792);
         Spell* sor = sSpellFactoryMgr.NewSpell(m_target, sorInfo, true, NULL);
         SpellCastTargets targets;
         targets.m_unitTarget = m_target->GetGUID();
@@ -8854,7 +8854,7 @@ bool Aura::DotCanCrit()
     if (caster == nullptr)
         return false;
 
-    SpellInfo* spell_info = this->GetSpellInfo();
+    SpellInfo const* spell_info = this->GetSpellInfo();
     if (spell_info == nullptr)
         return false;
 
@@ -8872,7 +8872,7 @@ bool Aura::DotCanCrit()
     if (aura == nullptr)
         return false;
 
-    SpellInfo* aura_spell_info = aura->GetSpellInfo();
+    SpellInfo const* aura_spell_info = aura->GetSpellInfo();
 
     uint8 i = 0;
     if (aura_spell_info->EffectApplyAuraName[1] == SPELL_AURA_ALLOW_DOT_TO_CRIT)
@@ -8895,7 +8895,7 @@ bool Aura::DotCanCrit()
     if (caster == NULL)
         return false;
 
-    SpellInfo* sp = this->GetSpellInfo();
+    SpellInfo const* sp = this->GetSpellInfo();
     uint32 index = MAX_TOTAL_AURAS_START;
     Aura* aura;
     bool found = false;
@@ -8907,7 +8907,7 @@ bool Aura::DotCanCrit()
         if (aura == NULL)
             break;
 
-        SpellInfo* aura_sp = aura->GetSpellInfo();
+        SpellInfo const* aura_sp = aura->GetSpellInfo();
 
         uint8 i = 0;
         if (aura_sp->EffectApplyAuraName[1] == SPELL_AURA_ALLOW_DOT_TO_CRIT)
@@ -8949,7 +8949,7 @@ bool Aura::DotCanCrit()
 
 bool Aura::IsCombatStateAffecting()
 {
-    SpellInfo* sp = m_spellInfo;
+    SpellInfo const* sp = m_spellInfo;
 
     if (sp->appliesAreaAura(SPELL_AURA_PERIODIC_DAMAGE) ||
         sp->appliesAreaAura(SPELL_AURA_PERIODIC_DAMAGE_PERCENT) ||
@@ -8963,7 +8963,7 @@ bool Aura::IsCombatStateAffecting()
 
 bool Aura::IsAreaAura()
 {
-    SpellInfo* sp = m_spellInfo;
+    SpellInfo const* sp = m_spellInfo;
 
     if (sp->HasEffect(SPELL_EFFECT_APPLY_GROUP_AREA_AURA) ||
         sp->HasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -418,13 +418,13 @@ class SERVER_DECL Aura : public EventableObject
 {
     public:
 
-        Aura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL);
+        Aura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL);
         ~Aura();
 
         void Remove();
         void AddMod(uint32 t, int32 a, uint32 miscValue, uint32 i);
 
-        inline SpellInfo* GetSpellInfo() const { return m_spellInfo; }
+        inline SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
         inline uint32 GetSpellId() const { return m_spellInfo->Id; }
         inline bool IsPassive() { if (!m_spellInfo) return false; return (m_spellInfo->IsPassive() && !m_areaAura); }
 
@@ -729,14 +729,14 @@ class SERVER_DECL Aura : public EventableObject
         void SpellAuraConvertRune(bool apply);
         void UpdateAuraModDecreaseSpeed();
 
-        void SendModifierLog(int32** m, int32 v, uint32* mask, uint8 type, bool pct = false);
-        void SendDummyModifierLog(std::map<SpellInfo*, uint32> * m, SpellInfo* spellInfo, uint32 i, bool apply, bool pct = false);
+        void SendModifierLog(int32** m, int32 v, const uint32* mask, uint8 type, bool pct = false);
+        void SendDummyModifierLog(std::map<SpellInfo const*, uint32> * m, SpellInfo const* spellInfo, uint32 i, bool apply, bool pct = false);
 
         // Events
         void EventPeriodicDamage(uint32);
         void EventPeriodicDamagePercent(uint32);
         void EventPeriodicHeal(uint32);
-        void EventPeriodicTriggerSpell(SpellInfo* spellInfo, bool overridevalues, int32 overridevalue);
+        void EventPeriodicTriggerSpell(SpellInfo const* spellInfo, bool overridevalues, int32 overridevalue);
         void EventPeriodicTrigger(uint32 amount, uint32 type);
         void EventPeriodicEnergize(uint32, uint32);
         void EventPeriodicEnergizeVariable(uint32, uint32);
@@ -769,7 +769,7 @@ class SERVER_DECL Aura : public EventableObject
 
         virtual bool IsAbsorb() { return false; }
 
-        SpellInfo* m_spellInfo;
+        SpellInfo const* m_spellInfo;
         AreaAuraList targets; // This is only used for AA
         uint64 m_casterGuid;
         uint16 m_auraSlot;

--- a/src/world/Spell/SpellEffects.cpp
+++ b/src/world/Spell/SpellEffects.cpp
@@ -527,7 +527,7 @@ void Spell::SpellEffectInstantKill(uint32 i)
             }
             if (DemonicSacEffectSpellId)
             {
-                SpellInfo* se = sSpellCustomizations.GetSpellInfo(DemonicSacEffectSpellId);
+                SpellInfo const* se = sSpellCustomizations.GetSpellInfo(DemonicSacEffectSpellId);
                 if (se && u_caster)
                     u_caster->CastSpell(u_caster, se, true);
             }
@@ -542,7 +542,7 @@ void Spell::SpellEffectInstantKill(uint32 i)
 
             //TO< Pet* >(u_caster)->Dismiss(true);
 
-            SpellInfo* se = sSpellCustomizations.GetSpellInfo(5);
+            SpellInfo const* se = sSpellCustomizations.GetSpellInfo(5);
             if (static_cast< Pet* >(u_caster)->GetPetOwner() == NULL)
                 return;
 
@@ -559,7 +559,7 @@ void Spell::SpellEffectInstantKill(uint32 i)
 
             //TO< Pet* >(unitTarget)->Dismiss(true);
 
-            SpellInfo* se = sSpellCustomizations.GetSpellInfo(5);
+            SpellInfo const* se = sSpellCustomizations.GetSpellInfo(5);
 
             SpellCastTargets targets(unitTarget->GetGUID());
             Spell* sp = sSpellFactoryMgr.NewSpell(p_caster, se, true, 0);
@@ -1455,8 +1455,8 @@ void Spell::SpellEffectApplyAura(uint32 i)  // Apply Aura
     //if we do not make a check to see if the aura owner is the same as the caster then we will stack the 2 auras and they will not be visible client sided
     if (itr == m_pendingAuras.end())
     {
-        if (GetSpellInfo()->custom_NameHash == SPELL_HASH_BLOOD_FRENZY && ProcedOnSpell)  //Warrior's Blood Frenzy
-            GetSpellInfo()->DurationIndex = ProcedOnSpell->DurationIndex;
+        //if (GetSpellInfo()->custom_NameHash == SPELL_HASH_BLOOD_FRENZY && ProcedOnSpell)  //Warrior's Blood Frenzy
+            //GetSpellInfo()->DurationIndex = ProcedOnSpell->DurationIndex;
 
         uint32 Duration = GetDuration();
 
@@ -1658,7 +1658,7 @@ void Spell::SpellEffectHeal(uint32 i) // Heal
                 if (unitTarget && unitTarget->IsPlayer() && pSpellId && unitTarget->GetHealthPct() < 30)
                 {
                     //check for that 10 second cooldown
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(pSpellId);
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(pSpellId);
                     if (spellInfo)
                     {
                         //heal value is received by the level of current active talent :s
@@ -1777,7 +1777,7 @@ void Spell::SpellEffectHeal(uint32 i) // Heal
 
                     if (new_dmg > 0)
                     {
-                        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(18562);
+                        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(18562);
                         Spell* spell = sSpellFactoryMgr.NewSpell(unitTarget, spellInfo, true, NULL);
                         spell->SetUnitTarget(unitTarget);
                         spell->Heal((int32)new_dmg);
@@ -2112,7 +2112,7 @@ void Spell::SpellEffectCreateItem(uint32 i)
 
             if ((learn_spell != 0) && (p_caster->getLevel() > 60) && !p_caster->HasSpell(learn_spell) && Rand(cast_chance))
             {
-                SpellInfo* dspellproto = sSpellCustomizations.GetSpellInfo(learn_spell);
+                SpellInfo const* dspellproto = sSpellCustomizations.GetSpellInfo(learn_spell);
 
                 if (dspellproto != NULL)
                 {
@@ -2145,7 +2145,7 @@ void Spell::SpellEffectCreateItem(uint32 i)
             // if something was discovered teach player that recipe and broadcast message
             if (discovered_recipe != 0)
             {
-                SpellInfo* se = sSpellCustomizations.GetSpellInfo(discovered_recipe);
+                SpellInfo const* se = sSpellCustomizations.GetSpellInfo(discovered_recipe);
 
                 if (se != NULL)
                 {
@@ -2820,7 +2820,7 @@ void Spell::SpellEffectEnergize(uint32 i) // Energize
         case 31786: // Paladin - Spiritual Attunement
             if (ProcedOnSpell)
             {
-                SpellInfo* motherspell = sSpellCustomizations.GetSpellInfo(pSpellId);
+                SpellInfo const* motherspell = sSpellCustomizations.GetSpellInfo(pSpellId);
                 if (motherspell)
                 {
                     //heal amount from procspell (we only proceed on a heal spell)
@@ -2926,7 +2926,7 @@ void Spell::SpellEffectTriggerMissile(uint32 i) // Trigger Missile
         return;
     }
 
-    SpellInfo* spInfo = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* spInfo = sSpellCustomizations.GetSpellInfo(spellid);
     if (spInfo == NULL)
     {
         LOG_ERROR("Spell %u (%s) has a trigger missle effect (%u) but has an invalid trigger spell ID. Spell needs fixing.", m_spellInfo->Id, m_spellInfo->Name.c_str(), i);
@@ -3126,7 +3126,7 @@ void Spell::SpellEffectOpenLock(uint32 i)
                     return;
 
             uint32 spellid = !gameObjTarget->GetGameObjectProperties()->raw.parameter_10 ? 23932 : gameObjTarget->GetGameObjectProperties()->raw.parameter_10;
-            SpellInfo* en = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* en = sSpellCustomizations.GetSpellInfo(spellid);
             Spell* sp = sSpellFactoryMgr.NewSpell(p_caster, en, true, NULL);
             SpellCastTargets tgt;
             tgt.m_unitTarget = gameObjTarget->GetGUID();
@@ -3281,7 +3281,7 @@ void Spell::SpellEffectLearnSpell(uint32 i) // Learn Spell
             playerTarget->addSpell(32605);
 
         //smth is wrong here, first we add this spell to player then we may cast it on player...
-        SpellInfo* spellinfo = sSpellCustomizations.GetSpellInfo(spellToLearn);
+        SpellInfo const* spellinfo = sSpellCustomizations.GetSpellInfo(spellToLearn);
         //remove specializations
         switch (spellinfo->Id)
         {
@@ -3397,7 +3397,7 @@ void Spell::SpellEffectDispel(uint32 i) // Dispel
     }
 
     Aura* aur;
-    SpellInfo* aursp;
+    SpellInfo const* aursp;
     std::list< uint32 > dispelledSpells;
     bool finish = false;
 
@@ -3440,7 +3440,7 @@ void Spell::SpellEffectDispel(uint32 i) // Dispel
                 {
                     if (aursp->custom_NameHash == SPELL_HASH_UNSTABLE_AFFLICTION)
                     {
-                        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(31117);
+                        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(31117);
                         Spell* spell = sSpellFactoryMgr.NewSpell(u_caster, spellInfo, true, NULL);
                         spell->forced_basepoints[0] = (aursp->EffectBasePoints[0] + 1) * 9;   //damage effect
                         spell->ProcedOnSpell = GetSpellInfo();
@@ -4087,7 +4087,7 @@ void Spell::SpellEffectClearQuest(uint32 i)
 
 void Spell::SpellEffectTriggerSpell(uint32 i) // Trigger Spell
 {
-    SpellInfo* entry = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
+    SpellInfo const* entry = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
     if (entry == NULL)
         return;
 
@@ -4733,7 +4733,7 @@ void Spell::SpellEffectFeedPet(uint32 i)  // Feed Pet
     if (deltaLvl > 20) damage = damage >> 1;
     damage *= 1000;
 
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
     Spell* sp = sSpellFactoryMgr.NewSpell(p_caster, spellInfo, true, NULL);
     sp->forced_basepoints[0] = damage;
     SpellCastTargets tgt;
@@ -4914,7 +4914,7 @@ void Spell::SpellEffectDestroyAllTotems(uint32 i)
     for (std::vector< uint32 >::iterator itr = spellids.begin(); itr != spellids.end(); ++itr)
     {
         uint32 spellid = *itr;
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
 
         if (sp != NULL)
         {
@@ -5102,7 +5102,7 @@ void Spell::SpellEffectDummyMelee(uint32 i)   // Normalized Weapon damage +
     {
         //count the number of sunder armors on target
         uint32 sunder_count = 0;
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(7386);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(7386);
         for (uint32 x = MAX_NEGATIVE_AURAS_EXTEDED_START; x < MAX_NEGATIVE_AURAS_EXTEDED_END; ++x)
             if (unitTarget->m_auras[x] && unitTarget->m_auras[x]->GetSpellInfo()->custom_NameHash == SPELL_HASH_SUNDER_ARMOR)
             {
@@ -5353,7 +5353,7 @@ void Spell::SpellEffectSpellSteal(uint32 i)
         return;
 
     Aura* aur;
-    SpellInfo* aursp;
+    SpellInfo const* aursp;
     std::list< uint32 > stealedSpells;
 
     for (uint32 x = start; x < end; x++)
@@ -5526,7 +5526,7 @@ void Spell::SpellEffectTriggerSpellWithValue(uint32 i)
 {
     if (!unitTarget) return;
 
-    SpellInfo* TriggeredSpell = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
+    SpellInfo const* TriggeredSpell = sSpellCustomizations.GetSpellInfo(GetSpellInfo()->EffectTriggerSpell[i]);
     if (TriggeredSpell == NULL)
         return;
 

--- a/src/world/Spell/SpellHelpers.h
+++ b/src/world/Spell/SpellHelpers.h
@@ -24,7 +24,7 @@ namespace ascemu { namespace World { namespace Spell { namespace Helpers
 {
     static uint32_t decimalToMask(uint32_t dec) { return (static_cast<uint32_t>(1) << (dec - 1)); }
 
-    static void spellModFlatFloatValue(int* m, float* v, uint32_t* group)
+    static void spellModFlatFloatValue(int* m, float* v, const uint32_t* group)
     {
         if (m == nullptr)
             return;
@@ -32,7 +32,7 @@ namespace ascemu { namespace World { namespace Spell { namespace Helpers
         SPELL_GROUP_FOREACH(*v += m[bit]);
     }
 
-    static void spellModFlatIntValue(int* m, int* v, uint32_t* group)
+    static void spellModFlatIntValue(int* m, int* v, const uint32_t* group)
     {
         if (m == nullptr)
             return;
@@ -40,7 +40,7 @@ namespace ascemu { namespace World { namespace Spell { namespace Helpers
         SPELL_GROUP_FOREACH(*v += m[bit]);
     }
 
-    static void spellModPercentageFloatValue(int* m, float* v, uint32_t* group)
+    static void spellModPercentageFloatValue(int* m, float* v, const uint32_t* group)
     {
         if (m == nullptr)
             return;
@@ -48,7 +48,7 @@ namespace ascemu { namespace World { namespace Spell { namespace Helpers
         SPELL_GROUP_FOREACH(*v += ((*v) * m[bit]) / 100.0f);
     }
 
-    static void spellModPercentageIntValue(int* m, int* v, uint32_t* group)
+    static void spellModPercentageIntValue(int* m, int* v, const uint32_t* group)
     {
         if (m == nullptr)
             return;

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -341,7 +341,7 @@ bool SpellInfo::HasEffect(uint32 effect) const
     return false;
 }
 
-bool SpellInfo::HasEffectApplyAuraName(uint32_t aura_name)
+bool SpellInfo::HasEffectApplyAuraName(uint32_t aura_name) const
 {
     for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
         if (Effect[i] == SPELL_EFFECT_APPLY_AURA && EffectApplyAuraName[i] == aura_name)
@@ -350,7 +350,7 @@ bool SpellInfo::HasEffectApplyAuraName(uint32_t aura_name)
     return false;
 }
 
-bool SpellInfo::HasCustomFlagForEffect(uint32 effect, uint32 flag)
+bool SpellInfo::HasCustomFlagForEffect(uint32 effect, uint32 flag) const
 {
     if (effect >= MAX_SPELL_EFFECTS)
         return false;
@@ -638,7 +638,7 @@ bool SpellInfo::isRequireCooldownSpell() const
     return cond1 || cond2;
 }
 
-bool SpellInfo::IsPassive()
+bool SpellInfo::IsPassive() const
 {
     return (Attributes & ATTRIBUTES_PASSIVE) != 0;
 }
@@ -662,7 +662,7 @@ bool SpellInfo::IsProfession()
     return false;
 }
 
-bool SpellInfo::IsPrimaryProfession()
+bool SpellInfo::IsPrimaryProfession() const
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
@@ -677,7 +677,7 @@ bool SpellInfo::IsPrimaryProfession()
     return false;
 }
 
-bool SpellInfo::IsPrimaryProfessionSkill(uint32 skill_id)
+bool SpellInfo::IsPrimaryProfessionSkill(uint32 skill_id) const
 {
     if (DBC::Structures::SkillLineEntry const* skill_line = sSkillLineStore.LookupEntry(skill_id))
         if (skill_line && skill_line->type == SKILL_TYPE_PROFESSION)
@@ -717,7 +717,7 @@ bool SpellInfo::appliesAreaAura(uint32 aura) const
     return false;
 }
 
-uint32 SpellInfo::GetAreaAuraEffectId()
+uint32 SpellInfo::GetAreaAuraEffectId() const
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -21,8 +21,8 @@ public:
 
     // helper functions
     bool HasEffect(uint32 effect) const;
-    bool HasEffectApplyAuraName(uint32_t aura_name);
-    bool HasCustomFlagForEffect(uint32 effect, uint32 flag);
+    bool HasEffectApplyAuraName(uint32_t aura_name) const;
+    bool HasCustomFlagForEffect(uint32 effect, uint32 flag) const;
 
     bool isDamagingSpell() const;
     bool isHealingSpell() const;
@@ -35,15 +35,15 @@ public:
     bool isTargetingStealthed() const;
     bool isRequireCooldownSpell() const;
 
-    bool IsPassive();
+    bool IsPassive() const;
     bool IsProfession();
-    bool IsPrimaryProfession();
-    bool IsPrimaryProfessionSkill(uint32 skill_id);
+    bool IsPrimaryProfession() const;
+    bool IsPrimaryProfessionSkill(uint32 skill_id) const;
 
     bool isDeathPersistent() const;
 
     bool appliesAreaAura(uint32 aura) const;
-    uint32 GetAreaAuraEffectId();
+    uint32 GetAreaAuraEffectId() const;
 
 #if VERSION_STRING != Cata
         //////////////////////////////////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ public:
         bool custom_always_apply;
         bool custom_is_melee_spell;
         bool custom_is_ranged_spell;
-	    bool CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player = NULL);
+	    bool CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player = NULL) const;
         uint32 custom_SchoolMask;
         uint32 CustomFlags;
         uint32 EffectCustomFlag[MAX_SPELL_EFFECTS];
@@ -362,7 +362,7 @@ public:
         bool custom_always_apply;
         bool custom_is_melee_spell;
         bool custom_is_ranged_spell;
-        bool CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player = NULL);
+        bool CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player = NULL) const;
         uint32 custom_SchoolMask;
         uint32 CustomFlags;
         uint32 EffectCustomFlag[MAX_SPELL_EFFECTS];

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -36,14 +36,14 @@ void SpellFactoryMgr::AddSpellByEntry(SpellInfo* info, spell_factory_function sp
 
 void SpellFactoryMgr::AddSpellById(uint32 spellId, spell_factory_function spell_func)
 {
-    AddSpellByEntry(sSpellCustomizations.GetSpellInfo(spellId), spell_func);
+    AddSpellByEntry(sSpellCustomizations.getSpellInfoUnsafe(spellId), spell_func);
 }
 
 void SpellFactoryMgr::AddSpellByNameHash(uint32 name_hash, spell_factory_function spell_func)
 {
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(it->first);
+        SpellInfo* sp = sSpellCustomizations.getSpellInfoUnsafe(it->first);
 
         if (!sp || sp->custom_NameHash != name_hash)
             continue;
@@ -60,14 +60,14 @@ void SpellFactoryMgr::AddAuraByEntry(SpellInfo* info, aura_factory_function aura
 
 void SpellFactoryMgr::AddAuraById(uint32 spellId, aura_factory_function aura_func)
 {
-    AddAuraByEntry(sSpellCustomizations.GetSpellInfo(spellId), aura_func);
+    AddAuraByEntry(sSpellCustomizations.getSpellInfoUnsafe(spellId), aura_func);
 }
 
 void SpellFactoryMgr::AddAuraByNameHash(uint32 name_hash, aura_factory_function aura_func)
 {
     for (auto it = sSpellCustomizations.GetSpellInfoStore()->begin(); it != sSpellCustomizations.GetSpellInfoStore()->end(); ++it)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(it->first);
+        SpellInfo* sp = sSpellCustomizations.getSpellInfoUnsafe(it->first);
 
         if (!sp || sp->custom_NameHash != name_hash)
             continue;
@@ -76,7 +76,7 @@ void SpellFactoryMgr::AddAuraByNameHash(uint32 name_hash, aura_factory_function 
     }
 }
 
-SpellInfo* SpellFactoryMgr::GetSpellEntryByDifficulty(uint32 id, uint8 difficulty)
+SpellInfo const* SpellFactoryMgr::GetSpellEntryByDifficulty(uint32 id, uint8 difficulty)
 {
 #if VERSION_STRING > TBC
     auto spell_difficulty = sSpellDifficultyStore.LookupEntry(id);
@@ -92,7 +92,7 @@ SpellInfo* SpellFactoryMgr::GetSpellEntryByDifficulty(uint32 id, uint8 difficult
 #endif
 }
 
-Spell* SpellFactoryMgr::NewSpell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur)
+Spell* SpellFactoryMgr::NewSpell(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur)
 {
     if (info->SpellFactoryFunc == NULL)
         return new Spell(Caster, info, triggered, aur);
@@ -104,7 +104,7 @@ Spell* SpellFactoryMgr::NewSpell(Object* Caster, SpellInfo* info, bool triggered
     }
 }
 
-Aura* SpellFactoryMgr::NewAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster)
+Aura* SpellFactoryMgr::NewAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster)
 {
     if (proto->AuraFactoryFunc == NULL)
         return new Aura(proto, duration, caster, target, temporary, i_caster);
@@ -374,7 +374,7 @@ bool SpellArea::IsFitToRequirements(Player* player, uint32 newZone, uint32 newAr
     return true;
 }
 
-bool SpellInfo::CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player)
+bool SpellInfo::CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player) const
 {
 #if VERSION_STRING > TBC
     // normal case

--- a/src/world/Spell/SpellMgr.h
+++ b/src/world/Spell/SpellMgr.h
@@ -54,16 +54,16 @@ class Aura;
 
 #define SPELL_FACTORY_FUNCTION(T) \
   public: \
-  static Spell* Create(Object* Caster, SpellInfo *info, bool triggered, Aura* aur) { return new T(Caster, info, triggered, aur); } \
-  T(Object* Caster, SpellInfo *info, bool triggered, Aura* aur) : Spell(Caster, info, triggered, aur) {}
+  static Spell* Create(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur) { return new T(Caster, info, triggered, aur); } \
+  T(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur) : Spell(Caster, info, triggered, aur) {}
 
 #define AURA_FACTORY_FUNCTION(T) \
   public: \
-  static Aura* Create(SpellInfo *proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new T(proto, duration, caster, target, temporary, i_caster); } \
-  T(SpellInfo *proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) : Aura(proto, duration, caster, target, temporary, i_caster) {}
+  static Aura* Create(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new T(proto, duration, caster, target, temporary, i_caster); } \
+  T(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) : Aura(proto, duration, caster, target, temporary, i_caster) {}
 
-typedef Spell* (*spell_factory_function)(Object* Caster, SpellInfo* info, bool triggered, Aura* aur);
-typedef Aura* (*aura_factory_function)(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster);
+typedef Spell* (*spell_factory_function)(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur);
+typedef Aura* (*aura_factory_function)(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary, Item* i_caster);
 
 class SERVER_DECL SpellFactoryMgr: public Singleton < SpellFactoryMgr >
 {
@@ -78,9 +78,9 @@ class SERVER_DECL SpellFactoryMgr: public Singleton < SpellFactoryMgr >
 		{
 		}
 
-		SpellInfo* GetSpellEntryByDifficulty(uint32 id, uint8 difficulty);
-		Spell* NewSpell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur);
-		Aura* NewAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL);
+		SpellInfo const* GetSpellEntryByDifficulty(uint32 id, uint8 difficulty);
+		Spell* NewSpell(Object* Caster, SpellInfo const* info, bool triggered, Aura* aur);
+		Aura* NewAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL);
 
 		// Spell area
 		void LoadSpellAreas();

--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -27,7 +27,7 @@
 
 initialiseSingleton(SpellProcMgr);
 
-bool SpellProc::CanProc(Unit* victim, SpellInfo* CastingSpell)
+bool SpellProc::CanProc(Unit* victim, SpellInfo const* CastingSpell)
 {
     return true;
 }
@@ -48,7 +48,7 @@ bool SpellProc::CanDelete(uint32 spellId, uint64 casterGuid, uint64 misc)
     return false;
 }
 
-bool SpellProc::CheckClassMask(Unit* victim, SpellInfo* CastingSpell)
+bool SpellProc::CheckClassMask(Unit* victim, SpellInfo const* CastingSpell)
 {
     if ((mProcClassMask[0] == 0 && mProcClassMask[1] == 0 && mProcClassMask[2] == 0) ||
         mProcClassMask[0] & CastingSpell->SpellGroupType[0] ||
@@ -59,7 +59,7 @@ bool SpellProc::CheckClassMask(Unit* victim, SpellInfo* CastingSpell)
         return false;
 }
 
-bool SpellProc::DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+bool SpellProc::DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
 {
     return false;
 }
@@ -68,7 +68,7 @@ void SpellProc::Init(Object* obj)
 {
 }
 
-uint32 SpellProc::CalcProcChance(Unit* victim, SpellInfo* CastingSpell)
+uint32 SpellProc::CalcProcChance(Unit* victim, SpellInfo const* CastingSpell)
 {
     // Check if proc chance is based on combo points
     if (mTarget->IsPlayer() && mOrigSpell && mOrigSpell->AttributesEx & ATTRIBUTESEX_REQ_COMBO_POINTS1 && mOrigSpell->AttributesExD & ATTRIBUTESEXD_PROCCHANCE_COMBOBASED)
@@ -77,14 +77,14 @@ uint32 SpellProc::CalcProcChance(Unit* victim, SpellInfo* CastingSpell)
         return mProcChance;
 }
 
-bool SpellProc::CanProcOnTriggered(Unit* victim, SpellInfo* CastingSpell)
+bool SpellProc::CanProcOnTriggered(Unit* victim, SpellInfo const* CastingSpell)
 {
     if (mOrigSpell != NULL && mOrigSpell->AttributesExC & ATTRIBUTESEXC_CAN_PROC_ON_TRIGGERED)
         return true;
     return false;
 }
 
-void SpellProc::CastSpell(Unit* victim, SpellInfo* CastingSpell, int* dmg_overwrite)
+void SpellProc::CastSpell(Unit* victim, SpellInfo const* CastingSpell, int* dmg_overwrite)
 {
     SpellCastTargets targets;
     if (mProcFlags & PROC_TARGET_SELF)
@@ -104,12 +104,12 @@ void SpellProc::CastSpell(Unit* victim, SpellInfo* CastingSpell, int* dmg_overwr
     spell->prepare(&targets);
 }
 
-SpellProc* SpellProcMgr::NewSpellProc(Unit* target, uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj)
+SpellProc* SpellProcMgr::NewSpellProc(Unit* target, uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj)
 {
     return NewSpellProc(target, sSpellCustomizations.GetSpellInfo(spell_id), sSpellCustomizations.GetSpellInfo(orig_spell_id), caster, procChance, procFlags, procCharges, groupRelation, procClassMask, obj);
 }
 
-SpellProc* SpellProcMgr::NewSpellProc(Unit* target, SpellInfo* spell, SpellInfo* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj)
+SpellProc* SpellProcMgr::NewSpellProc(Unit* target, SpellInfo const* spell, SpellInfo const* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj)
 {
     if (spell == NULL)
         return NULL;

--- a/src/world/Spell/SpellProc.h
+++ b/src/world/Spell/SpellProc.h
@@ -44,7 +44,7 @@ class SpellProc
         }
 
         // Returns true if this spell can proc, false otherwise
-        virtual bool CanProc(Unit* victim, SpellInfo* CastingSpell);
+        virtual bool CanProc(Unit* victim, SpellInfo const* CastingSpell);
 
         // Called when procFlags is to be compared.
         // Return true on success, false otherwise
@@ -55,30 +55,30 @@ class SpellProc
 
         // Called when is proccing from casting spell. It checks proc class mask with spell group type
         // Return true allow proc, false otherwise
-        virtual bool CheckClassMask(Unit* victim, SpellInfo* CastingSpell);
+        virtual bool CheckClassMask(Unit* victim, SpellInfo const* CastingSpell);
 
         // Called after proc chance is rolled
         // Return false so Unit::HandleProc execute subsequent statements
         // Return true if this handle everything, so Unit::HandleProc skips to next iteration
-        virtual bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type);
+        virtual bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type);
 
         // Called just after this object is created. Usefull for initialize object members
         virtual void Init(Object* obj);
 
-        virtual uint32 CalcProcChance(Unit* victim, SpellInfo* CastingSpell);
+        virtual uint32 CalcProcChance(Unit* victim, SpellInfo const* CastingSpell);
 
         // Called when trying to proc on a triggered spell
         // Return true allow proc, false otherwise
-        virtual bool CanProcOnTriggered(Unit* victim, SpellInfo* CastingSpell);
+        virtual bool CanProcOnTriggered(Unit* victim, SpellInfo const* CastingSpell);
 
         // Cast proc spell
-        virtual void CastSpell(Unit* victim, SpellInfo* CastingSpell, int* dmg_overwrite);
+        virtual void CastSpell(Unit* victim, SpellInfo const* CastingSpell, int* dmg_overwrite);
 
         // Spell to proc
-        SpellInfo* mSpell;
+        SpellInfo const* mSpell;
 
         // Spell that created this proc
-        SpellInfo* mOrigSpell;
+        SpellInfo const* mOrigSpell;
 
         // Unit 'owner' of this proc
         Unit* mTarget;
@@ -116,9 +116,9 @@ class SpellProcMgr : public Singleton < SpellProcMgr >
         {
         }
 
-        SpellProc* NewSpellProc(Unit* target, uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj);
+        SpellProc* NewSpellProc(Unit* target, uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj);
 
-        SpellProc* NewSpellProc(Unit* target, SpellInfo* spell, SpellInfo* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj);
+        SpellProc* NewSpellProc(Unit* target, SpellInfo const* spell, SpellInfo const* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj);
 
     private:
 

--- a/src/world/Spell/SpellProc_ClassScripts.cpp
+++ b/src/world/Spell/SpellProc_ClassScripts.cpp
@@ -42,7 +42,7 @@ class DamageShieldSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(DamageShieldSpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         // Allow only proc for player unit
         if (!mTarget->IsPlayer())
@@ -50,7 +50,7 @@ class DamageShieldSpellProc : public SpellProc
         return true;
     }
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         Player* plr = static_cast<Player*>(mTarget);
 
@@ -68,7 +68,7 @@ class JuggernautSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(JuggernautSpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (CastingSpell == NULL)
             return false;
@@ -105,7 +105,7 @@ class EarthShieldSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(EarthShieldSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         int32 value = mOrigSpell->EffectBasePoints[0];
         dmg_overwrite[0] = value;
@@ -113,7 +113,7 @@ class EarthShieldSpellProc : public SpellProc
         return false;
     }
 
-    void CastSpell(Unit* victim, SpellInfo* CastingSpell, int* dmg_overwrite)
+    void CastSpell(Unit* victim, SpellInfo const* CastingSpell, int* dmg_overwrite)
     {
         Unit* caster = mTarget->GetMapMgr()->GetUnit(mCaster);
         if (caster == NULL)
@@ -148,7 +148,7 @@ class FlametongueWeaponSpellProc : public SpellProc
         EnchantmentInstance* enchant = item->GetEnchantment(TEMP_ENCHANTMENT_SLOT);
         if (enchant != nullptr)
         {
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(enchant->Enchantment->spell[0]);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(enchant->Enchantment->spell[0]);
             if (sp != nullptr && sp->custom_NameHash == SPELL_HASH_FLAMETONGUE_WEAPON__PASSIVE_)
             {
                 wp_speed = item->GetItemProperties()->Delay;
@@ -165,14 +165,14 @@ class FlametongueWeaponSpellProc : public SpellProc
         return false;
     }
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (mTarget->IsPlayer())
             return true;
         return false;
     }
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         Item* item;
 
@@ -229,7 +229,7 @@ class PoisonSpellProc : public SpellProc
     }
 
     // Allow proc on ability cast (like eviscerate, envenom, fan of knives, rupture)
-    bool CanProcOnTriggered(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProcOnTriggered(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (CastingSpell != NULL && (CastingSpell->SpellGroupType[0] & 0x120000 || CastingSpell->SpellGroupType[1] & 0x240008))
             return true;
@@ -238,7 +238,7 @@ class PoisonSpellProc : public SpellProc
     }
 
     // Allow proc only if proccing hand is the one where poison was applied
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         Item* item;
 
@@ -286,7 +286,7 @@ class CutToTheChaseSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(CutToTheChaseSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         Aura* aura = mTarget->FindAuraByNameHash(SPELL_HASH_SLICE_AND_DICE);
         if (aura)
@@ -311,7 +311,7 @@ class DeadlyBrewSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(DeadlyBrewSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         mTarget->CastSpell(static_cast<Unit*>(NULL), 3409, true);    //Spell Id 3409: Crippling Poison
 
@@ -341,7 +341,7 @@ class ImprovedSpiritTapSpellProc : public SpellProc
         mProcFlags = PROC_ON_SPELL_CRIT_HIT;
     }
 
-    uint32 CalcProcChance(Unit* victim, SpellInfo* CastingSpell)
+    uint32 CalcProcChance(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (CastingSpell == NULL)
             return 0;
@@ -383,7 +383,7 @@ class DivineAegisSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(DivineAegisSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         if (CastingSpell == NULL)
             return true;
@@ -401,7 +401,7 @@ class ImprovedDevouringPlagueSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(ImprovedDevouringPlagueSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // Get dmg amt for 1 tick
         dmg = CastingSpell->EffectBasePoints[0] + 1;
@@ -419,7 +419,7 @@ class VampiricEmbraceSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(VampiricEmbraceSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // Only proc for damaging shadow spells
         if (CastingSpell->School != SCHOOL_SHADOW || !CastingSpell->isDamagingSpell())
@@ -445,7 +445,7 @@ class VampiricTouchEnergizeSpellProc : public SpellProc
         mReplenishmentSpell = sSpellCustomizations.GetSpellInfo(57669);
     }
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // Check for Mind Blast hit from this proc caster
         if (CastingSpell == NULL || CastingSpell->custom_NameHash != SPELL_HASH_MIND_BLAST || mCaster != victim->GetGUID())
@@ -458,7 +458,7 @@ class VampiricTouchEnergizeSpellProc : public SpellProc
     }
 
 private:
-    SpellInfo* mReplenishmentSpell;
+    SpellInfo const* mReplenishmentSpell;
 };
 
 class VampiricTouchDispelDamageSpellProc : public SpellProc
@@ -470,10 +470,10 @@ class VampiricTouchDispelDamageSpellProc : public SpellProc
         mDispelDmg = 8 * (mOrigSpell->EffectBasePoints[1] + 1);
     }
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // For PROC_ON_PRE_DISPELL_AURA_VICTIM, parameter dmg has aur->GetSpellId()
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(dmg);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(dmg);
 
         if (CastingSpell == NULL || sp == NULL || sp->custom_NameHash != SPELL_HASH_VAMPIRIC_TOUCH)
             return true;
@@ -491,7 +491,7 @@ class EmpoweredRenewSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(EmpoweredRenewSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // Get heal amt for 1 tick
         dmg = CastingSpell->EffectBasePoints[0] + 1;
@@ -505,7 +505,7 @@ class EmpoweredRenewSpellProc : public SpellProc
         return false;
     }
 
-    void CastSpell(Unit* victim, SpellInfo* CastingSpell, int* dmg_overwrite)
+    void CastSpell(Unit* victim, SpellInfo const* CastingSpell, int* dmg_overwrite)
     {
         SpellCastTargets targets;
         targets.m_unitTarget = victim->GetGUID();
@@ -524,7 +524,7 @@ class ImprovedMindBlastSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(ImprovedMindBlastSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // If spell is not Mind Blast (by SpellGroupType) or player is not on shadowform, don't proc
         if (!(CastingSpell->SpellGroupType[0] & mProcClassMask[0] && mTarget->IsPlayer() && static_cast<Player*>(mTarget)->GetShapeShift() == FORM_SHADOW))
@@ -538,7 +538,7 @@ class BodyAndSoulDummySpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(BodyAndSoulDummySpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (victim != NULL && mTarget->GetGUID() == victim->GetGUID())
             return true;
@@ -575,7 +575,7 @@ class PrayerOfMendingProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(PrayerOfMendingProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         Aura* aura = mTarget->getAuraWithId(mSpell->Id);
         if (aura == NULL)
@@ -647,7 +647,7 @@ class EyeForAnEyeSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(EyeForAnEyeSpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // If this player died by crit damage, don't do dmg back
         if (!mTarget->isAlive())
@@ -682,7 +682,7 @@ class SpiritualAttunementSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(SpiritualAttunementSpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (CastingSpell == NULL || !CastingSpell->isHealingSpell())
             return false;
@@ -705,7 +705,7 @@ class SealOfCorruptionSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(SealOfCorruptionSpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (victim == NULL || victim->FindAuraCountByHash(SPELL_HASH_BLOOD_CORRUPTION) < 5)
             return false;
@@ -718,7 +718,7 @@ class SealOfVengeanceSpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(SealOfVengeanceSpellProc);
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (victim == NULL || victim->FindAuraCountByHash(SPELL_HASH_HOLY_VENGEANCE) < 5)
             return false;
@@ -738,7 +738,7 @@ class HotStreakSpellProc : public SpellProc
         mCritsInARow = 0;
     }
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         // Check for classmask. Should proc only if CastingSpell is one listed in http://www.wowhead.com/spell=44448
         if (!CheckClassMask(victim, CastingSpell))
@@ -768,7 +768,7 @@ class ButcherySpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(ButcherySpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         dmg_overwrite[0] = mOrigSpell->EffectBasePoints[0] + 1;
 
@@ -797,7 +797,7 @@ class BladeBarrierSpellProc : public SpellProc
         dk = static_cast<DeathKnight*>(mTarget);
     }
 
-    bool CanProc(Unit* victim, SpellInfo* CastingSpell)
+    bool CanProc(Unit* victim, SpellInfo const* CastingSpell)
     {
         if (dk->IsAllRunesOfTypeInUse(RUNE_BLOOD))
             return true;
@@ -812,7 +812,7 @@ class DeathRuneMasterySpellProc : public SpellProc
 {
     SPELL_PROC_FACTORY_FUNCTION(DeathRuneMasterySpellProc);
 
-    bool DoEffect(Unit* victim, SpellInfo* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
+    bool DoEffect(Unit* victim, SpellInfo const* CastingSpell, uint32 flag, uint32 dmg, uint32 abs, int* dmg_overwrite, uint32 weapon_damage_type)
     {
         DeathKnight* dk = static_cast<DeathKnight*>(mTarget);
 

--- a/src/world/Spell/Spell_ClassScripts.cpp
+++ b/src/world/Spell/Spell_ClassScripts.cpp
@@ -124,9 +124,9 @@ class CheatDeathAura : public AbsorbAura
 {
 public:
 
-    static Aura* Create(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new CheatDeathAura(proto, duration, caster, target, temporary, i_caster); }
+    static Aura* Create(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new CheatDeathAura(proto, duration, caster, target, temporary, i_caster); }
 
-    CheatDeathAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
+    CheatDeathAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
         : AbsorbAura(proto, duration, caster, target, temporary, i_caster)
     {
         dSpell = sSpellCustomizations.GetSpellInfo(31231);
@@ -165,7 +165,8 @@ public:
         p_target->CastSpell(p_target->GetGUID(), 45182, true);
 
         // Better to add custom cooldown procedure then fucking with entry, or not!!
-        dSpell->RecoveryTime = 60000;
+		// Appled: needs better solution
+        //dSpell->RecoveryTime = 60000;
         p_target->Cooldown_Add(dSpell, NULL);
 
         // Calc abs and applying it
@@ -178,7 +179,7 @@ public:
 
 private:
 
-    SpellInfo* dSpell;
+    SpellInfo const* dSpell;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -348,9 +349,9 @@ class RuneStrileSpell : public Spell
 class AntiMagicShellAura : public AbsorbAura
 {
     public:
-    static Aura* Create(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new AntiMagicShellAura(proto, duration, caster, target, temporary, i_caster); }
+    static Aura* Create(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new AntiMagicShellAura(proto, duration, caster, target, temporary, i_caster); }
 
-    AntiMagicShellAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
+    AntiMagicShellAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
         : AbsorbAura(proto, duration, caster, target, temporary, i_caster) {}
 
     int32 CalcAbsorbAmount()
@@ -371,9 +372,9 @@ class AntiMagicShellAura : public AbsorbAura
 class SpellDeflectionAura : public AbsorbAura
 {
     public:
-    static Aura* Create(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new SpellDeflectionAura(proto, duration, caster, target, temporary, i_caster); }
+    static Aura* Create(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new SpellDeflectionAura(proto, duration, caster, target, temporary, i_caster); }
 
-    SpellDeflectionAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
+    SpellDeflectionAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
         : AbsorbAura(proto, duration, caster, target, temporary, i_caster) {}
 
     uint32 AbsorbDamage(uint32 School, uint32* dmg)
@@ -409,9 +410,9 @@ class BloodwormSpell : public Spell
 class WillOfTheNecropolisAura : public AbsorbAura
 {
     public:
-    static Aura* Create(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new WillOfTheNecropolisAura(proto, duration, caster, target, temporary, i_caster); }
+    static Aura* Create(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL) { return new WillOfTheNecropolisAura(proto, duration, caster, target, temporary, i_caster); }
 
-    WillOfTheNecropolisAura(SpellInfo* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
+    WillOfTheNecropolisAura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL)
         : AbsorbAura(proto, duration, caster, target, temporary, i_caster) {}
 
     uint32 AbsorbDamage(uint32 School, uint32* dmg)

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -683,7 +683,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
                 creatureProperties.AISpells[i] = fields[52 + i].GetUInt32();
                 if (creatureProperties.AISpells[i] != 0)
                 {
-                    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(creatureProperties.AISpells[i]);
+                    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(creatureProperties.AISpells[i]);
                     if (sp == nullptr)
                     {
                         uint8_t spell_number = i;
@@ -718,7 +718,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
                     if (creature_spell_data->Spells[i] == 0)
                         continue;
 
-                    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(creature_spell_data->Spells[i]);
+                    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(creature_spell_data->Spells[i]);
                     if (sp == nullptr)
                         continue;
 
@@ -2554,14 +2554,14 @@ void MySQLDataStore::loadSpellOverrideTable()
         uint32_t distinct_override_id = fields[0].GetUInt32();
 
         QueryResult* spellid_for_overrideid_result = WorldDatabase.Query("SELECT spellId FROM spelloverride WHERE overrideId = %u", distinct_override_id);
-        std::list<SpellInfo*>* list = new std::list <SpellInfo*>;
+        std::list<SpellInfo const*>* list = new std::list <SpellInfo const*>;
         if (spellid_for_overrideid_result != nullptr)
         {
             do
             {
                 Field* fieldsIn = spellid_for_overrideid_result->Fetch();
                 uint32_t spellid = fieldsIn[0].GetUInt32();
-                SpellInfo* spell = sSpellCustomizations.GetSpellInfo(spellid);
+                SpellInfo const* spell = sSpellCustomizations.GetSpellInfo(spellid);
                 if (spell == nullptr)
                 {
                     LOG_ERROR("Table `spelloverride` includes invalid spellId %u for overrideId %u! <skipped>", spellid, distinct_override_id);
@@ -3758,7 +3758,7 @@ MySQLStructure::NpcMonsterSay* MySQLDataStore::getMonstersayEventForCreature(uin
 //        Field* fields = result->Fetch();
 //        uint32 entry = fields[0].GetUInt32();
 //        uint32 spell = fields[1].GetUInt32();
-//        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spell);
+//        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spell);
 //
 //        if (spell && entry && spellInfo)
 //        {
@@ -3769,7 +3769,7 @@ MySQLStructure::NpcMonsterSay* MySQLDataStore::getMonstersayEventForCreature(uin
 //            }
 //            else
 //            {
-//                std::set<SpellInfo*> spellInfoSet;
+//                std::set<SpellInfo const*> spellInfoSet;
 //                spellInfoSet.insert(spellInfo);
 //                _defaultPetSpellsStore[entry] = spellInfoSet;
 //            }
@@ -3782,7 +3782,7 @@ MySQLStructure::NpcMonsterSay* MySQLDataStore::getMonstersayEventForCreature(uin
 //}
 
 //\brief This function is never called!     Zyres 2017/07/16 not used
-//std::set<SpellInfo*>* MySQLDataStore::getDefaultPetSpellsByEntry(uint32_t entry)
+//std::set<SpellInfo const*>* MySQLDataStore::getDefaultPetSpellsByEntry(uint32_t entry)
 //{
 //    PetDefaultSpellsMap::iterator itr = _defaultPetSpellsStore.find(entry);
 //    if (itr == _defaultPetSpellsStore.end())

--- a/src/world/Storage/MySQLDataStore.hpp
+++ b/src/world/Storage/MySQLDataStore.hpp
@@ -57,7 +57,7 @@ public:
     typedef std::unordered_map<uint32_t, PlayerCreateInfo> PlayerCreateInfoContainer;
     typedef std::vector<uint32_t> PlayerXPperLevel;
 
-    typedef std::map<uint32_t, std::list<SpellInfo*>*> SpellOverrideIdMap;
+    typedef std::map<uint32_t, std::list<SpellInfo const*>*> SpellOverrideIdMap;
 
     typedef std::map<uint32_t, uint32_t> NpcGossipTextIdMap;
 
@@ -89,7 +89,7 @@ public:
 
     typedef std::unordered_map<uint32_t, MySQLStructure::NpcMonsterSay*> NpcMonstersayContainer;
 
-    //typedef std::map<uint32_t, std::set<SpellInfo*>> PetDefaultSpellsMap;     Zyres 2017/07/16 not used
+    //typedef std::map<uint32_t, std::set<SpellInfo const*>> PetDefaultSpellsMap;     Zyres 2017/07/16 not used
 
     typedef std::set<MySQLStructure::ProfessionDiscovery*> ProfessionDiscoverySet;
 
@@ -195,7 +195,7 @@ public:
     MySQLStructure::LocalesWorldStringTable const* getLocalizedWorldStringTable(uint32_t entry, uint32_t sessionLocale);
 
     MySQLStructure::NpcMonsterSay* getMonstersayEventForCreature(uint32_t entry, MONSTER_SAY_EVENTS Event);
-    //std::set<SpellInfo*>* getDefaultPetSpellsByEntry(uint32_t entry);     Zyres 2017/07/16 not used
+    //std::set<SpellInfo const*>* getDefaultPetSpellsByEntry(uint32_t entry);     Zyres 2017/07/16 not used
 
     TransportCreaturesContainer* getTransportCreaturesStore() { return &_transportCreaturesStore; }
     

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -713,7 +713,7 @@ void AIInterface::_UpdateCombat(uint32 p_time)
                                 float his_facing = getNextTarget()->GetOrientation();
                                 if (fabs(our_facing - his_facing) < CREATURE_DAZE_TRIGGER_ANGLE && !getNextTarget()->HasAura(CREATURE_SPELL_TO_DAZE))
                                 {
-                                    SpellInfo* info = sSpellCustomizations.GetSpellInfo(CREATURE_SPELL_TO_DAZE);
+                                    SpellInfo const* info = sSpellCustomizations.GetSpellInfo(CREATURE_SPELL_TO_DAZE);
                                     Spell* sp = sSpellFactoryMgr.NewSpell(m_Unit, info, false, NULL);
                                     SpellCastTargets targets;
                                     targets.m_unitTarget = getNextTarget()->GetGUID();
@@ -766,7 +766,7 @@ void AIInterface::_UpdateCombat(uint32 p_time)
                         if (infront)
                         {
                             m_Unit->setAttackTimer(0, false);
-                            SpellInfo* info = sSpellCustomizations.GetSpellInfo(SPELL_RANGED_GENERAL);
+                            SpellInfo const* info = sSpellCustomizations.GetSpellInfo(SPELL_RANGED_GENERAL);
                             if (info)
                             {
                                 Spell* sp = sSpellFactoryMgr.NewSpell(m_Unit, info, false, NULL);
@@ -810,7 +810,7 @@ void AIInterface::_UpdateCombat(uint32 p_time)
                 float distance = m_Unit->CalcDistance(getNextTarget());
                 if (los && ((distance <= m_nextSpell->maxrange + m_Unit->GetModelHalfSize()) || m_nextSpell->maxrange == 0))  // Target is in Range -> Attack
                 {
-                    SpellInfo* spellInfo = m_nextSpell->spell;
+                    SpellInfo const* spellInfo = m_nextSpell->spell;
 
                     /* if in range stop moving so we don't interrupt the spell */
                     //do not stop for instant spells
@@ -1037,7 +1037,7 @@ void AIInterface::AttackReaction(Unit* pUnit, uint32 damage_dealt, uint32 spellI
     HandleEvent(EVENT_DAMAGETAKEN, pUnit, _CalcThreat(damage_dealt, spellId ? sSpellCustomizations.GetSpellInfo(spellId) : NULL, pUnit));
 }
 
-void AIInterface::HealReaction(Unit* caster, Unit* victim, SpellInfo* sp, uint32 amount)
+void AIInterface::HealReaction(Unit* caster, Unit* victim, SpellInfo const* sp, uint32 amount)
 {
     if (!caster || !victim)
         return;
@@ -2649,7 +2649,7 @@ void AIInterface::_UpdateMovement(uint32 p_time)
     }
 }
 
-void AIInterface::CastSpell(Unit* caster, SpellInfo* spellInfo, SpellCastTargets targets)
+void AIInterface::CastSpell(Unit* caster, SpellInfo const* spellInfo, SpellCastTargets targets)
 {
     ARCEMU_ASSERT(spellInfo != NULL);
     if (!isAiScriptType(AI_SCRIPT_PET) && disable_spell)
@@ -2667,9 +2667,9 @@ void AIInterface::CastSpell(Unit* caster, SpellInfo* spellInfo, SpellCastTargets
     nspell->prepare(&targets);
 }
 
-SpellInfo* AIInterface::getSpellEntry(uint32 spellId)
+SpellInfo const* AIInterface::getSpellEntry(uint32 spellId)
 {
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
 
     if (!spellInfo)
     {
@@ -2680,7 +2680,7 @@ SpellInfo* AIInterface::getSpellEntry(uint32 spellId)
     return spellInfo;
 }
 
-SpellCastTargets AIInterface::setSpellTargets(SpellInfo* spellInfo, Unit* target) const
+SpellCastTargets AIInterface::setSpellTargets(SpellInfo const* spellInfo, Unit* target) const
 {
     SpellCastTargets targets;
     targets.m_unitTarget = target ? target->GetGUID() : 0;
@@ -3279,7 +3279,7 @@ void AIInterface::CheckTarget(Unit* target)
         tauntedBy = nullptr;
 }
 
-uint32 AIInterface::_CalcThreat(uint32 damage, SpellInfo* sp, Unit* Attacker)
+uint32 AIInterface::_CalcThreat(uint32 damage, SpellInfo const* sp, Unit* Attacker)
 {
     if (!Attacker)
         return 0; // No attacker means no threat and we prevent crashes this way

--- a/src/world/Units/Creatures/AIInterface.h
+++ b/src/world/Units/Creatures/AIInterface.h
@@ -186,7 +186,7 @@ struct AI_Spell
     uint32 instance_mode;
     uint16 agent;
     uint32 procChance;
-    SpellInfo* spell;
+    SpellInfo const* spell;
     uint8 spellType;
     uint8 spelltargetType;
     uint32 cooldown;
@@ -312,9 +312,9 @@ class SERVER_DECL AIInterface : public IUpdatable
         void setOutOfCombatRange(uint32 val) { m_outOfCombatRange = val; }
 
         // Spell
-        void CastSpell(Unit* caster, SpellInfo* spellInfo, SpellCastTargets targets);
-        SpellInfo* getSpellEntry(uint32 spellId);
-        SpellCastTargets setSpellTargets(SpellInfo* spellInfo, Unit* target) const;
+        void CastSpell(Unit* caster, SpellInfo const* spellInfo, SpellCastTargets targets);
+        SpellInfo const* getSpellEntry(uint32 spellId);
+        SpellCastTargets setSpellTargets(SpellInfo const* spellInfo, Unit* target) const;
         AI_Spell* getSpell();
         void addSpellToList(AI_Spell* sp);
         ///\todo don't use this until i finish it !!
@@ -337,7 +337,7 @@ class SERVER_DECL AIInterface : public IUpdatable
 
         void OnDeath(Object* pKiller);
         void AttackReaction(Unit* pUnit, uint32 damage_dealt, uint32 spellId = 0);
-        void HealReaction(Unit* caster, Unit* victim, SpellInfo* sp, uint32 amount);
+        void HealReaction(Unit* caster, Unit* victim, SpellInfo const* sp, uint32 amount);
         void EventAiInterfaceParamsetFinish();
         void EventChangeFaction(Unit* ForceAttackersToHateThisInstead = NULL);    /// we have to tell our current enemies to stop attacking us, we should also forget about our targets
 
@@ -397,7 +397,7 @@ class SERVER_DECL AIInterface : public IUpdatable
         void _CalcDestinationAndMove(Unit* target, float dist);
         float _CalcCombatRange(Unit* target, bool ranged);
         float _CalcDistanceFromHome();
-        uint32 _CalcThreat(uint32 damage, SpellInfo* sp, Unit* Attacker);
+        uint32 _CalcThreat(uint32 damage, SpellInfo const* sp, Unit* Attacker);
 
         void SetAllowedToEnterCombat(bool val) { m_AllowedToEnterCombat = val; }
         inline bool GetAllowedToEnterCombat(void) { return m_AllowedToEnterCombat; }
@@ -432,7 +432,7 @@ class SERVER_DECL AIInterface : public IUpdatable
         float m_CallForHelpHealth;
         uint32 m_totemspelltimer;
         uint32 m_totemspelltime;
-        SpellInfo* totemspell;
+        SpellInfo const* totemspell;
 
         uint32 m_totalMoveTime;
         inline void AddStopTime(uint32 Time) { m_moveTimer += Time; }

--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -1720,7 +1720,7 @@ void Creature::OnPushToWorld()
     }
 
     std::set<uint32>::iterator itr = creature_properties->start_auras.begin();
-    SpellInfo* sp;
+    SpellInfo const* sp;
     for (; itr != creature_properties->start_auras.end(); ++itr)
     {
         sp = sSpellCustomizations.GetSpellInfo((*itr));
@@ -2362,7 +2362,7 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
 
     // on die and an target die proc
     {
-        SpellInfo* killerspell;
+        SpellInfo const* killerspell;
         if (spellid)
             killerspell = sSpellCustomizations.GetSpellInfo(spellid);
         else killerspell = NULL;

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -49,7 +49,7 @@
 #define SPIRITWOLF              29264
 #define DANCINGRUNEWEAPON       27893
 
-uint32 Pet::GetAutoCastTypeForSpell(SpellInfo* ent)
+uint32 Pet::GetAutoCastTypeForSpell(SpellInfo const* ent)
 {
     switch (ent->custom_NameHash)
     {
@@ -135,7 +135,7 @@ void Pet::SetNameForEntry(uint32 entry)
     }
 }
 
-bool Pet::CreateAsSummon(uint32 entry, CreatureProperties const* ci, Creature* created_from_creature, Player* owner, SpellInfo* created_by_spell, uint32 type, uint32 expiretime, LocationVector* Vec, bool dismiss_old_pet)
+bool Pet::CreateAsSummon(uint32 entry, CreatureProperties const* ci, Creature* created_from_creature, Player* owner, SpellInfo const* created_by_spell, uint32 type, uint32 expiretime, LocationVector* Vec, bool dismiss_old_pet)
 {
     if (ci == nullptr || owner == nullptr)
     {
@@ -537,7 +537,7 @@ void Pet::InitializeSpells()
 {
     for (PetSpellMap::iterator itr = mSpells.begin(); itr != mSpells.end(); ++itr)
     {
-        SpellInfo* info = itr->first;
+        SpellInfo const* info = itr->first;
 
         // Check that the spell isn't passive
         if (info->IsPassive())
@@ -558,7 +558,7 @@ void Pet::InitializeSpells()
     }
 }
 
-AI_Spell* Pet::CreateAISpell(SpellInfo* info)
+AI_Spell* Pet::CreateAISpell(SpellInfo const* info)
 {
     ARCEMU_ASSERT(info != NULL);
 
@@ -807,7 +807,7 @@ void Pet::InitializeMe(bool first)
             do
             {
                 Field* f = query->Fetch();
-                SpellInfo* spell = sSpellCustomizations.GetSpellInfo(f[2].GetUInt32());
+                SpellInfo const* spell = sSpellCustomizations.GetSpellInfo(f[2].GetUInt32());
                 uint16 flags = f[3].GetUInt16();
                 if (spell != NULL && mSpells.find(spell) == mSpells.end())
                     mSpells.insert(std::make_pair(spell, flags));
@@ -1064,7 +1064,7 @@ void Pet::UpdateSpellList(bool showLearnSpells)
 
             if (spellid != 0)
             {
-                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+                SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
                 if (sp != NULL)
                     AddSpell(sp, true, showLearnSpells);
             }
@@ -1076,7 +1076,7 @@ void Pet::UpdateSpellList(bool showLearnSpells)
         uint32 spellid = creature_properties->AISpells[i];
         if (spellid != 0)
         {
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
             if (sp != NULL)
                 AddSpell(sp, true, showLearnSpells);
         }
@@ -1110,7 +1110,7 @@ void Pet::UpdateSpellList(bool showLearnSpells)
 
     if (s || s2)
     {
-        SpellInfo* sp;
+        SpellInfo const* sp;
         for (uint32 idx = 0; idx < sSkillLineAbilityStore.GetNumRows(); ++idx)
         {
             auto skill_line_ability = sSkillLineAbilityStore.LookupEntry(idx);
@@ -1143,7 +1143,7 @@ void Pet::UpdateSpellList(bool showLearnSpells)
     }
 }
 
-void Pet::AddSpell(SpellInfo* sp, bool learning, bool showLearnSpell)
+void Pet::AddSpell(SpellInfo const* sp, bool learning, bool showLearnSpell)
 {
     if (sp == NULL)
         return;
@@ -1254,7 +1254,7 @@ void Pet::AddSpell(SpellInfo* sp, bool learning, bool showLearnSpell)
         SendSpellsToOwner();
 }
 
-void Pet::SetSpellState(SpellInfo* sp, uint16 State)
+void Pet::SetSpellState(SpellInfo const* sp, uint16 State)
 {
     PetSpellMap::iterator itr = mSpells.find(sp);
     if (itr == mSpells.end())
@@ -1276,7 +1276,7 @@ void Pet::SetSpellState(SpellInfo* sp, uint16 State)
     }
 }
 
-uint16 Pet::GetSpellState(SpellInfo* sp)
+uint16 Pet::GetSpellState(SpellInfo const* sp)
 {
     PetSpellMap::iterator itr = mSpells.find(sp);
     if (itr == mSpells.end())
@@ -1324,7 +1324,7 @@ void Pet::WipeTalents()
     SendSpellsToOwner();
 }
 
-void Pet::RemoveSpell(SpellInfo* sp, bool showUnlearnSpell)
+void Pet::RemoveSpell(SpellInfo const* sp, bool showUnlearnSpell)
 {
     mSpells.erase(sp);
     std::map<uint32, AI_Spell*>::iterator itr = m_AISpellStore.find(sp->Id);
@@ -1675,7 +1675,7 @@ void Pet::UpdateAP()
     SetAttackPower(AP);
 }
 
-uint32 Pet::CanLearnSpell(SpellInfo* sp)
+uint32 Pet::CanLearnSpell(SpellInfo const* sp)
 {
     // level requirement
     if (getLevel() < sp->spellLevel)
@@ -2113,7 +2113,7 @@ void Pet::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
 
     // on die and an target die proc
     {
-        SpellInfo* killerspell;
+        SpellInfo const* killerspell;
         if (spellid)
             killerspell = sSpellCustomizations.GetSpellInfo(spellid);
         else killerspell = NULL;

--- a/src/world/Units/Creatures/Pet.h
+++ b/src/world/Units/Creatures/Pet.h
@@ -123,7 +123,7 @@ enum PetType
     WARLOCKPET  = 2,
 };
 
-typedef std::map<SpellInfo*, uint16> PetSpellMap;
+typedef std::map<SpellInfo const*, uint16> PetSpellMap;
 struct PlayerPet;
 
 
@@ -143,7 +143,7 @@ class SERVER_DECL Pet : public Creature
 
         void LoadFromDB(Player* owner, PlayerPet* pi);
         /// returns false if an error occurred. The caller MUST delete us.
-        bool CreateAsSummon(uint32 entry, CreatureProperties const* properties_, Creature* created_from_creature, Player* owner, SpellInfo* created_by_spell, uint32 type, uint32 expiretime, LocationVector* Vec = NULL, bool dismiss_old_pet = true);
+        bool CreateAsSummon(uint32 entry, CreatureProperties const* properties_, Creature* created_from_creature, Player* owner, SpellInfo const* created_by_spell, uint32 type, uint32 expiretime, LocationVector* Vec = NULL, bool dismiss_old_pet = true);
 
         void Update(unsigned long time_passed);
         void OnPushToWorld();
@@ -206,27 +206,27 @@ class SERVER_DECL Pet : public Creature
         void SetDefaultActionbar();
         void SetActionBarSlot(uint32 slot, uint32 spell) { ActionBar[slot] = spell; }
 
-        void AddSpell(SpellInfo* sp, bool learning, bool showLearnSpell = true);
-        void RemoveSpell(SpellInfo* sp, bool showUnlearnSpell = true);
+        void AddSpell(SpellInfo const* sp, bool learning, bool showLearnSpell = true);
+        void RemoveSpell(SpellInfo const* sp, bool showUnlearnSpell = true);
         void WipeTalents();
         uint32 GetUntrainCost();
-        void SetSpellState(SpellInfo* sp, uint16 State);
-        uint16 GetSpellState(SpellInfo* sp);
+        void SetSpellState(SpellInfo const* sp, uint16 State);
+        uint16 GetSpellState(SpellInfo const* sp);
         bool HasSpell(uint32 SpellID)
         {
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
             if (sp)
                 return mSpells.find(sp) != mSpells.end();
             return false;
         }
         inline void RemoveSpell(uint32 SpellID)
         {
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
             if (sp) RemoveSpell(sp);
         }
         inline void SetSpellState(uint32 SpellID, uint16 State)
         {
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
             if (sp) SetSpellState(sp, State);
         }
         inline uint16 GetSpellState(uint32 SpellID)
@@ -234,20 +234,20 @@ class SERVER_DECL Pet : public Creature
             if (SpellID == 0)
                 return DEFAULT_SPELL_STATE;
 
-            SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+            SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
             if (sp)
                 return GetSpellState(sp);
             return DEFAULT_SPELL_STATE;
         }
 
-        AI_Spell* CreateAISpell(SpellInfo* info);
+        AI_Spell* CreateAISpell(SpellInfo const* info);
         inline PetSpellMap* GetSpells() { return &mSpells; }
         inline bool IsSummonedPet() { return Summon; }
 
         void SetAutoCastSpell(AI_Spell* sp);
         void Rename(std::string NewName);
         inline std::string & GetName() { return m_name; }
-        uint32 CanLearnSpell(SpellInfo* sp);
+        uint32 CanLearnSpell(SpellInfo const* sp);
         void UpdateSpellList(bool showLearnSpells = true);
 
         // talents
@@ -298,7 +298,7 @@ class SERVER_DECL Pet : public Creature
         std::string m_name;
         HappinessState GetHappinessState();
         void SetNameForEntry(uint32 entry);
-        uint32 GetAutoCastTypeForSpell(SpellInfo* ent);
+        uint32 GetAutoCastTypeForSpell(SpellInfo const* ent);
         void SafeDelete();
 
     std::list<AI_Spell*> m_autoCastSpells[AUTOCAST_EVENT_COUNT];

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -1465,7 +1465,7 @@ void Player::_EventCharmAttack()
             }
             else
             {
-                SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(currentCharm->GetOnMeleeSpell());
+                SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(currentCharm->GetOnMeleeSpell());
                 currentCharm->SetOnMeleeSpell(0);
                 Spell* spell = sSpellFactoryMgr.NewSpell(currentCharm, spellInfo, true, NULL);
                 SpellCastTargets targets;
@@ -2195,7 +2195,7 @@ void Player::_SavePetSpells(QueryBuffer* buf)
 
 void Player::AddSummonSpell(uint32 Entry, uint32 SpellID)
 {
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(SpellID);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(SpellID);
     std::map<uint32, std::set<uint32> >::iterator itr = SummonSpells.find(Entry);
     if (itr == SummonSpells.end())
         SummonSpells[Entry].insert(SpellID);
@@ -2389,7 +2389,7 @@ void Player::addSpell(uint32 spell_id)
 
     // Add the skill line for this spell if we don't already have it.
     auto skill_line_ability = objmgr.GetSpellSkill(spell_id);
-    SpellInfo* spell = sSpellCustomizations.GetSpellInfo(spell_id);
+    SpellInfo const* spell = sSpellCustomizations.GetSpellInfo(spell_id);
     if (skill_line_ability && !_HasSkillLine(skill_line_ability->skilline))
     {
         auto skill_line = sSkillLineStore.LookupEntry(skill_line_ability->skilline);
@@ -2998,7 +2998,7 @@ void Player::_SaveQuestLogEntry(QueryBuffer* buf)
     }
 }
 
-bool Player::canCast(SpellInfo* m_spellInfo)
+bool Player::canCast(SpellInfo const* m_spellInfo)
 {
     if (m_spellInfo->EquippedItemClass != 0)
     {
@@ -4355,7 +4355,7 @@ void Player::_ApplyItemMods(Item* item, int16 slot, bool apply, bool justdrokedo
                         if (Set->itemscount == item_set_entry->itemscount[x])
                         {
                             //cast new spell
-                            SpellInfo* info = sSpellCustomizations.GetSpellInfo(item_set_entry->SpellID[x]);
+                            SpellInfo const* info = sSpellCustomizations.GetSpellInfo(item_set_entry->SpellID[x]);
                             Spell* spell = sSpellFactoryMgr.NewSpell(this, info, true, NULL);
                             SpellCastTargets targets;
                             targets.m_unitTarget = this->GetGUID();
@@ -4623,7 +4623,7 @@ void Player::_ApplyItemMods(Item* item, int16 slot, bool apply, bool justdrokedo
         // Apply all enchantment bonuses
         item->ApplyEnchantmentBonuses();
 
-        SpellInfo* spells;
+        SpellInfo const* spells;
         for (uint8 k = 0; k < 5; ++k)
         {
             if (item->GetItemProperties()->Spells[k].Id == 0)
@@ -4662,7 +4662,7 @@ void Player::_ApplyItemMods(Item* item, int16 slot, bool apply, bool justdrokedo
         {
             if (item->GetItemProperties()->Spells[k].Trigger == ON_EQUIP)
             {
-                SpellInfo* spells = sSpellCustomizations.GetSpellInfo(item->GetItemProperties()->Spells[k].Id);
+                SpellInfo const* spells = sSpellCustomizations.GetSpellInfo(item->GetItemProperties()->Spells[k].Id);
                 if (spells != nullptr)
                 {
                     if (spells->RequiredShapeShift)
@@ -4710,13 +4710,13 @@ void Player::BuildPlayerRepop()
 
     if (getRace() == RACE_NIGHTELF)
     {
-        SpellInfo* inf = sSpellCustomizations.GetSpellInfo(9036);
+        SpellInfo const* inf = sSpellCustomizations.GetSpellInfo(9036);
         Spell* sp = sSpellFactoryMgr.NewSpell(this, inf, true, NULL);
         sp->prepare(&tgt);
     }
     else
     {
-        SpellInfo* inf = sSpellCustomizations.GetSpellInfo(8326);
+        SpellInfo const* inf = sSpellCustomizations.GetSpellInfo(8326);
         Spell* sp = sSpellFactoryMgr.NewSpell(this, inf, true, NULL);
         sp->prepare(&tgt);
     }
@@ -6290,7 +6290,7 @@ uint32 Player::CalcTalentResetCost(uint32 resetnum)
 
 int32 Player::CanShootRangedWeapon(uint32 spellid, Unit* target, bool autoshot)
 {
-    SpellInfo* spell_info = sSpellCustomizations.GetSpellInfo(spellid);
+    SpellInfo const* spell_info = sSpellCustomizations.GetSpellInfo(spellid);
     if (spell_info == nullptr)
         return -1;
 
@@ -6512,7 +6512,7 @@ bool Player::HasSpellwithNameHash(uint32 hash)
     {
         it = iter++;
         uint32 SpellID = *it;
-        SpellInfo* e = sSpellCustomizations.GetSpellInfo(SpellID);
+        SpellInfo const* e = sSpellCustomizations.GetSpellInfo(SpellID);
         if (e->custom_NameHash == hash)
             return true;
     }
@@ -6532,7 +6532,7 @@ void Player::removeSpellByHashName(uint32 hash)
     {
         it = iter++;
         uint32 SpellID = *it;
-        SpellInfo* e = sSpellCustomizations.GetSpellInfo(SpellID);
+        SpellInfo const* e = sSpellCustomizations.GetSpellInfo(SpellID);
         if (e->custom_NameHash == hash)
         {
             if (info->spell_list.find(e->Id) != info->spell_list.end())
@@ -6550,7 +6550,7 @@ void Player::removeSpellByHashName(uint32 hash)
     {
         it = iter++;
         uint32 SpellID = *it;
-        SpellInfo* e = sSpellCustomizations.GetSpellInfo(SpellID);
+        SpellInfo const* e = sSpellCustomizations.GetSpellInfo(SpellID);
         if (e->custom_NameHash == hash)
         {
             if (info->spell_list.find(e->Id) != info->spell_list.end())
@@ -6706,8 +6706,8 @@ void Player::ResetDualWield2H()
 void Player::Reset_Talents()
 {
     uint8 playerClass = getClass();
-    SpellInfo* spellInfo;
-    SpellInfo* spellInfo2;
+    SpellInfo const* spellInfo;
+    SpellInfo const* spellInfo2;
 
     // Loop through all talents.
     for (uint32 i = 0; i < sTalentStore.GetNumRows(); ++i)
@@ -7582,7 +7582,7 @@ void Player::ClearCooldownForSpell(uint32 spell_id)
     data << uint64_t(GetGUID());
     GetSession()->SendPacket(&data);
 
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spell_id);
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spell_id);
     if (spellInfo == nullptr)
     {
         return;
@@ -9469,7 +9469,7 @@ void Player::CompleteLoading()
 {
     // cast passive initial spells      -- grep note: these shouldn't require plyr to be in world
     SpellSet::iterator itr;
-    SpellInfo* info;
+    SpellInfo const* info;
     SpellCastTargets targets;
     targets.m_unitTarget = this->GetGUID();
     targets.m_targetMask = TARGET_FLAG_UNIT;
@@ -9504,7 +9504,7 @@ void Player::CompleteLoading()
 
     for (; i != loginauras.end(); ++i)
     {
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo((*i).id);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo((*i).id);
 
         if (sp->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET)
             continue; //do not load auras that only exist while pet exist. We should recast these when pet is created anyway
@@ -10020,7 +10020,7 @@ void Player::SetShapeShift(uint8 ss)
 
     // apply any talents/spells we have that apply only in this form.
     std::set<uint32>::iterator itr;
-    SpellInfo* sp;
+    SpellInfo const* sp;
     Spell* spe;
     SpellCastTargets t(GetGUID());
 
@@ -10674,7 +10674,7 @@ void Player::_AdvanceSkillLine(uint32 SkillLine, uint32 Count /* = 1 */)
 
 void Player::_LearnSkillSpells(uint32 SkillLine, uint32 curr_sk)
 {
-    SpellInfo* sp;
+    SpellInfo const* sp;
     uint32 removeSpellId = 0;
     for (uint32 idx = 0; idx < sSkillLineAbilityStore.GetNumRows(); ++idx)
     {
@@ -10690,7 +10690,7 @@ void Player::_LearnSkillSpells(uint32 SkillLine, uint32 curr_sk)
             {
                 // Player is able to learn this spell; check if they already have it, or a higher rank (shouldn't, but just in case)
                 bool addThisSpell = true;
-                SpellInfo* se;
+                SpellInfo const* se;
                 for (SpellSet::iterator itr = mSpells.begin(); itr != mSpells.end(); ++itr)
                 {
                     se = sSpellCustomizations.GetSpellInfo(*itr);
@@ -11163,7 +11163,7 @@ void Player::EventSummonPet(Pet* new_pet)
     {
         it = iter++;
         uint32 SpellID = *it;
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(SpellID);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(SpellID);
         if (spellInfo->custom_c_is_flags & SPELL_FLAG_IS_CASTED_ON_PET_SUMMON_PET_OWNER)
         {
             this->RemoveAllAuras(SpellID, this->GetGUID());   //this is required since unit::addaura does not check for talent stacking
@@ -11199,7 +11199,7 @@ void Player::EventDismissPet()
 
 void Player::AddShapeShiftSpell(uint32 id)
 {
-    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(id);
+    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(id);
     mShapeShiftSpells.insert(id);
 
     if (sp->RequiredShapeShift && ((uint32)1 << (GetShapeShift() - 1)) & sp->RequiredShapeShift)
@@ -11229,7 +11229,7 @@ void Player::UpdatePotionCooldown()
         {
             if (proto->Spells[i].Id && proto->Spells[i].Trigger == USE)
             {
-                SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(proto->Spells[i].Id);
+                SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(proto->Spells[i].Id);
                 if (spellInfo != NULL)
                 {
                     Cooldown_AddItem(proto, i);
@@ -11246,7 +11246,7 @@ bool Player::HasSpellWithAuraNameAndBasePoints(uint32 auraname, uint32 basepoint
 {
     for (SpellSet::iterator itr = mSpells.begin(); itr != mSpells.end(); ++itr)
     {
-        SpellInfo *sp = sSpellCustomizations.GetSpellInfo(*itr);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(*itr);
 
         for (uint8 i = 0; i < 3; ++i)
         {
@@ -11312,7 +11312,7 @@ void Player::_Cooldown_Add(uint32 Type, uint32 Misc, uint32 Time, uint32 SpellId
     LogDebugFlag(LF_SPELL, "Cooldown added cooldown for type %u misc %u time %u item %u spell %u", Type, Misc, Time - getMSTime(), ItemId, SpellId);
 }
 
-void Player::Cooldown_Add(SpellInfo* pSpell, Item* pItemCaster)
+void Player::Cooldown_Add(SpellInfo const* pSpell, Item* pItemCaster)
 {
     uint32 mstime = getMSTime();
     int32 cool_time;
@@ -11338,7 +11338,7 @@ void Player::Cooldown_Add(SpellInfo* pSpell, Item* pItemCaster)
     }
 }
 
-void Player::Cooldown_AddStart(SpellInfo* pSpell)
+void Player::Cooldown_AddStart(SpellInfo const* pSpell)
 {
     if (pSpell->StartRecoveryTime == 0)
         return;
@@ -11369,7 +11369,7 @@ void Player::Cooldown_AddStart(SpellInfo* pSpell)
     }
 }
 
-bool Player::Cooldown_CanCast(SpellInfo* pSpell)
+bool Player::Cooldown_CanCast(SpellInfo const* pSpell)
 {
     PlayerCooldownMap::iterator itr;
     uint32 mstime = getMSTime();
@@ -12162,7 +12162,7 @@ void Player::CalcExpertise()
 {
     int32 modifier = 0;
     int32 val = 0;
-    SpellInfo* entry = NULL;
+    SpellInfo const* entry = NULL;
 
 #if VERSION_STRING != Classic
     setUInt32Value(PLAYER_EXPERTISE, 0);
@@ -12535,7 +12535,7 @@ void Player::LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
         {
             addSpell(spellid);
 
-            SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
 
             if (rank > 0)
             {
@@ -12694,7 +12694,7 @@ void Player::LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
         {
             addSpell(spellid);
 
-            SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
+            SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellid);
             if (spellInfo == nullptr)
             {
                 LOG_ERROR("Your table `spells` miss skill spell %u!", spellid);
@@ -12712,7 +12712,7 @@ void Player::LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
                     removeSpell(respellid, false, false, 0);
                     RemoveAura(respellid);
 
-                    SpellInfo* spellInfoReq = sSpellCustomizations.GetSpellInfo(respellid);
+                    SpellInfo const* spellInfoReq = sSpellCustomizations.GetSpellInfo(respellid);
                     if (spellInfoReq == nullptr)
                     {
                         LOG_ERROR("Your table `spells` miss skill spell %u!", spellid);
@@ -12789,7 +12789,7 @@ void Player::SendPreventSchoolCast(uint32 SpellSchool, uint32 unTimeMs)
     {
         uint32 SpellId = (*sitr);
 
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(SpellId);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(SpellId);
 
         if (!spellInfo)
         {
@@ -13364,7 +13364,7 @@ void Player::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
 
     // on die and an target die proc
     {
-        SpellInfo* killerspell;
+        SpellInfo const* killerspell;
         if (spellid)
             killerspell = sSpellCustomizations.GetSpellInfo(spellid);
         else killerspell = NULL;
@@ -13431,7 +13431,7 @@ void Player::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
 
             if (self_res_spell == 0 && bReincarnation)
             {
-                SpellInfo* m_reincarnSpellInfo = sSpellCustomizations.GetSpellInfo(20608);
+                SpellInfo const* m_reincarnSpellInfo = sSpellCustomizations.GetSpellInfo(20608);
                 if (Cooldown_CanCast(m_reincarnSpellInfo))
                 {
 
@@ -13463,7 +13463,7 @@ void Player::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
     //check for spirit of Redemption
     if (HasSpell(20711))
     {
-        SpellInfo* sorInfo = sSpellCustomizations.GetSpellInfo(27827);
+        SpellInfo const* sorInfo = sSpellCustomizations.GetSpellInfo(27827);
 
         if (sorInfo != NULL)
         {
@@ -13967,7 +13967,7 @@ bool Player::LoadSpells(QueryResult* result)
 
         uint32 spellid = fields[0].GetUInt32();
 
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
         if (sp != NULL)
             mSpells.insert(spellid);
 
@@ -14026,7 +14026,7 @@ bool Player::LoadDeletedSpells(QueryResult* result)
 
         uint32 spellid = fields[0].GetUInt32();
 
-        SpellInfo* sp = sSpellCustomizations.GetSpellInfo(spellid);
+        SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(spellid);
         if (sp != NULL)
             mDeletedSpells.insert(spellid);
 

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -357,7 +357,7 @@ typedef std::map<uint32, ScriptOverrideList* >      SpellOverrideMap;
 typedef std::map<uint32, uint32>                    SpellOverrideExtraAuraMap;
 typedef std::map<uint32, FactionReputation*>        ReputationMap;
 typedef std::map<uint32, uint64>                    SoloSpells;
-typedef std::map<SpellInfo*, std::pair<uint32, uint32> >StrikeSpellMap;
+typedef std::map<SpellInfo const*, std::pair<uint32, uint32> >StrikeSpellMap;
 typedef std::map<uint32, OnHitSpell >               StrikeSpellDmgMap;
 typedef std::map<uint32, PlayerSkill>               SkillMap;
 typedef std::set<Player**>                          ReferenceSet;
@@ -559,10 +559,10 @@ public:
 
     public:
         void SetLastPotion(uint32 itemid) { m_lastPotionId = itemid; }
-        void Cooldown_AddStart(SpellInfo* pSpell);
-        void Cooldown_Add(SpellInfo* pSpell, Item* pItemCaster);
+        void Cooldown_AddStart(SpellInfo const* pSpell);
+        void Cooldown_Add(SpellInfo const* pSpell, Item* pItemCaster);
         void Cooldown_AddItem(ItemProperties const* pProto, uint32 x);
-        bool Cooldown_CanCast(SpellInfo* pSpell);
+        bool Cooldown_CanCast(SpellInfo const* pSpell);
         bool Cooldown_CanCast(ItemProperties const* pProto, uint32 x);
         void UpdatePotionCooldown();
         bool HasSpellWithAuraNameAndBasePoints(uint32 auraname, uint32 basepoints);
@@ -859,11 +859,11 @@ public:
         void SendPreventSchoolCast(uint32 SpellSchool, uint32 unTimeMs);
 
         /// PLEASE DO NOT INLINE!
-        void AddOnStrikeSpell(SpellInfo* sp, uint32 delay)
+        void AddOnStrikeSpell(SpellInfo const* sp, uint32 delay)
         {
-            m_onStrikeSpells.insert(std::map<SpellInfo*, std::pair<uint32, uint32>>::value_type(sp, std::make_pair(delay, 0)));
+            m_onStrikeSpells.insert(std::map<SpellInfo const*, std::pair<uint32, uint32>>::value_type(sp, std::make_pair(delay, 0)));
         }
-        void RemoveOnStrikeSpell(SpellInfo* sp)
+        void RemoveOnStrikeSpell(SpellInfo const* sp)
         {
             m_onStrikeSpells.erase(sp);
         }
@@ -1221,7 +1221,7 @@ public:
         uint32 GetBlockDamageReduction();
         void ApplyFeralAttackPower(bool apply, Item* item = NULL);
 
-        bool canCast(SpellInfo* m_spellInfo);
+        bool canCast(SpellInfo const* m_spellInfo);
 
         float GetSpellCritFromSpell() { return m_spellcritfromspell; }
         float GetHitFromSpell() { return m_hitfromspell; }
@@ -1351,7 +1351,7 @@ public:
         uint32 m_AutoShotAttackTimer;
         bool m_onAutoShot;
         uint64 m_AutoShotTarget;
-        SpellInfo* m_AutoShotSpell;
+        SpellInfo const* m_AutoShotSpell;
         void _InitialReputation();
         void EventActivateGameObject(GameObject* obj);
         void EventDeActivateGameObject(GameObject* obj);
@@ -1586,7 +1586,7 @@ public:
         void ApplyLevelInfo(LevelInfo* Info, uint32 Level);
         void BroadcastMessage(const char* Format, ...);
         std::map<uint32, std::set<uint32> > SummonSpells;
-        std::map<uint32, std::map<SpellInfo*, uint16>*> PetSpells;
+        std::map<uint32, std::map<SpellInfo const*, uint16>*> PetSpells;
         void AddSummonSpell(uint32 Entry, uint32 SpellID);
         void RemoveSummonSpell(uint32 Entry, uint32 SpellID);
         std::set<uint32>* GetSummonSpells(uint32 Entry);
@@ -1969,7 +1969,7 @@ public:
         void SummonRequest(uint32 Requestor, uint32 ZoneID, uint32 MapID, uint32 InstanceID, const LocationVector & Position);
 
         bool m_deathVision;
-        SpellInfo* last_heal_spell;
+        SpellInfo const* last_heal_spell;
         LocationVector m_sentTeleportPosition;
 
         bool InBattleground() const { return m_bgQueueInstanceId != 0; }

--- a/src/world/Units/Stats.cpp
+++ b/src/world/Units/Stats.cpp
@@ -534,7 +534,7 @@ uint32 GainStat(uint16 level, uint8 playerclass, uint8 Stat)
     return gain;
 }
 
-uint32 CalculateDamage(Unit* pAttacker, Unit* pVictim, uint32 weapon_damage_type, uint32* spellgroup, SpellInfo* ability)   // spellid is used only for 2-3 spells, that have AP bonus
+uint32 CalculateDamage(Unit* pAttacker, Unit* pVictim, uint32 weapon_damage_type, const uint32* spellgroup, SpellInfo const* ability)   // spellid is used only for 2-3 spells, that have AP bonus
 {
     ///\todo Some awesome formula to determine how much damage to deal consider this is melee damage weapon_damage_type: 0 = melee, 1 = offhand(dualwield), 2 = ranged
 

--- a/src/world/Units/Stats.h
+++ b/src/world/Units/Stats.h
@@ -38,7 +38,7 @@ enum Stats
 SERVER_DECL uint32 getConColor(uint16 AttackerLvl, uint16 VictimLvl);
 SERVER_DECL uint32 CalculateXpToGive(Unit* pVictim, Unit* pAttacker);
 SERVER_DECL uint32 CalculateStat(uint16 level, double a3, double a2, double a1, double a0);
-SERVER_DECL uint32 CalculateDamage(Unit* pAttacker, Unit* pVictim, uint32 weapon_damage_type, uint32* spellgroup, SpellInfo* ability);
+SERVER_DECL uint32 CalculateDamage(Unit* pAttacker, Unit* pVictim, uint32 weapon_damage_type, const uint32* spellgroup, SpellInfo const* ability);
 SERVER_DECL uint32 GainStat(uint16 level, uint8 playerclass, uint8 Stat);
 SERVER_DECL bool isEven(int num);
 

--- a/src/world/Units/Summons/TotemSummon.cpp
+++ b/src/world/Units/Summons/TotemSummon.cpp
@@ -127,8 +127,8 @@ void TotemSummon::SetupSpells()
     if (GetOwner() == NULL)
         return;
 
-    SpellInfo* creatorspell = sSpellCustomizations.GetSpellInfo(GetCreatedBySpell());
-    SpellInfo* TotemSpell = sSpellCustomizations.GetSpellInfo(creature_properties->AISpells[0]);
+    SpellInfo const* creatorspell = sSpellCustomizations.GetSpellInfo(GetCreatedBySpell());
+    SpellInfo const* TotemSpell = sSpellCustomizations.GetSpellInfo(creature_properties->AISpells[0]);
 
     if (TotemSpell == NULL)
     {

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -1256,7 +1256,7 @@ void Unit::GiveGroupXP(Unit* pVictim, Player* PlayerInGroup)
     }
 }
 
-uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool is_triggered, uint32 dmg, uint32 abs, uint32 weapon_damage_type)
+uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo const* CastingSpell, bool is_triggered, uint32 dmg, uint32 abs, uint32 weapon_damage_type)
 {
     uint32 resisted_dmg = 0;
     ++m_procCounter;
@@ -1316,14 +1316,14 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
 
         uint32 spellId = spell_proc->mSpell->Id;
 
-        SpellInfo* spe = spell_proc->mSpell;
+        SpellInfo const* spe = spell_proc->mSpell;
 
         uint32 origId;
         if (spell_proc->mOrigSpell != NULL)
             origId = spell_proc->mOrigSpell->Id;
         else
             origId = 0;
-        SpellInfo* ospinfo = sSpellCustomizations.GetSpellInfo(origId);  //no need to check if exists or not since we were not able to register this trigger if it would not exist :P
+        SpellInfo const* ospinfo = sSpellCustomizations.GetSpellInfo(origId);  //no need to check if exists or not since we were not able to register this trigger if it would not exist :P
 
         //this requires some specific spell check,not yet implemented
         //this sucks and should be rewrote
@@ -1663,7 +1663,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                         continue;
                     if (CastingSpell->School != SCHOOL_FIRE)
                         continue;
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);   //we already modified this spell on server loading so it must exist
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);   //we already modified this spell on server loading so it must exist
                     auto spell_duration = sSpellDurationStore.LookupEntry(spellInfo->DurationIndex);
                     uint32 tickcount = GetDuration(spell_duration) / spellInfo->EffectAmplitude[0];
                     dmg_overwrite[0] = ospinfo->EffectBasePoints[0] * dmg / (100 * tickcount);
@@ -1745,7 +1745,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                     Unit* new_caster = victim;
                     if (new_caster && new_caster->isAlive())
                     {
-                        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);   //we already modified this spell on server loading so it must exist
+                        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);   //we already modified this spell on server loading so it must exist
                         Spell* spell = sSpellFactoryMgr.NewSpell(new_caster, spellInfo, true, NULL);
                         SpellCastTargets targets;
                         targets.setDestination(GetPosition());
@@ -1860,7 +1860,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                     }
                     if (!amount)
                         continue;
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
                     Spell* spell = sSpellFactoryMgr.NewSpell(this, spellInfo, true, NULL);
                     spell->SetUnitTarget(this);
                     spell->Heal(amount * (ospinfo->EffectBasePoints[0] + 1) / 100);
@@ -1983,8 +1983,8 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                 {
                     if (!IsPlayer() || !dmg)
                         continue;
-                    SpellInfo* parentproc = sSpellCustomizations.GetSpellInfo(origId);
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+                    SpellInfo const* parentproc = sSpellCustomizations.GetSpellInfo(origId);
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
                     if (!parentproc || !spellInfo)
                         continue;
                     int32 val = parentproc->EffectBasePoints[0] + 1;
@@ -2119,10 +2119,10 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                         continue;
                     //!! The weird thing is that we need the spell that triggered this enchant spell in order to output logs ..we are using oldspell info too
                     //we have to recalc the value of this spell
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(origId);
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(origId);
                     uint32 AP_owerride = spellInfo->EffectBasePoints[0] + 1;
                     uint32 dmg2 = static_cast<Player*>(this)->GetMainMeleeDamage(AP_owerride);
-                    SpellInfo* sp_for_the_logs = sSpellCustomizations.GetSpellInfo(spellId);
+                    SpellInfo const* sp_for_the_logs = sSpellCustomizations.GetSpellInfo(spellId);
                     Strike(victim, MELEE, sp_for_the_logs, dmg2, 0, 0, true, false);
                     Strike(victim, MELEE, sp_for_the_logs, dmg2, 0, 0, true, false);
                     spellId = 33010; // WF animation
@@ -2298,7 +2298,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                         continue;
                     if (CastingSpell->custom_NameHash != SPELL_HASH_FLASH_OF_LIGHT && CastingSpell->custom_NameHash != SPELL_HASH_HOLY_LIGHT)
                         continue;
-                    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(54203);
+                    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(54203);
                     auto spell_duration = sSpellDurationStore.LookupEntry(spellInfo->DurationIndex);
                     uint32 tickcount = GetDuration(spell_duration) / spellInfo->EffectAmplitude[0];
                     dmg_overwrite[0] = ospinfo->EffectBasePoints[0] * dmg / (100 * tickcount);
@@ -2867,7 +2867,7 @@ void Unit::HandleProcDmgShield(uint32 flag, Unit* attacker)
             }
             else
             {
-                SpellInfo*	ability = sSpellCustomizations.GetSpellInfo((*i2).m_spellId);
+                SpellInfo const*	ability = sSpellCustomizations.GetSpellInfo((*i2).m_spellId);
                 this->Strike(attacker, RANGED, ability, 0, 0, (*i2).m_damage, true, true);  //can dmg shields miss at all ?
             }
         }
@@ -3043,7 +3043,7 @@ void Unit::RegeneratePower(bool isinterrupted)
     }
 }
 
-void Unit::CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInfo* ability, float ArmorPctReduce)
+void Unit::CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInfo const* ability, float ArmorPctReduce)
 {
     float AverageResistance = 0.0f;
     float ArmorReduce;
@@ -3103,7 +3103,7 @@ void Unit::CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInf
     }
 }
 
-uint32 Unit::GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability)
+uint32 Unit::GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, SpellInfo const* ability)
 {
     Item* it = NULL;
     float hitchance = 0.0f;
@@ -3315,7 +3315,7 @@ uint32 Unit::GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, Spel
     return roll_results[r];
 }
 
-void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, int32 add_damage, int32 pct_dmg_mod, uint32 exclusive_damage, bool disable_proc, bool skip_hit_check, bool force_crit)
+void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo const* ability, int32 add_damage, int32 pct_dmg_mod, uint32 exclusive_damage, bool disable_proc, bool skip_hit_check, bool force_crit)
 {
     //////////////////////////////////////////////////////////////////////////////////////////
     //Unacceptable Cases Processing
@@ -4165,7 +4165,7 @@ void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, 
             Spell* cspell;
 
             // Loop on hit spells, and strike with those.
-            for (std::map<SpellInfo*, std::pair<uint32, uint32>>::iterator itr = static_cast<Player*>(this)->m_onStrikeSpells.begin();
+            for (std::map<SpellInfo const*, std::pair<uint32, uint32>>::iterator itr = static_cast<Player*>(this)->m_onStrikeSpells.begin();
                  itr != static_cast<Player*>(this)->m_onStrikeSpells.end(); ++itr)
             {
                 if (itr->second.first)
@@ -4644,7 +4644,7 @@ void Unit::AddAura(Aura* aur)
             if (IsPlayer() && static_cast<Player*>(this)->AuraStackCheat)
                 maxStack = 999;
 
-            SpellInfo* info = aur->GetSpellInfo();
+            SpellInfo const* info = aur->GetSpellInfo();
             //uint32 flag3 = aur->GetSpellProto()->Flags3;
 
             AuraCheckResponse acr;
@@ -4752,7 +4752,7 @@ void Unit::AddAura(Aura* aur)
                                         {
                                             if (Entry->type[c] && Entry->spell[c])
                                             {
-                                                SpellInfo* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
+                                                SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
                                                 if (sp && sp->custom_c_is_flags & SPELL_FLAG_IS_POISON)
                                                 {
                                                     switch (sp->custom_NameHash)
@@ -4785,7 +4785,7 @@ void Unit::AddAura(Aura* aur)
                                             {
                                                 if (Entry->type[c] && Entry->spell[c])
                                                 {
-                                                    SpellInfo* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
+                                                    SpellInfo const* sp = sSpellCustomizations.GetSpellInfo(Entry->spell[c]);
                                                     if (sp && sp->custom_c_is_flags & SPELL_FLAG_IS_POISON)
                                                     {
                                                         switch (sp->custom_NameHash)
@@ -5251,7 +5251,7 @@ void Unit::RemoveAllAuraFromSelfType2(uint32 auratype, uint32 butskip_hash)
     for (uint32 x = MAX_TOTAL_AURAS_START; x < MAX_TOTAL_AURAS_END; x++)
         if (m_auras[x])
         {
-            SpellInfo* proto = m_auras[x]->GetSpellInfo();
+            SpellInfo const* proto = m_auras[x]->GetSpellInfo();
             if (proto->custom_BGR_one_buff_from_caster_on_self == auratype && proto->custom_NameHash != butskip_hash && m_auras[x]->GetCaster() == this)
                 RemoveAura(m_auras[x]->GetSpellId());//remove all morph auras containing to this spell (like wolf morph also gives speed)
         }
@@ -5364,7 +5364,7 @@ void Unit::castSpell(Spell* pSpell)
     pLastSpell = pSpell->GetSpellInfo();
 }
 
-int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg, bool isdot)
+int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellInfo const* spellInfo, int32 base_dmg, bool isdot)
 {
     float plus_damage = 0.0f;
     Unit* caster = this;
@@ -5457,7 +5457,7 @@ int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg
     return static_cast<int32>(plus_damage);
 }
 
-float Unit::CalcSpellDamageReduction(Unit* victim, SpellInfo* spell, float res)
+float Unit::CalcSpellDamageReduction(Unit* victim, SpellInfo const* spell, float res)
 {
     float reduced_damage = 0;
     reduced_damage += static_cast<float>(victim->DamageTakenMod[spell->School]);
@@ -5906,7 +5906,7 @@ bool Unit::HasVisialPosAurasOfNameHashWithCaster(uint32 namehash, Unit* caster)
     return false;
 }
 
-uint8 Unit::CastSpell(Unit* Target, SpellInfo* Sp, bool triggered)
+uint8 Unit::CastSpell(Unit* Target, SpellInfo const* Sp, bool triggered)
 {
     if (Sp == NULL)
         return SPELL_FAILED_UNKNOWN;
@@ -5928,13 +5928,13 @@ uint8 Unit::CastSpell(Unit* Target, SpellInfo* Sp, bool triggered)
 
 uint8 Unit::CastSpell(Unit* Target, uint32 SpellID, bool triggered)
 {
-    SpellInfo* ent = sSpellCustomizations.GetSpellInfo(SpellID);
+    SpellInfo const* ent = sSpellCustomizations.GetSpellInfo(SpellID);
     if (ent == NULL) return SPELL_FAILED_UNKNOWN;
 
     return CastSpell(Target, ent, triggered);
 }
 
-uint8 Unit::CastSpell(uint64 targetGuid, SpellInfo* Sp, bool triggered)
+uint8 Unit::CastSpell(uint64 targetGuid, SpellInfo const* Sp, bool triggered)
 {
     if (Sp == NULL)
         return SPELL_FAILED_UNKNOWN;
@@ -5946,7 +5946,7 @@ uint8 Unit::CastSpell(uint64 targetGuid, SpellInfo* Sp, bool triggered)
 
 uint8 Unit::CastSpell(uint64 targetGuid, uint32 SpellID, bool triggered)
 {
-    SpellInfo* ent = sSpellCustomizations.GetSpellInfo(SpellID);
+    SpellInfo const* ent = sSpellCustomizations.GetSpellInfo(SpellID);
     if (ent == NULL) return SPELL_FAILED_UNKNOWN;
 
     return CastSpell(targetGuid, ent, triggered);
@@ -5957,7 +5957,7 @@ uint8 Unit::CastSpell(Unit* Target, uint32 SpellID, uint32 forced_basepoints, bo
     return CastSpell(Target, sSpellCustomizations.GetSpellInfo(SpellID), forced_basepoints, triggered);
 }
 
-uint8 Unit::CastSpell(Unit* Target, SpellInfo* Sp, uint32 forced_basepoints, bool triggered)
+uint8 Unit::CastSpell(Unit* Target, SpellInfo const* Sp, uint32 forced_basepoints, bool triggered)
 {
     if (Sp == NULL)
         return SPELL_FAILED_UNKNOWN;
@@ -5983,7 +5983,7 @@ uint8 Unit::CastSpell(Unit* Target, uint32 SpellID, uint32 forced_basepoints, in
     return CastSpell(Target, sSpellCustomizations.GetSpellInfo(SpellID), forced_basepoints, charges, triggered);
 }
 
-uint8 Unit::CastSpell(Unit* Target, SpellInfo* Sp, uint32 forced_basepoints, int32 charges, bool triggered)
+uint8 Unit::CastSpell(Unit* Target, SpellInfo const* Sp, uint32 forced_basepoints, int32 charges, bool triggered)
 {
     if (Sp == NULL)
         return SPELL_FAILED_UNKNOWN;
@@ -6005,7 +6005,7 @@ uint8 Unit::CastSpell(Unit* Target, SpellInfo* Sp, uint32 forced_basepoints, int
     return newSpell->prepare(&targets);
 }
 
-void Unit::CastSpellAoF(LocationVector lv, SpellInfo* Sp, bool triggered)
+void Unit::CastSpellAoF(LocationVector lv, SpellInfo const* Sp, bool triggered)
 {
     if (Sp == nullptr)
         return;
@@ -6063,7 +6063,7 @@ uint32 Unit::FindAuraCountByHash(uint32 HashName, uint32 maxcount)
     return count;
 }
 
-AuraCheckResponse Unit::AuraCheck(SpellInfo* proto, Object* caster)
+AuraCheckResponse Unit::AuraCheck(SpellInfo const* proto, Object* caster)
 {
     AuraCheckResponse resp;
 
@@ -6074,7 +6074,7 @@ AuraCheckResponse Unit::AuraCheck(SpellInfo* proto, Object* caster)
     uint32 name_hash = proto->custom_NameHash;
     uint32 rank = proto->custom_RankNumber;
     Aura* aura;
-    SpellInfo* aura_sp;
+    SpellInfo const* aura_sp;
 
     // look for spells with same namehash
     for (uint32 x = MAX_TOTAL_AURAS_START; x < MAX_TOTAL_AURAS_END; x++)
@@ -6117,10 +6117,10 @@ AuraCheckResponse Unit::AuraCheck(SpellInfo* proto, Object* caster)
     return resp;
 }
 
-AuraCheckResponse Unit::AuraCheck(SpellInfo* proto, Aura* aur, Object* caster)
+AuraCheckResponse Unit::AuraCheck(SpellInfo const* proto, Aura* aur, Object* caster)
 {
     AuraCheckResponse resp;
-    SpellInfo* aura_sp = aur->GetSpellInfo();
+    SpellInfo const* aura_sp = aur->GetSpellInfo();
 
     // no error for now
     resp.Error = AURA_CHECK_RESULT_NONE;
@@ -6254,7 +6254,7 @@ void Unit::RemoveAurasByInterruptFlagButSkip(uint32 flag, uint32 skip)
                             continue;
 
                         //this spell gets removed only when casting smite
-                        SpellInfo* spi = sSpellCustomizations.GetSpellInfo(skip);
+                        SpellInfo const* spi = sSpellCustomizations.GetSpellInfo(skip);
                         if (spi && spi->custom_NameHash != SPELL_HASH_SMITE)
                             continue;
                     }
@@ -6265,7 +6265,7 @@ void Unit::RemoveAurasByInterruptFlagButSkip(uint32 flag, uint32 skip)
                             continue;
                         if (m_currentSpell && m_currentSpell->GetSpellInfo()->custom_NameHash == SPELL_HASH_INCINERATE)
                             continue;
-                        SpellInfo* spi = sSpellCustomizations.GetSpellInfo(skip);
+                        SpellInfo const* spi = sSpellCustomizations.GetSpellInfo(skip);
                         if (spi && spi->custom_NameHash != SPELL_HASH_SHADOW_BOLT && spi->custom_NameHash != SPELL_HASH_INCINERATE)
                             continue;
                     }
@@ -6275,7 +6275,7 @@ void Unit::RemoveAurasByInterruptFlagButSkip(uint32 flag, uint32 skip)
                     {
                         if (m_currentSpell && m_currentSpell->m_spellInfo->custom_NameHash == SPELL_HASH_FLASH_OF_LIGHT)
                             continue;
-                        SpellInfo* spi = sSpellCustomizations.GetSpellInfo(skip);
+                        SpellInfo const* spi = sSpellCustomizations.GetSpellInfo(skip);
                         if (spi && spi->custom_NameHash != SPELL_HASH_FLASH_OF_LIGHT)
                             continue;
                     }
@@ -6284,14 +6284,14 @@ void Unit::RemoveAurasByInterruptFlagButSkip(uint32 flag, uint32 skip)
                     {
                         if (m_currentSpell && m_currentSpell->GetSpellInfo()->custom_NameHash == SPELL_HASH_SHADOW_BOLT)
                             continue;
-                        SpellInfo* spi = sSpellCustomizations.GetSpellInfo(skip);
+                        SpellInfo const* spi = sSpellCustomizations.GetSpellInfo(skip);
                         if (spi && spi->custom_NameHash != SPELL_HASH_SHADOW_BOLT)
                             continue;
                     }
                     break;
                     case 16166: // [Shaman] Elemental Mastery
                     {
-                        SpellInfo* spi = sSpellCustomizations.GetSpellInfo(skip);
+                        SpellInfo const* spi = sSpellCustomizations.GetSpellInfo(skip);
                         if (spi && !(spi->School == SCHOOL_FIRE || spi->School == SCHOOL_FROST || spi->School == SCHOOL_NATURE))
                             continue;
                     }
@@ -6785,7 +6785,7 @@ bool Unit::GetSpeedDecrease()
     return false;
 }
 
-void Unit::EventCastSpell(Unit* Target, SpellInfo* Sp)
+void Unit::EventCastSpell(Unit* Target, SpellInfo const* Sp)
 {
     ARCEMU_ASSERT(Sp != NULL);
     Spell* pSpell = sSpellFactoryMgr.NewSpell(Target, Sp, true, NULL);
@@ -7582,7 +7582,7 @@ void Unit::EventStopChanneling(bool abort)
     spell->finish(abort);
 }
 
-void Unit::EventStrikeWithAbility(uint64 guid, SpellInfo* sp, uint32 damage)
+void Unit::EventStrikeWithAbility(uint64 guid, SpellInfo const* sp, uint32 damage)
 {
     Unit* victim = m_mapMgr ? m_mapMgr->GetUnit(guid) : NULL;
     if (victim)
@@ -7774,7 +7774,7 @@ void Unit::EventStunOrImmobilize(Unit* proc_target, bool is_victim)
         if (t_trigger_on_stun_chance < 100 && !Rand(t_trigger_on_stun_chance))
             return;
 
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(t_trigger_on_stun);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(t_trigger_on_stun);
 
         if (!spellInfo)
             return;
@@ -7815,7 +7815,7 @@ void Unit::EventChill(Unit* proc_target, bool is_victim)
         if (t_trigger_on_chill_chance < 100 && !Rand(t_trigger_on_chill_chance))
             return;
 
-        SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(t_trigger_on_chill);
+        SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(t_trigger_on_chill);
 
         if (!spellInfo)
             return;
@@ -7833,7 +7833,7 @@ void Unit::EventChill(Unit* proc_target, bool is_victim)
     }
 }
 
-void Unit::RemoveExtraStrikeTarget(SpellInfo* spell_info)
+void Unit::RemoveExtraStrikeTarget(SpellInfo const* spell_info)
 {
     ExtraStrike* es;
     for (std::list<ExtraStrike*>::iterator i = m_extraStrikeTargets.begin(); i != m_extraStrikeTargets.end(); ++i)
@@ -7849,7 +7849,7 @@ void Unit::RemoveExtraStrikeTarget(SpellInfo* spell_info)
     }
 }
 
-void Unit::AddExtraStrikeTarget(SpellInfo* spell_info, uint32 charges)
+void Unit::AddExtraStrikeTarget(SpellInfo const* spell_info, uint32 charges)
 {
     for (std::list<ExtraStrike*>::iterator i = m_extraStrikeTargets.begin(); i != m_extraStrikeTargets.end(); ++i)
     {
@@ -8154,7 +8154,7 @@ bool Unit::isLootable()
         return false;
 }
 
-SpellProc* Unit::AddProcTriggerSpell(SpellInfo* spell, SpellInfo* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj)
+SpellProc* Unit::AddProcTriggerSpell(SpellInfo const* spell, SpellInfo const* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj)
 {
     SpellProc* sp = NULL;
     if (spell != NULL)
@@ -8176,12 +8176,12 @@ SpellProc* Unit::AddProcTriggerSpell(SpellInfo* spell, SpellInfo* orig_spell, ui
     return sp;
 }
 
-SpellProc* Unit::AddProcTriggerSpell(uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask, Object* obj)
+SpellProc* Unit::AddProcTriggerSpell(uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask, Object* obj)
 {
     return AddProcTriggerSpell(sSpellCustomizations.GetSpellInfo(spell_id), sSpellCustomizations.GetSpellInfo(orig_spell_id), caster, procChance, procFlags, procCharges, groupRelation, procClassMask, obj);
 }
 
-SpellProc* Unit::AddProcTriggerSpell(SpellInfo* sp, uint64 caster, uint32* groupRelation, uint32* procClassMask, Object* obj)
+SpellProc* Unit::AddProcTriggerSpell(SpellInfo const* sp, uint64 caster, const uint32* groupRelation, uint32* procClassMask, Object* obj)
 {
     return AddProcTriggerSpell(sp, sp, caster, sp->procChance, sp->procFlags, sp->procCharges, groupRelation, procClassMask, obj);
 }
@@ -8268,7 +8268,7 @@ void Unit::Phase(uint8 command, uint32 newphase)
     UpdateVisibility();
 }
 
-uint64 Unit::GetCurrentUnitForSingleTargetAura(SpellInfo* spell)
+uint64 Unit::GetCurrentUnitForSingleTargetAura(SpellInfo const* spell)
 {
     UniqueAuraTargetMap::iterator itr;
 
@@ -8298,7 +8298,7 @@ uint64 Unit::GetCurrentUnitForSingleTargetAura(uint32* name_hashes, uint32* inde
     }
 }
 
-void Unit::SetCurrentUnitForSingleTargetAura(SpellInfo* spell, uint64 guid)
+void Unit::SetCurrentUnitForSingleTargetAura(SpellInfo const* spell, uint64 guid)
 {
     UniqueAuraTargetMap::iterator itr;
     itr = m_singleTargetAura.find(spell->custom_NameHash);
@@ -8309,7 +8309,7 @@ void Unit::SetCurrentUnitForSingleTargetAura(SpellInfo* spell, uint64 guid)
         m_singleTargetAura.insert(std::make_pair(spell->custom_NameHash, guid));
 }
 
-void Unit::RemoveCurrentUnitForSingleTargetAura(SpellInfo* spell)
+void Unit::RemoveCurrentUnitForSingleTargetAura(SpellInfo const* spell)
 {
     UniqueAuraTargetMap::iterator itr;
     itr = m_singleTargetAura.find(spell->custom_NameHash);
@@ -8359,7 +8359,7 @@ bool Unit::InRaid(Unit* u)
     return false;
 }
 
-bool Unit::IsCriticalDamageForSpell(Object* victim, SpellInfo* spell)
+bool Unit::IsCriticalDamageForSpell(Object* victim, SpellInfo const* spell)
 {
     bool result = false;
     float CritChance = 0.0f;
@@ -8441,7 +8441,7 @@ bool Unit::IsCriticalDamageForSpell(Object* victim, SpellInfo* spell)
     return result;
 }
 
-float Unit::GetCriticalDamageBonusForSpell(Object* victim, SpellInfo* spell, float amount)
+float Unit::GetCriticalDamageBonusForSpell(Object* victim, SpellInfo const* spell, float amount)
 {
     int32 critical_bonus = 100;
     spellModFlatIntValue(SM_PCriticalDamage, &critical_bonus, spell->SpellGroupType);
@@ -8481,7 +8481,7 @@ float Unit::GetCriticalDamageBonusForSpell(Object* victim, SpellInfo* spell, flo
     return amount;
 }
 
-bool Unit::IsCriticalHealForSpell(Object* victim, SpellInfo* spell)
+bool Unit::IsCriticalHealForSpell(Object* victim, SpellInfo const* spell)
 {
     int32 crit_chance = 0;
 
@@ -8496,7 +8496,7 @@ bool Unit::IsCriticalHealForSpell(Object* victim, SpellInfo* spell)
     return Rand(crit_chance);
 }
 
-float Unit::GetCriticalHealBonusForSpell(Object* victim, SpellInfo* spell, float amount)
+float Unit::GetCriticalHealBonusForSpell(Object* victim, SpellInfo const* spell, float amount)
 {
     int32 critical_bonus = 100;
     spellModFlatIntValue(this->SM_PCriticalDamage, &critical_bonus, spell->SpellGroupType);
@@ -8548,7 +8548,7 @@ void Unit::BuildPetSpellList(WorldPacket& data)
 
 void Unit::CastOnMeleeSpell()
 {
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(GetOnMeleeSpell());
+    SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(GetOnMeleeSpell());
     Spell* spell = sSpellFactoryMgr.NewSpell(this, spellInfo, true, NULL);
     spell->extra_cast_number = GetOnMeleeSpellEcn();
     SpellCastTargets targets;

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -683,7 +683,7 @@ void Unit::playSpellVisual(uint64_t guid, uint32_t spell_id)
 #endif
 }
 
-void Unit::applyDiminishingReturnTimer(uint32_t* duration, SpellInfo* spell)
+void Unit::applyDiminishingReturnTimer(uint32_t* duration, SpellInfo const* spell)
 {
     uint32_t status = spell->custom_DiminishStatus;
     uint32_t group  = status & 0xFFFF;
@@ -730,7 +730,7 @@ void Unit::applyDiminishingReturnTimer(uint32_t* duration, SpellInfo* spell)
     ++m_diminishCount[group];
 }
 
-void Unit::removeDiminishingReturnTimer(SpellInfo* spell)
+void Unit::removeDiminishingReturnTimer(SpellInfo const* spell)
 {
     uint32_t status = spell->custom_DiminishStatus;
     uint32_t group  = status & 0xFFFF;

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -141,7 +141,7 @@ struct AreaAura
 
 typedef struct
 {
-    SpellInfo* spell_info;
+    SpellInfo const* spell_info;
     uint32 charges;
 } ExtraStrike;
 
@@ -286,8 +286,8 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Spells
     void playSpellVisual(uint64_t guid, uint32_t spell_id);
-    void applyDiminishingReturnTimer(uint32_t* duration, SpellInfo* spell);
-    void removeDiminishingReturnTimer(SpellInfo* spell);
+    void applyDiminishingReturnTimer(uint32_t* duration, SpellInfo const* spell);
+    void removeDiminishingReturnTimer(SpellInfo const* spell);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Aura
@@ -348,36 +348,36 @@ public:
     uint8 getStandState() { return ((uint8)m_uint32Values[UNIT_FIELD_BYTES_1]); }
 
     //// Combat
-    uint32 GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability);
-    void Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, int32 add_damage, int32 pct_dmg_mod, uint32 exclusive_damage, bool disable_proc, bool skip_hit_check, bool force_crit = false);
+    uint32 GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, SpellInfo const* ability);
+    void Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo const* ability, int32 add_damage, int32 pct_dmg_mod, uint32 exclusive_damage, bool disable_proc, bool skip_hit_check, bool force_crit = false);
     uint32 m_procCounter;
-    uint32 HandleProc(uint32 flag, Unit* Victim, SpellInfo* CastingSpell, bool is_triggered = false, uint32 dmg = -1, uint32 abs = 0, uint32 weapon_damage_type = 0);
+    uint32 HandleProc(uint32 flag, Unit* Victim, SpellInfo const* CastingSpell, bool is_triggered = false, uint32 dmg = -1, uint32 abs = 0, uint32 weapon_damage_type = 0);
     void HandleProcDmgShield(uint32 flag, Unit* attacker);//almost the same as handleproc :P
-    bool IsCriticalDamageForSpell(Object* victim, SpellInfo* spell);
-    float GetCriticalDamageBonusForSpell(Object* victim, SpellInfo* spell, float amount);
-    bool IsCriticalHealForSpell(Object* victim, SpellInfo* spell);
-    float GetCriticalHealBonusForSpell(Object* victim, SpellInfo* spell, float amount);
+    bool IsCriticalDamageForSpell(Object* victim, SpellInfo const* spell);
+    float GetCriticalDamageBonusForSpell(Object* victim, SpellInfo const* spell, float amount);
+    bool IsCriticalHealForSpell(Object* victim, SpellInfo const* spell);
+    float GetCriticalHealBonusForSpell(Object* victim, SpellInfo const* spell, float amount);
 
-    void RemoveExtraStrikeTarget(SpellInfo* spell_info);
-    void AddExtraStrikeTarget(SpellInfo* spell_info, uint32 charges);
+    void RemoveExtraStrikeTarget(SpellInfo const* spell_info);
+    void AddExtraStrikeTarget(SpellInfo const* spell_info, uint32 charges);
 
     int32 GetAP();
     int32 GetRAP();
 
     uint8 CastSpell(Unit* Target, uint32 SpellID, bool triggered);
-    uint8 CastSpell(Unit* Target, SpellInfo* Sp, bool triggered);
+    uint8 CastSpell(Unit* Target, SpellInfo const* Sp, bool triggered);
     uint8 CastSpell(uint64 targetGuid, uint32 SpellID, bool triggered);
-    uint8 CastSpell(uint64 targetGuid, SpellInfo* Sp, bool triggered);
+    uint8 CastSpell(uint64 targetGuid, SpellInfo const* Sp, bool triggered);
     uint8 CastSpell(Unit* Target, uint32 SpellID, uint32 forced_basepoints, bool triggered);
-    uint8 CastSpell(Unit* Target, SpellInfo* Sp, uint32 forced_basepoints, bool triggered);
+    uint8 CastSpell(Unit* Target, SpellInfo const* Sp, uint32 forced_basepoints, bool triggered);
     uint8 CastSpell(Unit* Target, uint32 SpellID, uint32 forced_basepoints, int32 charges, bool triggered);
-    uint8 CastSpell(Unit* Target, SpellInfo* Sp, uint32 forced_basepoints, int32 charges, bool triggered);
-    void CastSpellAoF(LocationVector lv, SpellInfo* Sp, bool triggered);
-    void EventCastSpell(Unit* Target, SpellInfo* Sp);
+    uint8 CastSpell(Unit* Target, SpellInfo const* Sp, uint32 forced_basepoints, int32 charges, bool triggered);
+    void CastSpellAoF(LocationVector lv, SpellInfo const* Sp, bool triggered);
+    void EventCastSpell(Unit* Target, SpellInfo const* Sp);
 
     bool IsCasting();
     bool IsInInstance();
-    void CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInfo* ability, float ArmorPctReduce);
+    void CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInfo const* ability, float ArmorPctReduce);
     void RegenerateHealth();
     void RegeneratePower(bool isinterrupted);
     void setHRegenTimer(uint32 time) { m_H_regenTimer = static_cast<uint16>(time); }
@@ -496,17 +496,17 @@ public:
     bool IsControlledByPlayer();
 
     // Auras that can affect only one target at a time
-    uint64 GetCurrentUnitForSingleTargetAura(SpellInfo* spell);
+    uint64 GetCurrentUnitForSingleTargetAura(SpellInfo const* spell);
     uint64 GetCurrentUnitForSingleTargetAura(uint32* name_hashes, uint32* index);
-    void SetCurrentUnitForSingleTargetAura(SpellInfo* spell, uint64 guid);
-    void RemoveCurrentUnitForSingleTargetAura(SpellInfo* spell);
+    void SetCurrentUnitForSingleTargetAura(SpellInfo const* spell, uint64 guid);
+    void RemoveCurrentUnitForSingleTargetAura(SpellInfo const* spell);
     void RemoveCurrentUnitForSingleTargetAura(uint32 name_hash);
 
     // ProcTrigger
     std::list<SpellProc*> m_procSpells;
-    SpellProc* AddProcTriggerSpell(uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
-    SpellProc* AddProcTriggerSpell(SpellInfo* spell, SpellInfo* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
-    SpellProc* AddProcTriggerSpell(SpellInfo* sp, uint64 caster, uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
+    SpellProc* AddProcTriggerSpell(uint32 spell_id, uint32 orig_spell_id, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
+    SpellProc* AddProcTriggerSpell(SpellInfo const* spell, SpellInfo const* orig_spell, uint64 caster, uint32 procChance, uint32 procFlags, uint32 procCharges, const uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
+    SpellProc* AddProcTriggerSpell(SpellInfo const* sp, uint64 caster, const uint32* groupRelation, uint32* procClassMask = NULL, Object* obj = NULL);
     SpellProc* GetProcTriggerSpell(uint32 spellId, uint64 casterGuid = 0);
     void RemoveProcTriggerSpell(uint32 spellId, uint64 casterGuid = 0, uint64 misc = 0);
 
@@ -529,9 +529,9 @@ public:
     void InterruptSpell();
 
     //caller is the caster
-    int32 GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg, bool isdot);
+    int32 GetSpellDmgBonus(Unit* pVictim, SpellInfo const* spellInfo, int32 base_dmg, bool isdot);
 
-    float CalcSpellDamageReduction(Unit* victim, SpellInfo* spell, float res);
+    float CalcSpellDamageReduction(Unit* victim, SpellInfo const* spell, float res);
 
     uint32 m_addDmgOnce;
     uint32 m_ObjectSlots[4];
@@ -922,8 +922,8 @@ public:
 
     void SetFacing(float newo);     //only working if creature is idle
 
-    AuraCheckResponse AuraCheck(SpellInfo* proto, Object* caster = NULL);
-    AuraCheckResponse AuraCheck(SpellInfo* proto, Aura* aur, Object* caster = NULL);
+    AuraCheckResponse AuraCheck(SpellInfo const* proto, Object* caster = NULL);
+    AuraCheckResponse AuraCheck(SpellInfo const* proto, Aura* aur, Object* caster = NULL);
 
     uint16 m_diminishCount[DIMINISHING_GROUP_COUNT];
     uint8 m_diminishAuraCount[DIMINISHING_GROUP_COUNT];
@@ -946,7 +946,7 @@ public:
     uint8 FindVisualSlot(uint32 SpellId, bool IsPos);
     uint32 m_auravisuals[MAX_NEGATIVE_VISUAL_AURAS_END];
 
-    SpellInfo* pLastSpell;
+    SpellInfo const* pLastSpell;
     bool bProcInUse;
     bool bInvincible;
     Player* m_redirectSpellPackets;
@@ -968,7 +968,7 @@ public:
 
     void CancelSpell(Spell* ptr);
     void EventStopChanneling(bool abort);
-    void EventStrikeWithAbility(uint64 guid, SpellInfo* sp, uint32 damage);
+    void EventStrikeWithAbility(uint64 guid, SpellInfo const* sp, uint32 damage);
     void DispelAll(bool positive);
 
     void SendPowerUpdate(bool self);


### PR DESCRIPTION
- 'GetSpellInfo()' returns const reference to SpellInfo
- New function 'getSpellInfoUnsafe(uint32_t spell_id)' implemented temporarily for loading scripts into spells and for multiple spell SQL tables (ai_threattospellid, spell_effects_override, spell_ranks, spell_custom_assign, spell_coef_flags, spell_proc)
- New function 'checkAndReturnSpellEntryUnsafe(uint32_t spellid)' implemented temporarily for HackFixes.cpp

Breaks (need new solution):
- Karathress' Cataclysmic Bolt in Serpentshrine Caverns script
- Mage's Incanter's Absorption in ::SpellNonMeleeDamageLog
- Rogue's Cheat Death's cooldown hackfixed in Spell_ClassScripts.cpp
- Warrior's Blood Frenzy's duration in ::SpellEffectApplyAura