### PR TITLE
Fix possible null dereference

### DIFF
--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -2466,7 +2466,7 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
             charmer->UnPossess();
     }
 
-    if (m_mapMgr->m_battleground != NULL)
+    if (m_mapMgr != nullptr && m_mapMgr->m_battleground != nullptr)
         m_mapMgr->m_battleground->HookOnUnitDied(this);
 }
 

--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -2442,32 +2442,35 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
 
     SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DEAD);
 
-    if ((GetCreatedByGUID() == 0) && (GetTaggerGUID() != 0))
+    if (m_mapMgr != nullptr)
     {
-        Unit* owner = m_mapMgr->GetUnit(GetTaggerGUID());
+        if ((GetCreatedByGUID() == 0) && (GetTaggerGUID() != 0))
+        {
+            Unit* owner = m_mapMgr->GetUnit(GetTaggerGUID());
 
-        if (owner != NULL)
-            generateLoot();
+            if (owner != NULL)
+                generateLoot();
+        }
+
+        if (GetCharmedByGUID())
+        {
+            //remove owner warlock soul link from caster
+            Unit* owner = GetMapMgr()->GetUnit(GetCharmedByGUID());
+
+            if (owner != NULL && owner->IsPlayer())
+                static_cast<Player*>(owner)->EventDismissPet();
+        }
+
+        if (GetCharmedByGUID() != 0)
+        {
+            Unit* charmer = m_mapMgr->GetUnit(GetCharmedByGUID());
+            if (charmer != NULL)
+                charmer->UnPossess();
+        }
+
+        if (m_mapMgr->m_battleground != nullptr)
+            m_mapMgr->m_battleground->HookOnUnitDied(this);
     }
-
-    if (GetCharmedByGUID())
-    {
-        //remove owner warlock soul link from caster
-        Unit* owner = GetMapMgr()->GetUnit(GetCharmedByGUID());
-
-        if (owner != NULL && owner->IsPlayer())
-            static_cast<Player*>(owner)->EventDismissPet();
-    }
-
-    if (GetCharmedByGUID() != 0)
-    {
-        Unit* charmer = m_mapMgr->GetUnit(GetCharmedByGUID());
-        if (charmer != NULL)
-            charmer->UnPossess();
-    }
-
-    if (m_mapMgr != nullptr && m_mapMgr->m_battleground != nullptr)
-        m_mapMgr->m_battleground->HookOnUnitDied(this);
 }
 
 void Creature::SendChatMessage(uint8 type, uint32 lang, const char* msg, uint32 delay)


### PR DESCRIPTION
I'm using core based on https://github.com/AscEmu/AscEmu/commit/fb084e107c0b01862d9357c65d7e912b7ccb42da with https://github.com/sanctum32/AscEmu/tree/violet_hold based violet hold instance script implementation

World database has modifications applied by up to this core commit hash and queries by https://github.com/sanctum32/AscEmu/blob/violet_hold/sql/violet_hold.sql

There are no other modifications (except mentioned instance script)
It happened when I was testing violet hold with mmaps enabled.
It happened when intro npc was killed by violet hold guard.