### PR TITLE
Core/Spells: Refactor spell casting behaviour and autorepeat spells

### DIFF
--- a/src/scripts/InstanceScripts/Instance_AuchenaiCrypts.cpp
+++ b/src/scripts/InstanceScripts/Instance_AuchenaiCrypts.cpp
@@ -94,7 +94,7 @@ class SHIRRAKTHEDEADWATCHERAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -148,7 +148,7 @@ class SHIRRAKTHEDEADWATCHERAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;         // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -271,7 +271,7 @@ class AvatarOfTheMartyredAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -451,7 +451,7 @@ class EXARCHMALADAARAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -505,7 +505,7 @@ class EXARCHMALADAARAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Instance_BlackMorass.cpp
+++ b/src/scripts/InstanceScripts/Instance_BlackMorass.cpp
@@ -108,7 +108,7 @@ class ChronoLordAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -243,7 +243,7 @@ class TemporusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -384,7 +384,7 @@ class AenusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_BlackrockDepths.cpp
+++ b/src/scripts/InstanceScripts/Instance_BlackrockDepths.cpp
@@ -78,7 +78,7 @@ class AmbassadorFlamelash : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -183,7 +183,7 @@ class AnubShiah : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -307,7 +307,7 @@ class BaelGar : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -440,7 +440,7 @@ class EmperorDagranThaurissan : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -564,7 +564,7 @@ class Eviscerator : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -688,7 +688,7 @@ class FineousDarkvire : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -821,7 +821,7 @@ class GeneralAngerforge : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -954,7 +954,7 @@ class GolemLordArgelmach : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1078,7 +1078,7 @@ class GoroshTheDervish : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1202,7 +1202,7 @@ class Grizzle : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1335,7 +1335,7 @@ class HedrumTheCreeper : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1467,7 +1467,7 @@ class HighInterrogatorGerstahn : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1590,7 +1590,7 @@ class HoundmasterGrebmar : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1723,7 +1723,7 @@ class HurleyBlackbreath : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1856,7 +1856,7 @@ class LordIncendius : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1989,7 +1989,7 @@ class LordRoccor : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2112,7 +2112,7 @@ class Magmus : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2235,7 +2235,7 @@ class OkThorTheBreaker : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2367,7 +2367,7 @@ class Phalanx : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2490,7 +2490,7 @@ class PrincessMoiraBronzebeard : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2613,7 +2613,7 @@ class PyromancerLoregrain : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_BlackrockSpire.cpp
+++ b/src/scripts/InstanceScripts/Instance_BlackrockSpire.cpp
@@ -89,7 +89,7 @@ class GeneralDrakkisathAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -197,7 +197,7 @@ class PyroguardEmbersserAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -305,7 +305,7 @@ class RendBlackhandAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -431,7 +431,7 @@ class GythAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -540,7 +540,7 @@ class TheBeastAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -672,7 +672,7 @@ class HighlordOmokkAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -780,7 +780,7 @@ class ShadowHunterVoshAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -906,7 +906,7 @@ class WarMasterVooneAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1020,7 +1020,7 @@ class MotherSmolderwebAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1152,7 +1152,7 @@ class UrokDoomhowlAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1260,7 +1260,7 @@ class QuartermasterZigrisAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1380,7 +1380,7 @@ class HalyconAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1518,7 +1518,7 @@ class OverlordWyrmthalakAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_Botanica.cpp
+++ b/src/scripts/InstanceScripts/Instance_Botanica.cpp
@@ -73,7 +73,7 @@ class BloodProtectorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -174,7 +174,7 @@ class BloodGreenkeeperAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -273,7 +273,7 @@ class SunchemistAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -385,7 +385,7 @@ class SunResearcherAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -542,7 +542,7 @@ class CommanderSarannisAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -773,7 +773,7 @@ class HighBotanistFreywinnAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -959,7 +959,7 @@ class ThorngrinTheTenderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1119,7 +1119,7 @@ class LajAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1294,7 +1294,7 @@ class WarpSplinterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_DireMaul.cpp
+++ b/src/scripts/InstanceScripts/Instance_DireMaul.cpp
@@ -104,7 +104,7 @@ class AlzzinTheWildshaper : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -228,7 +228,7 @@ class CaptainKromcrush : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -352,7 +352,7 @@ class ChoRushTheObserver : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -494,7 +494,7 @@ class GuardFengus : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -627,7 +627,7 @@ class GuardMolDar : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -760,7 +760,7 @@ class GuardSlipKik : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -893,7 +893,7 @@ class Hydrospawn : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1001,7 +1001,7 @@ class MassiveGeyser : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1125,7 +1125,7 @@ class IllyanaRavenoak : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1258,7 +1258,7 @@ class Immolthar : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1366,7 +1366,7 @@ class EyeOfImmolThar : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1471,7 +1471,7 @@ class KingGordok : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1595,7 +1595,7 @@ class Lethtendris : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1702,7 +1702,7 @@ class LordHelNurath : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1815,7 +1815,7 @@ class MagisterKalendris : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1939,7 +1939,7 @@ class PrinceTortheldrin : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2072,7 +2072,7 @@ class Pusillin : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2196,7 +2196,7 @@ class SkarrTheUnbreakable : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2332,7 +2332,7 @@ class TendrisWarpwood : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2456,7 +2456,7 @@ class ZevrimThornhoof : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2598,7 +2598,7 @@ class GordokMageLord : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2722,7 +2722,7 @@ class GordokReaver : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2855,7 +2855,7 @@ class GordokBrute : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2979,7 +2979,7 @@ class FelLash : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_DrakTharonKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_DrakTharonKeep.cpp
@@ -303,7 +303,7 @@ class NovosTheSummonerAI : public CreatureAIScript
                 }
             }
             getCreature()->setMoveRoot(true);
-            getCreature()->InterruptSpell();
+            getCreature()->interruptSpell();
             getCreature()->RemoveAllAuras();
         }
 
@@ -359,7 +359,7 @@ class NovosTheSummonerAI : public CreatureAIScript
                 }
                 if (new_phase)
                 {
-                    getCreature()->InterruptSpell();
+                    getCreature()->interruptSpell();
                     getCreature()->RemoveAllAuras();
                     getCreature()->setMoveRoot(false);
                     _setMeleeDisabled(false);

--- a/src/scripts/InstanceScripts/Instance_MagistersTerrace.cpp
+++ b/src/scripts/InstanceScripts/Instance_MagistersTerrace.cpp
@@ -114,7 +114,7 @@ class SelinFireheartAI : public CreatureAIScript
 
         getCreature()->GetAIInterface()->StopMovement(0);
 
-        if (!FelCrystal->GetCurrentSpell())
+        if (!FelCrystal->isCastingNonMeleeSpell())
             FelCrystal->CastSpell(getCreature(), ManaRage, false);
 
         // Mana Rage giving of mana doesnt work so we give 10%(3231) / AIUpdate() Event.

--- a/src/scripts/InstanceScripts/Instance_ManaTombs.cpp
+++ b/src/scripts/InstanceScripts/Instance_ManaTombs.cpp
@@ -75,7 +75,7 @@ class EtherealDarkcasterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -170,7 +170,7 @@ class EtherealPriestAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -264,7 +264,7 @@ class EtherealTheurgistAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -353,7 +353,7 @@ class EtherealSorcererAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -453,7 +453,7 @@ class NexusStalkerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -541,7 +541,7 @@ class NexusTerrorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -635,7 +635,7 @@ class ManaLeechAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -740,7 +740,7 @@ class EtherealSpellbinderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -829,7 +829,7 @@ class EtherealWraithAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -963,7 +963,7 @@ class PandemoniusAI : public CreatureAIScript
         void AIUpdate()
         {
             uint32 t = (uint32)time(NULL);
-            if (t > spells[1].casttime && getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (t > spells[1].casttime && !getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 CastSpellOnRandomTarget(1, spells[1].mindist2cast, spells[1].maxdist2cast, 0, 100);
 
@@ -977,7 +977,7 @@ class PandemoniusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1023,7 +1023,7 @@ class PandemoniusAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1138,7 +1138,7 @@ class TavarokAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1189,7 +1189,7 @@ class TavarokAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1354,7 +1354,7 @@ class NexusPrinceShaffarAI : public CreatureAIScript
         {
             // not sure if it should be like that
             uint32 t = (uint32)time(NULL);
-            if (t > spells[4].casttime && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[4].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[4].info, spells[4].instant);
 
@@ -1368,7 +1368,7 @@ class NexusPrinceShaffarAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1434,7 +1434,7 @@ class NexusPrinceShaffarAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1540,7 +1540,7 @@ class YorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_Maraudon.cpp
+++ b/src/scripts/InstanceScripts/Instance_Maraudon.cpp
@@ -105,7 +105,7 @@ class CelebrasTheCursedAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -229,7 +229,7 @@ class LordVyletongueAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -353,7 +353,7 @@ class MeshlokTheHarvesterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -495,7 +495,7 @@ class PrincessTheradrasAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -628,7 +628,7 @@ class RazorlashAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -752,7 +752,7 @@ class TinkererGizlockAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -876,7 +876,7 @@ class NoxxionAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_PitOfSaron.cpp
+++ b/src/scripts/InstanceScripts/Instance_PitOfSaron.cpp
@@ -285,7 +285,7 @@ class IckAI : public CreatureAIScript
     void AIUpdate()
     {
         if (Phase == BATTLE)
-            if (!getCreature()->IsCasting())
+            if (!getCreature()->isCastingNonMeleeSpell())
                 CastSpells();
 
         

--- a/src/scripts/InstanceScripts/Instance_RazorfenDowns.cpp
+++ b/src/scripts/InstanceScripts/Instance_RazorfenDowns.cpp
@@ -104,7 +104,7 @@ class AmnennarTheColdbringerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -262,7 +262,7 @@ class PlaguemawTheRottingAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -385,7 +385,7 @@ class RagglesnoutAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -509,7 +509,7 @@ class TutenKashAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_ScarletMonastery.cpp
+++ b/src/scripts/InstanceScripts/Instance_ScarletMonastery.cpp
@@ -333,7 +333,7 @@ class MograineAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -505,7 +505,7 @@ class WhitemaneAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -638,7 +638,7 @@ class FairbanksAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_Scholomance.cpp
+++ b/src/scripts/InstanceScripts/Instance_Scholomance.cpp
@@ -97,7 +97,7 @@ class DoctorTheolenKrastinovAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -211,7 +211,7 @@ class InstructorMaliciaAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -318,7 +318,7 @@ class TheRavenianAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -431,7 +431,7 @@ class LadyIlluciaBarovAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -551,7 +551,7 @@ class RasForstwhisperAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -652,7 +652,7 @@ class JandiceBarovAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -754,7 +754,7 @@ class KormokAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -869,7 +869,7 @@ class VectusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -972,7 +972,7 @@ class LordAlexeiBarovAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1079,7 +1079,7 @@ class LorekeeperPolkeltAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1181,7 +1181,7 @@ class DarkmasterGandlingAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_SethekkHalls.cpp
+++ b/src/scripts/InstanceScripts/Instance_SethekkHalls.cpp
@@ -72,7 +72,7 @@ class AvianDarkhawkAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -161,7 +161,7 @@ class AvianRipperAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -263,7 +263,7 @@ class AvianWarhawkAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -364,7 +364,7 @@ class CobaltSerpentAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -458,7 +458,7 @@ class TimeLostControllerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -552,7 +552,7 @@ class TimeLostScryerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -641,7 +641,7 @@ class TimeLostShadowmageAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -735,7 +735,7 @@ class SethekkGuardAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -823,7 +823,7 @@ class SethekkInitiateAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -917,7 +917,7 @@ class SethekkOracleAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1011,7 +1011,7 @@ class SethekkProphetAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1105,7 +1105,7 @@ class SethekkRavenguardAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1193,7 +1193,7 @@ class SethekkShamanAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1287,7 +1287,7 @@ class SethekkTalonLordAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1592,7 +1592,7 @@ class DarkweaverSythAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1699,7 +1699,7 @@ class TalonKingIkissAI : public CreatureAIScript
             uint32 t = (uint32)time(NULL);
             spells[1].casttime = t + RandomUInt(5) + 10;
 
-            if (getCreature()->GetCurrentSpell() == NULL)
+            if (!getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->GetAIInterface()->StopMovement(1);
                 getCreature()->setAttackTimer(3000, false);
@@ -1766,8 +1766,7 @@ class TalonKingIkissAI : public CreatureAIScript
                 getCreature()->GetAIInterface()->StopMovement(2000);
                 getCreature()->setAttackTimer(6500, false);
 
-                if (getCreature()->GetCurrentSpell())
-                    getCreature()->GetCurrentSpell()->cancel();
+                getCreature()->interruptSpell();
 
                 getCreature()->CastSpell(getCreature(), spells[3].info, spells[3].instant);
 
@@ -1781,7 +1780,7 @@ class TalonKingIkissAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1841,7 +1840,7 @@ class TalonKingIkissAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2061,7 +2060,7 @@ class ANZUAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_ShadowLabyrinth.cpp
+++ b/src/scripts/InstanceScripts/Instance_ShadowLabyrinth.cpp
@@ -76,7 +76,7 @@ class CabalAcolyteAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -175,7 +175,7 @@ class CabalDeathswornAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -263,7 +263,7 @@ class CabalFanaticAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -357,7 +357,7 @@ class CabalShadowPriestAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -451,7 +451,7 @@ class CabalSpellbinderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -545,7 +545,7 @@ class CabalWarlockAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -639,7 +639,7 @@ class CabalZealotAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -770,7 +770,7 @@ class CabalRitualistAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -899,7 +899,7 @@ class FelOverseerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -994,7 +994,7 @@ class MaliciousInstructorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1126,7 +1126,7 @@ class AmbassadorHellmawAI : public CreatureAIScript
         void AIUpdate()
         {
             uint32 t = (uint32)time(NULL);
-            if (t > spells[1].casttime && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[1].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[1].info, spells[1].instant);
 
@@ -1140,7 +1140,7 @@ class AmbassadorHellmawAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1283,7 +1283,7 @@ class BlackheartTheInciterAI : public CreatureAIScript
         void AIUpdate()
         {
             uint32 t = (uint32)time(NULL);
-            if (t > spells[2].casttime && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[2].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 CastSpellOnRandomTarget(2, spells[2].mindist2cast, spells[2].maxdist2cast, 0, 100);
 
@@ -1297,7 +1297,7 @@ class BlackheartTheInciterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1348,7 +1348,7 @@ class BlackheartTheInciterAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1505,7 +1505,7 @@ class GrandmasterVorpilAI : public CreatureAIScript
 
         void AIUpdate()
         {
-            if (Teleported && getCreature()->GetCurrentSpell() == NULL)
+            if (Teleported && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpellAoF(getCreature()->GetPosition(), spells[2].info, spells[2].instant);
 
@@ -1519,7 +1519,7 @@ class GrandmasterVorpilAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1662,8 +1662,7 @@ class MurmurAI : public CreatureAIScript
                 RemoveAIUpdateEvent();
                 RegisterAIUpdateEvent(getCreature()->GetBaseAttackTime(MELEE));
 
-                if (getCreature()->GetCurrentSpell())
-                    getCreature()->GetCurrentSpell()->cancel();
+                getCreature()->interruptSpell();
 
                 getCreature()->CastSpell(getCreature(), SP_MURMUR_SONIC_BOOM2, true);
 
@@ -1672,7 +1671,7 @@ class MurmurAI : public CreatureAIScript
             }
 
             uint32 t = (uint32)time(NULL);
-            if (t > spells[3].casttime && getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetDistance2dSq(getCreature()->GetAIInterface()->getNextTarget()) >= 325.0f)
+            if (t > spells[3].casttime && !getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetDistance2dSq(getCreature()->GetAIInterface()->getNextTarget()) >= 325.0f)
             {
                 Unit* target = NULL;
                 target = FindTarget();
@@ -1699,7 +1698,7 @@ class MurmurAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1759,7 +1758,7 @@ class MurmurAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Instance_TheMechanar.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheMechanar.cpp
@@ -91,7 +91,7 @@ class ArcaneServantAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -233,7 +233,7 @@ class BloodwarderCenturionAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -368,7 +368,7 @@ class BloodwarderPhysicianAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -509,7 +509,7 @@ class BloodwarderSlayerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -622,7 +622,7 @@ class MechanarCrusherAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -756,7 +756,7 @@ class MechanarDrillerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -891,7 +891,7 @@ class MechanarTinkererAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1018,7 +1018,7 @@ class MechanarWreckerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1138,7 +1138,7 @@ class RagingFlamesAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1272,7 +1272,7 @@ class SunseekerAstromageAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1406,7 +1406,7 @@ class SunseekerEngineerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1546,7 +1546,7 @@ class SunseekerNetherbinderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1665,7 +1665,7 @@ class TempestForgeDestroyerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1784,7 +1784,7 @@ class TempestForgePatrollerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1945,7 +1945,7 @@ class GatewatcherGyroKillAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2110,7 +2110,7 @@ class GatewatcherIronHandAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2268,7 +2268,7 @@ class MechanoLordCapacitusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2445,7 +2445,7 @@ class NethermancerSepethreaAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2650,7 +2650,7 @@ class PathaleonTheCalculatorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_TheShatteredHalls.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheShatteredHalls.cpp
@@ -93,7 +93,7 @@ class FelOrcConvertAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -211,7 +211,7 @@ class ShatteredHandHeathenAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -334,7 +334,7 @@ class ShatteredHandLegionnaireAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -458,7 +458,7 @@ class ShatteredHandSavageAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -594,7 +594,7 @@ class ShadowmoonAcolyteAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -691,7 +691,7 @@ class ShatteredHandAssassinAI : public CreatureAIScript
         {
             CastTime();
             RegisterAIUpdateEvent(getCreature()->GetBaseAttackTime(MELEE));
-            if (getCreature()->GetCurrentSpell() && mTarget)
+            if (getCreature()->isCastingNonMeleeSpell() && mTarget)
                 getCreature()->CastSpell(mTarget, spells[0].info, spells[0].instant);
         }
 
@@ -723,7 +723,7 @@ class ShatteredHandAssassinAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -832,7 +832,7 @@ class ShatteredHandGladiatorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -942,7 +942,7 @@ class ShatteredHandHoundmasterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1068,7 +1068,7 @@ class ShatteredHandReaverAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1178,7 +1178,7 @@ class ShatteredHandSentryAI : public CreatureAIScript
 
         void AIUpdate()
         {
-            if (getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell())
+            if (getCreature()->GetAIInterface()->getNextTarget() && getCreature()->isCastingNonMeleeSpell())
             {
                 Unit* target = NULL;
                 target = getCreature()->GetAIInterface()->getNextTarget();
@@ -1195,7 +1195,7 @@ class ShatteredHandSentryAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1310,7 +1310,7 @@ class ShatteredHandSharpshooterAI : public CreatureAIScript
             if (getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetDistance2dSq(getCreature()->GetAIInterface()->getNextTarget()) <= 900.0f)
             {
                 setAIAgent(AGENT_SPELL);
-                if (getCreature()->GetCurrentSpell() == NULL)
+                if (!getCreature()->isCastingNonMeleeSpell())
                 {
                     uint32 Chance = RandomUInt(100);
                     if (Chance <= 70)
@@ -1413,7 +1413,7 @@ class ShatteredHandBrawlerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1696,7 +1696,7 @@ class GrandWarlockNethekurseAI : public CreatureAIScript
 
             uint32 t = (uint32)time(NULL);
             // not sure if this should work like that
-            if (t > spells[2].casttime && getCreature()->GetHealthPct() <= 20 && getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (t > spells[2].casttime && getCreature()->GetHealthPct() <= 20 && !getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 getCreature()->setAttackTimer(2500, false);
 
@@ -1715,7 +1715,7 @@ class GrandWarlockNethekurseAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1766,7 +1766,7 @@ class GrandWarlockNethekurseAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1910,7 +1910,7 @@ class BloodGuardPorungAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2301,7 +2301,7 @@ class WarchiefKargathBladefistAI : public CreatureAIScript
         void AIUpdate()
         {
             uint32 t = (uint32)time(NULL);
-            if (t > spells[0].casttime && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[0].casttime && getCreature()->GetAIInterface()->getNextTarget() && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->setAttackTimer(1500, false);
 

--- a/src/scripts/InstanceScripts/Instance_TheSlavePens.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheSlavePens.cpp
@@ -89,7 +89,7 @@ class CoilfangChampionAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -203,7 +203,7 @@ class CoilfangObserverAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -321,7 +321,7 @@ class CoilfangDefenderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -453,7 +453,7 @@ class CoilfangScaleHealerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -568,7 +568,7 @@ class CoilfangSoothsayerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -691,7 +691,7 @@ class CoilfangTechnicianAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -805,7 +805,7 @@ class CoilfangRayAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1036,7 +1036,7 @@ class MennuTheBetrayerAI : public CreatureAIScript
 
         void AIUpdate()
         {
-            if (TotemCounter != 0 && getCreature()->GetCurrentSpell() == NULL)
+            if (TotemCounter != 0 && !getCreature()->isCastingNonMeleeSpell())
             {
                 TotemSpawning();
                 return;
@@ -1048,7 +1048,7 @@ class MennuTheBetrayerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1237,7 +1237,7 @@ class RokmarTheCracklerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1294,7 +1294,7 @@ class RokmarTheCracklerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1409,7 +1409,7 @@ class QuagmirranAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1466,7 +1466,7 @@ class QuagmirranAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
@@ -93,7 +93,7 @@ class CoilfangEngineerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -221,7 +221,7 @@ class CoilfangOracleAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -341,7 +341,7 @@ class CoilfangWarriorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -469,7 +469,7 @@ class CoilfangSirenAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -610,7 +610,7 @@ class BogOverlordAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -737,7 +737,7 @@ class CoilfangSorceressAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -899,7 +899,7 @@ class CoilfangLeperAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1020,7 +1020,7 @@ class CoilfangSlavemasterAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1133,7 +1133,7 @@ class CoilfangWaterElementalAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1260,7 +1260,7 @@ class CoilfangMyrmidonAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1382,7 +1382,7 @@ class TidalSurgerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1495,7 +1495,7 @@ class SteamSurgerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1653,7 +1653,7 @@ class HydromancerThespiaAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1707,7 +1707,7 @@ class HydromancerThespiaAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1783,8 +1783,7 @@ class SteamriggerMechanicAI : public CreatureAIScript
             getCreature()->GetAIInterface()->ResetUnitToFollow();
             getCreature()->GetAIInterface()->SetUnitToFollowAngle(0.0f);
 
-            if (getCreature()->GetCurrentSpell() != NULL)
-                getCreature()->GetCurrentSpell()->cancel();
+            getCreature()->interruptSpell();
         }
 
         void OnCombatStop(Unit* mTarget)
@@ -1964,13 +1963,13 @@ class MekgineerSteamriggerAI : public CreatureAIScript
 
                     if (getCreature()->GetDistance2dSq(Gnome) > 250.0f)
                     {
-                        if (Gnome->GetCurrentSpell() != NULL)
-                            Gnome->GetCurrentSpell()->cancel();
+                        if (Gnome->isCastingNonMeleeSpell())
+                            Gnome->interruptSpell();
 
                         continue;
                     }
 
-                    if (Gnome->GetCurrentSpell() == NULL)
+                    if (!Gnome->isCastingNonMeleeSpell())
                     {
                         Gnome->GetAIInterface()->StopMovement(1);
                         Gnome->CastSpell(getCreature(), REPAIR, false);    // core problem? casted on self (and effect is applied on caster instead of _unit)
@@ -2016,7 +2015,7 @@ class MekgineerSteamriggerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2070,7 +2069,7 @@ class MekgineerSteamriggerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2393,7 +2392,7 @@ class WarlordKalitreshAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2447,7 +2446,7 @@ class WarlordKalitreshAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Instance_TheUnderbog.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheUnderbog.cpp
@@ -108,7 +108,7 @@ class BOGGIANTAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -239,7 +239,7 @@ class CLAWAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -365,7 +365,7 @@ class UNDERBATAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -476,7 +476,7 @@ class FENRAYAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -595,7 +595,7 @@ class LYKULSTINGERAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -732,7 +732,7 @@ class LYKULWASPAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -878,7 +878,7 @@ class WRATHFINWARRIORAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1005,7 +1005,7 @@ class WRATHFINSENTRYAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1116,7 +1116,7 @@ class WRATHFINMYRMIDONAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1234,7 +1234,7 @@ class UNDERBOGLORDAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1367,7 +1367,7 @@ class MURKBLOODSPEARMANAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1534,7 +1534,7 @@ class MURKBLOODORACLEAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1669,7 +1669,7 @@ class MURKBLOODHEALERAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1795,7 +1795,7 @@ class MURKBLOODTRIBESMANAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1937,7 +1937,7 @@ class UNDERBOGSHAMBLERAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2049,7 +2049,7 @@ class UNDERBOGFRENZYAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2141,7 +2141,7 @@ class UNDERBOGLURKERAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2263,7 +2263,7 @@ class HungarfenAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2368,7 +2368,7 @@ class GhazanAI : public CreatureAIScript
 
         void AIUpdate()
         {
-            if (getCreature()->GetHealthPct() <= 20 && !Enraged && getCreature()->GetCurrentSpell() == NULL)
+            if (getCreature()->GetHealthPct() <= 20 && !Enraged && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[3].info, spells[3].instant);
 
@@ -2382,7 +2382,7 @@ class GhazanAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2507,7 +2507,7 @@ class ClawAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2568,7 +2568,7 @@ class ClawAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt.
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2737,7 +2737,7 @@ class SwamplordMuselekAI : public CreatureAIScript
                 if (getCreature()->GetDistance2dSq(target) >= 100.0f && getCreature()->getDistanceSq(target) <= 900.0f && RandomUInt(3) != 1)
                 {
                     getCreature()->GetAIInterface()->StopMovement(2000);
-                    if (getCreature()->GetCurrentSpell() == NULL)
+                    if (!getCreature()->isCastingNonMeleeSpell())
                     {
                         uint32 t = (uint32)time(NULL);
                         uint32 RangedSpell = RandomUInt(100);
@@ -2777,7 +2777,7 @@ class SwamplordMuselekAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL)
+            if (!getCreature()->isCastingNonMeleeSpell())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2907,7 +2907,7 @@ class TheBlackStalkerAI : public CreatureAIScript
         void AIUpdate()
         {
             uint32 t = (uint32)time(NULL);
-            if (t > spells[3].casttime && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[3].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[3].info, spells[3].instant);
 
@@ -2920,7 +2920,7 @@ class TheBlackStalkerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2974,7 +2974,7 @@ class TheBlackStalkerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Instance_TheVioletHold.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheVioletHold.cpp
@@ -333,7 +333,7 @@ class VHCreatureAI : public CreatureAIScript
     
         void SpellCast(float randomValue)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Instance_Uldaman.cpp
+++ b/src/scripts/InstanceScripts/Instance_Uldaman.cpp
@@ -77,7 +77,7 @@ class Archaedas : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -182,7 +182,7 @@ class Revelosh : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -314,7 +314,7 @@ class Grimlok : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -437,7 +437,7 @@ class Baelog : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -569,7 +569,7 @@ class GalgannFirehammer : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -692,7 +692,7 @@ class Ironaya : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
@@ -871,10 +871,10 @@ class IllidariArchonAI : public CreatureAIScript
             SpellDesc* pDeath = FindSpellById(ILLIDARI_ARCHON_SHADOW_WORD_DEATH);
             if (mIsShadowPriest && getCreature()->getUInt32Value(UNIT_FIELD_HEALTH) <= 2500 && pDeath->mEnabled)
             {
-                Spell* pCurrentSpell = getCreature()->GetCurrentSpell();
-                if (pCurrentSpell != NULL && pCurrentSpell->pSpellId == pDeath->mInfo->getId())
+                Spell* pCurrentSpell = getCreature()->findCurrentCastedSpellBySpellId(pDeath->mInfo->getId());
+                if (pCurrentSpell != nullptr)
                 {
-                    pCurrentSpell->cancel();
+                    getCreature()->interruptSpell(pCurrentSpell->GetSpellInfo()->getId());
                 }
                 if (!mQueuedSpells.empty())
                     for (SpellDescList::iterator itr = mQueuedSpells.begin(); itr != mQueuedSpells.end(); ++itr)
@@ -1601,7 +1601,7 @@ class NajentusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1652,7 +1652,7 @@ class NajentusAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1796,7 +1796,7 @@ class SupremusAI : public CreatureAIScript
 
             uint32 val = RandomUInt(1000);
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 if (m_MoltenFlame)
                 {
@@ -1839,7 +1839,7 @@ class SupremusAI : public CreatureAIScript
 
             uint32 val = RandomUInt(1000);
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 if (m_MoltenPunch)
                 {
@@ -2074,7 +2074,7 @@ class GurtoggAI : public CreatureAIScript
             }
 
             // Phase 1
-            if (Phase == 1 && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell() == NULL)
+            if (Phase == 1 && getCreature()->GetAIInterface()->getNextTarget() && !getCreature()->isCastingNonMeleeSpell())
             {
                 // Bloodboil
                 if (t > spells[2].casttime)
@@ -2115,7 +2115,7 @@ class GurtoggAI : public CreatureAIScript
                 }
             }
 
-            if (Phase == 2 && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell() == NULL)
+            if (Phase == 2 && getCreature()->GetAIInterface()->getNextTarget() && !getCreature()->isCastingNonMeleeSpell())
             {
                 // Fel Rage check
                 if (t > spells[7].casttime - 62 && LastThreat != 0)
@@ -2226,7 +2226,7 @@ class GurtoggAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2279,7 +2279,7 @@ class GurtoggAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2909,7 +2909,7 @@ class ShahrazAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2959,7 +2959,7 @@ class ShahrazAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -3328,7 +3328,7 @@ class TeronGorefiendAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -3378,7 +3378,7 @@ class TeronGorefiendAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -3588,7 +3588,7 @@ class ShadeofakamaAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -5062,8 +5062,8 @@ class MaievAI : public CreatureAIScript
                         sendChatMessage(CHAT_MSG_MONSTER_YELL, 11496, "Ah, it is finished. You are beaten.");
 
                         mIllidanAI->getCreature()->Emote(EMOTE_ONESHOT_CUSTOMSPELL06);
-                        if (mIllidanAI->getCreature()->GetCurrentSpell() != NULL)
-                            mIllidanAI->getCreature()->GetCurrentSpell()->cancel();
+                        if (mIllidanAI->getCreature()->isCastingNonMeleeSpell())
+                            mIllidanAI->getCreature()->interruptSpell();
                         break;
                     case 2:
                         mIllidanAI->getCreature()->SetEmoteState(EMOTE_ONESHOT_CUSTOMSPELL07);

--- a/src/scripts/InstanceScripts/Raid_BlackwingLair.cpp
+++ b/src/scripts/InstanceScripts/Raid_BlackwingLair.cpp
@@ -83,7 +83,7 @@ class DTcaptainAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -192,7 +192,7 @@ class DTflamescaleAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -308,7 +308,7 @@ class DTwyrmkinAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -418,7 +418,7 @@ class TechnicianAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -524,7 +524,7 @@ class BlackWarlockAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -659,7 +659,7 @@ class LashlayerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -763,7 +763,7 @@ class FiremawAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -866,7 +866,7 @@ class EbonrocAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -969,7 +969,7 @@ class FlamegorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1124,7 +1124,7 @@ class VaelastraszAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
+++ b/src/scripts/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
@@ -305,7 +305,7 @@ class RageWinterchillAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -355,7 +355,7 @@ class RageWinterchillAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -534,7 +534,7 @@ class AnetheronAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -594,7 +594,7 @@ class AnetheronAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -754,7 +754,7 @@ class KazrogalAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -829,7 +829,7 @@ class KazrogalAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -997,7 +997,7 @@ class AzgalorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1047,7 +1047,7 @@ class AzgalorAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1399,7 +1399,7 @@ class ArchimondeAI : public CreatureAIScript
                 }
 
                 uint32 t = (uint32)time(NULL);
-                if (mTarget->IsPlayer() && isAlive() && !getCreature()->GetCurrentSpell() && t > spells[6].casttime)
+                if (mTarget->IsPlayer() && isAlive() && !getCreature()->isCastingNonMeleeSpell() && t > spells[6].casttime)
                 {
                     uint32 SpellID = 0;
                     if (mTarget->getClass() == WARRIOR || mTarget->getClass() == ROGUE || mTarget->getClass() == MAGE)
@@ -1443,14 +1443,14 @@ class ArchimondeAI : public CreatureAIScript
             //setAIAgent(AGENT_NULL);
 
             uint32 t = (uint32)time(NULL);
-            if (t > spells[3].casttime && getCreature()->GetCurrentSpell() == NULL)
+            if (t > spells[3].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[3].info, spells[3].instant);
 
                 spells[3].casttime = t + spells[3].cooldown;
             }
 
-            else if (t > spells[5].casttime && getCreature()->GetCurrentSpell() == NULL)
+            else if (t > spells[5].casttime && !getCreature()->isCastingNonMeleeSpell())
             {
                 getCreature()->CastSpell(getCreature(), spells[5].info, spells[5].instant);
 
@@ -1478,7 +1478,7 @@ class ArchimondeAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1529,7 +1529,7 @@ class ArchimondeAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Raid_Karazhan.cpp
+++ b/src/scripts/InstanceScripts/Raid_Karazhan.cpp
@@ -452,7 +452,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -650,7 +650,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1223,7 +1223,7 @@ public:
     void Trigger()
     {
         uint32 t = (uint32)time(NULL);
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget() && t > spells[0].casttime)
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget() && t > spells[0].casttime)
         {
             Unit* target = getCreature()->GetAIInterface()->GetSecondHated();
             getCreature()->CastSpell(target, spells[0].info, spells[0].instant);
@@ -1602,7 +1602,7 @@ public:
                 sendDBChatMessage(2041);     // I'm not finished yet! No, I have a few more tricks up me sleeve.
                 summoned = true;
             }
-            else if (getCreature()->GetManaPct() <= 20 && getCreature()->GetCurrentSpell() == NULL)
+            else if (getCreature()->GetManaPct() <= 20 && !getCreature()->isCastingNonMeleeSpell())
             {
                 if (!m_time_pyroblast)
                 {
@@ -1625,7 +1625,7 @@ public:
             else
                 SpellTrigger();
         }
-        else if (getCreature()->GetCurrentSpell() == NULL)
+        else if (!getCreature()->isCastingNonMeleeSpell())
         {
             m_time_pyroblast--;
             if (!m_time_pyroblast)
@@ -1803,7 +1803,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1858,7 +1858,7 @@ public:
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Player* > TargetTable;
             for (std::set< Object* >::iterator itr = getCreature()->GetInRangePlayerSetBegin(); itr != getCreature()->GetInRangePlayerSetEnd(); ++itr)
@@ -2139,7 +2139,7 @@ public:
         SpellCast(val);
 
         uint32 t = (uint32)time(NULL);
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             if (t > ImpTimer)
             {
@@ -2227,7 +2227,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2334,7 +2334,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2385,7 +2385,7 @@ public:
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Unit* > TargetTable;
             for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2492,7 +2492,7 @@ public:
         if (getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetDistance2dSq(getCreature()->GetAIInterface()->getNextTarget()) <= 1225.0f)
         {
             setAIAgent(AGENT_SPELL);
-            if (getCreature()->GetCurrentSpell() == NULL && RandomUInt(10) > 2)
+            if (!getCreature()->isCastingNonMeleeSpell() && RandomUInt(10) > 2)
             {
                 getCreature()->setAttackTimer(spells[0].attackstoptimer, false);
 
@@ -2510,7 +2510,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2892,7 +2892,7 @@ public:
                 break;
         }
         uint32 t = (uint32)time(NULL);
-        if (t > spells[1].casttime && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell() == NULL)
+        if (t > spells[1].casttime && getCreature()->GetAIInterface()->getNextTarget() && !getCreature()->isCastingNonMeleeSpell())
         {
             Enfeebler();
             spells[1].casttime = t + spells[1].cooldown;
@@ -2904,7 +2904,7 @@ public:
             m_spawn_infernal = 0;
             m_infernal = false;
         }
-        else if (t > spells[5].casttime && getCreature()->GetAIInterface()->getNextTarget() && getCreature()->GetCurrentSpell() == NULL)
+        else if (t > spells[5].casttime && getCreature()->GetAIInterface()->getNextTarget() && !getCreature()->isCastingNonMeleeSpell())
         {
             spells[5].casttime = -1;
             getCreature()->CastSpell(getCreature(), spells[5].info, spells[5].instant);
@@ -3081,7 +3081,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -3131,7 +3131,7 @@ public:
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Player* > TargetTable;
             for (std::set< Object* >::iterator itr = getCreature()->GetInRangePlayerSetBegin(); itr != getCreature()->GetInRangePlayerSetEnd(); ++itr)
@@ -3412,7 +3412,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -3675,8 +3675,8 @@ public:
         m_FlyPhaseTimer--;
         if (!m_FlyPhaseTimer)
         {
-            if (getCreature()->GetCurrentSpell() != NULL)
-                getCreature()->GetCurrentSpell()->cancel();
+            if (getCreature()->isCastingNonMeleeSpell())
+                getCreature()->interruptSpell();
 
             getCreature()->GetAIInterface()->m_canMove = true;
             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
@@ -3737,8 +3737,8 @@ public:
             || (m_phase == 2 && getCreature()->GetHealthPct() <= 50)
             || (m_phase == 4 && getCreature()->GetHealthPct() <= 25))
         {
-            if (getCreature()->GetCurrentSpell() != NULL)
-                getCreature()->GetCurrentSpell()->cancel();
+            if (getCreature()->isCastingNonMeleeSpell())
+                getCreature()->interruptSpell();
 
             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
             getCreature()->GetAIInterface()->StopMovement(0);
@@ -3800,7 +3800,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -3847,7 +3847,7 @@ public:
     {
         if (!maxdist2cast) maxdist2cast = 100.0f;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
             for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -4030,7 +4030,7 @@ public:
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Unit*> TargetTable;
             for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -4068,7 +4068,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4192,7 +4192,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4332,7 +4332,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4472,7 +4472,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4668,7 +4668,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4887,7 +4887,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -5064,7 +5064,7 @@ public:
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_Magtheridons_Lair.cpp
+++ b/src/scripts/InstanceScripts/Raid_Magtheridons_Lair.cpp
@@ -574,8 +574,8 @@ class ManticronCubeGO : public GameObjectAIScript
                 Magtheridon->GetAIInterface()->StopMovement(3000);
                 Magtheridon->setAttackTimer(3000, false);
 
-                if (Magtheridon->GetCurrentSpell())
-                    Magtheridon->GetCurrentSpell()->cancel();
+                if (Magtheridon->isCastingNonMeleeSpell())
+                    Magtheridon->interruptSpell();
 
                 // We add channeling player aura that does not allow that go to be used again in 1.3 min
                 Aura* aura = sSpellFactoryMgr.NewAura(sSpellCustomizations.GetSpellInfo(MIND_EXHAUSTION), (uint32)78000, Magtheridon, Channeler);
@@ -740,7 +740,7 @@ class HellfireWarderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -790,7 +790,7 @@ class HellfireWarderAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        /* From M4ksiu - Big THX to Capt who helped me with std stuff to make it simple and fully working <3 */
                 /* If anyone wants to use this function, then leave this note!                                         */
@@ -963,7 +963,7 @@ class HellfireChannelerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1016,7 +1016,7 @@ class HellfireChannelerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        /* From M4ksiu - Big THX to Capt who helped me with std stuff to make it simple and fully working <3 */
                 /* If anyone wants to use this function, then leave this note!                                         */
@@ -1125,7 +1125,7 @@ class BurningAbyssalAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1175,7 +1175,7 @@ class BurningAbyssalAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        /* From M4ksiu - Big THX to Capt who helped me with std stuff to make it simple and fully working <3 */
                 /* If anyone wants to use this function, then leave this note!                                         */
@@ -1405,7 +1405,7 @@ class MagtheridonAI : public CreatureAIScript
             {
                 getCreature()->SendChatMessageAlternateEntry(17257, CHAT_MSG_EMOTE, LANG_UNIVERSAL, " begins to cast Blast Nova!");
             }
-            if (timer_blastNova > 33 && getCreature()->GetCurrentSpell() == NULL && !aura)
+            if (timer_blastNova > 33 && !getCreature()->isCastingNonMeleeSpell() && !aura)
             {
                 getCreature()->GetAIInterface()->StopMovement(3000);
                 getCreature()->setAttackTimer(3000, false);
@@ -1417,7 +1417,7 @@ class MagtheridonAI : public CreatureAIScript
                 return;
             }
 
-            if (timer_enrage > 667 && getCreature()->GetCurrentSpell() == NULL && !aura)
+            if (timer_enrage > 667 && !getCreature()->isCastingNonMeleeSpell() && !aura)
             {
                 getCreature()->CastSpell(getCreature(), sSpellCustomizations.GetSpellInfo(ENRAGE), true);
 
@@ -1463,7 +1463,7 @@ class MagtheridonAI : public CreatureAIScript
             {
                 getCreature()->SendChatMessageAlternateEntry(17257, CHAT_MSG_MONSTER_EMOTE, LANG_UNIVERSAL, " begins to cast Blast Nova!");
             }
-            if (timer_blastNova > 33 && getCreature()->GetCurrentSpell() == NULL && !aura)
+            if (timer_blastNova > 33 && !getCreature()->isCastingNonMeleeSpell() && !aura)
             {
                 getCreature()->GetAIInterface()->StopMovement(3000);
                 getCreature()->setAttackTimer(3000, false);
@@ -1475,7 +1475,7 @@ class MagtheridonAI : public CreatureAIScript
                 return;
             }
 
-            if (timer_caveIn && (timer_caveIn != 1 || (getCreature()->GetCurrentSpell() == NULL && timer_caveIn == 1 && !aura)))
+            if (timer_caveIn && (timer_caveIn != 1 || (!getCreature()->isCastingNonMeleeSpell() && timer_caveIn == 1 && !aura)))
             {
                 timer_caveIn++;
                 if (timer_caveIn == 2)
@@ -1519,7 +1519,7 @@ class MagtheridonAI : public CreatureAIScript
                 }
             }
 
-            if (timer_enrage > 667 && getCreature()->GetCurrentSpell() == NULL && !aura)
+            if (timer_enrage > 667 && !getCreature()->isCastingNonMeleeSpell() && !aura)
             {
                 getCreature()->CastSpell(getCreature(), sSpellCustomizations.GetSpellInfo(ENRAGE), true);
 
@@ -1536,7 +1536,7 @@ class MagtheridonAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1586,7 +1586,7 @@ class MagtheridonAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;        // From M4ksiu - Big THX to Capt
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)

--- a/src/scripts/InstanceScripts/Raid_MoltenCore.cpp
+++ b/src/scripts/InstanceScripts/Raid_MoltenCore.cpp
@@ -60,7 +60,7 @@ class CoreRagerAI : public CreatureAIScript
 
         void SpellCast(uint32 val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 //Unit* target = _unit->GetAIInterface()->GetNextTarget();
                 if (m_mangle)
@@ -125,7 +125,7 @@ class SulfuronAI : public CreatureAIScript
 
         void SpellCast(uint32 val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 //Unit* target = _unit->GetAIInterface()->GetNextTarget();
 
@@ -247,7 +247,7 @@ class RagnarosAI : public CreatureAIScript
 
         void SpellCast(uint32 val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 Unit* target = getCreature()->GetAIInterface()->getNextTarget();
 

--- a/src/scripts/InstanceScripts/Raid_Naxxramas.cpp
+++ b/src/scripts/InstanceScripts/Raid_Naxxramas.cpp
@@ -374,8 +374,8 @@ void SpellFunc_MaexxnaWebWrap(SpellDesc* pThis, CreatureAIScript* pCreatureAI, U
         WebWrap->RegisterAIUpdateEvent(5000);
         WebWrap->mPlayerGuid = static_cast<Player*>(pTarget)->GetGUID();
 
-        if (pTarget->GetCurrentSpell() != NULL)
-            pTarget->GetCurrentSpell()->cancel();
+        if (pTarget->isCastingNonMeleeSpell())
+            pTarget->interruptSpell();
 
         // Somewhy root does not apply at all
         static_cast<Player*>(pTarget)->SafeTeleport(Maexxna->getCreature()->GetMapId(), Maexxna->getCreature()->GetInstanceID(), LocationVector(WebWrapPos[Id].x, WebWrapPos[Id].y, WebWrapPos[Id].z));

--- a/src/scripts/InstanceScripts/Raid_Naxxramas.h
+++ b/src/scripts/InstanceScripts/Raid_Naxxramas.h
@@ -1451,7 +1451,7 @@ class GluthAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1550,7 +1550,7 @@ class BonyConstructAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1648,7 +1648,7 @@ class DeathLordAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1771,7 +1771,7 @@ class RazuviousAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -1924,7 +1924,7 @@ class KorthazzAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2101,7 +2101,7 @@ class BlaumeuxAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2274,7 +2274,7 @@ class ZeliekAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2666,7 +2666,7 @@ class SapphironAI : public CreatureAIScript
     void AIUpdate()
     {
         uint32 t = (uint32)time(NULL);
-        if (t > spells[3].casttime && getCreature()->GetCurrentSpell() == NULL)
+        if (t > spells[3].casttime && !getCreature()->isCastingNonMeleeSpell())
         {
             getCreature()->CastSpell(getCreature(), spells[3].info, spells[3].instant);
 
@@ -2699,8 +2699,8 @@ class SapphironAI : public CreatureAIScript
             uint32 t = (uint32)time(NULL);
             if (t > PhaseTimer)
             {
-                if (getCreature()->GetCurrentSpell() != NULL)
-                    getCreature()->GetCurrentSpell()->cancel();
+                if (getCreature()->isCastingNonMeleeSpell())
+                    getCreature()->interruptSpell();
 
                 getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                 getCreature()->GetAIInterface()->StopMovement(0);
@@ -2744,7 +2744,7 @@ class SapphironAI : public CreatureAIScript
 
         if (FlightActions < 5)
         {
-            if (getCreature()->GetCurrentSpell() == NULL)
+            if (!getCreature()->isCastingNonMeleeSpell())
             {
                 if (getCreature()->GetAIInterface()->getNextTarget() != NULL)
                 {
@@ -2886,7 +2886,7 @@ class SapphironAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget() != NULL)
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget() != NULL)
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -2944,7 +2944,7 @@ class SapphironAI : public CreatureAIScript
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget() != NULL)
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget() != NULL)
         {
             std::vector<Unit*> TargetTable;
             for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -3653,7 +3653,7 @@ class KelthuzadAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -3713,7 +3713,7 @@ class KelthuzadAI : public CreatureAIScript
         if (!maxdist2cast) maxdist2cast = 100.0f;
         if (!maxhp2cast) maxhp2cast = 100;
 
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             std::vector<Unit*> TargetTable;
             for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -4014,7 +4014,7 @@ class UnstoppableAbominationAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;
@@ -4179,7 +4179,7 @@ class SoulWeaverAI : public CreatureAIScript
 
     void SpellCast(float val)
     {
-        if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+        if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
         {
             float comulativeperc = 0;
             Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_OnyxiasLair.cpp
+++ b/src/scripts/InstanceScripts/Raid_OnyxiasLair.cpp
@@ -202,8 +202,8 @@ class OnyxiaAI : public CreatureAIScript
             {
                 m_phase = 2;
                 getCreature()->SetCastSpeedMod(0.01f);
-                if (getCreature()->GetCurrentSpell() != NULL)
-                    getCreature()->GetCurrentSpell()->cancel();
+                if (getCreature()->isCastingNonMeleeSpell())
+                    getCreature()->interruptSpell();
 
                 getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                 //_unit->m_pacified++;
@@ -224,8 +224,8 @@ class OnyxiaAI : public CreatureAIScript
             {
                 m_phase = 3;
                 getCreature()->SetCastSpeedMod(1.0f);
-                if (getCreature()->GetCurrentSpell() != NULL)
-                    getCreature()->GetCurrentSpell()->cancel();
+                if (getCreature()->isCastingNonMeleeSpell())
+                    getCreature()->interruptSpell();
                 getCreature()->GetAIInterface()->m_canMove = true;
                 getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                 //_unit->m_pacified++;
@@ -364,7 +364,7 @@ class OnyxiaAI : public CreatureAIScript
 
         void SpellCast(uint32 val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())//_unit->getAttackTarget())
             {
                 if (m_fBreath)
                 {

--- a/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
@@ -348,7 +348,7 @@ class HydrossTheUnstableAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -523,7 +523,7 @@ class LurkerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -850,7 +850,7 @@ class LeotherasAI : public CreatureAIScript
                 //Chaos Blast
                 if (getCreature()->GetAIInterface()->getNextTarget())
                 {
-                    if (getCreature()->GetCurrentSpell() == NULL)
+                    if (!getCreature()->isCastingNonMeleeSpell())
                     {
                         if (RandomUInt(1))
                         {
@@ -882,7 +882,7 @@ class LeotherasAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1029,7 +1029,7 @@ class GreyheartSpellbinderAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1148,7 +1148,7 @@ class ShadowofLeotherasAI : public CreatureAIScript
             //Chaos Blast
             if (getCreature()->GetAIInterface()->getNextTarget())
             {
-                if (getCreature()->GetCurrentSpell() == NULL)
+                if (!getCreature()->isCastingNonMeleeSpell())
                 {
                     if (RandomUInt(1))
                     {
@@ -1542,7 +1542,7 @@ class MorogrimAI : public CreatureAIScript
 
         void AIUpdate()
         {
-            if (getCreature()->GetAIInterface()->getNextTarget() != NULL && getCreature()->GetCurrentSpell() == NULL)
+            if (getCreature()->GetAIInterface()->getNextTarget() != NULL && !getCreature()->isCastingNonMeleeSpell())
             {
                 Unit* target = NULL;
                 uint32 t = (uint32)time(NULL);
@@ -2141,7 +2141,7 @@ class VashjAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2294,7 +2294,7 @@ class TaintedElementalAI : public CreatureAIScript
         void AIUpdate()
         {
             ///\todo  Despawn after 15 secs
-            if (getCreature()->GetCurrentSpell() == NULL)
+            if (!getCreature()->isCastingNonMeleeSpell())
                 getCreature()->GetAIInterface()->SetNextSpell(spell_poison_spit);
         }
 
@@ -2543,7 +2543,7 @@ class ToxicSporeBatAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_TheEye.cpp
+++ b/src/scripts/InstanceScripts/Raid_TheEye.cpp
@@ -97,7 +97,7 @@ class AStarScryerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -147,7 +147,7 @@ class AStarScryerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -260,7 +260,7 @@ class StarScryerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -310,7 +310,7 @@ class StarScryerAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -489,7 +489,7 @@ class AstromancerLordAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -539,7 +539,7 @@ class AstromancerLordAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -660,7 +660,7 @@ class BloodVindicatorAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -710,7 +710,7 @@ class BloodVindicatorAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -831,7 +831,7 @@ class BloodLegionnareAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -881,7 +881,7 @@ class BloodLegionnareAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1002,7 +1002,7 @@ class BloodMarshalAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1052,7 +1052,7 @@ class BloodMarshalAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1175,7 +1175,7 @@ class PhoenixHawkAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1225,7 +1225,7 @@ class PhoenixHawkAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1346,7 +1346,7 @@ class CrystalSentinelAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1396,7 +1396,7 @@ class CrystalSentinelAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -1510,7 +1510,7 @@ class CrystalMechanicAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1560,7 +1560,7 @@ class CrystalMechanicAI : public CreatureAIScript
             if (!maxdist2cast) maxdist2cast = 100.0f;
             if (!maxhp2cast) maxhp2cast = 100;
 
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 std::vector<Unit*> TargetTable;
                 for (std::set<Object*>::iterator itr = getCreature()->GetInRangeSetBegin(); itr != getCreature()->GetInRangeSetEnd(); ++itr)
@@ -2257,7 +2257,7 @@ class AlarAI : public CreatureAIScript
         void CastSpell(int id)
         {
             if (spells[id].casttime > 0) return;
-            if (getCreature()->GetCurrentSpell() != NULL) return;
+            if (getCreature()->isCastingNonMeleeSpell()) return;
 
             Unit* target = NULL;
             target = getCreature()->GetAIInterface()->getNextTarget();

--- a/src/scripts/InstanceScripts/Raid_WorldBosses.cpp
+++ b/src/scripts/InstanceScripts/Raid_WorldBosses.cpp
@@ -160,7 +160,7 @@ class EmerissAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -360,7 +360,7 @@ class TaerarAI : public CreatureAIScript
             if (getCreature()->GetHealthPct() == 25 || getCreature()->GetHealthPct() == 50 || getCreature()->GetHealthPct() == 75)
             {
                 //Inturrupt any spell casting
-                getCreature()->InterruptSpell();
+                getCreature()->interruptSpell();
                 //Root self
                 getCreature()->CastSpell(getCreature(), 23973, true);
                 getCreature()->SetFaction(35);
@@ -383,7 +383,7 @@ class TaerarAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -513,7 +513,7 @@ class ShadeofTaerarAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -695,7 +695,7 @@ class YsondreAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -814,7 +814,7 @@ class DementedDruidSpiritAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1014,7 +1014,7 @@ class LethonAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1338,7 +1338,7 @@ class KruulAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1579,7 +1579,7 @@ class KazzakAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1757,7 +1757,7 @@ class AzuregosAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -1947,7 +1947,7 @@ class DoomwalkerAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -2107,7 +2107,7 @@ class TeremusAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/InstanceScripts/Raid_ZulGurub.cpp
+++ b/src/scripts/InstanceScripts/Raid_ZulGurub.cpp
@@ -126,7 +126,7 @@ class JeklikAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;
@@ -267,7 +267,7 @@ class VenoxisAI : public CreatureAIScript
 
         void SpellCast(float val)
         {
-            if (getCreature()->GetCurrentSpell() == NULL && getCreature()->GetAIInterface()->getNextTarget())
+            if (!getCreature()->isCastingNonMeleeSpell() && getCreature()->GetAIInterface()->getNextTarget())
             {
                 float comulativeperc = 0;
                 Unit* target = NULL;

--- a/src/scripts/LuaEngine/SpellFunctions.h
+++ b/src/scripts/LuaEngine/SpellFunctions.h
@@ -250,8 +250,8 @@ namespace LuaSpell
 
     int Cancel(lua_State* L, Spell* sp)
     {
-        if (!sp) return 0;
-        sp->cancel();
+        if (!sp || !sp->m_caster->IsInWorld()) return 0;
+        sp->m_caster->interruptSpell(sp->GetSpellInfo()->getId());
         return 0;
     }
 

--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -2309,7 +2309,7 @@ class LuaUnit
     {
         if (!ptr)
             return 0;
-        ptr->CancelSpell(ptr->GetCurrentSpell());
+        ptr->interruptSpell();
         return 0;
     }
 
@@ -2495,8 +2495,16 @@ class LuaUnit
     static int GetCurrentSpellId(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        if (ptr->GetCurrentSpell())
-            lua_pushnumber(L, ptr->GetCurrentSpell()->GetSpellInfo()->getId());
+        uint32_t spellId = 0;
+        for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+        {
+            if (ptr->getCurrentSpell(CurrentSpellType(i)) == nullptr)
+                continue;
+            spellId = ptr->getCurrentSpell(CurrentSpellType(i))->GetSpellInfo()->getId();
+            break;
+        }
+        if (spellId != 0)
+            lua_pushnumber(L, spellId);
         else
             lua_pushnil(L);
         return 1;
@@ -2505,8 +2513,16 @@ class LuaUnit
     static int GetCurrentSpell(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        if (ptr->GetCurrentSpell() != 0)
-            PUSH_SPELL(L, ptr->GetCurrentSpell());
+        Spell* curSpell = nullptr;
+        for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+        {
+            if (ptr->getCurrentSpell(CurrentSpellType(i)) == nullptr)
+                continue;
+            curSpell = ptr->getCurrentSpell(CurrentSpellType(i));
+            break;
+        }
+        if (curSpell != nullptr)
+            PUSH_SPELL(L, curSpell);
         else
             lua_pushnil(L);
         return 1;
@@ -4029,7 +4045,7 @@ class LuaUnit
     static int InterruptSpell(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        ptr->InterruptSpell();
+        ptr->interruptSpell();
         return 0;
     }
 

--- a/src/scripts/SpellHandlers/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/DeathKnightSpells.cpp
@@ -115,8 +115,19 @@ bool Strangulate(uint32 i, Aura* pAura, bool apply)
 
     Unit* unitTarget = pAura->GetTarget();
 
-    if (unitTarget->IsCasting())
-        unitTarget->InterruptSpell();
+    // Interrupt target's current casted spell (either channeled or generic spell with cast time)
+    if (pAura->GetTarget()->isCastingNonMeleeSpell(true, false, true))
+    {
+        if (pAura->GetTarget()->getCurrentSpell(CURRENT_CHANNELED_SPELL) != nullptr && pAura->GetTarget()->getCurrentSpell(CURRENT_CHANNELED_SPELL)->getCastTimeLeft() > 0)
+        {
+            pAura->GetTarget()->interruptSpellWithSpellType(CURRENT_CHANNELED_SPELL);
+        }
+        // No need to check cast time for generic spells, checked already in Object::isCastingNonMeleeSpell()
+        else if (pAura->GetTarget()->getCurrentSpell(CURRENT_GENERIC_SPELL) != nullptr)
+        {
+            pAura->GetTarget()->interruptSpellWithSpellType(CURRENT_GENERIC_SPELL);
+        }
+    }
 
     return true;
 }

--- a/src/scripts/SpellHandlers/PetAISpells.cpp
+++ b/src/scripts/SpellHandlers/PetAISpells.cpp
@@ -233,7 +233,7 @@ public:
     void AIUpdate()
     {
         Unit* curtarget = getCreature()->GetAIInterface()->getNextTarget();
-        if (getCreature()->GetCurrentSpell() == NULL && curtarget)
+        if (!getCreature()->isCastingNonMeleeSpell() && curtarget)
         {
             switch (dpsCycle)
             {

--- a/src/world/GameCata/Handlers/LootHandler.cpp
+++ b/src/world/GameCata/Handlers/LootHandler.cpp
@@ -67,8 +67,8 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recv_data)
     uint8_t lootSlot;
     recv_data >> lootSlot;
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    if (_player->isCastingNonMeleeSpell())
+        _player->interruptSpell();
 
     GameObject* pLootableGameObject = nullptr;
     Creature* pLootableCreature = nullptr;
@@ -244,8 +244,8 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& recv_data)
     if (lootguid == 0)
         return;
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    if (_player->isCastingNonMeleeSpell())
+        _player->interruptSpell();
 
     Unit* pt = nullptr;
     uint32_t guidtype = GET_TYPE_FROM_GUID(lootguid);
@@ -352,8 +352,8 @@ void WorldSession::HandleLootOpcode(WorldPacket& recv_data)
     if (_player->IsStealth())
         _player->RemoveStealth();
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    if (_player->isCastingNonMeleeSpell())
+        _player->interruptSpell();
 
     if (_player->IsInvisible())
         _player->RemoveInvisibility();

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -136,6 +136,7 @@ void GameObject::Update(unsigned long time_passed)
     if (m_deleted)
         return;
 
+    _UpdateSpells(time_passed);
 }
 
 void GameObject::Spawn(MapMgr* m)

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -66,7 +66,6 @@ class Spell;
 class UpdateMask;
 class EventableObject;
 
-
 enum HIGHGUID_TYPE
 {
     HIGHGUID_TYPE_PLAYER			= 0x00000000,
@@ -85,6 +84,15 @@ enum HIGHGUID_TYPE
 //===============================================
     HIGHGUID_TYPE_MASK				= 0xFFF00000,
     LOWGUID_ENTRY_MASK				= 0x00FFFFFF,
+};
+
+enum CurrentSpellType : uint8_t
+{
+    CURRENT_MELEE_SPELL         = 0,
+    CURRENT_GENERIC_SPELL       = 1,
+    CURRENT_CHANNELED_SPELL     = 2,
+    CURRENT_AUTOREPEAT_SPELL    = 3,
+    CURRENT_SPELL_MAX
 };
 
 #define GET_TYPE_FROM_GUID(x) (Arcemu::Util::GUID_HIPART((x)) & HIGHGUID_TYPE_MASK)
@@ -380,6 +388,28 @@ public:
 
     float getDistanceSq(LocationVector target) const;
     float getDistanceSq(float x, float y, float z) const;
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Spell functions
+    Spell* getCurrentSpell(CurrentSpellType spellType) const;
+    Spell* getCurrentSpellById(uint32_t spellId) const;
+    void setCurrentSpell(Spell* curSpell);
+
+    // If spellid is set to 0, function will interrupt any current spell
+    // TODO: implement delayed spells
+    void interruptSpell(uint32_t spellId = 0, bool checkMeleeSpell = true, bool checkDelayed = true);
+    void interruptSpellWithSpellType(CurrentSpellType spellType, bool checkDelayed = true);
+    // Searches for current casted spell, but skips melee spells
+    // TODO: implement delayed spells
+    bool isCastingNonMeleeSpell(bool checkDelayed = true, bool skipChanneled = false, bool skipAutorepeat = false, bool isAutoshoot = false) const;
+    Spell* findCurrentCastedSpellBySpellId(uint32_t spellId);
+
+    void _UpdateSpells(uint32_t time); // moved here from Unit class since GameObject can be caster as well
+
+private:
+    Spell* m_currentSpell[CURRENT_SPELL_MAX];
+
+public:
     // MIT End
 
         typedef std::set<Object*> InRangeSet;
@@ -935,11 +965,6 @@ public:
     public:
 
         bool m_loadedFromDB;
-
-        // Spell currently casting
-        Spell* m_currentSpell;
-        Spell* GetCurrentSpell() { return m_currentSpell; }
-        void SetCurrentSpell(Spell* cSpell) { m_currentSpell = cSpell; }
 
         // Andy's crap
         virtual Object* GetPlayerOwner();

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -439,10 +439,13 @@ void WorldSession::HandleDestroyItemOpcode(WorldPacket& recv_data)
         if (!pItem)
             return;
 
-        if (_player->GetCurrentSpell() && _player->GetCurrentSpell()->i_caster == pItem)
+        for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
         {
-            _player->GetCurrentSpell()->i_caster = NULL;
-            _player->GetCurrentSpell()->cancel();
+            if (_player->getCurrentSpell(CurrentSpellType(i)) != nullptr && _player->getCurrentSpell(CurrentSpellType(i))->i_caster == pItem)
+            {
+                _player->getCurrentSpell(CurrentSpellType(i))->i_caster = nullptr;
+                _player->interruptSpellWithSpellType(CurrentSpellType(i));
+            }
         }
 
         pItem->DeleteFromDB();
@@ -964,8 +967,7 @@ void WorldSession::HandleSellItemOpcode(WorldPacket& recv_data)
     recv_data >> itemguid;
     recv_data >> amount;
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    _player->interruptSpell();
 
     // Check if item exists
     if (!itemguid)
@@ -1083,8 +1085,7 @@ void WorldSession::HandleBuyItemInSlotOpcode(WorldPacket& recv_data)   // drag &
     if (amount < 1)
         amount = 1;
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    _player->interruptSpell();
 
     Creature* unit = _player->GetMapMgr()->GetCreature(GET_LOWGUID_PART(srcguid));
     if (unit == NULL || !unit->HasItems())

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -75,8 +75,8 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recv_data)
     Item* add;
     Loot* pLoot = NULL;
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    _player->interruptSpell();
+
     GameObject* pGO = NULL;
     Creature* pCreature = NULL;
     Item *lootSrcItem = NULL;
@@ -296,8 +296,7 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& recv_data)
     if (!lootguid)
         return;   // dunno why this happens
 
-    if (_player->IsCasting())
-        _player->InterruptSpell();
+    _player->interruptSpell();
 
     WorldPacket pkt;
     Unit* pt = 0;
@@ -451,8 +450,7 @@ void WorldSession::HandleLootOpcode(WorldPacket& recv_data)
     if (_player->IsStealth())    // Check if the player is stealthed
         _player->RemoveStealth(); // cebernic:RemoveStealth on looting. Blizzlike
 
-    if (_player->IsCasting())    // Check if the player is casting
-        _player->InterruptSpell(); // Cancel spell casting
+    _player->interruptSpell(); // Cancel spell casting (no need to check is casting, the function does it)
 
     if (_player->IsInvisible())    // Check if the player is invisible for what ever reason
         _player->RemoveInvisibility(); // Remove all invisibility
@@ -1675,7 +1673,6 @@ void WorldSession::HandleGameObjectUse(WorldPacket& recv_data)
         {
             spellInfo = sSpellCustomizations.GetSpellInfo(OPEN_CHEST);
             spell = sSpellFactoryMgr.NewSpell(plyr, spellInfo, true, NULL);
-            _player->m_currentSpell = spell;
             targets.m_unitTarget = obj->GetGUID();
             spell->prepare(&targets);
         }
@@ -1756,7 +1753,8 @@ void WorldSession::HandleGameObjectUse(WorldPacket& recv_data)
                 plyr->GetSession()->OutPacket(SMSG_FISH_NOT_HOOKED);
             }
 
-            auto spell = plyr->GetCurrentSpell();
+            // Fishing is channeled spell
+            auto spell = plyr->getCurrentSpell(CURRENT_CHANNELED_SPELL);
             if (spell != nullptr)
             {
                 if (success)

--- a/src/world/Server/Packets/Handlers/MovementHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MovementHandler.cpp
@@ -331,7 +331,7 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
                 GameObject_FishingNode* go_fishing_node = static_cast<GameObject_FishingNode*>(go);
                 go_fishing_node->EndFishing(true);
 
-                auto spell = _player->GetCurrentSpell();
+                auto spell = _player->getCurrentSpell(CURRENT_CHANNELED_SPELL);
                 if (spell != nullptr)
                 {
                     spell->SendChannelUpdate(0);

--- a/src/world/Server/Packets/Handlers/TaxiHandler.cpp
+++ b/src/world/Server/Packets/Handlers/TaxiHandler.cpp
@@ -242,8 +242,10 @@ void WorldSession::HandleActivateTaxiOpcode(WorldPacket& recv_data)
     // 0x000008 seems to enable detailed collision checking
 
     //! Check if the player is casting, obviously they should not be able to cast on a taxi
-    if (_player->GetCurrentSpell() != NULL)
-        _player->GetCurrentSpell()->cancel();
+    for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+    {
+        _player->interruptSpellWithSpellType(CurrentSpellType(i), false);
+    }
 
     _player->taxi_model_id = modelid;
     _player->TaxiStart(taxipath, modelid, 0);

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -988,7 +988,7 @@ void CreatureAIScript::_regenerateHealth()
 
 bool CreatureAIScript::_isCasting()
 {
-    return _creature->IsCasting();
+    return _creature->isCastingNonMeleeSpell();
 }
 
 bool CreatureAIScript::_isHeroic()
@@ -1338,7 +1338,7 @@ void CreatureAIScript::newAIUpdateSpellSystem()
             // stop spells and remove aura in case of duration
             if (_isTimerFinished(AISpell->mDurationTimerId) && AISpell->mForceRemoveAura)
             {
-                getCreature()->InterruptSpell();
+                getCreature()->interruptSpell();
                 _removeAura(AISpell->mSpellInfo->getId());
             }
         }
@@ -1435,7 +1435,7 @@ void CreatureAIScript::castSpellOnRandomTarget(CreatureAISpells* AiSpell)
     bool isTargetRandFriend = (AiSpell->mTargetType == TARGET_RANDOM_FRIEND ? true : false);
 
     // if we already cast a spell, do not set/cast another one!
-    if (getCreature()->GetCurrentSpell() == nullptr
+    if (!getCreature()->isCastingNonMeleeSpell()
         && getCreature()->GetAIInterface()->getNextTarget())
     {
         // set up targets in range by position, relation and hp range

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -323,8 +323,11 @@ void WorldSession::LogoutPlayer(bool Save)
         }
 
         // cancel current spell
-        if (_player->m_currentSpell != NULL)
-            _player->m_currentSpell->cancel();
+        for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+        {
+            if (_player->getCurrentSpell(CurrentSpellType(i)) != nullptr)
+                _player->interruptSpellWithSpellType(CurrentSpellType(i));
+        }
 
         _player->Social_TellFriendsOffline();
 

--- a/src/world/Spell/Spell.Legacy.h
+++ b/src/world/Spell/Spell.Legacy.h
@@ -48,7 +48,12 @@ typedef void(Spell::*pSpellTarget)(uint32 i, uint32 j);
 class SERVER_DECL Spell : public EventableObject
 {
     public:
-
+        // APGL Ends
+        // MIT Starts
+        int32_t getFullCastTime() const { return m_castTime; }
+        int32_t getCastTimeLeft() const { return m_timer; }
+        // MIT Ends
+        // APGL Starts
         friend class DummySpellHandler;
         Spell(Object* Caster, SpellInfo* info, bool triggered, Aura* aur);
         ~Spell();

--- a/src/world/Spell/SpellDefines.hpp
+++ b/src/world/Spell/SpellDefines.hpp
@@ -107,7 +107,7 @@ enum SpellAttributesExB
     ATTRIBUTESEXB_UNK4                              = 0x00000004,   // 3 request pet maybe
     ATTRIBUTESEXB_UNK5                              = 0x00000008,   // 4 something todo with temp enchanted items
     ATTRIBUTESEXB_PARTY_EFFECTING_AURA              = 0x00000010,   // 5 Party affecting aura's
-    ATTRIBUTESEXB_ACTIVATE_AUTO_SHOT                = 0x00000020,   // 6 spell that enable's auto shoot
+    ATTRIBUTESEXB_AUTOREPEAT                        = 0x00000020,   // 6 Autorepeat spells (Auto Shot, Shoot wand)
     ATTRIBUTESEXB_UNK8                              = 0x00000040,   // 7 Polymorph spells
     ATTRIBUTESEXB_UNK9                              = 0x00000080,   // 8
     ATTRIBUTESEXB_UNUSED1                           = 0x00000100,   // 9 not set in 3.0.3
@@ -119,7 +119,7 @@ enum SpellAttributesExB
     ATTRIBUTESEXB_SPELL_PLAYER_EVENT                = 0x00004000,   // 15 Player event's like logging in, finishing quests, triggering cinematic, being adored, Heartbroken etc
     ATTRIBUTESEXB_UNUSED3                           = 0x00008000,   // 16 not set in 3.0.3
     ATTRIBUTESEXB_CONTROL_UNIT                      = 0x00010000,   // 17 PvP Controller, RC, Creature taming, Taming Lesson
-    ATTRIBUTESEXB_REQ_RANGED_WEAPON                 = 0x00020000,   // 18 used by hunters shot and stings... Possibly triggers autoshot?
+    ATTRIBUTESEXB_NOT_RESET_AUTO_ATTACKS            = 0x00020000,   // 18 Doesn't reset timers for melee or ranged autoattacks
     ATTRIBUTESEXB_REQ_DEAD_PET                      = 0x00040000,   // 19
     ATTRIBUTESEXB_NOT_NEED_SHAPESHIFT               = 0x00080000,   // 20 does not necessarily need shapeshift
     ATTRIBUTESEXB_REQ_BEHIND_TARGET                 = 0x00100000,   // 21

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -1687,7 +1687,7 @@ void AIInterface::_UpdateCombat(uint32 p_time)
         }
     }
 
-    if (cansee && getNextTarget() && getNextTarget()->isAlive() && !isAiState(AI_STATE_EVADE) && !m_Unit->IsCasting())
+    if (cansee && getNextTarget() && getNextTarget()->isAlive() && !isAiState(AI_STATE_EVADE) && !m_Unit->isCastingNonMeleeSpell())
     {
         if (agent == AGENT_NULL || (isAiScriptType(AI_SCRIPT_PET) && !m_nextSpell))     // allow pets autocast
         {
@@ -2653,11 +2653,11 @@ float AIInterface::_CalcAggroRange(Unit* target)
     bool isMining = false;
     if (target->IsPlayer())
     {
-        if (target->IsCasting())
+        if (target->isCastingNonMeleeSpell())
         {
             // If nearby miners weren't spotted already we'll give them a little surprise.
-            Spell* sp = target->GetCurrentSpell();
-            if (sp->GetSpellInfo()->getEffect(0) == SPELL_EFFECT_OPEN_LOCK && sp->GetSpellInfo()->getEffectMiscValue(0) == LOCKTYPE_MINING)
+            Spell* sp = target->getCurrentSpell(CURRENT_GENERIC_SPELL);
+            if (sp != nullptr && sp->GetSpellInfo()->getEffect(0) == SPELL_EFFECT_OPEN_LOCK && sp->GetSpellInfo()->getEffectMiscValue(0) == LOCKTYPE_MINING)
             {
                 isMining = true;
             }
@@ -2971,7 +2971,7 @@ void AIInterface::_UpdateMovement(uint32 p_time)
     }
 
     //move after finishing our current spell
-    if (m_Unit->GetCurrentSpell() != NULL)
+    if (m_Unit->isCastingNonMeleeSpell())
         return;
 
     uint32 timediff = 0;

--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -710,8 +710,10 @@ void Creature::setDeathState(DeathState s)
         if (m_enslaveSpell)
             RemoveEnslave();
 
-        if (m_currentSpell)
-            m_currentSpell->cancel();
+        for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+        {
+            interruptSpellWithSpellType(CurrentSpellType(i));
+        }
 
         // if it's not a Pet, and not a summon and it has skinningloot then we will allow skinning
         if ((GetCreatedByGUID() == 0) && (GetSummonedByGUID() == 0) && lootmgr.IsSkinnable(creature_properties->Id))
@@ -2389,7 +2391,7 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
     if (GetChannelSpellTargetGUID() != 0)
     {
 
-        Spell* spl = GetCurrentSpell();
+        Spell* spl = getCurrentSpell(CURRENT_CHANNELED_SPELL);
 
         if (spl != NULL)
         {
@@ -2408,7 +2410,7 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
             }
 
             if (spl->GetSpellInfo()->getChannelInterruptFlags() == 48140)
-                spl->cancel();
+                interruptSpell(spl->GetSpellInfo()->getId());
         }
     }
 
@@ -2417,10 +2419,14 @@ void Creature::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
     {
         Unit* attacker = static_cast< Unit* >(*itr);
 
-        if (attacker->GetCurrentSpell() != NULL)
+        if (attacker->isCastingNonMeleeSpell())
         {
-            if (attacker->GetCurrentSpell()->m_targets.m_unitTarget == GetGUID())
-                attacker->GetCurrentSpell()->cancel();
+            for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+            {
+                Spell* curSpell = attacker->getCurrentSpell(CurrentSpellType(i));
+                if (curSpell != nullptr && curSpell->m_targets.m_unitTarget == GetGUID())
+                    attacker->interruptSpellWithSpellType(CurrentSpellType(i));
+            }
         }
     }
 

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -2385,9 +2385,9 @@ void Pet::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
     if (GetChannelSpellTargetGUID() != 0)
     {
 
-        Spell* spl = GetCurrentSpell();
+        Spell* spl = getCurrentSpell(CURRENT_CHANNELED_SPELL);
 
-        if (spl != NULL)
+        if (spl != nullptr)
         {
 
             for (uint8 i = 0; i < 3; i++)
@@ -2403,7 +2403,7 @@ void Pet::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
                 }
             }
 
-            if (spl->GetSpellInfo()->getChannelInterruptFlags() == 48140) spl->cancel();
+            if (spl->GetSpellInfo()->getChannelInterruptFlags() == 48140) interruptSpellWithSpellType(CURRENT_CHANNELED_SPELL);
         }
     }
 
@@ -2412,10 +2412,14 @@ void Pet::Die(Unit* pAttacker, uint32 damage, uint32 spellid)
     {
         Unit* attacker = static_cast< Unit* >(*itr);
 
-        if (attacker->GetCurrentSpell() != NULL)
+        if (attacker->isCastingNonMeleeSpell())
         {
-            if (attacker->GetCurrentSpell()->m_targets.m_unitTarget == GetGUID())
-                attacker->GetCurrentSpell()->cancel();
+            for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
+            {
+                Spell* curSpell = attacker->getCurrentSpell(CurrentSpellType(i));
+                if (curSpell != nullptr && curSpell->m_targets.m_unitTarget == GetGUID())
+                    attacker->interruptSpellWithSpellType(CurrentSpellType(i));
+            }
         }
     }
 

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -130,6 +130,65 @@ void Player::sendAuctionCommandResult(Auction* auction, uint32_t action, uint32_
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////
+// Spells
+void Player::updateAutoRepeatSpell()
+{
+    // Get the autorepeat spell
+    Spell* autoRepeatSpell = getCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+
+    // Check is target valid
+    // Note for self: remove this check when new Spell::canCast() is ready -Appled
+    Unit* target = GetMapMgr()->GetUnit(autoRepeatSpell->m_targets.m_unitTarget);
+    if (target == nullptr)
+    {
+        m_AutoShotAttackTimer = 0;
+        interruptSpellWithSpellType(CURRENT_AUTOREPEAT_SPELL);
+        return;
+    }
+
+    // If player is moving or casting a spell, interrupt wand casting and delay auto shot
+    const bool isAutoShot = autoRepeatSpell->GetSpellInfo()->getId() == 75;
+    if (m_isMoving || isCastingNonMeleeSpell(true, false, true, isAutoShot))
+    {
+        if (!isAutoShot)
+        {
+            interruptSpellWithSpellType(CURRENT_AUTOREPEAT_SPELL);
+        }
+        m_FirstCastAutoRepeat = true;
+        return;
+    }
+
+    // Apply delay to wand shooting
+    if (m_FirstCastAutoRepeat && m_AutoShotAttackTimer < 500 && !isAutoShot)
+    {
+        m_AutoShotAttackTimer = 500;
+    }
+    m_FirstCastAutoRepeat = false;
+
+    if (m_AutoShotAttackTimer == 0)
+    {
+        // TODO: implement ::CanShootRangedWeapon() into new Spell::canCast()
+        // also currently if target gets too far away, your autorepeat spell will get interrupted
+        // it's related most likely to ::CanShootRangedWeapon()
+        const int32_t canCastAutoRepeatSpell = CanShootRangedWeapon(autoRepeatSpell->GetSpellInfo()->getId(), target, isAutoShot);
+        if (canCastAutoRepeatSpell != SPELL_CANCAST_OK)
+        {
+            if (!isAutoShot)
+            {
+                interruptSpellWithSpellType(CURRENT_AUTOREPEAT_SPELL);
+            }
+            return;
+        }
+
+        m_AutoShotAttackTimer = m_uint32Values[UNIT_FIELD_RANGEDATTACKTIME];
+
+        // Cast the spell with triggered flag
+        Spell* newAutoRepeatSpell = sSpellFactoryMgr.NewSpell(this, autoRepeatSpell->GetSpellInfo(), true, nullptr);
+        newAutoRepeatSpell->prepare(&(autoRepeatSpell->m_targets));
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 // Messages
 void Player::sendReportToGmMessage(std::string playerName, std::string damageLog)
 {

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -429,6 +429,8 @@ public:
 #if VERSION_STRING == Cata
     uint32_t getFreePrimaryProfessionPoints() const { return getUInt32Value(PLAYER_CHARACTER_POINTS); }
 #endif
+    void updateAutoRepeatSpell();
+    bool m_FirstCastAutoRepeat;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Auction
@@ -1334,13 +1336,8 @@ public:
         bool HasWonRbgToday();
         void SetHasWonRbgToday(bool value);
 
-        void EventRepeatSpell();
         int32 CanShootRangedWeapon(uint32 spellid, Unit* target, bool autoshot);
-        uint32 m_AutoShotDuration;
         uint32 m_AutoShotAttackTimer;
-        bool m_onAutoShot;
-        uint64 m_AutoShotTarget;
-        SpellInfo* m_AutoShotSpell;
         void _InitialReputation();
         void EventActivateGameObject(GameObject* obj);
         void EventDeActivateGameObject(GameObject* obj);

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -393,7 +393,6 @@ public:
     void CastSpellAoF(LocationVector lv, SpellInfo* Sp, bool triggered);
     void EventCastSpell(Unit* Target, SpellInfo* Sp);
 
-    bool IsCasting();
     bool IsInInstance();
     void CalculateResistanceReduction(Unit* pVictim, dealdamage* dmg, SpellInfo* ability, float ArmorPctReduce);
     void RegenerateHealth();
@@ -523,9 +522,6 @@ public:
     };
     DeathState getDeathState() { return m_deathState; }
     void OnDamageTaken();
-
-    void castSpell(Spell* pSpell);
-    void InterruptSpell();
 
     //caller is the caster
     int32 GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg, bool isdot);
@@ -945,7 +941,6 @@ public:
     uint8 FindVisualSlot(uint32 SpellId, bool IsPos);
     uint32 m_auravisuals[MAX_NEGATIVE_VISUAL_AURAS_END];
 
-    SpellInfo* pLastSpell;
     bool bProcInUse;
     bool bInvincible;
     Player* m_redirectSpellPackets;
@@ -965,7 +960,6 @@ public:
     CombatStatusHandler CombatStatus;
     bool m_temp_summon;
 
-    void CancelSpell(Spell* ptr);
     void EventStopChanneling(bool abort);
     void EventStrikeWithAbility(uint64 guid, SpellInfo* sp, uint32 damage);
     void DispelAll(bool positive);
@@ -1244,7 +1238,6 @@ protected:
 
     uint32 m_meleespell;
     uint8 m_meleespell_ecn;         // extra_cast_number
-    void _UpdateSpells(uint32 time);
 
     uint16 m_H_regenTimer;
     uint16 m_P_regenTimer;


### PR DESCRIPTION
In addition removes some useless functions and hackfixes related to the spell system from source.

TODO: Possibly introduced new visual-only bug to autorepeat spells. Whenever you interrupt your Auto Shot (hunter only) or wand shoot, you get stuck into cast animation for other clients. On your client it does not occur. This happens only with the two spells I mentioned and I will look into it very soon.