### PR TITLE
Players should be able to see all other items on NPC's vendor list expect class, race and faction restricted items

### DIFF
--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -1513,10 +1513,6 @@ void WorldSession::SendInventoryList(Creature* unit)
 
                     if (curItem->HasFlag2(ITEM_FLAG2_ALLIANCE_ONLY) && !GetPlayer()->IsTeamAlliance())
                         continue;
-
-                    int8 Slot = _player->GetItemInterface()->GetItemSlotByType(curItem->InventoryType);
-                    if (_player->GetItemInterface()->CanEquipItemInSlot(INVENTORY_SLOT_NOT_SET, Slot, curItem, true, true))
-                        continue;
                 }
                 
                 uint32 av_am = (itr->max_amount > 0) ? itr->available_amount : 0xFFFFFFFF;


### PR DESCRIPTION
Players should be able to see on vendor's list, for example mail type items on a priest or rogue, and also items which require reputation or a higher level to equip, but not faction/class/race restricted items.