### PR TITLE
Implemented UNIT_FLAG_IGNORE_CREATURE_COMBAT, UNIT_FLAG_IGNORE_PLAYER_COMBAT

### DIFF
--- a/src/scripts/InstanceScripts/Instance_PitOfSaron.cpp
+++ b/src/scripts/InstanceScripts/Instance_PitOfSaron.cpp
@@ -425,7 +425,7 @@ class KrickAI : public CreatureAIScript
             setCanEnterCombat(false);
 
             // Clear Hatelist dont allow Combat and root the Unit
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             getCreature()->GetAIInterface()->setAiState(AI_STATE_IDLE);
             getCreature()->GetAIInterface()->WipeTargetList();
             getCreature()->GetAIInterface()->WipeHateList();

--- a/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
@@ -76,7 +76,7 @@ class ShadowfangKeepInstance : public InstanceScript
                     {
                         if (Creature* ArugalSpawn = spawnCreature(CN_ARUGAL_BOSS, ArugalAtFenrusLoc.x, ArugalAtFenrusLoc.y, ArugalAtFenrusLoc.z, ArugalAtFenrusLoc.o))
                         {
-                            ArugalSpawn->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                            ArugalSpawn->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                             ArugalSpawn->GetAIInterface()->SetAllowedToEnterCombat(false);
                             ArugalSpawn->GetAIInterface()->m_canMove = false;
                             if (ArugalSpawn->GetScript())
@@ -617,7 +617,7 @@ class AdamantGossip : public Arcemu::Gossip::Script
                     pPrisoner->getCreature()->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                     pPrisoner->getCreature()->SendScriptTextChatMessage(SAY_ADAMANT_FOLLOW);
                     pPrisoner->RegisterAIUpdateEvent(5000);
-                    pPrisoner->getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                    pPrisoner->getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                     pPrisoner->getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                     pPrisoner->getCreature()->EventAddEmote(EMOTE_ONESHOT_CHEER, 4000);
                     pPrisoner->eventStarted = true;
@@ -786,7 +786,7 @@ class AshcrombeGossip : public Arcemu::Gossip::Script
                     pPrisoner->getCreature()->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                     pPrisoner->getCreature()->SendScriptTextChatMessage(SAY_ASHCROMBE_FOLLOW);
                     pPrisoner->RegisterAIUpdateEvent(4000);
-                    pPrisoner->getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                    pPrisoner->getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                     pPrisoner->getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                     pPrisoner->getCreature()->Emote(EMOTE_ONESHOT_POINT);
                     pPrisoner->eventStarted = true;
@@ -1139,7 +1139,7 @@ class ArugalBossAI : public CreatureAIScript
                             voidwalker->despawn(4 * 60 * 1000); // Despawn in 4 mins
                         }
                     }
-                    getCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                    getCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                     getCreature()->GetAIInterface()->SetAllowedToEnterCombat(true);
                     getCreature()->GetAIInterface()->m_canMove = true;
 

--- a/src/scripts/InstanceScripts/Instance_TheShatteredHalls.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheShatteredHalls.cpp
@@ -273,7 +273,7 @@ class ShadowmoonDarkcasterAI : public CreatureAIScript
             GrandWarlock = getNearestCreature(178.811996f, 292.377991f, -8.190210f, CN_GRAND_WARLOCK_NETHEKURSE);
             if (GrandWarlock)
             {
-                GrandWarlock->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                GrandWarlock->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                 GrandWarlock->GetAIInterface()->SetAllowedToEnterCombat(false);
             }
         }

--- a/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
@@ -250,7 +250,7 @@ class NagaDistillerAI : public CreatureAIScript
 
         NagaDistillerAI(Creature* pCreature) : CreatureAIScript(pCreature)
         {
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
             _setMeleeDisabled(true);
             getCreature()->GetAIInterface()->m_canMove = false;
@@ -329,7 +329,7 @@ class WarlordKalitreshAI : public CreatureAIScript
             pDistiller = GetClosestDistiller();
             if (pDistiller)
             {
-                pDistiller->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                pDistiller->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                 pDistiller->SetChannelSpellTargetGUID(0);
                 pDistiller->SetChannelSpellId(0);
                 pDistiller->GetAIInterface()->WipeTargetList();
@@ -347,7 +347,7 @@ class WarlordKalitreshAI : public CreatureAIScript
 
                 Unit* pDistiller = NULL;
                 pDistiller = GetClosestDistiller();
-                if (!pDistiller || (pDistiller->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9) && RagePhase != 0))
+                if (!pDistiller || (pDistiller->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT) && RagePhase != 0))
                 {
                     getCreature()->GetAIInterface()->SetAllowedToEnterCombat(true);
                     getCreature()->GetAIInterface()->m_canMove = true;
@@ -403,7 +403,7 @@ class WarlordKalitreshAI : public CreatureAIScript
 
                     else if (t > EnrageTimer && RagePhase == 2)
                     {
-                        pDistiller->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                        pDistiller->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                         pDistiller->SetChannelSpellTargetGUID(0);
                         pDistiller->SetChannelSpellId(0);
                         pDistiller->GetAIInterface()->WipeTargetList();

--- a/src/scripts/InstanceScripts/Instance_UtgardeKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_UtgardeKeep.cpp
@@ -554,7 +554,7 @@ class SkarvaldTheConstructorGhostAI : public CreatureAIScript
 
         void OnLoad() override
         {
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
 
             Player* pTarget = getNearestPlayer();
             if (pTarget != nullptr)
@@ -581,7 +581,7 @@ class DalronnTheControllerGhostAI : public CreatureAIScript
 
         void OnLoad() override
         {
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
 
             Player* pTarget = getNearestPlayer();
             if (pTarget != nullptr)

--- a/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
@@ -1581,7 +1581,7 @@ class EssenceOfSufferingAI : public CreatureAIScript
                 setCanEnterCombat(false);
                 _setMeleeDisabled(false);
                 _setCastDisabled(true);
-                getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                 _removeAllAuras();
                 _removeAuraOnPlayers(EOS_AURA_OF_SUFFERING);
 
@@ -1635,7 +1635,7 @@ class EssenceOfDesireAI : public CreatureAIScript
                 setCanEnterCombat(false);
                 _setMeleeDisabled(false);
                 _setCastDisabled(true);
-                getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                 _removeAllAuras();
                 _removeAuraOnPlayers(EOD_AURA_OF_DESIRE);
 
@@ -1730,7 +1730,7 @@ class ReliquaryOfSoulsAI : public CreatureAIScript
 
         void OnCombatStart(Unit* /*mTarget*/) override
         {
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             _setMeleeDisabled(false);
             _setRangedDisabled(true);
 
@@ -4031,7 +4031,7 @@ class IllidanStormrageAI : public CreatureAIScript
                 _applyAura(ILLIDAN_DEATH1);
                 _applyAura(ILLIDAN_DEATH2);
 
-                pMaiev->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                pMaiev->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                 pMaiev->GetAIInterface()->setAiState(AI_STATE_IDLE);
                 pMaiev->GetAIInterface()->WipeTargetList();
                 pMaiev->GetAIInterface()->WipeHateList();

--- a/src/scripts/InstanceScripts/Raid_Magtheridons_Lair.cpp
+++ b/src/scripts/InstanceScripts/Raid_Magtheridons_Lair.cpp
@@ -712,7 +712,7 @@ class HellfireChannelerAI : public CreatureAIScript
 
                 Unit* Magtheridon = NULL;
                 Magtheridon = getNearestCreature(-22.657900f, 2.159050f, -0.345542f, 17257);
-                if (Magtheridon && Magtheridon->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9))
+                if (Magtheridon && Magtheridon->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT))
                 {
                     getCreature()->SetChannelSpellTargetGUID(Magtheridon->GetGUID());
                     getCreature()->SetChannelSpellId(SHADOW_GRASP);
@@ -784,7 +784,7 @@ class MagtheridonAI : public CreatureAIScript
             quake2 = addAISpell(QUAKE2, 0.0f, TARGET_VARIOUS);
             caveIn = addAISpell(CAVE_IN, 0.0f, TARGET_VARIOUS);
 
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
 
             Aura* aura = sSpellFactoryMgr.NewAura(sSpellCustomizations.GetSpellInfo(BANISHMENT), (uint32) - 1, getCreature(), getCreature());
             getCreature()->AddAura(aura);
@@ -814,7 +814,7 @@ class MagtheridonAI : public CreatureAIScript
 
         void OnCombatStop(Unit* /*mTarget*/) override
         {
-            if (getCreature()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9) || getCreature()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_2))
+            if (getCreature()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT) || getCreature()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_2))
                 return;
 
             GameObject* Gate = NULL;

--- a/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
@@ -420,7 +420,7 @@ class LeotherasAI : public CreatureAIScript
             info_chaos_blast = sSpellCustomizations.GetSpellInfo(CHAOS_BLAST_ANIMATION);
             info_whirlwind = sSpellCustomizations.GetSpellInfo(WHIRLWINDLEO);
 
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
 
             SwitchTimer = 0;
@@ -601,7 +601,7 @@ class LeotherasAI : public CreatureAIScript
                             IsMorphing = true;
                             getCreature()->setAttackTimer(15000, false);
                             getCreature()->SetStandState(STANDSTATE_KNEEL);
-                            getCreature()->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                            getCreature()->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
                             getCreature()->GetAIInterface()->m_canMove = false;
                             sendDBChatMessage(4781);     // No... no! What have you done? I am the master! Do you hear me? I am... aaggh! Can't... contain him.
@@ -774,7 +774,7 @@ class ShadowofLeotherasAI : public CreatureAIScript
         {
             info_chaos_blast = sSpellCustomizations.GetSpellInfo(CHAOS_BLAST_ANIMATION);
 
-            getCreature()->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
 
             getCreature()->SendChatMessage(CHAT_MSG_MONSTER_YELL, LANG_UNIVERSAL, "At last I am liberated. It has been too long since I have tasted true freedom!");
@@ -1374,7 +1374,7 @@ class VashjAI : public CreatureAIScript
                     getCreature()->GetAIInterface()->setWaypointScriptType(Movement::WP_MOVEMENT_SCRIPT_WANTEDWP);
                     getCreature()->GetAIInterface()->setWayPointToMove(1);
                     sendDBChatMessage(4764);     // The time is now! Leave none standing!
-                    getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+                    getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
                     getCreature()->CastSpell(getCreature(), sSpellCustomizations.GetSpellInfo(VASHJ_SHIELD), true);
                     getCreature()->GetAIInterface()->setOutOfCombatRange(3000);
                     Phase = 2;

--- a/src/scripts/InstanceScripts/Raid_TheEye.cpp
+++ b/src/scripts/InstanceScripts/Raid_TheEye.cpp
@@ -866,7 +866,7 @@ class KaelThasAI : public CreatureAIScript
 
         void OnCombatStart(Unit* /*mTarget*/) override
         {
-            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+            getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             SetAIUpdateFreq(24000);
             
             setAIAgent(AGENT_SPELL);

--- a/src/scripts/QuestScripts/Quest_BladeEdge_Mountains.cpp
+++ b/src/scripts/QuestScripts/Quest_BladeEdge_Mountains.cpp
@@ -162,7 +162,7 @@ public:
     void OnLoad() override
     {
         RegisterAIUpdateEvent(5000);
-        getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+        getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
         getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
         setAIAgent(AGENT_NULL);
         _setMeleeDisabled(true);

--- a/src/scripts/QuestScripts/Quest_Nagrand.cpp
+++ b/src/scripts/QuestScripts/Quest_Nagrand.cpp
@@ -250,7 +250,7 @@ public:
     ADD_CREATURE_FACTORY_FUNCTION(mogorQAI);
     mogorQAI(Creature* pCreature) : CreatureAIScript(pCreature)
     {
-        getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+        getCreature()->setUInt64Value(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
         getCreature()->GetAIInterface()->SetAllowedToEnterCombat(false);
     };
 

--- a/src/world/Management/Battleground/Battleground.cpp
+++ b/src/world/Management/Battleground/Battleground.cpp
@@ -887,7 +887,7 @@ Creature* CBattleground::SpawnSpiritGuide(float x, float y, float z, float o, ui
 
     pCreature->SetEquippedItem(MELEE, 22802);
 
-    pCreature->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_PLUS_MOB | UNIT_FLAG_NOT_ATTACKABLE_9 | UNIT_FLAG_UNKNOWN_10 | UNIT_FLAG_PVP); // 4928
+    pCreature->setUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_PLUS_MOB | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_UNKNOWN_10 | UNIT_FLAG_PVP); // 4928
 
     pCreature->SetBaseAttackTime(MELEE, 2000);
     pCreature->SetBaseAttackTime(OFFHAND, 2000);

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -491,12 +491,13 @@ void CreatureAIScript::setCanEnterCombat(bool enterCombat)
     //Zyres 10/21/2017 creatures can be attackable even if they can not enter combat... the following line is not correct.
     if (enterCombat)
     {
-        _creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+        _creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
     }
     else
     {
-        _creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9);
+        _creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT);
     }
+
     _creature->GetAIInterface()->SetAllowedToEnterCombat(enterCombat);
 }
 

--- a/src/world/Spell/SpellTarget.cpp
+++ b/src/world/Spell/SpellTarget.cpp
@@ -409,7 +409,7 @@ bool Spell::AddTarget(uint32 i, uint32 TargetType, Object* obj)
     if (obj->IsItem() && !(TargetType & SPELL_TARGET_REQUIRE_ITEM) && !m_triggeredSpell)
         return false;
 
-    if (u_caster != nullptr && u_caster->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9) && ((obj->IsPlayer() || obj->IsPet()) || (p_caster != nullptr || m_caster->IsPet())))
+    if (u_caster != nullptr && u_caster->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT) && ((obj->IsPlayer() || obj->IsPet()) || (p_caster != nullptr || m_caster->IsPet())))
         return false;
 
     if (TargetType & SPELL_TARGET_REQUIRE_FRIENDLY && !isFriendly(m_caster, obj))

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -1561,7 +1561,7 @@ void AIInterface::_UpdateTargets()
                     AttackReaction(target, 1, 0);
             }
         }
-        else if (m_aiTargets.size() == 0 && ((isAiScriptType(AI_SCRIPT_PET) && (m_Unit->IsPet() && static_cast< Pet* >(m_Unit)->GetPetState() == PET_STATE_AGGRESSIVE)) || (!m_Unit->IsPet() && mIsMeleeDisabled == false)))
+        else if (m_aiTargets.empty() && ((isAiScriptType(AI_SCRIPT_PET) && (m_Unit->IsPet() && static_cast< Pet* >(m_Unit)->GetPetState() == PET_STATE_AGGRESSIVE)) || (!m_Unit->IsPet() && mIsMeleeDisabled == false)))
         {
             Unit* target = FindTarget();
             if (target)
@@ -1570,8 +1570,8 @@ void AIInterface::_UpdateTargets()
             }
         }
     }
-    // Find new Targets when we are ooc
-    if ((isAiState(AI_STATE_IDLE) || isAiState(AI_STATE_SCRIPTIDLE)) && m_assistTargets.size() == 0)
+    // Find new Targets when we are out of combat
+    if ((isAiState(AI_STATE_IDLE) || isAiState(AI_STATE_SCRIPTIDLE)) && m_assistTargets.empty())
     {
         Unit* target = FindTarget();
         if (target)
@@ -2075,6 +2075,9 @@ void AIInterface::AttackReaction(Unit* pUnit, uint32 damage_dealt, uint32 spellI
     if (isAiState(AI_STATE_EVADE) || !pUnit || !pUnit->isAlive() || m_Unit->IsDead() || (m_Unit == pUnit) || isAiScriptType(AI_SCRIPT_PASSIVE) || isCombatDisabled())
         return;
 
+    if ((pUnit->IsPlayer() && m_Unit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT)) || (pUnit->IsCreature() && m_Unit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_CREATURE_COMBAT)))
+        return;
+
     if (worldConfig.terrainCollision.isCollisionEnabled && pUnit->IsPlayer())
     {
         if (m_Unit->GetMapMgr() != nullptr)
@@ -2280,7 +2283,7 @@ Unit* AIInterface::FindTarget()
             if (tmpPlr->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FEIGN_DEATH))
                 continue;
 
-            if (tmpPlr->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9))
+            if (tmpPlr->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT))
                 continue;
 
             if (tmpPlr->m_invisible)
@@ -2497,7 +2500,7 @@ bool AIInterface::FindFriends(float dist)
         if (pUnit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE))
             continue;
 
-        if (pUnit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_9))
+        if (pUnit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IGNORE_PLAYER_COMBAT))
             continue;
 
         if (!(pUnit->m_phase & m_Unit->m_phase))   //We can't help a friendly unit if it is not in our phase

--- a/src/world/Units/UnitDefines.hpp
+++ b/src/world/Units/UnitDefines.hpp
@@ -686,8 +686,8 @@ enum UnitFieldFlags : uint32_t // UNIT_FIELD_FLAGS #46 - these are client flags
     UNIT_FLAG_UNKNOWN_5                  = 0x00000010, // 5           16  ? some NPCs have this
     UNIT_FLAG_NO_REAGANT_COST            = 0x00000020, // 6           32  no reagant cost
     UNIT_FLAG_PLUS_MOB                   = 0x00000040, // 7           64  ? some NPCs have this (Rare/Elite/Boss?)
-    UNIT_FLAG_UNKNOWN_8                  = 0x00000080, // 8          128  ? can change attackable status
-    UNIT_FLAG_NOT_ATTACKABLE_9           = 0x00000100, // 9          256  changes attackable status
+    UNIT_FLAG_IGNORE_CREATURE_COMBAT     = 0x00000080, // 8          128  unit will not enter combat with creatures
+    UNIT_FLAG_IGNORE_PLAYER_COMBAT       = 0x00000100, // 9          256  unit will not enter combat with players
     UNIT_FLAG_UNKNOWN_10                 = 0x00000200, // 10         512  ? some NPCs have this
     UNIT_FLAG_LOOTING                    = 0x00000400, // 11        1024
     UNIT_FLAG_SELF_RES                   = 0x00000800, // 12        2048  ? some NPCs have this
@@ -878,8 +878,8 @@ static const UnitFlagNames UnitFlagToName[] =
     { UNIT_FLAG_UNKNOWN_5, "UNIT_FLAG_UNKNOWN_5" },
     { UNIT_FLAG_NO_REAGANT_COST, "UNIT_FLAG_NO_REAGANT_COST" },
     { UNIT_FLAG_PLUS_MOB, "UNIT_FLAG_PLUS_MOB" },
-    { UNIT_FLAG_UNKNOWN_8, "UNIT_FLAG_UNKNOWN_8" },
-    { UNIT_FLAG_NOT_ATTACKABLE_9, "UNIT_FLAG_NOT_ATTACKABLE_9" },
+    { UNIT_FLAG_IGNORE_CREATURE_COMBAT, "UNIT_FLAG_IGNORE_CREATURE_COMBAT" },
+    { UNIT_FLAG_IGNORE_PLAYER_COMBAT, "UNIT_FLAG_IGNORE_PLAYER_COMBAT" },
     { UNIT_FLAG_UNKNOWN_10, "UNIT_FLAG_UNKNOWN_10" },
     { UNIT_FLAG_LOOTING, "UNIT_FLAG_LOOTING" },
     { UNIT_FLAG_SELF_RES, "UNIT_FLAG_SELF_RES" },


### PR DESCRIPTION
These two new flags, when they're set, it stops unit from entering combat with creatures or players

It was tested in violet hold bosses and other creatures which had this flag set.

Signed-off-by: sanctum32 <andriuspel@gmail.com>
  