### PR TITLE
Fix Visual Studio build

### DIFF
--- a/dep/libmpq/libmpq/mpq_libmpq04.h
+++ b/dep/libmpq/libmpq/mpq_libmpq04.h
@@ -57,7 +57,7 @@ public:
             token[strlen(token) - 1] = 0;
             std::string s = token;
             filelist.push_back(s);
-            counter += strlen(token) + 2;
+            counter += static_cast<uint32_t>(strlen(token) + 2);
             token = strtok(NULL, seps);
         }
 

--- a/src/tools/ToolsWotLK/map_extractor/System.cpp
+++ b/src/tools/ToolsWotLK/map_extractor/System.cpp
@@ -109,9 +109,9 @@ static const char* const langs[] = {"enGB", "enUS", "deDE", "esES", "frFR", "koK
 
 void CreateDir( const std::string& Path )
 {
-    if(chdir(Path.c_str()) == 0)
+    if(_chdir(Path.c_str()) == 0)
     {
-            chdir("../");
+            _chdir("../");
             return;
     }
 
@@ -271,7 +271,7 @@ uint32 ReadMapDBC()
         map_ids[x].name[max_map_name_length - 1] = '\0';
     }
     printf("Done! (%u maps loaded)\n", (uint32)map_count);
-    return map_count;
+    return static_cast<uint32_t>(map_count);
 }
 
 void ReadAreaTableDBC()
@@ -293,7 +293,7 @@ void ReadAreaTableDBC()
     for(uint32 x = 0; x < area_count; ++x)
         areas[dbc.getRecord(x).getUInt(0)] = dbc.getRecord(x).getUInt(3);
 
-    maxAreaId = dbc.getMaxId();
+    maxAreaId = static_cast<uint32_t>(dbc.getMaxId());
 
     printf("Done! (%u areas loaded)\n", (uint32)area_count);
 }

--- a/src/tools/ToolsWotLK/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/ToolsWotLK/mmaps_generator/MapBuilder.cpp
@@ -251,10 +251,10 @@ namespace MMAP
             rcCalcBounds(meshData.liquidVerts.getCArray(), meshData.liquidVerts.size() / 3, lmin, lmax);
 
         // convert coord bounds to grid bounds
-        maxX = 32 - bmin[0] / GRID_SIZE;
-        maxY = 32 - bmin[2] / GRID_SIZE;
-        minX = 32 - bmax[0] / GRID_SIZE;
-        minY = 32 - bmax[2] / GRID_SIZE;
+        maxX = static_cast<uint32_t>(32 - bmin[0] / GRID_SIZE);
+        maxY = static_cast<uint32_t>(32 - bmin[2] / GRID_SIZE);
+        minX = static_cast<uint32_t>(32 - bmax[0] / GRID_SIZE);
+        minY = static_cast<uint32_t>(32 - bmax[2] / GRID_SIZE);
     }
 
     void MapBuilder::buildMeshFromFile(char* name)
@@ -463,7 +463,7 @@ namespace MMAP
 
         int polyBits = STATIC_POLY_BITS;
 
-        int maxTiles = tiles->size();
+        int maxTiles = static_cast<int>(tiles->size());
         int maxPolysPerTile = 1 << polyBits;
 
         /***          calculate bounds of map         ***/
@@ -755,8 +755,8 @@ namespace MMAP
         params.walkableHeight = BASE_UNIT_DIM*config.walkableHeight;    // agent height
         params.walkableRadius = BASE_UNIT_DIM*config.walkableRadius;    // agent radius
         params.walkableClimb = BASE_UNIT_DIM*config.walkableClimb;      // keep less that walkableHeight (aka agent height)!
-        params.tileX = (((bmin[0] + bmax[0]) / 2) - navMesh->getParams()->orig[0]) / GRID_SIZE;
-        params.tileY = (((bmin[2] + bmax[2]) / 2) - navMesh->getParams()->orig[2]) / GRID_SIZE;
+        params.tileX = static_cast<int>((((bmin[0] + bmax[0]) / 2) - navMesh->getParams()->orig[0]) / GRID_SIZE);
+        params.tileY = static_cast<int>((((bmin[2] + bmax[2]) / 2) - navMesh->getParams()->orig[2]) / GRID_SIZE);
         rcVcopy(params.bmin, bmin);
         rcVcopy(params.bmax, bmax);
         params.cs = config.cs;
@@ -991,7 +991,7 @@ namespace MMAP
             return false;
 
         MmapTileHeader header;
-        int count = fread(&header, sizeof(MmapTileHeader), 1, file);
+        int count = static_cast<int>(fread(&header, sizeof(MmapTileHeader), 1, file));
         fclose(file);
         if (count != 1)
             return false;

--- a/src/tools/ToolsWotLK/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/ToolsWotLK/mmaps_generator/PathGenerator.cpp
@@ -85,7 +85,7 @@ bool handleArgs(int argc, char** argv,
             if (!param)
                 return false;
 
-            float maxangle = atof(param);
+            float maxangle = static_cast<float>(atof(param));
             if (maxangle <= 90.f && maxangle >= 45.f)
                 maxAngle = maxangle;
             else
@@ -293,6 +293,6 @@ int main(int argc, char** argv)
         builder.buildAllMaps(threads);
 
     if (!silent)
-        printf("Finished. MMAPS were built in %u ms!\n", Util::GetTimeDifferenceToNow(startTime));
+        printf("Finished. MMAPS were built in %I64d ms!\n", Util::GetTimeDifferenceToNow(startTime));
     return 0;
 }

--- a/src/tools/ToolsWotLK/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/ToolsWotLK/mmaps_generator/TerrainBuilder.cpp
@@ -188,8 +188,8 @@ namespace MMAP
                 uint8 v9[V9_SIZE_SQ];
                 uint8 v8[V8_SIZE_SQ];
                 int count = 0;
-                count += fread(v9, sizeof(uint8), V9_SIZE_SQ, mapFile);
-                count += fread(v8, sizeof(uint8), V8_SIZE_SQ, mapFile);
+                count += static_cast<int>(fread(v9, sizeof(uint8), V9_SIZE_SQ, mapFile));
+                count += static_cast<int>(fread(v8, sizeof(uint8), V8_SIZE_SQ, mapFile));
                 if (count != expected)
                     printf("TerrainBuilder::loadMap: Failed to read some data expected %d, read %d\n", expected, count);
 
@@ -206,8 +206,8 @@ namespace MMAP
                 uint16 v9[V9_SIZE_SQ];
                 uint16 v8[V8_SIZE_SQ];
                 int count = 0;
-                count += fread(v9, sizeof(uint16), V9_SIZE_SQ, mapFile);
-                count += fread(v8, sizeof(uint16), V8_SIZE_SQ, mapFile);
+                count += static_cast<int>(fread(v9, sizeof(uint16), V9_SIZE_SQ, mapFile));
+                count += static_cast<int>(fread(v8, sizeof(uint16), V8_SIZE_SQ, mapFile));
                 if (count != expected)
                     printf("TerrainBuilder::loadMap: Failed to read some data expected %d, read %d\n", expected, count);
 
@@ -222,8 +222,8 @@ namespace MMAP
             else
             {
                 int count = 0;
-                count += fread(V9, sizeof(float), V9_SIZE_SQ, mapFile);
-                count += fread(V8, sizeof(float), V8_SIZE_SQ, mapFile);
+                count += static_cast<int>(fread(V9, sizeof(float), V9_SIZE_SQ, mapFile));
+                count += static_cast<int>(fread(V8, sizeof(float), V8_SIZE_SQ, mapFile));
                 if (count != expected)
                     printf("TerrainBuilder::loadMap: Failed to read some data expected %d, read %d\n", expected, count);
             }
@@ -674,7 +674,7 @@ namespace MMAP
 
                 // transform data
                 float scale = instance.iScale;
-                G3D::Matrix3 rotation = G3D::Matrix3::fromEulerAnglesXYZ(G3D::pi()*instance.iRot.z/-180.f, G3D::pi()*instance.iRot.x/-180.f, G3D::pi()*instance.iRot.y/-180.f);
+                G3D::Matrix3 rotation = G3D::Matrix3::fromEulerAnglesXYZ(static_cast<float>(G3D::pi())*instance.iRot.z/-180.f, static_cast<float>(G3D::pi())*instance.iRot.x/-180.f, static_cast<float>(G3D::pi())*instance.iRot.y/-180.f);
                 G3D::Vector3 position = instance.iPos;
                 position.x -= 32*GRID_SIZE;
                 position.y -= 32*GRID_SIZE;

--- a/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/adtfile.cpp
+++ b/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/adtfile.cpp
@@ -199,7 +199,7 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY)
             }
         }
         //======================
-        ADT.seek(nextpos);
+        ADT.seek(static_cast<int>(nextpos));
     }
     ADT.close();
     fclose(dirfile);

--- a/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/gameobject_extract.cpp
+++ b/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/gameobject_extract.cpp
@@ -111,7 +111,7 @@ void ExtractGameobjectModels()
         if (result)
         {
             uint32 displayId = it->getUInt(0);
-            uint32 path_length = strlen(name);
+            uint32 path_length = static_cast<uint32_t>(strlen(name));
             fwrite(&displayId, sizeof(uint32), 1, model_list);
             fwrite(&path_length, sizeof(uint32), 1, model_list);
             fwrite(name, sizeof(char), path_length, model_list);

--- a/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/model.cpp
+++ b/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/model.cpp
@@ -169,7 +169,7 @@ ModelInstance::ModelInstance(MPQFile& f, char const* ModelInstName, uint32 mapID
 
     fseek(input, 8, SEEK_SET); // get the correct no of vertices
     int nVertices;
-    int count = fread(&nVertices, sizeof(int), 1, input);
+    int count = static_cast<int>(fread(&nVertices, sizeof(int), 1, input));
     fclose(input);
 
     if (count != 1 || nVertices == 0)
@@ -190,7 +190,7 @@ ModelInstance::ModelInstance(MPQFile& f, char const* ModelInstName, uint32 mapID
     fwrite(&pos, sizeof(float), 3, pDirfile);
     fwrite(&rot, sizeof(float), 3, pDirfile);
     fwrite(&sc, sizeof(float), 1, pDirfile);
-    uint32 nlen = strlen(ModelInstName);
+    uint32 nlen = static_cast<uint32_t>(strlen(ModelInstName));
     fwrite(&nlen, sizeof(uint32), 1, pDirfile);
     fwrite(ModelInstName, sizeof(char), nlen, pDirfile);
 }

--- a/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -492,7 +492,7 @@ int main(int argc, char ** argv)
             printf("FATAL ERROR: Map.dbc not found in data file.\n");
             return 1;
         }
-        map_count=dbc->getRecordCount ();
+        map_count=static_cast<uint32_t>(dbc->getRecordCount());
         map_ids=new map_id[map_count];
         for (unsigned int x=0;x<map_count;++x)
         {

--- a/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/ToolsWotLK/vmap_tools/vmap4_extractor/wmo.cpp
@@ -390,7 +390,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         fwrite(VERT,4,3,output);
         for (uint32 i=0; i<nVertices; ++i)
             if(IndexRenum[i] >= 0)
-                check -= fwrite(MOVT+3*i, sizeof(float), 3, output);
+                check -= static_cast<int>(fwrite(MOVT+3*i, sizeof(float), 3, output));
 
         assert(check==0);
 
@@ -516,7 +516,7 @@ WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint
 
     fseek(input, 8, SEEK_SET); // get the correct no of vertices
     int nVertices;
-    int count = fread(&nVertices, sizeof (int), 1, input);
+    int count = static_cast<int>(fread(&nVertices, sizeof (int), 1, input));
     fclose(input);
 
     if (count != 1 || nVertices == 0)
@@ -549,7 +549,7 @@ WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint
     fwrite(&scale, sizeof(float), 1, pDirfile);
     fwrite(&pos2, sizeof(float), 3, pDirfile);
     fwrite(&pos3, sizeof(float), 3, pDirfile);
-    uint32 nlen=strlen(WmoInstName);
+    uint32 nlen=static_cast<uint32_t>(strlen(WmoInstName));
     fwrite(&nlen, sizeof(uint32), 1, pDirfile);
     fwrite(WmoInstName, sizeof(char), nlen, pDirfile);
 

--- a/src/world/GameWotLK/Data/MovementInfoWotLK.h
+++ b/src/world/GameWotLK/Data/MovementInfoWotLK.h
@@ -52,7 +52,7 @@ struct MovementInfo
     {
     }
 
-    bool hasFlag(uint32_t flag) const { return flags & flag; }
+    bool hasFlag(uint32_t flag) const { return (flags & flag) != 0; }
     bool isOnTransport() const { return hasFlag(MOVEFLAG_TRANSPORT); }
     bool isSwimming() const { return hasFlag(MOVEFLAG_SWIMMING); }
     bool isFlying() const { return hasFlag(MOVEFLAG_FLYING); }
@@ -62,6 +62,6 @@ struct MovementInfo
     bool isFallingOrRedirected() const { return isFalling() || isRedirected(); }
     bool isSplineMover() const { return hasFlag(MOVEFLAG_SPLINE_MOVER); }
 
-    bool hasFlag2(uint32_t flag2) const { return flags2 & flag2; }
+    bool hasFlag2(uint32_t flag2) const { return (flags2 & flag2) != 0; }
     bool isInterpolated() const { return hasFlag2(MOVEFLAG2_INTERPOLATED_MOVE); }
 };

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -636,7 +636,7 @@ public:
         bool HasFlag(const uint16 index, uint32 flag) const
         {
             ARCEMU_ASSERT(index < m_valuesCount);
-            return m_uint32Values[index] & flag;
+            return (m_uint32Values[index] & flag) != 0;
         }
 
         void ApplyModFlag(uint16 index, uint32 flag, bool apply)

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -425,7 +425,7 @@ bool Master::_StartDB()
     wdb_result = !wdb_result ? wdb_result : !worldConfig.worldDb.password.empty();
     wdb_result = !wdb_result ? wdb_result : !worldConfig.worldDb.host.empty();
     wdb_result = !wdb_result ? wdb_result : !worldConfig.worldDb.dbName.empty();
-    wdb_result = !wdb_result ? wdb_result : worldConfig.worldDb.port;
+    wdb_result = !wdb_result ? wdb_result : worldConfig.worldDb.port != 0;
 
     Database_World = Database::CreateDatabaseInterface();
 
@@ -447,7 +447,7 @@ bool Master::_StartDB()
     cdb_result = !cdb_result ? cdb_result : !worldConfig.charDb.password.empty();
     cdb_result = !cdb_result ? cdb_result : !worldConfig.charDb.host.empty();
     cdb_result = !cdb_result ? cdb_result : !worldConfig.charDb.dbName.empty();
-    cdb_result = !cdb_result ? cdb_result : worldConfig.charDb.port;
+    cdb_result = !cdb_result ? cdb_result : worldConfig.charDb.port != 0;
 
     Database_Character = Database::CreateDatabaseInterface();
 

--- a/src/world/Server/WorldConfig.cpp
+++ b/src/world/Server/WorldConfig.cpp
@@ -581,7 +581,7 @@ void WorldConfig::loadWorldConfigValues(bool reload /*false*/)
     guild.maxMembers = Config.MainConfig.getIntDefault("Guild", "MaxMembers", 80);
     guild.maxXpPerDay = Config.MainConfig.getIntDefault("Guild", "MaxXpPerDay", 6246000);
     guild.maxRepPerWeek = Config.MainConfig.getIntDefault("Guild", "MaxRepPerWeek", 4375);
-    guild.levlingEnabled = Config.MainConfig.getIntDefault("Guild", "LevlingEnabled", true);
+    guild.levlingEnabled = Config.MainConfig.getBoolDefault("Guild", "LevlingEnabled", true);
     guild.undeletabelLevel = Config.MainConfig.getIntDefault("Guild", "UndeletabelLevel", 4);
     guild.eventLogCount = Config.MainConfig.getIntDefault("Guild", "EventLogCount", 100);
     guild.newsLogCount = Config.MainConfig.getIntDefault("Guild", "NewsLogCount", 250);

--- a/src/world/Spell/SpellCastTargets.cpp
+++ b/src/world/Spell/SpellCastTargets.cpp
@@ -233,10 +233,10 @@ void SpellCastTargets::write(WorldPacket& data) const
 
 bool SpellCastTargets::hasSource() const
 {
-    return GetTargetMask() & TARGET_FLAG_SOURCE_LOCATION;
+    return (GetTargetMask() & TARGET_FLAG_SOURCE_LOCATION) != 0;
 }
 
 bool SpellCastTargets::hasDestination() const
 {
-    return GetTargetMask() & TARGET_FLAG_DEST_LOCATION;
+    return (GetTargetMask() & TARGET_FLAG_DEST_LOCATION) != 0;
 }

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -3594,7 +3594,7 @@ void Player::LoadFromDBProc(QueryResultVector & results)
         la.dur = atol(auraDuration.c_str());
 
         std::getline(savedPlayerBuffsStream, auraPositivValue, ',');
-        la.positive = (auraPositivValue.c_str());
+        la.positive = auraPositivValue.c_str() == nullptr ? false : true;
 
         std::getline(savedPlayerBuffsStream, auraCharges, ',');
         la.charges = atol(auraCharges.c_str());
@@ -4391,7 +4391,7 @@ void Player::LoadFromDBProc(QueryResultVector & results)
         la.dur = atol(auraDuration.c_str());
 
         std::getline(savedPlayerBuffsStream, auraPositivValue, ',');
-        la.positive = (auraPositivValue.c_str());
+        la.positive = auraPositivValue.c_str() == nullptr ? false : true;
 
         std::getline(savedPlayerBuffsStream, auraCharges, ',');
         la.charges = atol(auraCharges.c_str());


### PR DESCRIPTION
Ugly casts but required for /wX
Fixes warnings such as:
warning C4800: 'uint32_t': forcing value to bool 'true' or 'false' (performance warning)
warning C4091: 'typedef ': ignored on left of '' when no variable is declared
warning C4996: 'chdir': The POSIX name for this item is deprecated.
etc
