### PR TITLE
DBC: Verify fields in spell related DBC files

### DIFF
--- a/src/scripts/SpellHandlers/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/DeathKnightSpells.cpp
@@ -83,7 +83,7 @@ bool DeathStrike(uint8_t /*effectIndex*/, Spell* pSpell)
         // A deadly attack that deals $s2% weapon damage plus ${$m1*$m2/100}
         // and heals the Death Knight for $F% of $Ghis:her; maximum health for each of $Ghis:her; diseases on the target.
         // $F is dmg_multiplier.
-        float amt = static_cast<float>(pSpell->p_caster->getMaxHealth()) * pSpell->GetSpellInfo()->getDmg_multiplier(0) / 100.0f;
+        float amt = static_cast<float>(pSpell->p_caster->getMaxHealth()) * pSpell->GetSpellInfo()->getEffectDamageMultiplier(0) / 100.0f;
 
         // Calculate heal amount with diseases on target
         uint32 val = static_cast<uint32>(amt * count);

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -164,16 +164,16 @@ bool ChatHandler::HandleNpcAddTrainerSpellCommand(const char* args, WorldSession
         creature_target->getEntry(), (int)0, learn_spell->getId(), cost, reqspell, (int)0, (int)0, reqlevel, delspell, (int)0);
 #else
     sp.spellCost = cost;
-    sp.spell = learn_spell->Id;
+    sp.spell = learn_spell->getId();
     sp.reqLevel = reqlevel;
 
     creature_trainer->Spells.push_back(sp);
     creature_trainer->SpellCount++;
 
-    SystemMessage(m_session, "Added spell %s (%u) to trainer %s (%u).", learn_spell->Name.c_str(), learn_spell->Id, creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
-    sGMLog.writefromsession(m_session, "added spell  %s (%u) to trainer %s (%u)", learn_spell->Name.c_str(), learn_spell->Id, creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
+    SystemMessage(m_session, "Added spell %s (%u) to trainer %s (%u).", learn_spell->getName().c_str(), learn_spell->getId(), creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
+    sGMLog.writefromsession(m_session, "added spell  %s (%u) to trainer %s (%u)", learn_spell->getName().c_str(), learn_spell->getId(), creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
     WorldDatabase.Execute("REPLACE INTO trainer_spells VALUES(%u, %u, %u, %u, %u, %u)",
-                          creature_target->getEntry(), learn_spell->Id, cost, (int)0, (int)0, reqlevel);
+                          creature_target->getEntry(), learn_spell->getId(), cost, (int)0, (int)0, reqlevel);
 #endif
 
     return true;

--- a/src/world/GameCata/Handlers/NPCHandler.cpp
+++ b/src/world/GameCata/Handlers/NPCHandler.cpp
@@ -59,7 +59,7 @@ void WorldSession::SendTrainerList(Creature* pCreature)
                 }
 
                 SpellInfo* learnedSpellInfo = sSpellCustomizations.GetSpellInfo(pSpell->learnedSpell[i]);
-                if (learnedSpellInfo && learnedSpellInfo->IsPrimaryProfession())
+                if (learnedSpellInfo && learnedSpellInfo->isPrimaryProfession())
                     primary_prof_first_rank = true;
             }
             if (!valid)
@@ -105,7 +105,7 @@ void WorldSession::SendTrainerList(Creature* pCreature)
             }
 
             SpellInfo* spell = sSpellCustomizations.GetSpellInfo(pSpell->spell);
-            if (spell && spell->IsPrimaryProfession())
+            if (spell && spell->isPrimaryProfession())
                 data << uint32_t(primary_prof_first_rank && can_learn_primary_prof ? 1 : 0);
             else
                 data << uint32_t(1);

--- a/src/world/GameCata/Handlers/SpellHandler.cpp
+++ b/src/world/GameCata/Handlers/SpellHandler.cpp
@@ -38,10 +38,10 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    if (!_player->isAlive() && _player->getShapeShiftForm() != FORM_SPIRITOFREDEMPTION && !(spellInfo->Attributes & ATTRIBUTES_DEAD_CASTABLE)) //They're dead, not in spirit of redemption and the spell can't be cast while dead.
+    if (!_player->isAlive() && _player->getShapeShiftForm() != FORM_SPIRITOFREDEMPTION && !(spellInfo->getAttributes() & ATTRIBUTES_DEAD_CASTABLE)) //They're dead, not in spirit of redemption and the spell can't be cast while dead.
         return;
 
-    LogDetail("WORLD: got cast spell packet, spellId - %i (%s), data length = %i", spellId, spellInfo->Name.c_str(), recvPacket.size());
+    LogDetail("WORLD: got cast spell packet, spellId - %i (%s), data length = %i", spellId, spellInfo->getName().c_str(), recvPacket.size());
 
     // Check does player have the spell
     if (!GetPlayer()->HasSpell(spellId))
@@ -52,7 +52,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     }
 
     // Check is player trying to cast a passive spell
-    if (spellInfo->IsPassive())
+    if (spellInfo->isPassive())
     {
         sCheatLog.writefromsession(this, "Cast passive spell %lu.", spellId);
         LogDetail("WORLD: Spell isn't cast because player \'%s\' is cheating", GetPlayer()->GetName());
@@ -81,7 +81,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
         if (targets.m_unitTarget && targets.m_unitTarget != _player->getGuid())
         {
             // send the error message
-            _player->SendCastResult(spellInfo->Id, SPELL_FAILED_BAD_TARGETS, castCount, 0);
+            _player->SendCastResult(spellInfo->getId(), SPELL_FAILED_BAD_TARGETS, castCount, 0);
             return;
         }
     }
@@ -229,7 +229,7 @@ void WorldSession::HandleCancelAuraOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    if (spellInfo->IsPassive())
+    if (spellInfo->isPassive())
     {
         return;
     }

--- a/src/world/GameCata/Storage/DBCStructures.cpp
+++ b/src/world/GameCata/Storage/DBCStructures.cpp
@@ -131,7 +131,7 @@ uint32_t DBC::Structures::SpellEntry::GetStartRecoveryTime() const
 uint32_t DBC::Structures::SpellEntry::GetMechanic() const
 {
     SpellCategoriesEntry const* cat = GetSpellCategories();
-    return cat ? cat->Mechanic : 0;
+    return cat ? cat->MechanicsType : 0;
 }
 
 uint32_t DBC::Structures::SpellEntry::GetRecoveryTime() const
@@ -179,7 +179,7 @@ uint32_t DBC::Structures::SpellEntry::GetDmgClass() const
 uint32_t DBC::Structures::SpellEntry::GetDispel() const
 {
     SpellCategoriesEntry const* cat = GetSpellCategories();
-    return cat ? cat->Dispel : 0;
+    return cat ? cat->DispelType : 0;
 }
 
 uint32_t DBC::Structures::SpellEntry::GetMaxAffectedTargets() const
@@ -191,7 +191,7 @@ uint32_t DBC::Structures::SpellEntry::GetMaxAffectedTargets() const
 uint32_t DBC::Structures::SpellEntry::GetStackAmount() const
 {
     SpellAuraOptionsEntry const* aura = GetSpellAuraOptions();
-    return aura ? aura->StackAmount : 0;
+    return aura ? aura->MaxStackAmount : 0;
 }
 
 uint32_t DBC::Structures::SpellEntry::GetManaCostPercentage() const
@@ -293,13 +293,13 @@ int32_t DBC::Structures::SpellEntry::GetEffectMiscValue(SpellEffectIndex index) 
 uint32_t DBC::Structures::SpellEntry::GetStances() const
 {
     SpellShapeshiftEntry const* ss = GetSpellShapeshift();
-    return ss ? ss->Stances : 0;
+    return ss ? ss->Shapeshifts : 0;
 }
 
 uint32_t DBC::Structures::SpellEntry::GetStancesNot() const
 {
     SpellShapeshiftEntry const* ss = GetSpellShapeshift();
-    return ss ? ss->StancesNot : 0;
+    return ss ? ss->ShapeshiftsExcluded : 0;
 }
 
 uint32_t DBC::Structures::SpellEntry::GetProcFlags() const

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -1432,7 +1432,7 @@ namespace DBC
         struct SpellAuraOptionsEntry
         {
             //uint32_t Id;                      // 0
-            uint32_t StackAmount;               // 1
+            uint32_t MaxStackAmount;            // 1
             uint32_t procChance;                // 2
             uint32_t procCharges;               // 3
             uint32_t procFlags;                 // 4
@@ -1448,8 +1448,8 @@ namespace DBC
             uint32_t TargetAuraStateNot;        // 4
             uint32_t casterAuraSpell;           // 5
             uint32_t targetAuraSpell;           // 6
-            uint32_t excludeCasterAuraSpell;    // 7
-            uint32_t excludeTargetAuraSpell;    // 8
+            uint32_t CasterAuraSpellNot;        // 7
+            uint32_t TargetAuraSpellNot;        // 8
         };
 
         // SpellCastingRequirements.dbc
@@ -1479,8 +1479,8 @@ namespace DBC
             //uint32_t Id;                      // 0
             uint32_t Category;                  // 1
             uint32_t DmgClass;                  // 2
-            uint32_t Dispel;                    // 3
-            uint32_t Mechanic;                  // 4
+            uint32_t DispelType;                // 3
+            uint32_t MechanicsType;             // 4
             uint32_t PreventionType;            // 5
             uint32_t StartRecoveryCategory;     // 6
         };
@@ -1523,11 +1523,11 @@ namespace DBC
         // SpellClassOptions.dbc
         struct SpellClassOptionsEntry
         {
-            //uint32_t Id;                      // 0
-            //uint32_t modalNextSpell;          // 1
-            uint32_t SpellFamilyFlags[3];       // 2-4
-            uint32_t SpellFamilyName;           // 5
-            //char* Description;                // 6
+            //uint32_t Id;                                  // 0
+            //uint32_t modalNextSpell;                      // 1
+            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
+            uint32_t SpellFamilyName;                       // 5
+            //char* Description;                            // 6
             
             // helpers
             bool IsFitToFamilyMask(uint64 /*familyFlags*/, uint32_t /*familyFlags2*/ = 0) const
@@ -1767,11 +1767,11 @@ namespace DBC
         struct SpellShapeshiftEntry
         {
             //uint32_t Id;                      // 0
-            uint32_t StancesNot;                // 1
-            // uint32_t unk_320_2;              // 2
-            uint32_t Stances;                   // 3
-            // uint32_t unk_320_3;              // 4
-            // uint32_t StanceBarOrder;         // 5
+            uint32_t ShapeshiftsExcluded;       // 1
+            //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
+            uint32_t Shapeshifts;               // 3
+            //uint32_t Shapeshifts1;            // 4 unused, all zeros
+            //uint32_t StanceBarOrder;          // 5
         };
 
         // SpellTargetRestrictions.dbc
@@ -1812,13 +1812,14 @@ namespace DBC
             int32_t powerType;                                    // 14
             uint32_t rangeIndex;                                  // 15
             float speed;                                          // 16
-            uint32_t SpellVisual[2];                              // 17-18
+            uint32_t SpellVisual;                                 // 17
+            //uint32_t SpellVisual1;                              // 18
             uint32_t spellIconID;                                 // 19
             uint32_t activeIconID;                                // 20
-            char* Name;                                           // 21
-            char* Rank;                                           // 22
-            char* Description;                                    // 23
-            char* BuffDescription;                                // 24
+            const char* Name;                                     // 21
+            const char* Rank;                                     // 22
+            //char* Description;                                  // 23 not used
+            //char* BuffDescription;                              // 24 not used
             uint32_t School;                                      // 25
             uint32_t RuneCostID;                                  // 26
             //uint32_t spellMissileID;                            // 27

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -568,119 +568,96 @@ namespace DBC
         struct SpellEntry
         {
             uint32_t Id;                                                // 0
-            uint32_t Category;                                          // 1
-            uint32_t DispelType;                                        // 2
-            uint32_t MechanicsType;                                     // 3
-            uint32_t Attributes;                                        // 4
-            uint32_t AttributesEx;                                      // 5
-            uint32_t AttributesExB;                                     // 6
-            uint32_t AttributesExC;                                     // 7
-            uint32_t AttributesExD;                                     // 8
-            uint32_t AttributesExE;                                     // 9
-            uint32_t AttributesExF;                                     // 10
-            uint32_t AttributesExG;                                     // 11 
-            uint32_t RequiredShapeShift;                                // 12
-          //uint32_t Unknown;                                           // 13 (12-13 Stances[2])
-            uint32_t ShapeshiftExclude;                                 // 14 
-          //uint32_t Unknown;                                           // 15 (14-15 StancesExcluded[2])
-            uint32_t Targets;                                           // 16
-            uint32_t TargetCreatureType;                                // 17
-            uint32_t RequiresSpellFocus;                                // 18
-            uint32_t FacingCasterFlags;                                 // 19
-            uint32_t CasterAuraState;                                   // 20
-            uint32_t TargetAuraState;                                   // 21
-            uint32_t CasterAuraStateNot;                                // 22
-            uint32_t TargetAuraStateNot;                                // 23
-            uint32_t casterAuraSpell;                                   // 24
-            uint32_t targetAuraSpell;                                   // 25
-            uint32_t casterAuraSpellNot;                                // 26
-            uint32_t targetAuraSpellNot;                                // 27
-            uint32_t CastingTimeIndex;                                  // 28
-            uint32_t RecoveryTime;                                      // 29
-            uint32_t CategoryRecoveryTime;                              // 30
-            uint32_t InterruptFlags;                                    // 31
-            uint32_t AuraInterruptFlags;                                // 32
-            uint32_t ChannelInterruptFlags;                             // 33
-            uint32_t procFlags;                                         // 34
-            uint32_t procChance;                                        // 35
-            uint32_t procCharges;                                       // 36
-            uint32_t maxLevel;                                          // 37
-            uint32_t baseLevel;                                         // 38
-            uint32_t spellLevel;                                        // 39
-            uint32_t DurationIndex;                                     // 40
-            int32_t powerType;                                         // 41
-            uint32_t manaCost;                                          // 42
-            uint32_t manaCostPerlevel;                                  // 43
-            uint32_t manaPerSecond;                                     // 44
-            uint32_t manaPerSecondPerLevel;                             // 45
-            uint32_t rangeIndex;                                        // 46
-            float speed;                                              // 47
-            uint32_t modalNextSpell;                                    // 48 comment this out
-            uint32_t maxstack;                                          // 49
-            uint32_t Totem[2];                                          // 50 - 51
-            uint32_t Reagent[8];                                        // 52 - 59 int32_t
-            uint32_t ReagentCount[8];                                   // 60 - 67
-            int32_t  EquippedItemClass;                                 // 68
-            uint32_t EquippedItemSubClass;                              // 69 int32_t
-            uint32_t RequiredItemFlags;                                 // 70 int32_t
-            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 71 - 73
-            uint32_t EffectDieSides[MAX_SPELL_EFFECTS];                 // 74 - 76
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];        // 77 - 79
-            int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
-            int32_t EffectMechanic[MAX_SPELL_EFFECTS];                  // 83 - 85 uint32_t
-            uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
-            uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
-            uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
-            uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
-            uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];             // 101 - 103
-            uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
-            uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109 
-            uint32_t EffectMiscValue[MAX_SPELL_EFFECTS];                // 110 - 112 int32_t
-            uint32_t EffectMiscValueB[MAX_SPELL_EFFECTS];               // 113 - 115 int32_t
-            uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];       // 119 - 121
-            uint32_t EffectSpellClassMask[3][3];                        // 122 - 130
-            uint32_t SpellVisual;                                       // 131
-            uint32_t field114;                                          // 132 (131-132 SpellVisual[2])
-            uint32_t spellIconID;                                       // 133
-            uint32_t activeIconID;                                      // 134 activeIconID;
-            uint32_t spellPriority;                                     // 135
-            const char* Name;                                         // 136
-          //char* NameAlt[15];                                        // 137 - 151 (136-151 Name[16])
-          //uint32_t NameFlags;                                         // 152 not used
-            const char* Rank;                                         // 153
-          //char* RankAlt[15];                                        // 154 - 168 (153-168 Rank[16])
-          //uint32_t RankFlags;                                         // 169 not used
-            char* Description;                                        // 170  comment this out
-          //char* DescriptionAlt[15];                                 // 171 - 185 (170-185 Description[16])
-          //uint32_t DescriptionFlags;                                  // 186 not used
-            const char* BuffDescription;                              // 187  comment this out
-          //char* BuffDescription[15];                                // 188 - 202 (187-202 BuffDescription[16])
-          //uint32_t buffdescflags;                                     // 203 not used
-            uint32_t ManaCostPercentage;                                // 204
-            uint32_t StartRecoveryCategory;                             // 205
-            uint32_t StartRecoveryTime;                                 // 206
-            uint32_t MaxTargetLevel;                                    // 207
-            uint32_t SpellFamilyName;                                   // 208
-            uint32_t SpellGroupType[MAX_SPELL_EFFECTS];                 // 209 - 211
-            uint32_t MaxTargets;                                        // 212
-            uint32_t Spell_Dmg_Type;                                    // 213
-            uint32_t PreventionType;                                    // 214
-            int32_t StanceBarOrder;                                     // 215  comment this out
-            float dmg_multiplier[MAX_SPELL_EFFECTS];                  // 216 - 218
-            uint32_t MinFactionID;                                      // 219  comment this out
-            uint32_t MinReputation;                                     // 220  comment this out
-            uint32_t RequiredAuraVision;                                // 221  comment this out
-            uint32_t TotemCategory[2];                                  // 222 - 223
-            int32_t RequiresAreaId;                                     // 224
-            uint32_t School;                                            // 225
-            uint32_t RuneCostID;                                        // 226
-          //uint32_t SpellMissileID;                                    // 227
-          //uint32_t PowerDisplayId;                                    // 228
-          //float EffectBonusMultiplier[MAX_SPELL_EFFECTS];           // 229 - 231
-          //uint32_t SpellDescriptionVariable;                          // 232
-            uint32_t SpellDifficultyID;                                 // 233  comment this out
+            uint32_t School;                                            // 1 NOT in bitmask!
+            uint32_t Category;                                          // 2
+            //uint32_t castUI;                                          // 3 not used
+            uint32_t DispelType;                                        // 4
+            uint32_t MechanicsType;                                     // 5
+            uint32_t Attributes;                                        // 6
+            uint32_t AttributesEx;                                      // 7
+            uint32_t AttributesExB;                                     // 8
+            uint32_t AttributesExC;                                     // 9
+            uint32_t AttributesExD;                                     // 10
+            uint32_t Shapeshifts;                                       // 11
+            uint32_t ShapeshiftsExcluded;                               // 12
+            uint32_t Targets;                                           // 13
+            uint32_t TargetCreatureType;                                // 14
+            uint32_t RequiresSpellFocus;                                // 15
+            uint32_t CasterAuraState;                                   // 16
+            uint32_t TargetAuraState;                                   // 17
+            uint32_t CastingTimeIndex;                                  // 18
+            uint32_t RecoveryTime;                                      // 19
+            uint32_t CategoryRecoveryTime;                              // 20
+            uint32_t InterruptFlags;                                    // 21
+            uint32_t AuraInterruptFlags;                                // 22
+            uint32_t ChannelInterruptFlags;                             // 23
+            uint32_t procFlags;                                         // 24
+            uint32_t procChance;                                        // 25
+            uint32_t procCharges;                                       // 26
+            uint32_t maxLevel;                                          // 27
+            uint32_t baseLevel;                                         // 28
+            uint32_t spellLevel;                                        // 29
+            uint32_t DurationIndex;                                     // 30
+            int32_t powerType;                                          // 31
+            uint32_t manaCost;                                          // 32
+            uint32_t manaCostPerlevel;                                  // 33
+            uint32_t manaPerSecond;                                     // 34
+            uint32_t manaPerSecondPerLevel;                             // 35
+            uint32_t rangeIndex;                                        // 36
+            float speed;                                                // 37
+            //uint32_t modalNextSpell;                                  // 38 not used
+            uint32_t MaxStackAmount;                                    // 39
+            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 40 - 41
+            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 42 - 49
+            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 50 - 57
+            int32_t EquippedItemClass;                                  // 58
+            int32_t EquippedItemSubClass;                               // 59
+            int32_t EquippedItemInventoryTypeMask;                      // 60
+            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 61 - 63
+            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 64 - 66
+            uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 67 - 69
+            float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 70 - 72
+            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 73 - 75
+            int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 76 - 78
+            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 79 - 81
+            uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 82 - 84
+            uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 85 - 87
+            uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 88 - 90
+            uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 91 - 93
+            uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 94 - 96
+            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 97 - 99
+            uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 100 - 102
+            uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 105
+            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 106 - 108
+            uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 109 - 111
+            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 112 - 114
+            uint32_t SpellVisual;                                       // 115
+            //uint32_t SpellVisual1;                                    // 116 not used
+            uint32_t spellIconID;                                       // 117
+            uint32_t activeIconID;                                      // 118 activeIconID;
+            uint32_t spellPriority;                                     // 119
+            const char* Name[8];                                        // 120 - 127
+            //uint32_t NameFlags;                                       // 128 not used
+            const char* Rank[8];                                        // 129 - 136
+            //uint32_t RankFlags;                                       // 137 not used
+            //const char* Description[8];                               // 138 - 145 not used
+            //uint32_t DescriptionFlags;                                // 146 not used
+            //const char* BuffDescription[8];                           // 147 - 154 not used
+            //uint32_t buffdescflags;                                   // 155 not used
+            uint32_t ManaCostPercentage;                                // 156
+            uint32_t StartRecoveryCategory;                             // 157
+            uint32_t StartRecoveryTime;                                 // 158
+            uint32_t MaxTargetLevel;                                    // 159
+            uint32_t SpellFamilyName;                                   // 160
+            uint32_t SpellFamilyFlags[2];                               // 161 - 162
+            uint32_t MaxTargets;                                        // 163
+            uint32_t DmgClass;                                          // 164
+            uint32_t PreventionType;                                    // 165
+            //int32_t StanceBarOrder;                                   // 166 not used
+            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 167 - 169
+            //uint32_t MinFactionID;                                    // 170 not used
+            //uint32_t MinReputation;                                   // 171 not used
+            //uint32_t RequiredAuraVision;                              // 172 not used
         };
 
         struct SpellItemEnchantmentEntry

--- a/src/world/GameTBC/Storage/DBCStructures.h
+++ b/src/world/GameTBC/Storage/DBCStructures.h
@@ -570,8 +570,8 @@ namespace DBC
         {
             uint32_t Id;                                                // 0
             uint32_t Category;                                          // 1
-            uint32_t DispelType;                                        // 2
-            uint32_t castUI;                                            // 3
+            //uint32_t castUI;                                          // 2 not used
+            uint32_t DispelType;                                        // 3
             uint32_t MechanicsType;                                     // 4
             uint32_t Attributes;                                        // 5
             uint32_t AttributesEx;                                      // 6
@@ -580,8 +580,8 @@ namespace DBC
             uint32_t AttributesExD;                                     // 9
             uint32_t AttributesExE;                                     // 10
             uint32_t AttributesExF;                                     // 11
-            uint32_t RequiredShapeShift;                                // 12
-            uint32_t ShapeshiftExclude;                                 // 13
+            uint32_t Shapeshifts;                                       // 12
+            uint32_t ShapeshiftsExcluded;                               // 13
             uint32_t Targets;                                           // 14
             uint32_t TargetCreatureType;                                // 15
             uint32_t RequiresSpellFocus;                                // 16
@@ -590,89 +590,83 @@ namespace DBC
             uint32_t TargetAuraState;                                   // 19
             uint32_t CasterAuraStateNot;                                // 20
             uint32_t TargetAuraStateNot;                                // 21
-            uint32_t CastingTimeIndex;                                  // 28
-            uint32_t RecoveryTime;                                      // 29
-            uint32_t CategoryRecoveryTime;                              // 30
-            uint32_t InterruptFlags;                                    // 31
-            uint32_t AuraInterruptFlags;                                // 32
-            uint32_t ChannelInterruptFlags;                             // 33
-            uint32_t procFlags;                                         // 34
-            uint32_t procChance;                                        // 35
-            int32_t procCharges;                                       // 36
-            uint32_t maxLevel;                                          // 37
-            uint32_t baseLevel;                                         // 38
-            uint32_t spellLevel;                                        // 39
-            uint32_t DurationIndex;                                     // 40
-            uint32_t powerType;                                         // 41
-            uint32_t manaCost;                                          // 42
-            uint32_t manaCostPerlevel;                                  // 43
-            uint32_t manaPerSecond;                                     // 44
-            uint32_t manaPerSecondPerLevel;                             // 45
-            uint32_t rangeIndex;                                        // 46
-            float speed;                                              // 47
-            uint32_t modalNextSpell;                                    // 48 comment this out
-            uint32_t maxstack;                                          // 49
-            uint32_t Totem[2];                                          // 50 - 51
-            uint32_t Reagent[8];                                        // 52 - 59 int32_t
-            uint32_t ReagentCount[8];                                   // 60 - 67
-            int32_t  EquippedItemClass;                                 // 68
-            uint32_t EquippedItemSubClass;                              // 69 int32_t
-            uint32_t RequiredItemFlags;                                 // 70 int32_t
-            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 71 - 73
-            uint32_t EffectDieSides[MAX_SPELL_EFFECTS];                 // 74 - 76
-            uint32_t EffectBaseDice[3];
-            float  EffectDicePerLevel[3];
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];        // 77 - 79
+            uint32_t CastingTimeIndex;                                  // 22
+            uint32_t RecoveryTime;                                      // 23
+            uint32_t CategoryRecoveryTime;                              // 24
+            uint32_t InterruptFlags;                                    // 25
+            uint32_t AuraInterruptFlags;                                // 26
+            uint32_t ChannelInterruptFlags;                             // 27
+            uint32_t procFlags;                                         // 28
+            uint32_t procChance;                                        // 29
+            uint32_t procCharges;                                       // 30
+            uint32_t maxLevel;                                          // 31
+            uint32_t baseLevel;                                         // 32
+            uint32_t spellLevel;                                        // 33
+            uint32_t DurationIndex;                                     // 34
+            int32_t powerType;                                          // 35
+            uint32_t manaCost;                                          // 36
+            uint32_t manaCostPerlevel;                                  // 37
+            uint32_t manaPerSecond;                                     // 38
+            uint32_t manaPerSecondPerLevel;                             // 39
+            uint32_t rangeIndex;                                        // 40
+            float speed;                                                // 41
+            //uint32_t modalNextSpell;                                  // 42 not used
+            uint32_t MaxStackAmount;                                    // 43
+            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 44 - 45
+            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 46 - 53
+            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 54 - 61
+            int32_t EquippedItemClass;                                  // 62
+            int32_t EquippedItemSubClass;                               // 63
+            int32_t EquippedItemInventoryTypeMask;                      // 64
+            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 65 - 67
+            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 68 - 70
+            uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 71 - 73
+            float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 74 - 76
+            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
             int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
-            int32_t EffectMechanic[MAX_SPELL_EFFECTS];                  // 83 - 85 uint32_t
+            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
             uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
             uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
             uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
             uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
             uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];             // 101 - 103
+            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
             uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
             uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109
-            uint32_t EffectMiscValue[MAX_SPELL_EFFECTS];                // 110 - 112 int32_t
-            uint32_t EffectMiscValueB[MAX_SPELL_EFFECTS];               // 113 - 115 int32_t
+            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
+            int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
             uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];       // 119 - 121
-            uint32_t SpellVisual;                                       // 131
-            uint32_t field114;                                          // 132 (131-132 SpellVisual[2])
-            uint32_t spellIconID;                                       // 133
-            uint32_t activeIconID;                                      // 134 activeIconID;
-            uint32_t spellPriority;                                     // 135
-            const char* Name;                                         // 136
-          //char* NameAlt[15];                                        // 137 - 151 (136-151 Name[16])
-          //uint32_t NameFlags;                                         // 152 not used
-            const char* Rank;                                         // 153
-          //char* RankAlt[15];                                        // 154 - 168 (153-168 Rank[16])
-          //uint32_t RankFlags;                                         // 169 not used
-            char* Description;                                        // 170  comment this out
-          //char* DescriptionAlt[15];                                 // 171 - 185 (170-185 Description[16])
-          //uint32_t DescriptionFlags;                                  // 186 not used
-            const char* BuffDescription;                              // 187  comment this out
-          //char* BuffDescription[15];                                // 188 - 202 (187-202 BuffDescription[16])
-          //uint32_t buffdescflags;                                     // 203 not used
-            uint32_t ManaCostPercentage;                                // 204
-            uint32_t unkflags;                             // 205
-            uint32_t StartRecoveryTime;                                 // 206
-            uint32 StartRecoveryCategory;
-            //uint32_t MaxTargetLevel;                                    // 207
-            uint32_t SpellFamilyName;                                   // 208
-            uint64_t SpellGroupType;                 // 209 - 211
-            uint32_t MaxTargets;                                        // 212
-            uint32_t Spell_Dmg_Type;                                    // 213
-            uint32_t PreventionType;                                    // 214
-            int32_t StanceBarOrder;                                     // 215  comment this out
-            float dmg_multiplier[MAX_SPELL_EFFECTS];                  // 216 - 218
-            uint32_t MinFactionID;                                      // 219  comment this out
-            uint32_t MinReputation;                                     // 220  comment this out
-            uint32_t RequiredAuraVision;                                // 221  comment this out
-            uint32_t TotemCategory[2];                                  // 222 - 223
-            uint32_t RequiresAreaId;                                     // 224
-            uint32_t School;                                            // 225
-
+            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
+            uint32_t SpellVisual;                                       // 122
+            //uint32_t SpellVisual1;                                    // 123 not used
+            uint32_t spellIconID;                                       // 124
+            uint32_t activeIconID;                                      // 125 activeIconID;
+            uint32_t spellPriority;                                     // 126
+            const char* Name[16];                                       // 127 - 142
+            //uint32_t NameFlags;                                       // 143 not used
+            const char* Rank[16];                                       // 144 - 159
+            //uint32_t RankFlags;                                       // 160 not used
+            //const char* Description[16];                              // 161 - 176 not used
+            //uint32_t DescriptionFlags;                                // 177 not used
+            //const char* BuffDescription[16];                          // 178 - 193 not used
+            //uint32_t buffdescflags;                                   // 194 not used
+            uint32_t ManaCostPercentage;                                // 195
+            uint32_t StartRecoveryCategory;                             // 196
+            uint32_t StartRecoveryTime;                                 // 197
+            uint32_t MaxTargetLevel;                                    // 198
+            uint32_t SpellFamilyName;                                   // 199
+            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 200 - 201
+            uint32_t MaxTargets;                                        // 202
+            uint32_t DmgClass;                                          // 203
+            uint32_t PreventionType;                                    // 204
+            //int32_t StanceBarOrder;                                   // 205 not used
+            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 206 - 208
+            //uint32_t MinFactionID;                                    // 209 not used
+            //uint32_t MinReputation;                                   // 210 not used
+            //uint32_t RequiredAuraVision;                              // 211 not used
+            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 212 - 213
+            int32_t AreaGroupId;                                        // 214
+            uint32_t School;                                            // 215
         };
 
         struct SpellItemEnchantmentEntry

--- a/src/world/GameWotLK/Storage/DBCStructures.h
+++ b/src/world/GameWotLK/Storage/DBCStructures.h
@@ -1159,10 +1159,10 @@ namespace DBC
             uint32_t AttributesExE;                                     // 9
             uint32_t AttributesExF;                                     // 10
             uint32_t AttributesExG;                                     // 11 
-            uint32_t RequiredShapeShift;                                // 12
-          //uint32_t Unknown;                                           // 13 (12-13 Stances[2])
-            uint32_t ShapeshiftExclude;                                 // 14 
-          //uint32_t Unknown;                                           // 15 (14-15 StancesExcluded[2])
+            uint32_t Shapeshifts;                                       // 12
+            //uint32_t Shapeshifts1;                                    // 13 not used, all zeros
+            uint32_t ShapeshiftsExcluded;                               // 14
+            //uint32_t ShapeshiftsExcluded1;                            // 15 not used, all zeros
             uint32_t Targets;                                           // 16
             uint32_t TargetCreatureType;                                // 17
             uint32_t RequiresSpellFocus;                                // 18
@@ -1188,79 +1188,75 @@ namespace DBC
             uint32_t baseLevel;                                         // 38
             uint32_t spellLevel;                                        // 39
             uint32_t DurationIndex;                                     // 40
-            int32_t powerType;                                         // 41
+            int32_t powerType;                                          // 41
             uint32_t manaCost;                                          // 42
             uint32_t manaCostPerlevel;                                  // 43
             uint32_t manaPerSecond;                                     // 44
             uint32_t manaPerSecondPerLevel;                             // 45
             uint32_t rangeIndex;                                        // 46
-            float speed;                                              // 47
-            uint32_t modalNextSpell;                                    // 48 comment this out
-            uint32_t maxstack;                                          // 49
-            uint32_t Totem[2];                                          // 50 - 51
-            uint32_t Reagent[8];                                        // 52 - 59 int32_t
-            uint32_t ReagentCount[8];                                   // 60 - 67
-            int32_t  EquippedItemClass;                                 // 68
-            uint32_t EquippedItemSubClass;                              // 69 int32_t
-            uint32_t RequiredItemFlags;                                 // 70 int32_t
+            float speed;                                                // 47
+            //uint32_t modalNextSpell;                                  // 48 not used
+            uint32_t MaxStackAmount;                                    // 49
+            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 50 - 51
+            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 52 - 59
+            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 60 - 67
+            int32_t EquippedItemClass;                                  // 68
+            int32_t EquippedItemSubClass;                               // 69
+            int32_t EquippedItemInventoryTypeMask;                      // 70
             uint32_t Effect[MAX_SPELL_EFFECTS];                         // 71 - 73
-            uint32_t EffectDieSides[MAX_SPELL_EFFECTS];                 // 74 - 76
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];        // 77 - 79
+            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 74 - 76
+            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
             int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
-            int32_t EffectMechanic[MAX_SPELL_EFFECTS];                  // 83 - 85 uint32_t
+            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
             uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
             uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
             uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
             uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
             uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];             // 101 - 103
+            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
             uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
             uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109 
-            uint32_t EffectMiscValue[MAX_SPELL_EFFECTS];                // 110 - 112 int32_t
-            uint32_t EffectMiscValueB[MAX_SPELL_EFFECTS];               // 113 - 115 int32_t
+            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
+            int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
             uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];       // 119 - 121
-            uint32_t EffectSpellClassMask[3][3];                        // 122 - 130
+            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
+            uint32_t EffectSpellClassMask[MAX_SPELL_EFFECTS][3];        // 122 - 130
             uint32_t SpellVisual;                                       // 131
-            uint32_t field114;                                          // 132 (131-132 SpellVisual[2])
+            //uint32_t SpellVisual1;                                    // 132 not used
             uint32_t spellIconID;                                       // 133
             uint32_t activeIconID;                                      // 134 activeIconID;
             uint32_t spellPriority;                                     // 135
-            const char* Name;                                         // 136
-          //char* NameAlt[15];                                        // 137 - 151 (136-151 Name[16])
-          //uint32_t NameFlags;                                         // 152 not used
-            const char* Rank;                                         // 153
-          //char* RankAlt[15];                                        // 154 - 168 (153-168 Rank[16])
-          //uint32_t RankFlags;                                         // 169 not used
-            char* Description;                                        // 170  comment this out
-          //char* DescriptionAlt[15];                                 // 171 - 185 (170-185 Description[16])
-          //uint32_t DescriptionFlags;                                  // 186 not used
-            const char* BuffDescription;                              // 187  comment this out
-          //char* BuffDescription[15];                                // 188 - 202 (187-202 BuffDescription[16])
-          //uint32_t buffdescflags;                                     // 203 not used
+            const char* Name[16];                                       // 136 - 151
+            //uint32_t NameFlags;                                       // 152 not used
+            const char* Rank[16];                                       // 153 - 168
+            //uint32_t RankFlags;                                       // 169 not used
+            //const char* Description[16];                              // 170 - 185 not used
+            //uint32_t DescriptionFlags;                                // 186 not used
+            //const char* BuffDescription[16];                          // 187 - 202 not used
+            //uint32_t buffdescflags;                                   // 203 not used
             uint32_t ManaCostPercentage;                                // 204
             uint32_t StartRecoveryCategory;                             // 205
             uint32_t StartRecoveryTime;                                 // 206
             uint32_t MaxTargetLevel;                                    // 207
             uint32_t SpellFamilyName;                                   // 208
-            uint32_t SpellGroupType[MAX_SPELL_EFFECTS];                 // 209 - 211
+            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 209 - 211
             uint32_t MaxTargets;                                        // 212
-            uint32_t Spell_Dmg_Type;                                    // 213
+            uint32_t DmgClass;                                          // 213
             uint32_t PreventionType;                                    // 214
-            int32_t StanceBarOrder;                                     // 215  comment this out
-            float dmg_multiplier[MAX_SPELL_EFFECTS];                  // 216 - 218
-            uint32_t MinFactionID;                                      // 219  comment this out
-            uint32_t MinReputation;                                     // 220  comment this out
-            uint32_t RequiredAuraVision;                                // 221  comment this out
-            uint32_t TotemCategory[2];                                  // 222 - 223
-            int32_t RequiresAreaId;                                     // 224
+            //int32_t StanceBarOrder;                                   // 215 not used
+            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 216 - 218
+            //uint32_t MinFactionID;                                    // 219 not used
+            //uint32_t MinReputation;                                   // 220 not used
+            //uint32_t RequiredAuraVision;                              // 221 not used
+            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 222 - 223
+            int32_t AreaGroupId;                                        // 224
             uint32_t School;                                            // 225
             uint32_t RuneCostID;                                        // 226
-          //uint32_t SpellMissileID;                                    // 227
-          //uint32_t PowerDisplayId;                                    // 228
-          //float EffectBonusMultiplier[MAX_SPELL_EFFECTS];           // 229 - 231
-          //uint32_t SpellDescriptionVariable;                          // 232
-            uint32_t SpellDifficultyID;                                 // 233  comment this out
+            //uint32_t SpellMissileID;                                  // 227 not used
+            //uint32_t PowerDisplayId;                                  // 228 not used
+            float EffectBonusMultiplier[MAX_SPELL_EFFECTS];             // 229 - 231
+            //uint32_t SpellDescriptionVariable;                        // 232 not used
+            uint32_t SpellDifficultyId;                                 // 233
         };
 
         struct SpellItemEnchantmentEntry

--- a/src/world/Management/AchievementMgr.cpp
+++ b/src/world/Management/AchievementMgr.cpp
@@ -1330,11 +1330,11 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type)
                     else if (achievementCriteria->number_of_mounts.unknown == 778 && sp && (sp->getEffect(0) == SPELL_EFFECT_SUMMON))
                     {
                         // Companion pet? Make sure it's a companion pet, not some other summon-type spell
-                        if (strncmp(sp->getDescription().c_str(), "Right Cl", 8) == 0)
-                        {
-                            // "Right Click to summon and dismiss " ...
+                        // temporary solution since spell description is no longer loaded -Appled
+                        const auto creatureEntry = sp->getEffectMiscValue(0);
+                        auto creatureProperties = sMySQLStore.getCreatureProperties(creatureEntry);
+                        if (creatureProperties != nullptr && creatureProperties->Type == UNIT_TYPE_NONCOMBAT_PET)
                             ++nm;
-                        }
                     }
                     ++sl;
                 }

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -2955,7 +2955,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
     uint32 vproc = PROC_ON_ANY_HOSTILE_ACTION | PROC_ON_ANY_DAMAGE_VICTIM; /*| PROC_ON_SPELL_HIT_VICTIM;*/
 
     //A school damage is not necessarily magic
-    switch (spellInfo->getSpell_Dmg_Type())
+    switch (spellInfo->getDmgClass())
     {
         case SPELL_DMG_TYPE_RANGED:
         {
@@ -3005,7 +3005,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
         {
             res = this->GetCriticalDamageBonusForSpell(pVictim, spellInfo, res);
 
-            switch (spellInfo->getSpell_Dmg_Type())
+            switch (spellInfo->getDmgClass())
             {
                 case SPELL_DMG_TYPE_RANGED:
                 {

--- a/src/world/Server/Packets/Handlers/SpellHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SpellHandler.cpp
@@ -424,7 +424,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     }
 
     // Check is player trying to cast a passive spell
-    if (spellInfo->IsPassive())
+    if (spellInfo->isPassive())
     {
         sCheatLog.writefromsession(this, "WORLD: Player %u tried to cast a passive spell %u, ignored", _player->getGuidLow(), spellId);
         LogDetail("WORLD: Player %u tried to cast a passive spell %u, ignored", _player->getGuidLow(), spellId);
@@ -525,7 +525,7 @@ void WorldSession::HandleCancelAuraOpcode(WorldPacket& recvPacket)
     }
 
     // You can't cancel a passive aura
-    if (spellInfo->IsPassive())
+    if (spellInfo->isPassive())
     {
         return;
     }
@@ -630,7 +630,7 @@ void WorldSession::HandlePetCastSpell(WorldPacket& recvPacket)
         return;
     }
 
-    if (spellInfo->IsPassive())
+    if (spellInfo->isPassive())
     {
         return;
     }

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -877,11 +877,11 @@ CreatureAISpells* CreatureAIScript::addAISpell(uint32_t spellId, float castChanc
     {
         uint32_t spellDuration = duration * 1000;
         if (spellDuration == 0)
-            spellDuration = spellInfo->getSpellDuration(nullptr);
+            spellDuration = spellInfo->getSpellDefaultDuration(nullptr);
 
         uint32_t spellCooldown = cooldown * 1000;
         if (spellCooldown == 0)
-            spellCooldown = spellInfo->getSpellDuration(nullptr);
+            spellCooldown = spellInfo->getSpellDefaultDuration(nullptr);
 
         CreatureAISpells* newAISpell = new CreatureAISpells(spellInfo, castChance, targetType, spellDuration, spellCooldown, forceRemove, isTriggered);
 

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -227,7 +227,7 @@ void ScriptMgr::DumpUnimplementedSpells()
         if (!sp)
             continue;
 
-        if (!sp->HasEffect(SPELL_EFFECT_DUMMY) && !sp->HasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->HasEffect(SPELL_EFFECT_SEND_EVENT))
+        if (!sp->hasEffect(SPELL_EFFECT_DUMMY) && !sp->hasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->hasEffect(SPELL_EFFECT_SEND_EVENT))
             continue;
 
         HandleDummySpellMap::iterator sitr = _spells.find(sp->getId());
@@ -340,7 +340,7 @@ void ScriptMgr::register_dummy_spell(uint32 entry, exp_handle_dummy_spell callba
         return;
     }
 
-    if (!sp->HasEffect(SPELL_EFFECT_DUMMY) && !sp->HasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->HasEffect(SPELL_EFFECT_SEND_EVENT))
+    if (!sp->hasEffect(SPELL_EFFECT_DUMMY) && !sp->hasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->hasEffect(SPELL_EFFECT_SEND_EVENT))
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr registered a dummy handler for Spell ID: %u (%s), but spell has no dummy/script/send event effect!", entry, sp->getName().c_str());
 
     _spells.insert(HandleDummySpellMap::value_type(entry, callback));
@@ -442,7 +442,7 @@ void ScriptMgr::register_script_effect(uint32 entry, exp_handle_script_effect ca
         return;
     }
 
-    if (!sp->HasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->HasEffect(SPELL_EFFECT_SEND_EVENT))
+    if (!sp->hasEffect(SPELL_EFFECT_SCRIPT_EFFECT) && !sp->hasEffect(SPELL_EFFECT_SEND_EVENT))
         LogDebugFlag(LF_SCRIPT_MGR, "ScriptMgr registered a script effect handler for Spell ID: %u (%s), but spell has no scripted effect!", entry, sp->getName().c_str());
 
     SpellScriptEffects.insert(std::pair< uint32, exp_handle_script_effect >(entry, callback));

--- a/src/world/Spell/Customization/HackFixes.cpp
+++ b/src/world/Spell/Customization/HackFixes.cpp
@@ -58,10 +58,7 @@ void CreateDummySpell(uint32 id)
     sp->setEffect(SPELL_EFFECT_DUMMY, 0);
     sp->setEffectImplicitTargetA(EFF_TARGET_DUEL, 0);
     sp->custom_NameHash = crc32((const unsigned char*)name, (unsigned int)strlen(name));
-    sp->setDmg_multiplier(1.0f, 0);
-#if VERSION_STRING != Cata
-    sp->setStanceBarOrder(-1);
-#endif
+    sp->setEffectDamageMultiplier(1.0f, 0);
     sWorld.dummySpellList.push_back(sp);
 }
 
@@ -679,6 +676,10 @@ void ApplyNormalFixes()
         //SCHOOL_SHADOW = 32,
         //SCHOOL_ARCANE = 64
 
+#if VERSION_STRING == Classic
+        // Classic doesn't have schools bitwise in DBC
+        sp->custom_SchoolMask = 1 << sp->getSchool();
+#else
         // Save School as custom_SchoolMask, and set School as an index
         sp->custom_SchoolMask = sp->getSchool();
         for (uint8 i = 0; i < SCHOOL_COUNT; ++i)
@@ -689,7 +690,7 @@ void ApplyNormalFixes()
                 break;
             }
         }
-
+#endif
         ARCEMU_ASSERT(sp->getSchool() < SCHOOL_COUNT);
 
         //there are some spells that change the "damage" value of 1 effect to another : devastate = bonus first then damage
@@ -930,7 +931,7 @@ void ApplyNormalFixes()
             case 69403:
             {
                 sp->setSchool(SCHOOL_HOLY); //the procspells of the original seal of command have physical school instead of holy
-                sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_MAGIC); //heh, crazy spell uses melee/ranged/magic dmg type for 1 spell. Now which one is correct ?
+                sp->setDmgClass(SPELL_DMG_TYPE_MAGIC); //heh, crazy spell uses melee/ranged/magic dmg type for 1 spell. Now which one is correct ?
             } break;
 
             // SPELL_HASH_JUDGEMENT_OF_COMMAND
@@ -947,7 +948,7 @@ void ApplyNormalFixes()
             case 68019:
             case 71551:
             {
-                sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_MAGIC);
+                sp->setDmgClass(SPELL_DMG_TYPE_MAGIC);
             } break;
 
 
@@ -1192,7 +1193,7 @@ void ApplyNormalFixes()
             case 71122:
             {
                 sp->setSchool(SCHOOL_HOLY); //Consecration is a holy redirected spell.
-                sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_MAGIC); //Speaks for itself.
+                sp->setDmgClass(SPELL_DMG_TYPE_MAGIC); //Speaks for itself.
             } break;
 
             //////////////////////////////////////////////////////////////////////////////////////////
@@ -1587,7 +1588,7 @@ void ApplyNormalFixes()
     // Wands
     sp = Spell::checkAndReturnSpellEntry(SPELL_RANGED_WAND);
     if (sp != nullptr)
-        sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_RANGED);
+        sp->setDmgClass(SPELL_DMG_TYPE_RANGED);
 
 
     //////////////////////////////////////////////////////
@@ -1807,14 +1808,14 @@ void ApplyNormalFixes()
     if (sp != nullptr)
     {
         sp->setSchool(SCHOOL_HOLY);
-        sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_MAGIC);
+        sp->setDmgClass(SPELL_DMG_TYPE_MAGIC);
     }
     sp = Spell::checkAndReturnSpellEntry(31893);
     if (sp != nullptr)
     {
         sp->setProcFlags(PROC_ON_PHYSICAL_ATTACK);
         sp->setSchool(SCHOOL_HOLY);
-        sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_MAGIC);
+        sp->setDmgClass(SPELL_DMG_TYPE_MAGIC);
     }
 
     //Paladin - Divine Storm
@@ -1835,18 +1836,18 @@ void ApplyNormalFixes()
     if (sp != nullptr)
     {
         sp->setSpellFamilyName(0);
-        sp->setSpellGroupType(0, 0);
-        sp->setSpellGroupType(0, 1);
-        sp->setSpellGroupType(0, 2);
+        sp->setSpellFamilyFlags(0, 0);
+        sp->setSpellFamilyFlags(0, 1);
+        sp->setSpellFamilyFlags(0, 2);
     }
 
     sp = Spell::checkAndReturnSpellEntry(54180);
     if (sp != nullptr)
     {
         sp->setSpellFamilyName(0);
-        sp->setSpellGroupType(0, 0);
-        sp->setSpellGroupType(0, 1);
-        sp->setSpellGroupType(0, 2);
+        sp->setSpellFamilyFlags(0, 0);
+        sp->setSpellFamilyFlags(0, 1);
+        sp->setSpellFamilyFlags(0, 2);
     }
 
     //Paladin - Avenging Wrath marker - Is forced debuff
@@ -2204,7 +2205,7 @@ void ApplyNormalFixes()
     sp = Spell::checkAndReturnSpellEntry(2094);
     if (sp != nullptr)
     {
-        sp->setSpell_Dmg_Type(SPELL_DMG_TYPE_RANGED);
+        sp->setDmgClass(SPELL_DMG_TYPE_RANGED);
         sp->custom_is_ranged_spell = true;
     }
 

--- a/src/world/Spell/Customization/SpellCustomizations.cpp
+++ b/src/world/Spell/Customization/SpellCustomizations.cpp
@@ -37,16 +37,16 @@ initialiseSingleton(SpellCustomizations);
 SpellCustomizations::SpellCustomizations() {}
 SpellCustomizations::~SpellCustomizations() {}
 
+// APGL End
+// MIT Start
 void SpellCustomizations::LoadSpellInfoData()
 {
-#if VERSION_STRING != Cata
-    for (uint32 i = 0; i < MAX_SPELL_ID; ++i)
+    for (auto i = 0; i < MAX_SPELL_ID; ++i)
     {
-
-        DBC::Structures::SpellEntry const* dbc_spell_entry = sSpellStore.LookupEntry(i);
+        auto dbc_spell_entry = sSpellStore.LookupEntry(i);
         if (dbc_spell_entry != nullptr)
         {
-            uint32 spell_id = dbc_spell_entry->Id;
+            uint32_t spell_id = dbc_spell_entry->Id;
             SpellInfo& spellInfo = _spellInfoContainerStore[spell_id];
             spellInfo.setId(spell_id);
             spellInfo.setAttributes(dbc_spell_entry->Attributes);
@@ -54,28 +54,48 @@ void SpellCustomizations::LoadSpellInfoData()
             spellInfo.setAttributesExB(dbc_spell_entry->AttributesExB);
             spellInfo.setAttributesExC(dbc_spell_entry->AttributesExC);
             spellInfo.setAttributesExD(dbc_spell_entry->AttributesExD);
+#if VERSION_STRING >= TBC
             spellInfo.setAttributesExE(dbc_spell_entry->AttributesExE);
             spellInfo.setAttributesExF(dbc_spell_entry->AttributesExF);
-#if VERSION_STRING > TBC
+#endif
+#if VERSION_STRING >= WotLK
             spellInfo.setAttributesExG(dbc_spell_entry->AttributesExG);
 #endif
-            spellInfo.setRequiredShapeShift(dbc_spell_entry->RequiredShapeShift);
-            spellInfo.setShapeshiftExclude(dbc_spell_entry->ShapeshiftExclude);
+            spellInfo.setCastingTimeIndex(dbc_spell_entry->CastingTimeIndex);
+            spellInfo.setDurationIndex(dbc_spell_entry->DurationIndex);
+            spellInfo.setPowerType(dbc_spell_entry->powerType);
+            spellInfo.setRangeIndex(dbc_spell_entry->rangeIndex);
+            spellInfo.setSpeed(dbc_spell_entry->speed);
+            spellInfo.setSpellVisual(dbc_spell_entry->SpellVisual);
+            spellInfo.setSpellIconID(dbc_spell_entry->spellIconID);
+            spellInfo.setActiveIconID(dbc_spell_entry->activeIconID);
+            spellInfo.setSchool(dbc_spell_entry->School);
+#if VERSION_STRING >= WotLK
+            spellInfo.setRuneCostID(dbc_spell_entry->RuneCostID);
+            spellInfo.setSpellDifficultyID(dbc_spell_entry->SpellDifficultyId);
+#endif
+
+#if VERSION_STRING < Cata
+            spellInfo.setRequiredShapeShift(dbc_spell_entry->Shapeshifts);
+            spellInfo.setShapeshiftExclude(dbc_spell_entry->ShapeshiftsExcluded);
             spellInfo.setTargets(dbc_spell_entry->Targets);
             spellInfo.setTargetCreatureType(dbc_spell_entry->TargetCreatureType);
             spellInfo.setRequiresSpellFocus(dbc_spell_entry->RequiresSpellFocus);
+#if VERSION_STRING >= TBC
             spellInfo.setFacingCasterFlags(dbc_spell_entry->FacingCasterFlags);
+#endif
             spellInfo.setCasterAuraState(dbc_spell_entry->CasterAuraState);
             spellInfo.setTargetAuraState(dbc_spell_entry->TargetAuraState);
+#if VERSION_STRING >= TBC
             spellInfo.setCasterAuraStateNot(dbc_spell_entry->CasterAuraStateNot);
             spellInfo.setTargetAuraStateNot(dbc_spell_entry->TargetAuraStateNot);
-#if VERSION_STRING > TBC
+#endif
+#if VERSION_STRING == WotLK
             spellInfo.setCasterAuraSpell(dbc_spell_entry->casterAuraSpell);
             spellInfo.setTargetAuraSpell(dbc_spell_entry->targetAuraSpell);
             spellInfo.setCasterAuraSpellNot(dbc_spell_entry->casterAuraSpellNot);
             spellInfo.setTargetAuraSpellNot(dbc_spell_entry->targetAuraSpellNot);
 #endif
-            spellInfo.setCastingTimeIndex(dbc_spell_entry->CastingTimeIndex);
             spellInfo.setRecoveryTime(dbc_spell_entry->RecoveryTime);
             spellInfo.setCategoryRecoveryTime(dbc_spell_entry->CategoryRecoveryTime);
             spellInfo.setInterruptFlags(dbc_spell_entry->InterruptFlags);
@@ -87,175 +107,83 @@ void SpellCustomizations::LoadSpellInfoData()
             spellInfo.setMaxLevel(dbc_spell_entry->maxLevel);
             spellInfo.setBaseLevel(dbc_spell_entry->baseLevel);
             spellInfo.setSpellLevel(dbc_spell_entry->spellLevel);
-            spellInfo.setDurationIndex(dbc_spell_entry->DurationIndex);
-            spellInfo.setPowerType(dbc_spell_entry->powerType);
             spellInfo.setManaCost(dbc_spell_entry->manaCost);
             spellInfo.setManaCostPerlevel(dbc_spell_entry->manaCostPerlevel);
             spellInfo.setManaPerSecond(dbc_spell_entry->manaPerSecond);
             spellInfo.setManaPerSecondPerLevel(dbc_spell_entry->manaPerSecondPerLevel);
-            spellInfo.setRangeIndex(dbc_spell_entry->rangeIndex);
-            spellInfo.setSpeed(dbc_spell_entry->speed);
-            spellInfo.setModalNextSpell(dbc_spell_entry->modalNextSpell);
-            spellInfo.setMaxstack(dbc_spell_entry->maxstack);
-
-            for (uint8 j = 0; j < MAX_SPELL_TOTEMS; ++j)
+            spellInfo.setMaxstack(dbc_spell_entry->MaxStackAmount);
+            for (auto j = 0; j < MAX_SPELL_TOTEMS; ++j)
                 spellInfo.setTotem(dbc_spell_entry->Totem[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_REAGENTS; ++j)
+            for (auto j = 0; j < MAX_SPELL_REAGENTS; ++j)
+            {
                 spellInfo.setReagent(dbc_spell_entry->Reagent[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_REAGENTS; ++j)
                 spellInfo.setReagentCount(dbc_spell_entry->ReagentCount[j], j);
-
+            }
             spellInfo.setEquippedItemClass(dbc_spell_entry->EquippedItemClass);
             spellInfo.setEquippedItemSubClass(dbc_spell_entry->EquippedItemSubClass);
-            spellInfo.setRequiredItemFlags(dbc_spell_entry->RequiredItemFlags);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
+            spellInfo.setEquippedItemInventoryTypeMask(dbc_spell_entry->EquippedItemInventoryTypeMask);
+            for (auto j = 0; j < MAX_SPELL_EFFECTS; ++j)
+            {
                 spellInfo.setEffect(dbc_spell_entry->Effect[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectDieSides(dbc_spell_entry->EffectDieSides[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectRealPointsPerLevel(dbc_spell_entry->EffectRealPointsPerLevel[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectBasePoints(dbc_spell_entry->EffectBasePoints[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectMechanic(dbc_spell_entry->EffectMechanic[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectImplicitTargetA(dbc_spell_entry->EffectImplicitTargetA[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectImplicitTargetB(dbc_spell_entry->EffectImplicitTargetB[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectRadiusIndex(dbc_spell_entry->EffectRadiusIndex[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectApplyAuraName(dbc_spell_entry->EffectApplyAuraName[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectAmplitude(dbc_spell_entry->EffectAmplitude[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectMultipleValue(dbc_spell_entry->EffectMultipleValue[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectChainTarget(dbc_spell_entry->EffectChainTarget[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectItemType(dbc_spell_entry->EffectItemType[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
                 spellInfo.setEffectMiscValue(dbc_spell_entry->EffectMiscValue[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
+#if VERSION_STRING >= TBC
                 spellInfo.setEffectMiscValueB(dbc_spell_entry->EffectMiscValueB[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-                spellInfo.setEffectTriggerSpell(dbc_spell_entry->EffectTriggerSpell[j], j);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-                spellInfo.setEffectPointsPerComboPoint(dbc_spell_entry->EffectPointsPerComboPoint[j], j);
-
-#if VERSION_STRING > TBC
-            for (uint8 x = 0; x < 3; ++x)
-                for (uint8 j = 0; j < 3; ++j)
-                    spellInfo.setEffectSpellClassMask(dbc_spell_entry->EffectSpellClassMask[x][j], x, j);
 #endif
-
-            spellInfo.setSpellVisual(dbc_spell_entry->SpellVisual);
-            spellInfo.setField114(dbc_spell_entry->field114);
-            spellInfo.setSpellIconID(dbc_spell_entry->spellIconID);
-            spellInfo.setActiveIconID(dbc_spell_entry->activeIconID);
+                spellInfo.setEffectTriggerSpell(dbc_spell_entry->EffectTriggerSpell[j], j);
+                spellInfo.setEffectPointsPerComboPoint(dbc_spell_entry->EffectPointsPerComboPoint[j], j);
+#if VERSION_STRING == WotLK
+                for (auto x = 0; x < 3; ++x)
+                    spellInfo.setEffectSpellClassMask(dbc_spell_entry->EffectSpellClassMask[j][x], j, x);
+#endif
+            }
             spellInfo.setSpellPriority(dbc_spell_entry->spellPriority);
-            spellInfo.setName(dbc_spell_entry->Name);
-            spellInfo.setRank(dbc_spell_entry->Rank);
-            spellInfo.setDescription(dbc_spell_entry->Description);
-            spellInfo.setBuffDescription(dbc_spell_entry->BuffDescription);
+            spellInfo.setName(dbc_spell_entry->Name[0]);
+            spellInfo.setRank(dbc_spell_entry->Rank[0]);
             spellInfo.setManaCostPercentage(dbc_spell_entry->ManaCostPercentage);
             spellInfo.setStartRecoveryCategory(dbc_spell_entry->StartRecoveryCategory);
             spellInfo.setStartRecoveryTime(dbc_spell_entry->StartRecoveryTime);
-#if VERSION_STRING > TBC
             spellInfo.setMaxTargetLevel(dbc_spell_entry->MaxTargetLevel);
-#endif
             spellInfo.setSpellFamilyName(dbc_spell_entry->SpellFamilyName);
-
-#if VERSION_STRING > TBC
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-                spellInfo.setSpellGroupType(dbc_spell_entry->SpellGroupType[j], j);
+#if VERSION_STRING == Classic
+            for (auto j = 0; j < 2; ++j)
+                spellInfo.setSpellFamilyFlags(dbc_spell_entry->SpellFamilyFlags[j], j);
+#else
+            for (auto j = 0; j < MAX_SPELL_EFFECTS; ++j)
+                spellInfo.setSpellFamilyFlags(dbc_spell_entry->SpellFamilyFlags[j], j);
 #endif
-
             spellInfo.setMaxTargets(dbc_spell_entry->MaxTargets);
-            spellInfo.setSpell_Dmg_Type(dbc_spell_entry->Spell_Dmg_Type);
+            spellInfo.setDmgClass(dbc_spell_entry->DmgClass);
             spellInfo.setPreventionType(dbc_spell_entry->PreventionType);
-            spellInfo.setStanceBarOrder(dbc_spell_entry->StanceBarOrder);
-
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-                spellInfo.setDmg_multiplier(dbc_spell_entry->dmg_multiplier[j], j);
-
-            spellInfo.setMinFactionID(dbc_spell_entry->MinFactionID);
-            spellInfo.setMinReputation(dbc_spell_entry->MinReputation);
-            spellInfo.setRequiredAuraVision(dbc_spell_entry->RequiredAuraVision);
-
-            for (uint8 j = 0; j < MAX_SPELL_TOTEM_CATEGORIES; ++j)
+            for (auto j = 0; j < MAX_SPELL_EFFECTS; ++j)
+                spellInfo.setEffectDamageMultiplier(dbc_spell_entry->EffectDamageMultiplier[j], j);
+#if VERSION_STRING >= TBC
+            for (auto j = 0; j < MAX_SPELL_TOTEM_CATEGORIES; ++j)
                 spellInfo.setTotemCategory(dbc_spell_entry->TotemCategory[j], j);
-
-            spellInfo.setRequiresAreaId(dbc_spell_entry->RequiresAreaId);
-            spellInfo.setSchool(dbc_spell_entry->School);
-#if VERSION_STRING > TBC
-            spellInfo.setRuneCostID(dbc_spell_entry->RuneCostID);
-
-            spellInfo.setSpellDifficultyID(dbc_spell_entry->SpellDifficultyID);
+            spellInfo.setRequiresAreaId(dbc_spell_entry->AreaGroupId);
 #endif
         }
     }
 #else
-    for (uint32 i = 0; i < MAX_SPELL_ID; ++i)
-    {
-        DBC::Structures::SpellEntry const* dbc_spell_entry = sSpellStore.LookupEntry(i);
-        if (dbc_spell_entry == nullptr)
-        {
-            continue;
-        }
-        else
-        {
-            uint32 spell_id = dbc_spell_entry->Id;
-            SpellInfo& spellInfo = _spellInfoContainerStore[spell_id];
-            spellInfo.setId(spell_id);
-            spellInfo.Attributes = dbc_spell_entry->Attributes;
-            spellInfo.AttributesEx = dbc_spell_entry->AttributesEx;
-            spellInfo.AttributesExB = dbc_spell_entry->AttributesExB;
-            spellInfo.AttributesExC = dbc_spell_entry->AttributesExC;
-            spellInfo.AttributesExD = dbc_spell_entry->AttributesExD;
-            spellInfo.AttributesExE = dbc_spell_entry->AttributesExE;
-            spellInfo.AttributesExF = dbc_spell_entry->AttributesExF;
-            spellInfo.AttributesExG = dbc_spell_entry->AttributesExG;
-            spellInfo.AttributesExH = dbc_spell_entry->AttributesExH;
-            spellInfo.AttributesExI = dbc_spell_entry->AttributesExI;
-            spellInfo.AttributesExJ = dbc_spell_entry->AttributesExJ;
-            spellInfo.CastingTimeIndex = dbc_spell_entry->CastingTimeIndex;
-            spellInfo.DurationIndex = dbc_spell_entry->DurationIndex;
-            spellInfo.powerType = dbc_spell_entry->powerType;
-            spellInfo.rangeIndex = dbc_spell_entry->rangeIndex;
-            spellInfo.speed = dbc_spell_entry->speed;
-            spellInfo.SpellVisual = dbc_spell_entry->SpellVisual[0];
-            spellInfo.field114 = dbc_spell_entry->SpellVisual[1];
-            spellInfo.spellIconID = dbc_spell_entry->spellIconID;
-            spellInfo.activeIconID = dbc_spell_entry->activeIconID;
-            spellInfo.Name = dbc_spell_entry->Name;
-            spellInfo.Rank = dbc_spell_entry->Rank;
-            spellInfo.Description = dbc_spell_entry->Description;
-            spellInfo.BuffDescription = dbc_spell_entry->BuffDescription;
-            spellInfo.School = dbc_spell_entry->School;
-            spellInfo.RuneCostID = dbc_spell_entry->RuneCostID;
-            spellInfo.SpellDifficultyID = dbc_spell_entry->SpellDifficultyId;
+            spellInfo.setAttributesExH(dbc_spell_entry->AttributesExH);
+            spellInfo.setAttributesExI(dbc_spell_entry->AttributesExI);
+            spellInfo.setAttributesExJ(dbc_spell_entry->AttributesExJ);
 
-            // dbc links
+            spellInfo.setName(dbc_spell_entry->Name);
+            spellInfo.setRank(dbc_spell_entry->Rank);
+
+            // Initialize DBC links
             spellInfo.SpellScalingId = dbc_spell_entry->SpellScalingId;
             spellInfo.SpellAuraOptionsId = dbc_spell_entry->SpellAuraOptionsId;
             spellInfo.SpellAuraRestrictionsId = dbc_spell_entry->SpellAuraRestrictionsId;
@@ -272,178 +200,171 @@ void SpellCustomizations::LoadSpellInfoData()
             spellInfo.SpellTargetRestrictionsId = dbc_spell_entry->SpellTargetRestrictionsId;
             spellInfo.SpellTotemsId = dbc_spell_entry->SpellTotemsId;
 
-            // data from SpellScaling.dbc
-            // data from SpellAuraOptions.dbc
+            // Data from SpellAuraOptions.dbc
             if (dbc_spell_entry->SpellAuraOptionsId && dbc_spell_entry->GetSpellAuraOptions() != nullptr)
             {
-                spellInfo.maxstack = dbc_spell_entry->GetSpellAuraOptions()->StackAmount;
-                spellInfo.procChance = dbc_spell_entry->GetSpellAuraOptions()->procChance;
-                spellInfo.procCharges = dbc_spell_entry->GetSpellAuraOptions()->procCharges;
-                spellInfo.procFlags = dbc_spell_entry->GetSpellAuraOptions()->procFlags;
+                spellInfo.setMaxstack(dbc_spell_entry->GetSpellAuraOptions()->MaxStackAmount);
+                spellInfo.setProcChance(dbc_spell_entry->GetSpellAuraOptions()->procChance);
+                spellInfo.setProcCharges(dbc_spell_entry->GetSpellAuraOptions()->procCharges);
+                spellInfo.setProcFlags(dbc_spell_entry->GetSpellAuraOptions()->procFlags);
             }
 
-            // data from SpellAuraRestrictions.dbc
+            // Data from SpellAuraRestrictions.dbc
             if (dbc_spell_entry->SpellAuraRestrictionsId && dbc_spell_entry->GetSpellAuraRestrictions() != nullptr)
             {
-                spellInfo.CasterAuraState = dbc_spell_entry->GetSpellAuraRestrictions()->CasterAuraState;
-                spellInfo.TargetAuraState = dbc_spell_entry->GetSpellAuraRestrictions()->TargetAuraState;
-                spellInfo.CasterAuraStateNot = dbc_spell_entry->GetSpellAuraRestrictions()->CasterAuraStateNot;
-                spellInfo.TargetAuraStateNot = dbc_spell_entry->GetSpellAuraRestrictions()->TargetAuraStateNot;
-                spellInfo.casterAuraSpell = dbc_spell_entry->GetSpellAuraRestrictions()->casterAuraSpell;
-                spellInfo.targetAuraSpell = dbc_spell_entry->GetSpellAuraRestrictions()->targetAuraSpell;
-                spellInfo.casterAuraSpellNot = dbc_spell_entry->GetSpellAuraRestrictions()->excludeCasterAuraSpell;
-                spellInfo.targetAuraSpellNot = dbc_spell_entry->GetSpellAuraRestrictions()->excludeTargetAuraSpell;
+                spellInfo.setCasterAuraState(dbc_spell_entry->GetSpellAuraRestrictions()->CasterAuraState);
+                spellInfo.setTargetAuraState(dbc_spell_entry->GetSpellAuraRestrictions()->TargetAuraState);
+                spellInfo.setCasterAuraStateNot(dbc_spell_entry->GetSpellAuraRestrictions()->CasterAuraStateNot);
+                spellInfo.setTargetAuraStateNot(dbc_spell_entry->GetSpellAuraRestrictions()->TargetAuraStateNot);
+                spellInfo.setCasterAuraSpell(dbc_spell_entry->GetSpellAuraRestrictions()->casterAuraSpell);
+                spellInfo.setTargetAuraSpell(dbc_spell_entry->GetSpellAuraRestrictions()->targetAuraSpell);
+                spellInfo.setCasterAuraSpellNot(dbc_spell_entry->GetSpellAuraRestrictions()->CasterAuraSpellNot);
+                spellInfo.setTargetAuraSpellNot(dbc_spell_entry->GetSpellAuraRestrictions()->TargetAuraSpellNot);
             }
 
-            // data from SpellCastingRequirements.dbc
+            // Data from SpellCastingRequirements.dbc
             if (dbc_spell_entry->SpellCastingRequirementsId && dbc_spell_entry->GetSpellCastingRequirements() != nullptr)
             {
-                spellInfo.FacingCasterFlags = dbc_spell_entry->GetSpellCastingRequirements()->FacingCasterFlags;
-                spellInfo.RequiresAreaId = dbc_spell_entry->GetSpellCastingRequirements()->AreaGroupId;
-                spellInfo.RequiresSpellFocus = dbc_spell_entry->GetSpellCastingRequirements()->RequiresSpellFocus;
+                spellInfo.setFacingCasterFlags(dbc_spell_entry->GetSpellCastingRequirements()->FacingCasterFlags);
+                spellInfo.setRequiresAreaId(dbc_spell_entry->GetSpellCastingRequirements()->AreaGroupId);
+                spellInfo.setRequiresSpellFocus(dbc_spell_entry->GetSpellCastingRequirements()->RequiresSpellFocus);
             }
 
-            // data from SpellCategories.dbc
+            // Data from SpellCategories.dbc
             if (dbc_spell_entry->SpellCategoriesId && dbc_spell_entry->GetSpellCategories() != nullptr)
             {
-                spellInfo.Category = dbc_spell_entry->GetSpellCategories()->Category;
-                spellInfo.DispelType = dbc_spell_entry->GetSpellCategories()->Dispel;
-                spellInfo.Spell_Dmg_Type = dbc_spell_entry->GetSpellCategories()->DmgClass;
-                spellInfo.MechanicsType = dbc_spell_entry->GetSpellCategories()->Mechanic;
-                spellInfo.PreventionType = dbc_spell_entry->GetSpellCategories()->PreventionType;
-                spellInfo.StartRecoveryCategory = dbc_spell_entry->GetSpellCategories()->StartRecoveryCategory;
+                spellInfo.setCategory(dbc_spell_entry->GetSpellCategories()->Category);
+                spellInfo.setDispelType(dbc_spell_entry->GetSpellCategories()->DispelType);
+                spellInfo.setDmgClass(dbc_spell_entry->GetSpellCategories()->DmgClass);
+                spellInfo.setMechanicsType(dbc_spell_entry->GetSpellCategories()->MechanicsType);
+                spellInfo.setPreventionType(dbc_spell_entry->GetSpellCategories()->PreventionType);
+                spellInfo.setStartRecoveryCategory(dbc_spell_entry->GetSpellCategories()->StartRecoveryCategory);
             }
 
-            // data from SpellClassOptions.dbc
+            // Data from SpellClassOptions.dbc
             if (dbc_spell_entry->SpellClassOptionsId && dbc_spell_entry->GetSpellClassOptions() != nullptr)
             {
-                spellInfo.SpellFamilyName = dbc_spell_entry->GetSpellClassOptions()->SpellFamilyName;
-
-                for (uint8_t j = 0; j < 3; ++j)
-                {
-                    spellInfo.SpellGroupType[j] = dbc_spell_entry->GetSpellClassOptions()->SpellFamilyFlags[j];
-                }
-
+                spellInfo.setSpellFamilyName(dbc_spell_entry->GetSpellClassOptions()->SpellFamilyName);
+                for (auto j = 0; j < MAX_SPELL_EFFECTS; ++j)
+                    spellInfo.setSpellFamilyFlags(dbc_spell_entry->GetSpellClassOptions()->SpellFamilyFlags[j], j);
             }
 
-            // data from SpellCooldowns.dbc
+            // Data from SpellCooldowns.dbc
             if (dbc_spell_entry->SpellCooldownsId && dbc_spell_entry->GetSpellCooldowns() != nullptr)
             {
-                spellInfo.CategoryRecoveryTime = dbc_spell_entry->GetSpellCooldowns()->CategoryRecoveryTime;
-                spellInfo.RecoveryTime = dbc_spell_entry->GetSpellCooldowns()->RecoveryTime;
-                spellInfo.StartRecoveryTime = dbc_spell_entry->GetSpellCooldowns()->StartRecoveryTime;
+                spellInfo.setCategoryRecoveryTime(dbc_spell_entry->GetSpellCooldowns()->CategoryRecoveryTime);
+                spellInfo.setRecoveryTime(dbc_spell_entry->GetSpellCooldowns()->RecoveryTime);
+                spellInfo.setStartRecoveryTime(dbc_spell_entry->GetSpellCooldowns()->StartRecoveryTime);
             }
 
-            // data from SpellEquippedItems.dbc
+            // Data from SpellEquippedItems.dbc
             if (dbc_spell_entry->SpellEquippedItemsId && dbc_spell_entry->GetSpellEquippedItems() != nullptr)
             {
-                spellInfo.EquippedItemClass = dbc_spell_entry->GetSpellEquippedItems()->EquippedItemClass;
-                spellInfo.EquippedItemInventoryTypeMask = dbc_spell_entry->GetSpellEquippedItems()->EquippedItemInventoryTypeMask;
-                spellInfo.EquippedItemSubClass = dbc_spell_entry->GetSpellEquippedItems()->EquippedItemSubClassMask;
+                spellInfo.setEquippedItemClass(dbc_spell_entry->GetSpellEquippedItems()->EquippedItemClass);
+                spellInfo.setEquippedItemInventoryTypeMask(dbc_spell_entry->GetSpellEquippedItems()->EquippedItemInventoryTypeMask);
+                spellInfo.setEquippedItemSubClass(dbc_spell_entry->GetSpellEquippedItems()->EquippedItemSubClassMask);
             }
 
-            // data from SpellInterrupts.dbc
+            // Data from SpellInterrupts.dbc
             if (dbc_spell_entry->SpellInterruptsId && dbc_spell_entry->GetSpellInterrupts() != nullptr)
             {
-                spellInfo.AuraInterruptFlags = dbc_spell_entry->GetSpellInterrupts()->AuraInterruptFlags;
-                spellInfo.ChannelInterruptFlags = dbc_spell_entry->GetSpellInterrupts()->ChannelInterruptFlags;
-                spellInfo.InterruptFlags = dbc_spell_entry->GetSpellInterrupts()->InterruptFlags;
+                spellInfo.setAuraInterruptFlags(dbc_spell_entry->GetSpellInterrupts()->AuraInterruptFlags);
+                spellInfo.setChannelInterruptFlags(dbc_spell_entry->GetSpellInterrupts()->ChannelInterruptFlags);
+                spellInfo.setInterruptFlags(dbc_spell_entry->GetSpellInterrupts()->InterruptFlags);
             }
 
-            // data from SpellLevels.dbc
+            // Data from SpellLevels.dbc
             if (dbc_spell_entry->SpellLevelsId && dbc_spell_entry->GetSpellLevels() != nullptr)
             {
-                spellInfo.baseLevel = dbc_spell_entry->GetSpellLevels()->baseLevel;
-                spellInfo.maxLevel = dbc_spell_entry->GetSpellLevels()->maxLevel;
-                spellInfo.spellLevel = dbc_spell_entry->GetSpellLevels()->spellLevel;
+                spellInfo.setBaseLevel(dbc_spell_entry->GetSpellLevels()->baseLevel);
+                spellInfo.setMaxLevel(dbc_spell_entry->GetSpellLevels()->maxLevel);
+                spellInfo.setSpellLevel(dbc_spell_entry->GetSpellLevels()->spellLevel);
             }
 
-            // data from SpellPower.dbc
+            // Data from SpellPower.dbc
             if (dbc_spell_entry->SpellPowerId && dbc_spell_entry->GetSpellPower() != nullptr)
             {
-                spellInfo.manaCost = dbc_spell_entry->GetSpellPower()->manaCost;
-                spellInfo.manaCostPerlevel = dbc_spell_entry->GetSpellPower()->manaCostPerlevel;
-                spellInfo.ManaCostPercentage = dbc_spell_entry->GetSpellPower()->ManaCostPercentage;
-                spellInfo.manaPerSecond = dbc_spell_entry->GetSpellPower()->manaPerSecond;
-                spellInfo.manaPerSecondPerLevel = dbc_spell_entry->GetSpellPower()->manaPerSecondPerLevel;
+                spellInfo.setManaCost(dbc_spell_entry->GetSpellPower()->manaCost);
+                spellInfo.setManaCostPerlevel(dbc_spell_entry->GetSpellPower()->manaCostPerlevel);
+                spellInfo.setManaCostPercentage(dbc_spell_entry->GetSpellPower()->ManaCostPercentage);
+                spellInfo.setManaPerSecond(dbc_spell_entry->GetSpellPower()->manaPerSecond);
+                spellInfo.setManaPerSecondPerLevel(dbc_spell_entry->GetSpellPower()->manaPerSecondPerLevel);
             }
 
-            // data from SpellReagents.dbc
+            // Data from SpellReagents.dbc
             if (dbc_spell_entry->SpellReagentsId && dbc_spell_entry->GetSpellReagents() != nullptr)
             {
-                for (uint8_t j = 0; j < MAX_SPELL_REAGENTS; ++j)
+                for (auto j = 0; j < MAX_SPELL_REAGENTS; ++j)
                 {
-                    spellInfo.Reagent[j] = dbc_spell_entry->GetSpellReagents()->Reagent[j];
-                    spellInfo.ReagentCount[j] = dbc_spell_entry->GetSpellReagents()->ReagentCount[j];
+                    spellInfo.setReagent(dbc_spell_entry->GetSpellReagents()->Reagent[j], j);
+                    spellInfo.setReagentCount(dbc_spell_entry->GetSpellReagents()->ReagentCount[j], j);
                 }
             }
 
-            // data from SpellShapeshift.dbc
+            // Data from SpellShapeshift.dbc
             if (dbc_spell_entry->SpellShapeshiftId && dbc_spell_entry->GetSpellShapeshift() != nullptr)
             {
-                spellInfo.RequiredShapeShift = dbc_spell_entry->GetSpellShapeshift()->Stances;
-                spellInfo.ShapeshiftExclude = dbc_spell_entry->GetSpellShapeshift()->StancesNot;
+                spellInfo.setRequiredShapeShift(dbc_spell_entry->GetSpellShapeshift()->Shapeshifts);
+                spellInfo.setShapeshiftExclude(dbc_spell_entry->GetSpellShapeshift()->ShapeshiftsExcluded);
             }
 
-            // data from SpellTargetRestrictions.dbc
+            // Data from SpellTargetRestrictions.dbc
             if (dbc_spell_entry->SpellTargetRestrictionsId && dbc_spell_entry->GetSpellTargetRestrictions() != nullptr)
             {
-                spellInfo.MaxTargets = dbc_spell_entry->GetSpellTargetRestrictions()->MaxAffectedTargets;
-                spellInfo.MaxTargetLevel = dbc_spell_entry->GetSpellTargetRestrictions()->MaxTargetLevel;
-                spellInfo.TargetCreatureType = dbc_spell_entry->GetSpellTargetRestrictions()->TargetCreatureType;
-                spellInfo.Targets = dbc_spell_entry->GetSpellTargetRestrictions()->Targets;
+                spellInfo.setMaxTargets(dbc_spell_entry->GetSpellTargetRestrictions()->MaxAffectedTargets);
+                spellInfo.setMaxTargetLevel(dbc_spell_entry->GetSpellTargetRestrictions()->MaxTargetLevel);
+                spellInfo.setTargetCreatureType(dbc_spell_entry->GetSpellTargetRestrictions()->TargetCreatureType);
+                spellInfo.setTargets(dbc_spell_entry->GetSpellTargetRestrictions()->Targets);
             }
 
-            // data from SpellTotems.dbc
+            // Data from SpellTotems.dbc
             if (dbc_spell_entry->SpellTotemsId && dbc_spell_entry->GetSpellTotems() != nullptr)
             {
-                for (uint8_t j = 0; j < MAX_SPELL_TOTEMS; ++j)
+                for (auto j = 0; j < MAX_SPELL_TOTEMS; ++j)
                 {
-                    spellInfo.TotemCategory[j] = dbc_spell_entry->GetSpellTotems()->TotemCategory[j];
-                    spellInfo.Totem[j] = dbc_spell_entry->GetSpellTotems()->Totem[j];
+                    spellInfo.setTotemCategory(dbc_spell_entry->GetSpellTotems()->TotemCategory[j], j);
+                    spellInfo.setTotem(dbc_spell_entry->GetSpellTotems()->Totem[j], j);
                 }
             }
 
-            // data from SpellEffect.dbc
-            for (uint8_t j = 0; j < MAX_SPELL_EFFECTS; ++j)
+            // Data from SpellEffect.dbc
+            for (auto j = 0; j < MAX_SPELL_EFFECTS; ++j)
             {
-                DBC::Structures::SpellEffectEntry const* spell_effect_entry = GetSpellEffectEntry(spell_id, SpellEffectIndex(j));
-                if (spell_effect_entry == nullptr)
+                const auto spell_effect_entry = GetSpellEffectEntry(spell_id, SpellEffectIndex(j));
+                if (spell_effect_entry != nullptr)
                 {
-                    continue;
-                }
-                else
-                {
-                    spellInfo.Effect[j] = spell_effect_entry->Effect;
-                    spellInfo.EffectMultipleValue[j] = spell_effect_entry->EffectMultipleValue;
-                    spellInfo.EffectApplyAuraName[j] = spell_effect_entry->EffectApplyAuraName;
-                    spellInfo.EffectAmplitude[j] = spell_effect_entry->EffectAmplitude;
-                    spellInfo.EffectBasePoints[j] = spell_effect_entry->EffectBasePoints;
-                    spellInfo.EffectBonusMultiplier[j] = spell_effect_entry->EffectBonusMultiplier;
-                    spellInfo.dmg_multiplier[j] = spell_effect_entry->EffectDamageMultiplier;
-                    spellInfo.EffectChainTarget[j] = spell_effect_entry->EffectChainTarget;
-                    spellInfo.EffectDieSides[j] = spell_effect_entry->EffectDieSides;
-                    spellInfo.EffectItemType[j] = spell_effect_entry->EffectItemType;
-                    spellInfo.EffectMechanic[j] = spell_effect_entry->EffectMechanic;
-                    spellInfo.EffectMiscValue[j] = spell_effect_entry->EffectMiscValue;
-                    spellInfo.EffectMiscValueB[j] = spell_effect_entry->EffectMiscValueB;
-                    spellInfo.EffectPointsPerComboPoint[j] = spell_effect_entry->EffectPointsPerComboPoint;
-                    spellInfo.EffectRadiusIndex[j] = spell_effect_entry->EffectRadiusIndex;
-                    spellInfo.EffectRadiusMaxIndex[j] = spell_effect_entry->EffectRadiusMaxIndex;
-                    spellInfo.EffectRealPointsPerLevel[j] = spell_effect_entry->EffectRealPointsPerLevel;
-                    spellInfo.EffectSpellClassMask[j] = spell_effect_entry->EffectSpellClassMask[j];
-                    spellInfo.EffectTriggerSpell[j] = spell_effect_entry->EffectTriggerSpell;
-                    spellInfo.EffectImplicitTargetA[j] = spell_effect_entry->EffectImplicitTargetA;
-                    spellInfo.EffectImplicitTargetB[j] = spell_effect_entry->EffectImplicitTargetB;
-                    spellInfo.EffectSpellId[j] = spell_effect_entry->EffectSpellId;
-                    spellInfo.EffectIndex[j] = spell_effect_entry->EffectIndex;
+                    spellInfo.setEffect(spell_effect_entry->Effect, j);
+                    spellInfo.setEffectMultipleValue(spell_effect_entry->EffectMultipleValue, j);
+                    spellInfo.setEffectApplyAuraName(spell_effect_entry->EffectApplyAuraName, j);
+                    spellInfo.setEffectAmplitude(spell_effect_entry->EffectAmplitude, j);
+                    spellInfo.setEffectBasePoints(spell_effect_entry->EffectBasePoints, j);
+                    spellInfo.setEffectBonusMultiplier(spell_effect_entry->EffectBonusMultiplier, j);
+                    spellInfo.setEffectMultipleValue(spell_effect_entry->EffectDamageMultiplier, j);
+                    spellInfo.setEffectChainTarget(spell_effect_entry->EffectChainTarget, j);
+                    spellInfo.setEffectDieSides(spell_effect_entry->EffectDieSides, j);
+                    spellInfo.setEffectItemType(spell_effect_entry->EffectItemType, j);
+                    spellInfo.setEffectMechanic(spell_effect_entry->EffectMechanic, j);
+                    spellInfo.setEffectMiscValue(spell_effect_entry->EffectMiscValue, j);
+                    spellInfo.setEffectMiscValueB(spell_effect_entry->EffectMiscValueB, j);
+                    spellInfo.setEffectPointsPerComboPoint(spell_effect_entry->EffectPointsPerComboPoint, j);
+                    spellInfo.setEffectRadiusIndex(spell_effect_entry->EffectRadiusIndex, j);
+                    spellInfo.setEffectRadiusMaxIndex(spell_effect_entry->EffectRadiusMaxIndex, j);
+                    spellInfo.setEffectRealPointsPerLevel(spell_effect_entry->EffectRealPointsPerLevel, j);
+                    for (auto x = 0; x < 3; ++x)
+                        spellInfo.setEffectSpellClassMask(spell_effect_entry->EffectSpellClassMask[x], j, x);
+                    spellInfo.setEffectTriggerSpell(spell_effect_entry->EffectTriggerSpell, j);
+                    spellInfo.setEffectImplicitTargetA(spell_effect_entry->EffectImplicitTargetA, j);
+                    spellInfo.setEffectImplicitTargetB(spell_effect_entry->EffectImplicitTargetB, j);
+                    spellInfo.setEffectSpellId(spell_effect_entry->EffectSpellId, j);
+                    spellInfo.setEffectIndex(spell_effect_entry->EffectIndex, j);
                 }
             }
-
         }
     }
 #endif
 }
+// MIT End
+// APGL Start
 
 SpellInfo* SpellCustomizations::GetSpellInfo(uint32 spell_id)
 {
@@ -725,7 +646,7 @@ void SpellCustomizations::SetMeleeSpellBool(SpellInfo* spell_entry)
 {
     for (uint8 z = 0; z < 3; z++)
     {
-        if (spell_entry->getEffect(z) == SPELL_EFFECT_SCHOOL_DAMAGE && spell_entry->getSpell_Dmg_Type() == SPELL_DMG_TYPE_MELEE)
+        if (spell_entry->getEffect(z) == SPELL_EFFECT_SCHOOL_DAMAGE && spell_entry->getDmgClass() == SPELL_DMG_TYPE_MELEE)
         {
             spell_entry->custom_is_melee_spell = true;
             continue;
@@ -755,7 +676,7 @@ void SpellCustomizations::SetRangedSpellBool(SpellInfo* spell_entry)
 {
     for (uint8 z = 0; z < 3; z++)
     {
-        if (spell_entry->getEffect(z) == SPELL_EFFECT_SCHOOL_DAMAGE && spell_entry->getSpell_Dmg_Type() == SPELL_DMG_TYPE_RANGED)
+        if (spell_entry->getEffect(z) == SPELL_EFFECT_SCHOOL_DAMAGE && spell_entry->getDmgClass() == SPELL_DMG_TYPE_RANGED)
         {
             spell_entry->custom_is_ranged_spell = true;
         }

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -546,8 +546,8 @@ uint64 Spell::GetSinglePossibleEnemy(uint32 i, float prange)
         r = GetSpellInfo()->custom_base_range_or_radius_sqr;
         if (u_caster != nullptr)
         {
-            spellModFlatFloatValue(u_caster->SM_FRadius, &r, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageFloatValue(u_caster->SM_PRadius, &r, GetSpellInfo()->getSpellGroupType());
+            spellModFlatFloatValue(u_caster->SM_FRadius, &r, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageFloatValue(u_caster->SM_PRadius, &r, GetSpellInfo()->getSpellFamilyFlags());
         }
     }
     float srcx = m_caster->GetPositionX(), srcy = m_caster->GetPositionY(), srcz = m_caster->GetPositionZ();
@@ -601,8 +601,8 @@ uint64 Spell::GetSinglePossibleFriend(uint32 i, float prange)
         r = GetSpellInfo()->custom_base_range_or_radius_sqr;
         if (u_caster != nullptr)
         {
-            spellModFlatFloatValue(u_caster->SM_FRadius, &r, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageFloatValue(u_caster->SM_PRadius, &r, GetSpellInfo()->getSpellGroupType());
+            spellModFlatFloatValue(u_caster->SM_FRadius, &r, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageFloatValue(u_caster->SM_PRadius, &r, GetSpellInfo()->getSpellFamilyFlags());
         }
     }
     float srcx = m_caster->GetPositionX(), srcy = m_caster->GetPositionY(), srcz = m_caster->GetPositionZ();
@@ -816,12 +816,12 @@ uint8 Spell::DidHit(uint32 effindex, Unit* target)
 
     if (GetSpellInfo()->getEffect(static_cast<uint8_t>(effindex)) == SPELL_EFFECT_DISPEL)
     {
-        spellModFlatFloatValue(u_victim->SM_FRezist_dispell, &resistchance, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageFloatValue(u_victim->SM_PRezist_dispell, &resistchance, GetSpellInfo()->getSpellGroupType());
+        spellModFlatFloatValue(u_victim->SM_FRezist_dispell, &resistchance, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageFloatValue(u_victim->SM_PRezist_dispell, &resistchance, GetSpellInfo()->getSpellFamilyFlags());
     }
 
     float hitchance = 0;
-    spellModFlatFloatValue(u_caster->SM_FHitchance, &hitchance, GetSpellInfo()->getSpellGroupType());
+    spellModFlatFloatValue(u_caster->SM_FHitchance, &hitchance, GetSpellInfo()->getSpellFamilyFlags());
     resistchance -= hitchance;
 
     if (hasAttribute(ATTRIBUTES_IGNORE_INVULNERABILITY))
@@ -878,8 +878,8 @@ uint8 Spell::prepare(SpellCastTargets* targets)
 
         if (m_castTime && u_caster != nullptr)
         {
-            spellModFlatIntValue(u_caster->SM_FCastTime, (int32*)&m_castTime, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(u_caster->SM_PCastTime, (int32*)&m_castTime, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(u_caster->SM_FCastTime, (int32*)&m_castTime, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(u_caster->SM_PCastTime, (int32*)&m_castTime, GetSpellInfo()->getSpellFamilyFlags());
         }
 
         // handle MOD_CAST_TIME
@@ -965,7 +965,7 @@ uint8 Spell::prepare(SpellCastTargets* targets)
         {
             /* talents procing - don't remove stealth either */
             if (!hasAttribute(ATTRIBUTES_PASSIVE) &&
-                !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->IsPassive()))
+                !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->isPassive()))
             {
                 p_caster->RemoveAura(p_caster->m_stealth);
                 p_caster->m_stealth = 0;
@@ -1343,7 +1343,7 @@ void Spell::castMe(bool check)
                 && GetSpellInfo()->getId() != 1)  //check spells that get trigger spell 1 after spell loading
             {
                 /* talents procing - don't remove stealth either */
-                if (!hasAttribute(ATTRIBUTES_PASSIVE) && !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->IsPassive()))
+                if (!hasAttribute(ATTRIBUTES_PASSIVE) && !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->isPassive()))
                 {
                     p_caster->RemoveAura(p_caster->m_stealth);
                     p_caster->m_stealth = 0;
@@ -1733,7 +1733,7 @@ void Spell::AddTime(uint32 type)
         }
 
         float ch = 0;
-        spellModFlatFloatValue(u_caster->SM_PNonInterrupt, &ch, GetSpellInfo()->getSpellGroupType());
+        spellModFlatFloatValue(u_caster->SM_PNonInterrupt, &ch, GetSpellInfo()->getSpellFamilyFlags());
         if (Rand(ch))
             return;
 
@@ -2776,7 +2776,7 @@ void Spell::SendChannelUpdate(uint32 time)
 
         if (p_caster != nullptr)
         {
-            if (m_spellInfo->HasEffect(SPELL_EFFECT_SUMMON) && (p_caster->getCharmGuid() != 0))
+            if (m_spellInfo->hasEffect(SPELL_EFFECT_SUMMON) && (p_caster->getCharmGuid() != 0))
             {
                 Unit* u = p_caster->GetMapMgr()->GetUnit(p_caster->getCharmGuid());
                 if ((u != nullptr) && (u->getCreatedBySpellId() == m_spellInfo->getId()))
@@ -2971,8 +2971,8 @@ bool Spell::HasPower()
     //apply modifiers
     if (u_caster != nullptr)
     {
-        spellModFlatIntValue(u_caster->SM_FCost, &cost, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(u_caster->SM_PCost, &cost, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FCost, &cost, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(u_caster->SM_PCost, &cost, GetSpellInfo()->getSpellFamilyFlags());
     }
 
     if (cost <= 0)
@@ -3129,8 +3129,8 @@ bool Spell::TakePower()
     //apply modifiers
     if (u_caster != nullptr)
     {
-        spellModFlatIntValue(u_caster->SM_FCost, &cost, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(u_caster->SM_PCost, &cost, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FCost, &cost, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(u_caster->SM_PCost, &cost, GetSpellInfo()->getSpellFamilyFlags());
     }
 
     if (cost <= 0)
@@ -3620,8 +3620,8 @@ void Spell::HandleAddAura(uint64 guid)
     {
         if (u_caster != nullptr)
         {
-            spellModFlatIntValue(u_caster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(u_caster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(u_caster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(u_caster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
         }
         for (int i = 0; i < (charges - 1); ++i)
         {
@@ -3806,8 +3806,8 @@ uint32 Spell::GetDuration()
 
             if (u_caster != nullptr)
             {
-                ascemu::World::Spell::Helpers::spellModFlatIntValue(u_caster->SM_FDur, (int32*)&this->Dur, GetSpellInfo()->getSpellGroupType());
-                ascemu::World::Spell::Helpers::spellModPercentageIntValue(u_caster->SM_PDur, (int32*)&this->Dur, GetSpellInfo()->getSpellGroupType());
+                ascemu::World::Spell::Helpers::spellModFlatIntValue(u_caster->SM_FDur, (int32*)&this->Dur, GetSpellInfo()->getSpellFamilyFlags());
+                ascemu::World::Spell::Helpers::spellModPercentageIntValue(u_caster->SM_PDur, (int32*)&this->Dur, GetSpellInfo()->getSpellFamilyFlags());
             }
         }
         else
@@ -3831,8 +3831,8 @@ float Spell::GetRadius(uint32 i)
     Rad[i] = ::GetRadius(sSpellRadiusStore.LookupEntry(GetSpellInfo()->getEffectRadiusIndex(static_cast<uint8_t>(i))));
     if (u_caster != nullptr)
     {
-        ascemu::World::Spell::Helpers::spellModFlatFloatValue(u_caster->SM_FRadius, &Rad[i], GetSpellInfo()->getSpellGroupType());
-        ascemu::World::Spell::Helpers::spellModPercentageFloatValue(u_caster->SM_PRadius, &Rad[i], GetSpellInfo()->getSpellGroupType());
+        ascemu::World::Spell::Helpers::spellModFlatFloatValue(u_caster->SM_FRadius, &Rad[i], GetSpellInfo()->getSpellFamilyFlags());
+        ascemu::World::Spell::Helpers::spellModPercentageFloatValue(u_caster->SM_PRadius, &Rad[i], GetSpellInfo()->getSpellFamilyFlags());
     }
 
     return Rad[i];
@@ -4463,10 +4463,8 @@ uint8 Spell::CanCast(bool tolerate)
                 if (GetSpellInfo()->getEquippedItemSubClass() && !(GetSpellInfo()->getEquippedItemSubClass() & (1 << proto->SubClass)))
                     return SPELL_FAILED_BAD_TARGETS;
 
-#if VERSION_STRING != Cata
-                if (GetSpellInfo()->getRequiredItemFlags() && !(GetSpellInfo()->getRequiredItemFlags() & (1 << proto->InventoryType)))
+                if (GetSpellInfo()->getEquippedItemInventoryTypeMask() && !(GetSpellInfo()->getEquippedItemInventoryTypeMask() & (1 << proto->InventoryType)))
                     return SPELL_FAILED_BAD_TARGETS;
-#endif
 
                 if (GetSpellInfo()->getEffect(0) == SPELL_EFFECT_ENCHANT_ITEM &&
                     GetSpellInfo()->getBaseLevel() && (GetSpellInfo()->getBaseLevel() > proto->ItemLevel))
@@ -4615,8 +4613,8 @@ uint8 Spell::CanCast(bool tolerate)
      */
     if (u_caster != nullptr)
     {
-        spellModFlatFloatValue(u_caster->SM_FRange, &maxRange, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageFloatValue(u_caster->SM_PRange, &maxRange, GetSpellInfo()->getSpellGroupType());
+        spellModFlatFloatValue(u_caster->SM_FRange, &maxRange, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageFloatValue(u_caster->SM_PRange, &maxRange, GetSpellInfo()->getSpellFamilyFlags());
     }
 
     // Targeted Location Checks (AoE spells)
@@ -4938,7 +4936,7 @@ uint8 Spell::CanCast(bool tolerate)
                 /* burlex: units are always facing the target! */
                 if (p_caster && facing_flags != SPELL_INFRONT_STATUS_REQUIRE_SKIPCHECK)
                 {
-                    if (GetSpellInfo()->getSpell_Dmg_Type() == SPELL_DMG_TYPE_RANGED)
+                    if (GetSpellInfo()->getDmgClass() == SPELL_DMG_TYPE_RANGED)
                     {
                         // our spell is a ranged spell
                         if (!p_caster->isInFront(target))
@@ -5577,28 +5575,28 @@ exit:
         int32 spell_flat_modifers = 0;
         int32 spell_pct_modifers = 100;
 
-        spellModFlatIntValue(u_caster->SM_FMiscEffect, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(u_caster->SM_PMiscEffect, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FMiscEffect, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(u_caster->SM_PMiscEffect, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
 
-        spellModFlatIntValue(u_caster->SM_FEffectBonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(u_caster->SM_PEffectBonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FEffectBonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(u_caster->SM_PEffectBonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
 
-        spellModFlatIntValue(u_caster->SM_FDamageBonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(u_caster->SM_PDamageBonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FDamageBonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(u_caster->SM_PDamageBonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
 
         switch (i)
         {
             case 0:
-                spellModFlatIntValue(u_caster->SM_FEffect1_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-                spellModPercentageIntValue(u_caster->SM_PEffect1_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+                spellModFlatIntValue(u_caster->SM_FEffect1_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+                spellModPercentageIntValue(u_caster->SM_PEffect1_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
                 break;
             case 1:
-                spellModFlatIntValue(u_caster->SM_FEffect2_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-                spellModPercentageIntValue(u_caster->SM_PEffect2_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+                spellModFlatIntValue(u_caster->SM_FEffect2_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+                spellModPercentageIntValue(u_caster->SM_PEffect2_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
                 break;
             case 2:
-                spellModFlatIntValue(u_caster->SM_FEffect3_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-                spellModPercentageIntValue(u_caster->SM_PEffect3_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+                spellModFlatIntValue(u_caster->SM_FEffect3_Bonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+                spellModPercentageIntValue(u_caster->SM_PEffect3_Bonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
                 break;
         }
 
@@ -5614,11 +5612,11 @@ exit:
             int32 spell_flat_modifers = 0;
             int32 spell_pct_modifers = 100;
 
-            spellModFlatIntValue(item_creator->SM_FMiscEffect, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(item_creator->SM_PMiscEffect, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(item_creator->SM_FMiscEffect, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(item_creator->SM_PMiscEffect, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
 
-            spellModFlatIntValue(item_creator->SM_FEffectBonus, &spell_flat_modifers, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(item_creator->SM_PEffectBonus, &spell_pct_modifers, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(item_creator->SM_FEffectBonus, &spell_flat_modifers, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(item_creator->SM_PEffectBonus, &spell_pct_modifers, GetSpellInfo()->getSpellFamilyFlags());
 
             value = float2int32(value * (float)(spell_pct_modifers / 100.0f)) + spell_flat_modifers;
         }
@@ -5820,7 +5818,7 @@ int32 Spell::DoCalculateEffect(uint32 i, Unit* target, int32 value)
         {
             if (p_caster != nullptr)
             {
-                value += (uint32)((p_caster->GetAP() * 0.1526f) + (p_caster->GetPower(POWER_TYPE_ENERGY) * GetSpellInfo()->getDmg_multiplier(static_cast<uint8_t>(i))));
+                value += (uint32)((p_caster->GetAP() * 0.1526f) + (p_caster->GetPower(POWER_TYPE_ENERGY) * GetSpellInfo()->getEffectDamageMultiplier(static_cast<uint8_t>(i))));
                 p_caster->SetPower(POWER_TYPE_ENERGY, 0);
             }
         } break;
@@ -6046,8 +6044,8 @@ int32 Spell::DoCalculateEffect(uint32 i, Unit* target, int32 value)
             value = value * (GetSpellInfo()->getEffectBasePoints(static_cast<uint8_t>(i)) + 1) / 100;
             if (p_caster != nullptr)
             {
-                spellModFlatIntValue(p_caster->SM_FMiscEffect, &value, GetSpellInfo()->getSpellGroupType());
-                spellModPercentageIntValue(p_caster->SM_PMiscEffect, &value, GetSpellInfo()->getSpellGroupType());
+                spellModFlatIntValue(p_caster->SM_FMiscEffect, &value, GetSpellInfo()->getSpellFamilyFlags());
+                spellModPercentageIntValue(p_caster->SM_PMiscEffect, &value, GetSpellInfo()->getSpellFamilyFlags());
             }
         } break;
 
@@ -6524,11 +6522,11 @@ void Spell::Heal(int32 amount, bool ForceCrit)
 
         int penalty_pct = 0;
         int penalty_flt = 0;
-        spellModFlatIntValue(u_caster->SM_PPenalty, &penalty_pct, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_PPenalty, &penalty_pct, GetSpellInfo()->getSpellFamilyFlags());
         bonus += amount * penalty_pct / 100;
-        spellModFlatIntValue(u_caster->SM_FPenalty, &penalty_flt, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FPenalty, &penalty_flt, GetSpellInfo()->getSpellFamilyFlags());
         bonus += penalty_flt;
-        spellModFlatIntValue(u_caster->SM_CriticalChance, &critchance, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_CriticalChance, &critchance, GetSpellInfo()->getSpellFamilyFlags());
 
 
         if (p_caster != nullptr)
@@ -6659,12 +6657,12 @@ void Spell::Heal(int32 amount, bool ForceCrit)
         amount += amount * (int32)(u_caster->HealDonePctMod[school]);
         amount += float2int32(amount * unitTarget->HealTakenPctMod[school]);
 
-        spellModPercentageIntValue(u_caster->SM_PDamageBonus, &amount, GetSpellInfo()->getSpellGroupType());
+        spellModPercentageIntValue(u_caster->SM_PDamageBonus, &amount, GetSpellInfo()->getSpellFamilyFlags());
 
         if (ForceCrit || ((critical = Rand(critchance)) != 0))
         {
             int32 critical_bonus = 100;
-            spellModFlatIntValue(u_caster->SM_PCriticalDamage, &critical_bonus, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(u_caster->SM_PCriticalDamage, &critical_bonus, GetSpellInfo()->getSpellFamilyFlags());
 
             if (critical_bonus > 0)
             {
@@ -6747,7 +6745,7 @@ void Spell::Heal(int32 amount, bool ForceCrit)
     }
 }
 
-uint32 Spell::GetType() { return (GetSpellInfo()->getSpell_Dmg_Type() == SPELL_DMG_TYPE_NONE ? SPELL_DMG_TYPE_MAGIC : GetSpellInfo()->getSpell_Dmg_Type()); }
+uint32 Spell::GetType() { return (GetSpellInfo()->getDmgClass() == SPELL_DMG_TYPE_NONE ? SPELL_DMG_TYPE_MAGIC : GetSpellInfo()->getDmgClass()); }
 
 Item* Spell::GetItemTarget() const
 {
@@ -7182,7 +7180,7 @@ uint32 Spell::GetTargetType(uint32 value, uint32 i)
     //CHAIN SPELLS ALWAYS CHAIN!
     uint32 jumps = m_spellInfo->getEffectChainTarget(static_cast<uint8_t>(i));
     if (u_caster != nullptr)
-        spellModFlatIntValue(u_caster->SM_FAdditionalTargets, (int32*)&jumps, m_spellInfo->getSpellGroupType());
+        spellModFlatIntValue(u_caster->SM_FAdditionalTargets, (int32*)&jumps, m_spellInfo->getSpellFamilyFlags());
     if (jumps != 0)
         type |= SPELL_TARGET_AREA_CHAIN;
 

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -9,7 +9,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 SpellCastResult Spell::canCast(bool tolerate)
 {
-    if (p_caster != nullptr && !GetSpellInfo()->IsPassive() && !m_triggeredSpell)
+    if (p_caster != nullptr && !GetSpellInfo()->isPassive() && !m_triggeredSpell)
     {
         // You can't cast other spells if you have the player flag preventing cast
         if (p_caster->hasPlayerFlags(PLAYER_FLAG_PREVENT_SPELL_CAST))
@@ -34,7 +34,7 @@ SpellCastResult Spell::canCast(bool tolerate)
             {
                 if (u_caster->m_auras[i] == nullptr)
                     continue;
-                if (!u_caster->m_auras[i]->GetSpellInfo()->HasEffectApplyAuraName(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
+                if (!u_caster->m_auras[i]->GetSpellInfo()->hasEffectApplyAuraName(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
                     continue;
                 if (u_caster->m_auras[i]->GetSpellInfo()->isAffectingSpell(GetSpellInfo()))
                 {

--- a/src/world/Spell/SpellAuras.cpp
+++ b/src/world/Spell/SpellAuras.cpp
@@ -977,7 +977,7 @@ void Aura::Remove()
         caster->setChannelSpellId(0);
     }
 
-    if ((caster != nullptr) && caster->IsPlayer() && m_spellInfo->HasEffect(SPELL_EFFECT_SUMMON))
+    if ((caster != nullptr) && caster->IsPlayer() && m_spellInfo->hasEffect(SPELL_EFFECT_SUMMON))
     {
         Unit* charm = caster->GetMapMgr()->GetUnit(caster->getCharmGuid());
         if ((charm != nullptr) && (charm->getCreatedBySpellId() == m_spellInfo->getId()))
@@ -1499,7 +1499,7 @@ void Aura::EventUpdateAreaAura(float r)
         return;
     }
 
-    uint32 AreaAuraEffectId = m_spellInfo->GetAreaAuraEffectId();
+    uint32 AreaAuraEffectId = m_spellInfo->getAreaAuraEffect();
     if (AreaAuraEffectId == 0)
     {
         LOG_ERROR("Spell %u (%s) has tried to update Area Aura targets but Spell has no Area Aura effect.", m_spellInfo->getId(), m_spellInfo->getName().c_str());
@@ -1570,7 +1570,7 @@ void Aura::ClearAATargets()
     }
     targets.clear();
 
-    if (m_target->IsPlayer() && m_spellInfo->HasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA))
+    if (m_target->IsPlayer() && m_spellInfo->hasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA))
     {
         Player* p = static_cast<Player*>(m_target);
 
@@ -1583,7 +1583,7 @@ void Aura::ClearAATargets()
         }
     }
 
-    if (m_spellInfo->HasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
+    if (m_spellInfo->hasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
     {
         Unit* u = m_target->GetMapMgr()->GetUnit(m_target->getCreatedByGuid());
 
@@ -1780,7 +1780,7 @@ void Aura::SpellAuraPeriodicDamage(bool apply)
                 }
             }
         }
-        uint32* gr = GetSpellInfo()->getSpellGroupType();
+        uint32* gr = GetSpellInfo()->getSpellFamilyFlags();
         if (gr)
         {
             if (c != nullptr)
@@ -2200,8 +2200,8 @@ void Aura::SpellAuraPeriodicHeal(bool apply)
         Unit* c = GetUnitCaster();
         if (c != nullptr)
         {
-            spellModFlatIntValue(c->SM_FMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(c->SM_PMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(c->SM_FMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(c->SM_PMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
         }
 
         if (val > 0)
@@ -2327,7 +2327,7 @@ void Aura::EventPeriodicHeal(uint32 amount)
                 if (c->IsPlayer())
                 {
                     int durmod = 0;
-                    spellModFlatIntValue(c->SM_FDur, &durmod, m_spellInfo->getSpellGroupType());
+                    spellModFlatIntValue(c->SM_FDur, &durmod, m_spellInfo->getSpellFamilyFlags());
                     bonus += bonus * durmod / 15000;
                 }
             }
@@ -2341,7 +2341,7 @@ void Aura::EventPeriodicHeal(uint32 amount)
         spellModFlatIntValue(c->SM_FPenalty, &penalty_flt, GetSpellProto()->SpellGroupType);
         bonus += penalty_flt;
         */
-        spellModPercentageIntValue(c->SM_PPenalty, &bonus, m_spellInfo->getSpellGroupType());
+        spellModPercentageIntValue(c->SM_PPenalty, &bonus, m_spellInfo->getSpellFamilyFlags());
     }
 
     int amp = m_spellInfo->getEffectAmplitude(mod->m_effectIndex);
@@ -2386,7 +2386,7 @@ void Aura::EventPeriodicHeal(uint32 amount)
     if (c != nullptr)
     {
         add += float2int32(add * (m_target->HealTakenPctMod[m_spellInfo->getSchool()] + c->HealDonePctMod[GetSpellInfo()->getSchool()]));
-        spellModPercentageIntValue(c->SM_PDOT, &add, m_spellInfo->getSpellGroupType());
+        spellModPercentageIntValue(c->SM_PDOT, &add, m_spellInfo->getSpellFamilyFlags());
 
         if (this->DotCanCrit())
         {
@@ -3379,11 +3379,11 @@ void Aura::SpellAuraPeriodicTriggerSpellWithValue(bool apply)
 
         float amptitude = static_cast<float>(GetSpellInfo()->getEffectAmplitude(mod->m_effectIndex));
         Unit* caster = GetUnitCaster();
-        uint32 numticks = m_spellInfo->getSpellDuration(caster) / m_spellInfo->getEffectAmplitude(mod->m_effectIndex);
+        uint32 numticks = m_spellInfo->getSpellDefaultDuration(caster) / m_spellInfo->getEffectAmplitude(mod->m_effectIndex);
         if (caster != nullptr)
         {
-            spellModFlatFloatValue(caster->SM_FAmptitude, &amptitude, m_spellInfo->getSpellGroupType());
-            spellModPercentageFloatValue(caster->SM_PAmptitude, &amptitude, m_spellInfo->getSpellGroupType());
+            spellModFlatFloatValue(caster->SM_FAmptitude, &amptitude, m_spellInfo->getSpellFamilyFlags());
+            spellModPercentageFloatValue(caster->SM_PAmptitude, &amptitude, m_spellInfo->getSpellFamilyFlags());
             if (m_spellInfo->getChannelInterruptFlags() != 0)
                 amptitude *= caster->GetCastSpeedMod();
         }
@@ -3424,7 +3424,7 @@ void Aura::SpellAuraPeriodicTriggerSpell(bool apply)
 
     /*
     // This should be fixed in other way...
-    if (IsPassive() &&
+    if (isPassive() &&
     m_spellProto->dummy != 2010 &&
     m_spellProto->dummy != 2020 &&
     m_spellProto->dummy != 2255 &&
@@ -3457,11 +3457,11 @@ void Aura::SpellAuraPeriodicTriggerSpell(bool apply)
 
         float amptitude = static_cast<float>(GetSpellInfo()->getEffectAmplitude(mod->m_effectIndex));
         Unit* caster = GetUnitCaster();
-        uint32 numticks = m_spellInfo->getSpellDuration(caster) / m_spellInfo->getEffectAmplitude(mod->m_effectIndex);
+        uint32 numticks = m_spellInfo->getSpellDefaultDuration(caster) / m_spellInfo->getEffectAmplitude(mod->m_effectIndex);
         if (caster != nullptr)
         {
-            spellModFlatFloatValue(caster->SM_FAmptitude, &amptitude, m_spellInfo->getSpellGroupType());
-            spellModPercentageFloatValue(caster->SM_PAmptitude, &amptitude, m_spellInfo->getSpellGroupType());
+            spellModFlatFloatValue(caster->SM_FAmptitude, &amptitude, m_spellInfo->getSpellFamilyFlags());
+            spellModPercentageFloatValue(caster->SM_PAmptitude, &amptitude, m_spellInfo->getSpellFamilyFlags());
             if (m_spellInfo->getChannelInterruptFlags() != 0)
                 amptitude *= caster->GetCastSpeedMod();
         }
@@ -4497,24 +4497,18 @@ void Aura::SpellAuraProcTriggerSpell(bool apply)
             return;
         }
 
-#if VERSION_STRING != Cata
         // Initialize mask
         groupRelation[0] = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex, 0);
         groupRelation[1] = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex, 1);
         groupRelation[2] = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex, 2);
-#else
-        groupRelation[0] = GetSpellInfo()->EffectSpellClassMask[0];
-        groupRelation[1] = GetSpellInfo()->EffectSpellClassMask[1];
-        groupRelation[2] = GetSpellInfo()->EffectSpellClassMask[2];
-#endif
 
         // Initialize charges
         charges = GetSpellInfo()->getProcCharges();
         Unit* ucaster = GetUnitCaster();
         if (ucaster != nullptr)
         {
-            spellModFlatIntValue(ucaster->SM_FCharges, &charges, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(ucaster->SM_PCharges, &charges, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(ucaster->SM_FCharges, &charges, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(ucaster->SM_PCharges, &charges, GetSpellInfo()->getSpellFamilyFlags());
         }
 
         m_target->AddProcTriggerSpell(spellId, GetSpellInfo()->getId(), m_casterGuid, GetSpellInfo()->getProcChance(), GetSpellInfo()->getProcFlags(), charges, groupRelation, nullptr);
@@ -4753,8 +4747,8 @@ void Aura::EventPeriodicLeech(uint32 amount)
 
     amount += bonus;
 
-    spellModFlatIntValue(m_caster->SM_FDOT, (int32*)&amount, sp->getSpellGroupType());
-    spellModPercentageIntValue(m_caster->SM_PDOT, (int32*)&amount, sp->getSpellGroupType());
+    spellModFlatIntValue(m_caster->SM_FDOT, (int32*)&amount, sp->getSpellFamilyFlags());
+    spellModPercentageIntValue(m_caster->SM_PDOT, (int32*)&amount, sp->getSpellFamilyFlags());
 
 
     if (DotCanCrit())
@@ -4877,8 +4871,8 @@ void Aura::SpellAuraModHitChance(bool apply)
     Unit* c = GetUnitCaster();
     if (c != nullptr)
     {
-        spellModFlatIntValue(c->SM_FMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(c->SM_PMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(c->SM_FMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(c->SM_PMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
     }
 
     if (apply)
@@ -6478,11 +6472,7 @@ void Aura::SpellAuraHover(bool apply)
 void Aura::SpellAuraAddPctMod(bool apply)
 {
     int32 val = apply ? mod->m_amount : -mod->m_amount;
-#if VERSION_STRING != Cata
     uint32* AffectedGroups = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex);
-#else
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
-#endif
 
     switch (mod->m_miscValue)  //let's generate warnings for unknown types of modifiers
     {
@@ -6643,11 +6633,7 @@ void Aura::SendModifierLog(int32** m, int32 v, uint32* mask, uint8 type, bool pc
 void Aura::SendDummyModifierLog(std::map< SpellInfo*, uint32 >* m, SpellInfo* spellInfo, uint32 i, bool apply, bool pct)
 {
     int32 v = spellInfo->getEffectBasePoints(static_cast<uint8_t>(i)) + 1;
-#if VERSION_STRING != Cata
     uint32* mask = spellInfo->getEffectSpellClassMask(static_cast<uint8_t>(i));
-#else
-    uint32* mask = spellInfo->EffectSpellClassMask;
-#endif
     uint8 type = static_cast<uint8>(spellInfo->getEffectMiscValue(static_cast<uint8_t>(i)));
 
     if (apply)
@@ -6696,7 +6682,6 @@ void Aura::SpellAuraAddClassTargetTrigger(bool apply)
             return;
         }
 
-#if VERSION_STRING != Cata
         // Initialize proc class mask
         procClassMask[0] = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex, 0);
         procClassMask[1] = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex, 1);
@@ -6706,25 +6691,14 @@ void Aura::SpellAuraAddClassTargetTrigger(bool apply)
         groupRelation[0] = sp->getEffectSpellClassMask(mod->m_effectIndex, 0);
         groupRelation[1] = sp->getEffectSpellClassMask(mod->m_effectIndex, 1);
         groupRelation[2] = sp->getEffectSpellClassMask(mod->m_effectIndex, 2);
-#else
-        // Initialize proc class mask
-        procClassMask[0] = GetSpellInfo()->EffectSpellClassMask[0];
-        procClassMask[1] = GetSpellInfo()->EffectSpellClassMask[1];
-        procClassMask[2] = GetSpellInfo()->EffectSpellClassMask[2];
-
-        // Initialize mask
-        groupRelation[0] = sp->EffectSpellClassMask[0];
-        groupRelation[1] = sp->EffectSpellClassMask[1];
-        groupRelation[2] = sp->EffectSpellClassMask[2];
-#endif
 
         // Initialize charges
         charges = GetSpellInfo()->getProcCharges();
         Unit* ucaster = GetUnitCaster();
         if (ucaster != nullptr)
         {
-            spellModFlatIntValue(ucaster->SM_FCharges, &charges, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(ucaster->SM_PCharges, &charges, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(ucaster->SM_FCharges, &charges, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(ucaster->SM_PCharges, &charges, GetSpellInfo()->getSpellFamilyFlags());
         }
 
         m_target->AddProcTriggerSpell(sp->getId(), GetSpellInfo()->getId(), m_casterGuid, GetSpellInfo()->getEffectBasePoints(mod->m_effectIndex) + 1, PROC_ON_CAST_SPELL, charges, groupRelation, procClassMask);
@@ -7500,7 +7474,7 @@ void Aura::SpellAuraModReputationAdjust(bool apply)
 {
     /*SetPositive();
     bool updateclient = true;
-    if (IsPassive())
+    if (isPassive())
     updateclient = false;	 // don't update client on passive
 
     if (m_target->GetTypeId()==TYPEID_PLAYER)
@@ -7870,11 +7844,7 @@ void Aura::SpellAuraModHealingByAP(bool apply)
 void Aura::SpellAuraAddFlatModifier(bool apply)
 {
     int32 val = apply ? mod->m_amount : -mod->m_amount;
-#if VERSION_STRING != Cata
     uint32* AffectedGroups = GetSpellInfo()->getEffectSpellClassMask(mod->m_effectIndex);
-#else
-    uint32* AffectedGroups = GetSpellInfo()->EffectSpellClassMask;
-#endif
 
     switch (mod->m_miscValue) //let's generate warnings for unknown types of modifiers
     {
@@ -9327,7 +9297,6 @@ void Aura::Refresh()
 //MIT
 bool Aura::DotCanCrit()
 {
-#if VERSION_STRING != Cata
     Unit* caster = this->GetUnitCaster();
     if (caster == nullptr)
         return false;
@@ -9375,80 +9344,14 @@ bool Aura::DotCanCrit()
 
 
     if (aura_spell_info->getSpellFamilyName() == spell_info->getSpellFamilyName() &&
-        (aura_spell_info->getEffectSpellClassMask(i, 0) & spell_info->getSpellGroupType(0) ||
-         aura_spell_info->getEffectSpellClassMask(i, 1) & spell_info->getSpellGroupType(1) ||
-         aura_spell_info->getEffectSpellClassMask(i, 2) & spell_info->getSpellGroupType(2)))
+        (aura_spell_info->getEffectSpellClassMask(i, 0) & spell_info->getSpellFamilyFlags(0) ||
+         aura_spell_info->getEffectSpellClassMask(i, 1) & spell_info->getSpellFamilyFlags(1) ||
+         aura_spell_info->getEffectSpellClassMask(i, 2) & spell_info->getSpellFamilyFlags(2)))
     {
         return true;
     }
 
     return false;
-#else
-    Unit* caster = this->GetUnitCaster();
-    if (caster == nullptr)
-        return false;
-
-    SpellInfo* sp = this->GetSpellInfo();
-    bool found = false;
-
-    for (;;)
-    {
-        Aura * aura = caster->getAuraWithAuraEffect(SPELL_AURA_ALLOW_DOT_TO_CRIT);
-
-        if (aura == nullptr)
-            break;
-
-        SpellInfo* aura_sp = aura->GetSpellInfo();
-
-        uint8 i = 0;
-        if (aura_sp->EffectApplyAuraName[1] == SPELL_AURA_ALLOW_DOT_TO_CRIT)
-            i = 1;
-        else if (aura_sp->EffectApplyAuraName[2] == SPELL_AURA_ALLOW_DOT_TO_CRIT)
-            i = 2;
-
-        if (aura_sp->SpellFamilyName == sp->SpellFamilyName &&
-            (aura_sp->EffectSpellClassMask[0] & sp->SpellGroupType[0] ||
-             aura_sp->EffectSpellClassMask[1] & sp->SpellGroupType[1] ||
-             aura_sp->EffectSpellClassMask[2] & sp->SpellGroupType[2]))
-        {
-            found = true;
-            break;
-        }
-    }
-
-    if (found)
-        return true;
-
-    if (caster->IsPlayer())
-    {
-        switch (caster->getClass())
-        {
-            case ROGUE:
-            {
-                // Rupture can be critical in patch 3.3.3
-                switch (sp->getId())
-                {
-                    //SPELL_HASH_RUPTURE
-                    case 1943:
-                    case 8639:
-                    case 8640:
-                    case 11273:
-                    case 11274:
-                    case 11275:
-                    case 14874:
-                    case 14903:
-                    case 15583:
-                    case 26867:
-                    case 48671:
-                    case 48672:
-                        return true;
-                }
-            } break;
-        }
-    }
-
-    return false;
-#endif
 }
 
 
@@ -9470,12 +9373,12 @@ bool Aura::IsAreaAura()
 {
     SpellInfo* sp = m_spellInfo;
 
-    if (sp->HasEffect(SPELL_EFFECT_APPLY_GROUP_AREA_AURA) ||
-        sp->HasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||
-        sp->HasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA) ||
-        sp->HasEffect(SPELL_EFFECT_APPLY_FRIEND_AREA_AURA) ||
-        sp->HasEffect(SPELL_EFFECT_APPLY_ENEMY_AREA_AURA) ||
-        sp->HasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
+    if (sp->hasEffect(SPELL_EFFECT_APPLY_GROUP_AREA_AURA) ||
+        sp->hasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||
+        sp->hasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA) ||
+        sp->hasEffect(SPELL_EFFECT_APPLY_FRIEND_AREA_AURA) ||
+        sp->hasEffect(SPELL_EFFECT_APPLY_ENEMY_AREA_AURA) ||
+        sp->hasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
         return true;
 
     return false;
@@ -9499,12 +9402,12 @@ void AbsorbAura::SpellAuraSchoolAbsorb(bool apply)
     Unit* caster = GetUnitCaster();
     if (caster != nullptr)
     {
-        spellModFlatIntValue(caster->SM_FMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(caster->SM_PMiscEffect, &val, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(caster->SM_FMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(caster->SM_PMiscEffect, &val, GetSpellInfo()->getSpellFamilyFlags());
 
         //This will fix talents that affects damage absorbed.
         int flat = 0;
-        spellModFlatIntValue(caster->SM_FMiscEffect, &flat, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(caster->SM_FMiscEffect, &flat, GetSpellInfo()->getSpellFamilyFlags());
         val += val * flat / 100;
 
         //For spells Affected by Bonus Healing we use Dspell_coef_override.

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -109,7 +109,7 @@ class SERVER_DECL Aura : public EventableObject
 
         inline SpellInfo* GetSpellInfo() const { return m_spellInfo; }
         inline uint32 GetSpellId() const { return m_spellInfo->getId(); }
-        inline bool IsPassive() { if (!m_spellInfo) return false; return (m_spellInfo->IsPassive() && !m_areaAura); }
+        inline bool IsPassive() { if (!m_spellInfo) return false; return (m_spellInfo->isPassive() && !m_areaAura); }
 #ifdef AE_TBC
     // MIT
     void addAuraVisual();

--- a/src/world/Spell/SpellEffects.cpp
+++ b/src/world/Spell/SpellEffects.cpp
@@ -631,14 +631,14 @@ void Spell::SpellEffectSchoolDMG(uint8_t effectIndex) // dmg school
     {
         if (GetSpellInfo()->getId() == 32445 || GetSpellInfo()->getId() == 28883)
         {
-            int32 reduce = (int32)(GetSpellInfo()->getDmg_multiplier(effectIndex) * 100.0f);
+            int32 reduce = (int32)(GetSpellInfo()->getEffectDamageMultiplier(effectIndex) * 100.0f);
             reduce -= 100;
 
             if (reduce && chaindamage)
             {
                 if (u_caster != nullptr)
                 {
-                    spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellGroupType());
+                    spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellFamilyFlags());
                 }
                 chaindamage += ((GetSpellInfo()->getEffectBasePoints(effectIndex) + 51) * reduce / 100);
             }
@@ -650,13 +650,13 @@ void Spell::SpellEffectSchoolDMG(uint8_t effectIndex) // dmg school
         }
         else
         {
-            int32 reduce = (int32)(GetSpellInfo()->getDmg_multiplier(effectIndex) * 100.0f);
+            int32 reduce = (int32)(GetSpellInfo()->getEffectDamageMultiplier(effectIndex) * 100.0f);
 
             if (reduce && chaindamage)
             {
                 if (u_caster != nullptr)
                 {
-                    spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellGroupType());
+                    spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellFamilyFlags());
                 }
                 chaindamage = chaindamage * reduce / 100;
             }
@@ -1438,7 +1438,7 @@ void Spell::SpellEffectTeleportUnits(uint8_t effectIndex)    // Teleport Units
     uint32 spellId = GetSpellInfo()->getId();
 
     // Portals
-    if (m_spellInfo->HasCustomFlagForEffect(effectIndex, TELEPORT_TO_COORDINATES))
+    if (m_spellInfo->hasCustomFlagForEffect(effectIndex, TELEPORT_TO_COORDINATES))
     {
         TeleportCoords const* teleport_coord = sMySQLStore.getTeleportCoord(spellId);
         if (teleport_coord == nullptr)
@@ -1452,7 +1452,7 @@ void Spell::SpellEffectTeleportUnits(uint8_t effectIndex)    // Teleport Units
     }
 
     // Hearthstone and co.
-    if (m_spellInfo->HasCustomFlagForEffect(effectIndex, TELEPORT_TO_BINDPOINT))
+    if (m_spellInfo->hasCustomFlagForEffect(effectIndex, TELEPORT_TO_BINDPOINT))
     {
         if (unitTarget->IsPlayer())
         {
@@ -1464,7 +1464,7 @@ void Spell::SpellEffectTeleportUnits(uint8_t effectIndex)    // Teleport Units
     }
 
     // Summon
-    if (m_spellInfo->HasCustomFlagForEffect(effectIndex, TELEPORT_TO_CASTER))
+    if (m_spellInfo->hasCustomFlagForEffect(effectIndex, TELEPORT_TO_CASTER))
     {
         if (u_caster == nullptr)
             return;
@@ -1474,7 +1474,7 @@ void Spell::SpellEffectTeleportUnits(uint8_t effectIndex)    // Teleport Units
     }
 
     // Shadowstep for example
-    if (m_spellInfo->HasCustomFlagForEffect(effectIndex, TELEPORT_BEHIND_TARGET))
+    if (m_spellInfo->hasCustomFlagForEffect(effectIndex, TELEPORT_BEHIND_TARGET))
     {
         if (p_caster == nullptr)
             return;
@@ -1718,7 +1718,7 @@ void Spell::SpellEffectApplyAura(uint8_t effectIndex)  // Apply Aura
         uint32 Duration = GetDuration();
 
         // Handle diminishing returns, if it should be resisted, it'll make duration 0 here.
-        if (!(GetSpellInfo()->IsPassive())) // Passive
+        if (!(GetSpellInfo()->isPassive())) // Passive
         {
             unitTarget->applyDiminishingReturnTimer(&Duration, GetSpellInfo());
         }
@@ -1967,7 +1967,7 @@ void Spell::SpellEffectHeal(uint8_t effectIndex) // Heal
             int32 reduce = GetSpellInfo()->getEffectDieSides(effectIndex) + 1;
             if (u_caster != nullptr)
             {
-                spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellGroupType());
+                spellModFlatIntValue(u_caster->SM_PJumpReduce, &reduce, GetSpellInfo()->getSpellFamilyFlags());
             }
             chaindamage -= (reduce * chaindamage) / 100;
             Heal((int32)chaindamage);
@@ -4564,8 +4564,8 @@ void Spell::SpellEffectThreat(uint8_t effectIndex) // Threat
 
     int32 amount = GetSpellInfo()->getEffectBasePoints(effectIndex);
 
-    spellModFlatIntValue(u_caster->SM_FMiscEffect, &amount, GetSpellInfo()->getSpellGroupType());
-    spellModPercentageIntValue(u_caster->SM_PMiscEffect, &amount, GetSpellInfo()->getSpellGroupType());
+    spellModFlatIntValue(u_caster->SM_FMiscEffect, &amount, GetSpellInfo()->getSpellFamilyFlags());
+    spellModPercentageIntValue(u_caster->SM_PMiscEffect, &amount, GetSpellInfo()->getSpellFamilyFlags());
 
 
     bool chck = unitTarget->GetAIInterface()->modThreatByPtr(u_caster, amount);
@@ -5108,8 +5108,8 @@ void Spell::SpellEffectSelfResurrect(uint8_t effectIndex)
         case 21169: //Reincarnation. Resurrect with 20% health and mana
         {
             int32 amt = 20;
-            spellModFlatIntValue(unitTarget->SM_FMiscEffect, &amt, GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(unitTarget->SM_PMiscEffect, &amt, GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(unitTarget->SM_FMiscEffect, &amt, GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(unitTarget->SM_PMiscEffect, &amt, GetSpellInfo()->getSpellFamilyFlags());
             health = uint32((unitTarget->getMaxHealth() * amt) / 100);
             mana = uint32((unitTarget->GetMaxPower(POWER_TYPE_MANA) * amt) / 100);
         }
@@ -5382,8 +5382,8 @@ void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
     Pet* pPet = p_caster->GetSummon();
     if (pPet)
     {
-        spellModFlatIntValue(p_caster->SM_FMiscEffect, &damage, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(p_caster->SM_PMiscEffect, &damage, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(p_caster->SM_FMiscEffect, &damage, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(p_caster->SM_PMiscEffect, &damage, GetSpellInfo()->getSpellFamilyFlags());
 
         //\note remove all dynamic flags
         pPet->setDynamicFlags(0);
@@ -5401,8 +5401,8 @@ void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
         if (pPet == nullptr)//no pets to Revive
             return;
 
-        spellModFlatIntValue(p_caster->SM_FMiscEffect, &damage, GetSpellInfo()->getSpellGroupType());
-        spellModPercentageIntValue(p_caster->SM_PMiscEffect, &damage, GetSpellInfo()->getSpellGroupType());
+        spellModFlatIntValue(p_caster->SM_FMiscEffect, &damage, GetSpellInfo()->getSpellFamilyFlags());
+        spellModPercentageIntValue(p_caster->SM_PMiscEffect, &damage, GetSpellInfo()->getSpellFamilyFlags());
 
         pPet->setHealth((uint32)((pPet->getMaxHealth() * damage) / 100));
     }

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -12,114 +12,6 @@ This file is released under the MIT license. See README-MIT for more information
 
 SpellInfo::SpellInfo()
 {
-#if VERSION_STRING != Cata
-    Id = 0;
-    Category = 0;
-    DispelType = 0;
-    MechanicsType = 0;
-    Attributes = 0;
-    AttributesEx = 0;
-    AttributesExB = 0;
-    AttributesExC = 0;
-    AttributesExD = 0;
-    AttributesExE = 0;
-    AttributesExF = 0;
-    AttributesExG = 0;
-    RequiredShapeShift = 0;
-    ShapeshiftExclude = 0;
-    Targets = 0;
-    TargetCreatureType = 0;
-    RequiresSpellFocus = 0;
-    FacingCasterFlags = 0;
-    CasterAuraState = 0;
-    TargetAuraState = 0;
-    CasterAuraStateNot = 0;
-    TargetAuraStateNot = 0;
-    casterAuraSpell = 0;
-    targetAuraSpell = 0;
-    casterAuraSpellNot = 0;
-
-    CustomFlags = 0;
-
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        EffectCustomFlag[i] = 0;
-
-    SpellFactoryFunc = NULL;
-    AuraFactoryFunc = NULL;
-    custom_proc_interval = 0;
-    custom_BGR_one_buff_on_target = 0;
-    custom_c_is_flags = 0;
-    custom_RankNumber = 0;
-    custom_NameHash = 0;
-    custom_ThreatForSpell = 0;
-    custom_ThreatForSpellCoef = 0;
-    custom_spell_coef_flags = 0;
-    custom_base_range_or_radius_sqr = 0;
-    cone_width = 0;
-    casttime_coef = 0;
-    fixed_dddhcoef = 0;
-    fixed_hotdotcoef = 0;
-    Dspell_coef_override = 0;
-    OTspell_coef_override = 0;
-    ai_target_type = 0;
-    custom_self_cast_only = false;
-    custom_apply_on_shapeshift_change = false;
-    custom_is_melee_spell = false;
-    custom_is_ranged_spell = false;
-
-    custom_SchoolMask = 0;
-    SpellVisual = 0;
-    field114 = 0;
-    spellIconID = 0;
-    activeIconID = 0;
-    spellPriority = 0;
-    Name = "";
-    Rank = "";
-    Description = "";
-    BuffDescription = "";
-    ManaCostPercentage = 0;
-    StartRecoveryCategory = 0;
-    StartRecoveryTime = 0;
-    MaxTargetLevel = 0;
-    SpellFamilyName = 0;
-    MaxTargets = 0;
-    Spell_Dmg_Type = 0;
-    PreventionType = 0;
-    StanceBarOrder = 0;
-    MinFactionID = 0;
-    MinReputation = 0;
-    RequiredAuraVision = 0;
-    RequiresAreaId = 0;
-    School = 0;
-    RuneCostID = 0;
-    SpellDifficultyID = 0;
-    targetAuraSpellNot = 0;
-    CastingTimeIndex = 0;
-    RecoveryTime = 0;
-    CategoryRecoveryTime = 0;
-    InterruptFlags = 0;
-    AuraInterruptFlags = 0;
-    ChannelInterruptFlags = 0;
-    procFlags = 0;
-    procChance = 0;
-    procCharges = 0;
-    maxLevel = 0;
-    baseLevel = 0;
-    spellLevel = 0;
-    DurationIndex = 0;
-    powerType = 0;
-    manaCost = 0;
-    manaCostPerlevel = 0;
-    manaPerSecond = 0;
-    manaPerSecondPerLevel = 0;
-    rangeIndex = 0;
-    speed = 0;
-    modalNextSpell = 0;
-    maxstack = 0;
-    EquippedItemClass = 0;
-    EquippedItemSubClass = 0;
-    RequiredItemFlags = 0;
-#else
     Id = 0;
     Category = 0;
     DispelType = 0;
@@ -135,24 +27,103 @@ SpellInfo::SpellInfo()
     AttributesExH = 0;
     AttributesExI = 0;
     AttributesExJ = 0;
+    Shapeshifts = 0;
+    ShapeshiftsExcluded = 0;
+    Targets = 0;
+    TargetCreatureType = 0;
+    RequiresSpellFocus = 0;
+    FacingCasterFlags = 0;
+    CasterAuraState = 0;
+    TargetAuraState = 0;
+    CasterAuraStateNot = 0;
+    TargetAuraStateNot = 0;
+    casterAuraSpell = 0;
+    targetAuraSpell = 0;
+    casterAuraSpellNot = 0;
+    targetAuraSpellNot = 0;
     CastingTimeIndex = 0;
+    RecoveryTime = 0;
+    CategoryRecoveryTime = 0;
+    InterruptFlags = 0;
+    AuraInterruptFlags = 0;
+    ChannelInterruptFlags = 0;
+    procFlags = 0;
+    procChance = 0;
+    procCharges = 0;
+    maxLevel = 0;
+    baseLevel = 0;
+    spellLevel = 0;
     DurationIndex = 0;
     powerType = 0;
+    manaCost = 0;
+    manaCostPerlevel = 0;
+    manaPerSecond = 0;
+    manaPerSecondPerLevel = 0;
     rangeIndex = 0;
     speed = 0;
+    MaxStackAmount = 0;
+    for (auto i = 0; i < MAX_SPELL_TOTEMS; ++i)
+        Totem[i] = 0;
+    for (auto i = 0; i < MAX_SPELL_REAGENTS; ++i)
+    {
+        Reagent[i] = 0;
+        ReagentCount[i] = 0;
+    }
+    EquippedItemClass = 0;
+    EquippedItemSubClass = 0;
+    EquippedItemInventoryTypeMask = 0;
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        Effect[i] = 0;
+        EffectDieSides[i] = 0;
+        EffectRealPointsPerLevel[i] = 0;
+        EffectBasePoints[i] = 0;
+        EffectMechanic[i] = 0;
+        EffectImplicitTargetA[i] = 0;
+        EffectImplicitTargetB[i] = 0;
+        EffectRadiusIndex[i] = 0;
+        EffectApplyAuraName[i] = 0;
+        EffectAmplitude[i] = 0;
+        EffectMultipleValue[i] = 0;
+        EffectChainTarget[i] = 0;
+        EffectItemType[i] = 0;
+        EffectMiscValue[i] = 0;
+        EffectMiscValueB[i] = 0;
+        EffectTriggerSpell[i] = 0;
+        EffectPointsPerComboPoint[i] = 0;
+        for (auto u = 0; u < MAX_SPELL_EFFECTS; ++u)
+            EffectSpellClassMask[i][u] = 0;
+#if VERSION_STRING >= Cata
+        EffectRadiusMaxIndex[i] = 0;
+        EffectSpellId[i] = 0;
+        EffectIndex[i] = 0;
+#endif
+        SpellFamilyFlags[i] = 0;
+        EffectDamageMultiplier[i] = 0;
+    }
     SpellVisual = 0;
-    field114 = 0;
     spellIconID = 0;
     activeIconID = 0;
+    spellPriority = 0;
     Name = "";
     Rank = "";
-    Description = "";
-    BuffDescription = "";
+    ManaCostPercentage = 0;
+    StartRecoveryCategory = 0;
+    StartRecoveryTime = 0;
+    MaxTargetLevel = 0;
+    SpellFamilyName = 0;
+    MaxTargets = 0;
+    DmgClass = 0;
+    PreventionType = 0;
+    for (auto i = 0; i < MAX_SPELL_TOTEM_CATEGORIES; ++i)
+        TotemCategory[i] = 0;
+    AreaGroupId = 0;
     School = 0;
     RuneCostID = 0;
-    SpellDifficultyID = 0;
-
-    //dbc links
+    SpellDifficultyId = 0;
+    
+#if VERSION_STRING >= Cata
+    // DBC links
     SpellScalingId = 0;
     SpellAuraOptionsId = 0;
     SpellAuraRestrictionsId = 0;
@@ -168,122 +139,9 @@ SpellInfo::SpellInfo()
     SpellShapeshiftId = 0;
     SpellTargetRestrictionsId = 0;
     SpellTotemsId = 0;
+#endif
 
-    // data from SpellScaling.dbc
-    // data from SpellAuraOptions.dbc
-    maxstack = 0;
-    procChance = 0;
-    procCharges = 0;
-    procFlags = 0;
-
-    // data from SpellAuraRestrictions.dbc
-    CasterAuraState = 0;
-    TargetAuraState = 0;
-    CasterAuraStateNot = 0;
-    TargetAuraStateNot = 0;
-    casterAuraSpell = 0;
-    targetAuraSpell = 0;
-    casterAuraSpellNot = 0;
-    targetAuraSpellNot = 0;
-
-    // data from SpellCastingRequirements.dbc
-    FacingCasterFlags = 0;
-    RequiresAreaId = 0;
-    RequiresSpellFocus = 0;
-
-    // data from SpellCategories.dbc
-    Category = 0;
-    DispelType = 0;
-    Spell_Dmg_Type = 0;
-    MechanicsType = 0;
-    PreventionType = 0;
-    StartRecoveryCategory = 0;
-
-    // data from SpellClassOptions.dbc
-    SpellFamilyName = 0;
-    for (uint8_t i = 0; i < 3; ++i)
-        SpellGroupType[i] = 0;
-
-    // data from SpellCooldowns.dbc
-    CategoryRecoveryTime = 0;
-    RecoveryTime = 0;
-    StartRecoveryTime = 0;
-
-    // data from SpellEquippedItems.dbc
-    EquippedItemClass = 0;
-    EquippedItemInventoryTypeMask = 0;
-    EquippedItemSubClass = 0;
-
-    // data from SpellInterrupts.dbc
-    AuraInterruptFlags = 0;
-    ChannelInterruptFlags = 0;
-    InterruptFlags = 0;
-
-    // data from SpellLevels.dbc
-    baseLevel = 0;
-    maxLevel = 0;
-    spellLevel = 0;
-
-    // data from SpellPower.dbc
-    manaCost = 0;
-    manaCostPerlevel = 0;
-    ManaCostPercentage = 0;
-    manaPerSecond = 0;
-    manaPerSecondPerLevel = 0;
-
-    // data from SpellReagents.dbc
-    for (uint8_t i = 0; i < MAX_SPELL_REAGENTS; ++i)
-    {
-        Reagent[i] = 0;
-        ReagentCount[i] = 0;
-    }
-
-    // data from SpellShapeshift.dbc
-    RequiredShapeShift = 0;
-    ShapeshiftExclude = 0;
-
-    // data from SpellTargetRestrictions.dbc
-    MaxTargets = 0;
-    MaxTargetLevel = 0;
-    TargetCreatureType = 0;
-    Targets = 0;
-
-    // data from SpellTotems.dbc
-    for (uint8_t i = 0; i < MAX_SPELL_TOTEMS; ++i)
-    {
-        TotemCategory[i] = 0;
-        Totem[i] = 0;
-    }
-
-    // data from SpellEffect.dbc
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
-        Effect[i] = 0;
-        EffectMultipleValue[i] = 0;
-        EffectApplyAuraName[i] = 0;
-        EffectAmplitude[i] = 0;
-        EffectBasePoints[i] = 0;
-        EffectBonusMultiplier[i] = 0;
-        dmg_multiplier[i] = 0;
-        EffectChainTarget[i] = 0;
-        EffectDieSides[i] = 0;
-        EffectItemType[i] = 0;
-        EffectMechanic[i] = 0;
-        EffectMiscValue[i] = 0;
-        EffectMiscValueB[i] = 0;
-        EffectPointsPerComboPoint[i] = 0;
-        EffectRadiusIndex[i] = 0;
-        EffectRadiusMaxIndex[i] = 0;
-        EffectRealPointsPerLevel[i] = 0;
-        EffectSpellClassMask[i] = 0;
-        EffectTriggerSpell[i] = 0;
-        EffectImplicitTargetA[i] = 0;
-        EffectImplicitTargetB[i] = 0;
-        EffectSpellId[i] = 0;
-        EffectIndex[i] = 0;
-    }
-
-    // custom values
+    // Custom values
     custom_proc_interval = 0;
     custom_BGR_one_buff_on_target = 0;
     custom_c_is_flags = 0;
@@ -308,62 +166,59 @@ SpellInfo::SpellInfo()
     custom_SchoolMask = 0;
     CustomFlags = 0;
 
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
         EffectCustomFlag[i] = 0;
-    }
 
     SpellFactoryFunc = nullptr;
     AuraFactoryFunc = nullptr;
-#endif
 }
 
 SpellInfo::~SpellInfo() {}
 
 
-bool SpellInfo::HasEffect(uint32_t effect) const
+bool SpellInfo::hasEffect(uint32_t effect) const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == effect)
-        {
             return true;
-        }
     }
 
     return false;
 }
 
-bool SpellInfo::HasEffectApplyAuraName(uint32_t aura_name)
+bool SpellInfo::hasEffectApplyAuraName(uint32_t auraType) const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        if (Effect[i] == SPELL_EFFECT_APPLY_AURA && EffectApplyAuraName[i] == aura_name)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        if (Effect[i] == SPELL_EFFECT_APPLY_AURA && EffectApplyAuraName[i] == auraType)
             return true;
+    }
 
     return false;
 }
 
-bool SpellInfo::HasCustomFlagForEffect(uint32_t effect, uint32_t flag)
+bool SpellInfo::hasCustomFlagForEffect(uint32_t effectIndex, uint32_t flag) const
 {
-    if (effect >= MAX_SPELL_EFFECTS)
+    if (effectIndex >= MAX_SPELL_EFFECTS)
         return false;
 
-    if ((EffectCustomFlag[effect] & flag) != 0)
+    if ((EffectCustomFlag[effectIndex] & flag) != 0)
         return true;
-    else
-        return false;
+
+    return false;
 }
 
 bool SpellInfo::isDamagingSpell() const
 {
-    if (HasEffect(SPELL_EFFECT_SCHOOL_DAMAGE)          ||
-        HasEffect(SPELL_EFFECT_ENVIRONMENTAL_DAMAGE)   ||
-        HasEffect(SPELL_EFFECT_HEALTH_LEECH)           ||
-        HasEffect(SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL) ||
-        HasEffect(SPELL_EFFECT_ADD_EXTRA_ATTACKS)      ||
-        HasEffect(SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)  ||
-        HasEffect(SPELL_EFFECT_POWER_BURN)             ||
-        HasEffect(SPELL_EFFECT_ATTACK))
+    if (hasEffect(SPELL_EFFECT_SCHOOL_DAMAGE)          ||
+        hasEffect(SPELL_EFFECT_ENVIRONMENTAL_DAMAGE)   ||
+        hasEffect(SPELL_EFFECT_HEALTH_LEECH)           ||
+        hasEffect(SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL) ||
+        hasEffect(SPELL_EFFECT_ADD_EXTRA_ATTACKS)      ||
+        hasEffect(SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)  ||
+        hasEffect(SPELL_EFFECT_POWER_BURN)             ||
+        hasEffect(SPELL_EFFECT_ATTACK))
         return true;
 
     if (appliesAreaAura(SPELL_AURA_PERIODIC_DAMAGE)         ||
@@ -378,9 +233,7 @@ bool SpellInfo::isDamagingSpell() const
 bool SpellInfo::isHealingSpell() const
 {
     if (firstBeneficialEffect() != -1)
-    {
         return true;
-    }
 
     switch (Id)
     {
@@ -438,9 +291,7 @@ bool SpellInfo::isHealingSpell() const
         case 68009: // Flash of Light Rank 9
         case 68010: // Flash of Light Rank 9
         case 71930:
-        {
             return true;
-        }
         default:
             break;
     }
@@ -454,26 +305,26 @@ int SpellInfo::firstBeneficialEffect() const
     {
         switch (Effect[i])
         {
-        case SPELL_EFFECT_HEALTH_LEECH:
-        case SPELL_EFFECT_HEAL:
-        case SPELL_EFFECT_HEAL_MAX_HEALTH:
-            return i;
-        case SPELL_EFFECT_APPLY_AURA:
-        case SPELL_EFFECT_APPLY_GROUP_AREA_AURA:
-        case SPELL_EFFECT_APPLY_RAID_AREA_AURA:
-        {
-            switch (EffectApplyAuraName[i])
-            {
-            case SPELL_AURA_PERIODIC_HEAL:
-            case SPELL_AURA_PERIODIC_HEALTH_FUNNEL:
+            case SPELL_EFFECT_HEALTH_LEECH:
+            case SPELL_EFFECT_HEAL:
+            case SPELL_EFFECT_HEAL_MAX_HEALTH:
                 return i;
-            default:
+            case SPELL_EFFECT_APPLY_AURA:
+            case SPELL_EFFECT_APPLY_GROUP_AREA_AURA:
+            case SPELL_EFFECT_APPLY_RAID_AREA_AURA:
+            {
+                switch (EffectApplyAuraName[i])
+                {
+                    case SPELL_AURA_PERIODIC_HEAL:
+                    case SPELL_AURA_PERIODIC_HEALTH_FUNNEL:
+                        return i;
+                    default:
+                        break;
+                }
                 break;
             }
-            break;
-        }
-        default:
-            break;
+            default:
+                break;
         }
     }
 
@@ -482,57 +333,49 @@ int SpellInfo::firstBeneficialEffect() const
 
 bool SpellInfo::isAffectingSpell(SpellInfo const* spellInfo) const
 {
-    // TODO: Verify for cata
-#if VERSION_STRING != Cata
     if (spellInfo == nullptr)
         return false;
 
     if (spellInfo->SpellFamilyName != SpellFamilyName)
         return false;
 
+    // If any of the effect indexes contain same mask, the spells affect each other
+    // TODO: this always returns false on classic and TBC since EffectSpellClassMask field does not exist there
     for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         for (auto u = 0; u < MAX_SPELL_EFFECTS; ++u)
         {
-            // If any of the effect indexes contain same mask, the spells affect each other
-            if (EffectSpellClassMask[u][i] && (EffectSpellClassMask[u][i] & spellInfo->SpellGroupType[i]))
+            // todo: test on Cata
+            if (EffectSpellClassMask[u][i] && (EffectSpellClassMask[u][i] & spellInfo->SpellFamilyFlags[i]))
                 return true;
         }
     }
-#endif
     return false;
 }
 
-uint32_t SpellInfo::getSpellDuration(Unit* caster) const
+uint32_t SpellInfo::getSpellDefaultDuration(Unit const* caster) const
 {
     auto spell_duration = sSpellDurationStore.LookupEntry(DurationIndex);
     if (spell_duration == nullptr)
-    {
         return 0;
-    }
 
     if (caster == nullptr)
-    {
         return spell_duration->Duration1;
-    }
 
     auto ret = spell_duration->Duration1 + (spell_duration->Duration2 * caster->getLevel());
     if (ret > spell_duration->Duration3)
-    {
         return spell_duration->Duration3;
-    }
+
     return ret;
 }
 
 bool SpellInfo::hasTargetType(uint32_t type) const
 {
-    for (auto i = 0; i < 3; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (EffectImplicitTargetA[i] == type ||
             EffectImplicitTargetB[i] == type)
-        {
             return true;
-        }
     }
 
     return false;
@@ -542,31 +385,23 @@ int SpellInfo::aiTargetType() const
 {
     /*  this is not good as one spell effect can target self and other one an enemy,
     maybe we should make it for each spell effect or use as flags */
-    if (
-        hasTargetType(EFF_TARGET_INVISIBLE_OR_HIDDEN_ENEMIES_AT_LOCATION_RADIUS) ||
+    if (hasTargetType(EFF_TARGET_INVISIBLE_OR_HIDDEN_ENEMIES_AT_LOCATION_RADIUS) ||
         hasTargetType(EFF_TARGET_ALL_TARGETABLE_AROUND_LOCATION_IN_RADIUS)       ||
         hasTargetType(EFF_TARGET_ALL_ENEMY_IN_AREA)                              ||
         hasTargetType(EFF_TARGET_ALL_ENEMY_IN_AREA_INSTANT)                      ||
         hasTargetType(EFF_TARGET_ALL_ENEMY_IN_AREA_CHANNELED)                    ||
-        hasTargetType(EFF_TARGET_ALL_TARGETABLE_AROUND_LOCATION_IN_RADIUS_OVER_TIME)
-    )
-    {
+        hasTargetType(EFF_TARGET_ALL_TARGETABLE_AROUND_LOCATION_IN_RADIUS_OVER_TIME))
         return TTYPE_DESTINATION;
-    }
 
-    if (
-        hasTargetType(EFF_TARGET_LOCATION_TO_SUMMON)      ||
+    if (hasTargetType(EFF_TARGET_LOCATION_TO_SUMMON)      ||
         hasTargetType(EFF_TARGET_IN_FRONT_OF_CASTER)      ||
         hasTargetType(EFF_TARGET_ALL_FRIENDLY_IN_AREA)    ||
         hasTargetType(EFF_TARGET_PET_SUMMON_LOCATION)     ||
         hasTargetType(EFF_TARGET_LOCATION_INFRONT_CASTER) ||
-        hasTargetType(EFF_TARGET_CONE_IN_FRONT)
-    )
-    {
+        hasTargetType(EFF_TARGET_CONE_IN_FRONT))
         return TTYPE_SOURCE;
-    }
-    if (
-        hasTargetType(EFF_TARGET_SINGLE_ENEMY)                      ||
+
+    if (hasTargetType(EFF_TARGET_SINGLE_ENEMY)                      ||
         hasTargetType(EFF_TARGET_ALL_ENEMIES_AROUND_CASTER)         ||
         hasTargetType(EFF_TARGET_DUEL)                              ||
         hasTargetType(EFF_TARGET_SCRIPTED_OR_SINGLE_TARGET)         ||
@@ -574,14 +409,10 @@ int SpellInfo::aiTargetType() const
         hasTargetType(EFF_TARGET_CURRENT_SELECTION)                 ||
         hasTargetType(EFF_TARGET_TARGET_AT_ORIENTATION_TO_CASTER)   ||
         hasTargetType(EFF_TARGET_MULTIPLE_GUARDIAN_SUMMON_LOCATION) ||
-        hasTargetType(EFF_TARGET_SELECTED_ENEMY_CHANNELED)
-    )
-    {
+        hasTargetType(EFF_TARGET_SELECTED_ENEMY_CHANNELED))
         return TTYPE_SINGLETARGET;
-    }
 
-    if (
-        hasTargetType(EFF_TARGET_ALL_PARTY_AROUND_CASTER)     ||
+    if (hasTargetType(EFF_TARGET_ALL_PARTY_AROUND_CASTER)     ||
         hasTargetType(EFF_TARGET_SINGLE_FRIEND)               ||
         hasTargetType(EFF_TARGET_PET_MASTER)                  ||
         hasTargetType(EFF_TARGET_ALL_PARTY_IN_AREA_CHANNELED) ||
@@ -590,21 +421,14 @@ int SpellInfo::aiTargetType() const
         hasTargetType(EFF_TARGET_ALL_PARTY)                   ||
         hasTargetType(EFF_TARGET_ALL_RAID)                    ||
         hasTargetType(EFF_TARGET_PARTY_MEMBER)                ||
-        hasTargetType(EFF_TARGET_AREAEFFECT_PARTY_AND_CLASS)
-    )
-    {
+        hasTargetType(EFF_TARGET_AREAEFFECT_PARTY_AND_CLASS))
         return TTYPE_OWNER;
-    }
 
-    if (
-        hasTargetType(EFF_TARGET_SELF) ||
+    if (hasTargetType(EFF_TARGET_SELF) ||
         hasTargetType(4) ||
         hasTargetType(EFF_TARGET_PET) ||
-        hasTargetType(EFF_TARGET_MINION)
-    )
-    {
+        hasTargetType(EFF_TARGET_MINION))
         return TTYPE_CASTER;
-    }
 
     return TTYPE_NULL;
 }
@@ -615,9 +439,7 @@ bool SpellInfo::isTargetingStealthed() const
         hasTargetType(EFF_TARGET_ALL_ENEMIES_AROUND_CASTER) ||
         hasTargetType(EFF_TARGET_ALL_ENEMY_IN_AREA_CHANNELED) ||
         hasTargetType(EFF_TARGET_ALL_ENEMY_IN_AREA_INSTANT))
-    {
         return true;
-    }
 
     switch (Id)
     {
@@ -636,9 +458,7 @@ bool SpellInfo::isTargetingStealthed() const
         case 58732: // Magma Totem Rank 6
         case 58734: // Magma Totem Rank 7
         case 58735: // Magma Totem Rank 7
-        {
             return true;
-        }
         default:
             break;
     }
@@ -654,50 +474,51 @@ bool SpellInfo::isRequireCooldownSpell() const
     return cond1 || cond2;
 }
 
-bool SpellInfo::IsPassive()
+bool SpellInfo::isPassive() const
 {
     return (Attributes & ATTRIBUTES_PASSIVE) != 0;
 }
 
-bool SpellInfo::IsProfession()
+bool SpellInfo::isProfession() const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_SKILL)
         {
-            uint32_t skill = EffectMiscValue[i];
+            auto skill = EffectMiscValue[i];
 
             //Profession skill
             if (skill == SKILL_FISHING || skill == SKILL_COOKING || skill == SKILL_FIRST_AID)
                 return true;
 
-            if (IsPrimaryProfessionSkill(skill))
+            if (isPrimaryProfessionSkill(skill))
                 return true;
         }
     }
     return false;
 }
 
-bool SpellInfo::IsPrimaryProfession()
+bool SpellInfo::isPrimaryProfession() const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_SKILL)
         {
-            uint32_t skill = EffectMiscValue[i];
-
-            if (IsPrimaryProfessionSkill(skill))
+            auto skill = EffectMiscValue[i];
+            if (isPrimaryProfessionSkill(skill))
                 return true;
         }
     }
     return false;
 }
 
-bool SpellInfo::IsPrimaryProfessionSkill(uint32_t skill_id)
+bool SpellInfo::isPrimaryProfessionSkill(uint32_t skill_id) const
 {
-    if (DBC::Structures::SkillLineEntry const* skill_line = sSkillLineStore.LookupEntry(skill_id))
+    if (auto skill_line = sSkillLineStore.LookupEntry(skill_id))
+    {
         if (skill_line && skill_line->type == SKILL_TYPE_PROFESSION)
             return true;
+    }
 
     return false;
 }
@@ -707,9 +528,9 @@ bool SpellInfo::isDeathPersistent() const
     return (AttributesExC & ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD) != 0;
 }
 
-bool SpellInfo::appliesAreaAura(uint32_t aura) const
+bool SpellInfo::appliesAreaAura(uint32_t auraType) const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         switch (Effect[i])
         {
@@ -720,10 +541,8 @@ bool SpellInfo::appliesAreaAura(uint32_t aura) const
             case SPELL_EFFECT_APPLY_FRIEND_AREA_AURA:
             case SPELL_EFFECT_APPLY_ENEMY_AREA_AURA:
             case SPELL_EFFECT_APPLY_OWNER_AREA_AURA:
-                if (EffectApplyAuraName[i] == aura)
-                {
+                if (EffectApplyAuraName[i] == auraType)
                     return true;
-                }
                 break;
             default:
                 break;
@@ -733,9 +552,9 @@ bool SpellInfo::appliesAreaAura(uint32_t aura) const
     return false;
 }
 
-uint32_t SpellInfo::GetAreaAuraEffectId()
+uint32_t SpellInfo::getAreaAuraEffect() const
 {
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_APPLY_GROUP_AREA_AURA ||
             Effect[i] == SPELL_EFFECT_APPLY_RAID_AREA_AURA ||

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -21,9 +21,9 @@ public:
     ~SpellInfo();
 
     // helper functions
-    bool HasEffect(uint32_t effect) const;
-    bool HasEffectApplyAuraName(uint32_t aura_name);
-    bool HasCustomFlagForEffect(uint32_t effect, uint32_t flag);
+    bool hasEffect(uint32_t effect) const;
+    bool hasEffectApplyAuraName(uint32_t auraType) const;
+    bool hasCustomFlagForEffect(uint32_t effectIndex, uint32_t flag) const;
 
     bool isDamagingSpell() const;
     bool isHealingSpell() const;
@@ -32,27 +32,28 @@ public:
     // Checks if spell (in most cases an aura) affects another spell, based on spell group mask
     bool isAffectingSpell(SpellInfo const* spellInfo) const;
 
-    uint32_t getSpellDuration(Unit* caster) const;
+    uint32_t getSpellDefaultDuration(Unit const* caster) const;
 
     bool hasTargetType(uint32_t type) const;
     int aiTargetType() const;
     bool isTargetingStealthed() const;
     bool isRequireCooldownSpell() const;
 
-    bool IsPassive();
-    bool IsProfession();
-    bool IsPrimaryProfession();
-    bool IsPrimaryProfessionSkill(uint32_t skill_id);
+    bool isPassive() const;
+    bool isProfession() const;
+    bool isPrimaryProfession() const;
+    bool isPrimaryProfessionSkill(uint32_t skill_id) const;
 
     bool isDeathPersistent() const;
 
-    bool appliesAreaAura(uint32_t aura) const;
-    uint32_t GetAreaAuraEffectId();
+    bool appliesAreaAura(uint32_t auraType) const;
+    uint32_t getAreaAuraEffect() const;
 
     uint32_t getId() const { return Id; }
     void setId(uint32_t value) { Id = value; }
 
     uint32_t getCategory() const { return Category; }
+    void setCategory(uint32_t value) { Category = value; }
 
     uint32_t getDispelType() const { return DispelType; }
     void setDispelType(uint32_t value) { DispelType = value; }              // used in HackFixes.cpp
@@ -88,11 +89,20 @@ public:
     uint32_t getAttributesExG() const { return AttributesExG; }
     void setAttributesExG(uint32_t value) { AttributesExG = value; }        // used in SpellCustomizations.cpp
 
-    uint32_t getRequiredShapeShift() const { return RequiredShapeShift; }
-    void setRequiredShapeShift(uint32_t value) { RequiredShapeShift = value; } // used in HackFixes.cpp / SpellCustomizations.cpp
+    uint32_t getAttributesExH() const { return AttributesExH; }
+    void setAttributesExH(uint32_t value) { AttributesExH = value; }        // used in SpellCustomizations.cpp
 
-    uint32_t getShapeshiftExclude() const { return ShapeshiftExclude; }
-    void setShapeshiftExclude(uint32_t value) { ShapeshiftExclude = value; } // used in SpellCustomizations.cpp
+    uint32_t getAttributesExI() const { return AttributesExI; }
+    void setAttributesExI(uint32_t value) { AttributesExI = value; }        // used in SpellCustomizations.cpp
+
+    uint32_t getAttributesExJ() const { return AttributesExJ; }
+    void setAttributesExJ(uint32_t value) { AttributesExJ = value; }        // used in SpellCustomizations.cpp
+
+    uint32_t getRequiredShapeShift() const { return Shapeshifts; }
+    void setRequiredShapeShift(uint32_t value) { Shapeshifts = value; } // used in HackFixes.cpp / SpellCustomizations.cpp
+
+    uint32_t getShapeshiftExclude() const { return ShapeshiftsExcluded; }
+    void setShapeshiftExclude(uint32_t value) { ShapeshiftsExcluded = value; } // used in SpellCustomizations.cpp
 
     uint32_t getTargets() const { return Targets; }                           // not used!
     void setTargets(uint32_t value) { Targets = value; }                    // used in SpellCustomizations.cpp
@@ -193,8 +203,8 @@ public:
     float getSpeed() const { return speed; }
     void setSpeed(float value) { speed = value; }    // used in HackFixes.cpp / SpellCustomizations.cpp
 
-    uint32_t getMaxstack() const { return maxstack; }
-    void setMaxstack(uint32_t value) { maxstack = value; }    // used in HackFixes.cpp / SpellCustomizations.cpp
+    uint32_t getMaxstack() const { return MaxStackAmount; }
+    void setMaxstack(uint32_t value) { MaxStackAmount = value; }    // used in HackFixes.cpp / SpellCustomizations.cpp
 
     uint32_t getTotem(uint8_t idx) const
     {
@@ -237,6 +247,9 @@ public:
 
     int32_t getEquippedItemSubClass() const { return EquippedItemSubClass; }
     void setEquippedItemSubClass(int32_t value) { EquippedItemSubClass = value; }    // used in SpellCustomizations.cpp
+
+    int32_t getEquippedItemInventoryTypeMask() const { return EquippedItemInventoryTypeMask; }
+    void setEquippedItemInventoryTypeMask(int32_t value) { EquippedItemInventoryTypeMask = value; }
 
     uint32_t getEffect(uint8_t idx) const
     {
@@ -286,13 +299,13 @@ public:
         EffectBasePoints[idx] = pointsPerLevel;
     }
 
-    int32_t getEffectMechanic(uint8_t idx) const
+    uint32_t getEffectMechanic(uint8_t idx) const
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
         return EffectMechanic[idx];
     }
 
-    void setEffectMechanic(int32_t mechanic, uint8_t idx)                       // used in HackFixes.cpp / SpellCustomizations.cpp
+    void setEffectMechanic(uint32_t mechanic, uint8_t idx)                       // used in HackFixes.cpp / SpellCustomizations.cpp
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
         EffectMechanic[idx] = mechanic;
@@ -445,26 +458,21 @@ public:
     uint32_t getSpellVisual() const { return SpellVisual; }
     void setSpellVisual(uint32_t value) { SpellVisual = value; }                 // used in SpellCustomizations.cpp
 
-    uint32_t getField114() const { return field114; }
-    void setField114(uint32_t value) { field114 = value; }                       // used in SpellCustomizations.cpp
-
     uint32_t getSpellIconID() const { return spellIconID; }
     void setSpellIconID(uint32_t value) { spellIconID = value; }                 // used in SpellCustomizations.cpp
 
     uint32_t getActiveIconID() const { return activeIconID; }
     void setActiveIconID(uint32_t value) { activeIconID = value; }               // used in SpellCustomizations.cpp
 
+    // todo: implement
+    uint32_t getSpellPriority() const { return spellPriority; }
+    void setSpellPriority(uint32_t value) { spellPriority = value; }
+
     std::string getName() const { return Name; }
     void setName(std::string value) { Name = value; }               // used in SpellCustomizations.cpp
 
     std::string getRank() const { return Rank; }
     void setRank(std::string value) { Rank = value; }               // used in SpellCustomizations.cpp
-
-    std::string getDescription() const { return Description; }
-    void setDescription(std::string value) { Description = value; }               // used in SpellCustomizations.cpp
-
-    std::string getBuffDescription() const { return BuffDescription; }
-    void setBuffDescription(std::string value) { BuffDescription = value; }               // used in SpellCustomizations.cpp
 
     uint32_t getManaCostPercentage() const { return ManaCostPercentage; }
     void setManaCostPercentage(uint32_t value) { ManaCostPercentage = value; }        // used in SpellCustomizations.cpp
@@ -481,42 +489,44 @@ public:
     uint32_t getSpellFamilyName() const { return SpellFamilyName; }
     void setSpellFamilyName(uint32_t value) { SpellFamilyName = value; }        // used in HackFixes.cpp / SpellCustomizations.cpp
 
-    uint32_t getSpellGroupType(uint8_t idx) const
+    // todo: classic has only two mask fields while other versions have three mask fields
+    uint32_t getSpellFamilyFlags(uint8_t idx) const
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
-        return SpellGroupType[idx];
+        return SpellFamilyFlags[idx];
     }
 
-    uint32_t* getSpellGroupType()
+    uint32_t* getSpellFamilyFlags()
     {
-        return SpellGroupType;
+        return SpellFamilyFlags;
     }
 
-    void setSpellGroupType(uint32_t value, uint8_t idx)                             // used in HackFixes.cpp / SpellCustomizations.cpp
+    // todo: classic has only two mask fields while other versions have three mask fields
+    void setSpellFamilyFlags(uint32_t value, uint8_t idx)                             // used in HackFixes.cpp / SpellCustomizations.cpp
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
-        SpellGroupType[idx] = value;
+        SpellFamilyFlags[idx] = value;
     }
 
     uint32_t getMaxTargets() const { return MaxTargets; }
     void setMaxTargets(uint32_t value) { MaxTargets = value; }        // used in HackFixes.cpp / SpellCustomizations.cpp
 
-    uint32_t getSpell_Dmg_Type() const { return Spell_Dmg_Type; }
-    void setSpell_Dmg_Type(uint32_t value) { Spell_Dmg_Type = value; }        // used in HackFixes.cpp / SpellCustomizations.cpp
+    uint32_t getDmgClass() const { return DmgClass; }
+    void setDmgClass(uint32_t value) { DmgClass = value; }        // used in HackFixes.cpp / SpellCustomizations.cpp
 
     uint32_t getPreventionType() const { return PreventionType; }
     void setPreventionType(uint32_t value) { PreventionType = value; }        // used in SpellCustomizations.cpp
 
-    float getDmg_multiplier(uint8_t idx) const
+    float getEffectDamageMultiplier(uint8_t idx) const
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
-        return dmg_multiplier[idx];
+        return EffectDamageMultiplier[idx];
     }
 
-    void setDmg_multiplier(float dmgMultiplier, uint8_t idx)                       // used in HackFixes.cpp / SpellCustomizations.cpp
+    void setEffectDamageMultiplier(float dmgMultiplier, uint8_t idx)                       // used in HackFixes.cpp / SpellCustomizations.cpp
     {
         ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
-        dmg_multiplier[idx] = dmgMultiplier;
+        EffectDamageMultiplier[idx] = dmgMultiplier;
     }
 
     uint32_t getTotemCategory(uint8_t idx) const
@@ -531,8 +541,8 @@ public:
         TotemCategory[idx] = category;
     }
 
-    int32_t getRequiresAreaId() const { return RequiresAreaId; }
-    void setRequiresAreaId(int32_t value) { RequiresAreaId = value; }   // used in SpellCustomizations.cpp
+    int32_t getRequiresAreaId() const { return AreaGroupId; }
+    void setRequiresAreaId(int32_t value) { AreaGroupId = value; }   // used in SpellCustomizations.cpp
 
     uint32_t getSchool() const { return School; }
     void setSchool(uint32_t value) { School = value; }                  // used in HackFixes.cpp / SpellCustomizations.cpp
@@ -540,15 +550,8 @@ public:
     uint32_t getRuneCostID() const { return RuneCostID; }
     void setRuneCostID(uint32_t value) { RuneCostID = value; }          // used in pellCustomizations.cpp
 
-    uint32_t getSpellDifficultyID() const { return SpellDifficultyID; }
-    void setSpellDifficultyID(uint32_t value) { SpellDifficultyID = value; }          // used in pellCustomizations.cpp
-
-#if VERSION_STRING != Cata
-    uint32_t getModalNextSpell() const { return modalNextSpell; }           // not used!
-    void setModalNextSpell(uint32_t value) { modalNextSpell = value; }    // used in SpellCustomizations.cpp
-
-    uint32_t getRequiredItemFlags() const { return RequiredItemFlags; }
-    void setRequiredItemFlags(uint32_t value) { RequiredItemFlags = value; }    // used in SpellCustomizations.cpp
+    uint32_t getSpellDifficultyID() const { return SpellDifficultyId; }
+    void setSpellDifficultyID(uint32_t value) { SpellDifficultyId = value; }          // used in pellCustomizations.cpp
 
     uint32_t getEffectSpellClassMask(uint8_t idx1, uint8_t idx2) const
     {
@@ -568,21 +571,31 @@ public:
         EffectSpellClassMask[idx1][idx2] = spellClass;
     }
 
-    uint32_t getSpellPriority() const { return spellPriority; }
-    void setSpellPriority(uint32_t value) { spellPriority = value; }               // used in SpellCustomizations.cpp
+    void setEffectBonusMultiplier(float value, uint8_t idx)
+    {
+        ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
+        EffectBonusMultiplier[idx] = value;
+    }
 
-    int32_t getStanceBarOrder() const { return StanceBarOrder; }
-    void setStanceBarOrder(int32_t value) { StanceBarOrder = value; }        // used in HackFixes.cpp / SpellCustomizations.cpp
+#if VERSION_STRING >= Cata
+    void setEffectRadiusMaxIndex(uint32_t value, uint8_t idx)
+    {
+        ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
+        EffectRadiusMaxIndex[idx] = value;
+    }
 
-    uint32_t getMinFactionID() const { return MinFactionID; }
-    void setMinFactionID(uint32_t value) { MinFactionID = value; }        // used in SpellCustomizations.cpp
+    void setEffectSpellId(uint32_t value, uint8_t idx)
+    {
+        ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
+        EffectSpellId[idx] = value;
+    }
 
-    uint32_t getMinReputation() const { return MinReputation; }
-    void setMinReputation(uint32_t value) { MinReputation = value; }        // used in SpellCustomizations.cpp
-
-    uint32_t getRequiredAuraVision() const { return RequiredAuraVision; }
-    void setRequiredAuraVision(uint32_t value) { RequiredAuraVision = value; }        // used in SpellCustomizations.cpp
-
+    void setEffectIndex(uint32_t value, uint8_t idx)
+    {
+        ARCEMU_ASSERT(idx < MAX_SPELL_EFFECTS);
+        EffectIndex[idx] = value;
+    }
+#endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
     //custom values
@@ -615,16 +628,17 @@ public:
         return EffectCustomFlag[idx];
     }
 
-    bool CheckLocation(uint32_t map_id, uint32_t zone_id, uint32_t area_id, Player* player = NULL);
+    bool checkLocation(uint32_t map_id, uint32_t zone_id, uint32_t area_id, Player* player = nullptr) const;
         
 private:
-
     //////////////////////////////////////////////////////////////////////////////////////////
-    // from dbc files
+    // Applied values from DBC
     uint32_t Id;
+    // Data from SpellCategories.dbc (in Cataclysm)
     uint32_t Category;
     uint32_t DispelType;
     uint32_t MechanicsType;
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t Attributes;
     uint32_t AttributesEx;
     uint32_t AttributesExB;
@@ -633,12 +647,19 @@ private:
     uint32_t AttributesExE;
     uint32_t AttributesExF;
     uint32_t AttributesExG;
-    uint32_t RequiredShapeShift;          // (12-13 Stances[2])
-    uint32_t ShapeshiftExclude;           // (14-15 StancesExcluded[2])
-    uint32_t Targets;                     // not used!
+    uint32_t AttributesExH;
+    uint32_t AttributesExI;
+    uint32_t AttributesExJ;
+    // Data from SpellShapeshift.dbc (in Cataclysm)
+    uint32_t Shapeshifts;
+    uint32_t ShapeshiftsExcluded;
+    // Data from SpellTargetRestrictions.dbc (in Cataclysm)
+    uint32_t Targets;
     uint32_t TargetCreatureType;
+    // Data from SpellCastingRequirements.dbc (in Cataclysm)
     uint32_t RequiresSpellFocus;
     uint32_t FacingCasterFlags;
+    // Data from SpellAuraRestrictions.dbc (in Cataclysm)
     uint32_t CasterAuraState;
     uint32_t TargetAuraState;
     uint32_t CasterAuraStateNot;
@@ -647,39 +668,51 @@ private:
     uint32_t targetAuraSpell;
     uint32_t casterAuraSpellNot;
     uint32_t targetAuraSpellNot;
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t CastingTimeIndex;
+    // Data from SpellCooldowns.dbc (in Cataclysm)
     uint32_t RecoveryTime;
     uint32_t CategoryRecoveryTime;
+    // Data from SpellInterrupts.dbc (in Cataclysm)
     uint32_t InterruptFlags;
     uint32_t AuraInterruptFlags;
     uint32_t ChannelInterruptFlags;
+    // Data from SpellAuraOptions.dbc (in Cataclysm)
     uint32_t procFlags;
     uint32_t procChance;
     uint32_t procCharges;
+    // Data from SpellLevels.dbc (in Cataclysm)
     uint32_t maxLevel;
     uint32_t baseLevel;
     uint32_t spellLevel;
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t DurationIndex;
     int32_t powerType;
+    // Data from SpellPower.dbc (in Cataclysm)
     uint32_t manaCost;
-    uint32_t manaCostPerlevel;        // not used!
-    uint32_t manaPerSecond;           // not used!
-    uint32_t manaPerSecondPerLevel;   // not used!
+    uint32_t manaCostPerlevel;
+    uint32_t manaPerSecond;
+    uint32_t manaPerSecondPerLevel;
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t rangeIndex;
     float speed;
-    uint32_t modalNextSpell;          // not used!
-    uint32_t maxstack;
+    // Data from SpellAuraOptions.dbc (in Cataclysm)
+    uint32_t MaxStackAmount;
+    // Data from SpellTotems.dbc (in Cataclysm)
     uint32_t Totem[MAX_SPELL_TOTEMS];
-    uint32_t Reagent[MAX_SPELL_REAGENTS];
+    // Data from SpellReagents.dbc (in Cataclysm)
+    int32_t Reagent[MAX_SPELL_REAGENTS];
     uint32_t ReagentCount[MAX_SPELL_REAGENTS];
+    // Data from SpellEquippedItems.dbc (in Cataclysm)
     int32_t EquippedItemClass;
     int32_t EquippedItemSubClass;
-    uint32_t RequiredItemFlags;
+    int32_t EquippedItemInventoryTypeMask;
+    // Data from SpellEffect.dbc (in Cataclysm)
     uint32_t Effect[MAX_SPELL_EFFECTS];
     int32_t EffectDieSides[MAX_SPELL_EFFECTS];
     float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];
     int32_t EffectBasePoints[MAX_SPELL_EFFECTS];
-    int32_t EffectMechanic[MAX_SPELL_EFFECTS];
+    uint32_t EffectMechanic[MAX_SPELL_EFFECTS];
     uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];
     uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];
     uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];
@@ -692,299 +725,146 @@ private:
     int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                //can be: speed slot-type, summon
     uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];
     float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];
-    uint32_t EffectSpellClassMask[3][3];
+    uint32_t EffectSpellClassMask[MAX_SPELL_EFFECTS][3];
+#if VERSION_STRING >= Cata
+    uint32_t EffectRadiusMaxIndex[MAX_SPELL_EFFECTS];
+    uint32_t EffectSpellId[MAX_SPELL_EFFECTS];
+    uint32_t EffectIndex[MAX_SPELL_EFFECTS];
+#endif
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t SpellVisual;
-    uint32_t field114;                                          // (131-132 SpellVisual[2])
     uint32_t spellIconID;
     uint32_t activeIconID;
     uint32_t spellPriority;
     std::string Name;
     std::string Rank;
-    std::string Description;
-    std::string BuffDescription;
+    // Data from SpellPower.dbc (in Cataclysm)
     uint32_t ManaCostPercentage;
+    // Data from SpellCategories.dbc (in Cataclysm)
     uint32_t StartRecoveryCategory;
+    // Data from SpellCooldowns.dbc (in Cataclysm)
     uint32_t StartRecoveryTime;
+    // Data from SpellTargetRestrictions.dbc (in Cataclysm)
     uint32_t MaxTargetLevel;
+    // Data from SpellClassOptions.dbc (in Cataclysm)
     uint32_t SpellFamilyName;
-    uint32_t SpellGroupType[MAX_SPELL_EFFECTS];
+    uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];
+    // Data from SpellTargetRestrictions.dbc (in Cataclysm)
     uint32_t MaxTargets;
-    uint32_t Spell_Dmg_Type;
+    // Data from SpellCategories.dbc (in Cataclysm)
+    uint32_t DmgClass;
     uint32_t PreventionType;
-    int32_t StanceBarOrder;
-    float dmg_multiplier[MAX_SPELL_EFFECTS];
-    uint32_t MinFactionID;          // not used!
-    uint32_t MinReputation;         // not used!
-    uint32_t RequiredAuraVision;    // not used!
+    // Data from SpellEffect.dbc (in Cataclysm)
+    float EffectDamageMultiplier[MAX_SPELL_EFFECTS];
+    // Data from SpellTotems.dbc (in Cataclysm)
     uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];     // not used!
-    int32_t RequiresAreaId;
+    // Data from SpellCastingRequirements.dbc (in Cataclysm)
+    int32_t AreaGroupId;
+    // Data from Spell.dbc (in Cataclysm)
     uint32_t School;
     uint32_t RuneCostID;
-    //uint32_t SpellMissileID;
-    //uint32_t SpellDescriptionVariable;
-    uint32_t SpellDifficultyID;
+    // Data from SpellEffect.dbc (in Cataclysm)
+    float EffectBonusMultiplier[MAX_SPELL_EFFECTS];
+    // Data from SpellDifficulty.dbc (in Cataclysm)
+    uint32_t SpellDifficultyId;
 
 public:
-
-        //////////////////////////////////////////////////////////////////////////////////////////
-        //custom values
-        
-        // from MySQL table spell_proc - 1887 spells
-        uint32_t custom_proc_interval;
-
-        // from MySQL table spell_custom_assign - 1970 spells
-        uint32_t custom_BGR_one_buff_on_target;
-
-        // from MySQL table spell_custom_assign - 353 spells
-        // also flags added in SpellCustomizations::SetMissingCIsFlags
-        uint32_t custom_c_is_flags;
-
-        // from MySQL table spell_ranks - 6546 spells
-        uint32_t custom_RankNumber;
-
-        // set in HackFixes.cpp for all Dummy Trigger
-        uint32_t custom_NameHash;
-
-        // from MySQL table ai_threattospellid - 144 spells
-        int32_t custom_ThreatForSpell;
-
-        // from MySQL table ai_threattospellid - 118 spells
-        float custom_ThreatForSpellCoef;
-
-        // from MySQL table spell_coef_flags - 16499 spells
-        uint32_t custom_spell_coef_flags;
-
-        // set in HackFixes.cpp for all spells
-        float custom_base_range_or_radius_sqr;
-
-        // set in HackFixes.cpp - 1 spell (26029)
-        float cone_width;
-
-        // set in HackFixes.cpp for all spells
-        float casttime_coef;
-
-        // set in HackFixes.cpp for most spells
-        float fixed_dddhcoef;
-
-        // set in HackFixes.cpp for most spells
-        float fixed_hotdotcoef;
-
-        // from MySQL table spell_coef_override - 151 spells
-        float Dspell_coef_override;
-
-        // from MySQL table spell_coef_override - 151 spells
-        float OTspell_coef_override;
-
-        // set in HackFixes.cpp for all spells
-        // check out SpellInfo::aiTargetType
-        int ai_target_type;
-
-        // set in Hackfixes.cpp - 5 spells
-        // from MySQL table spell_custom_assign - 6 spells
-        bool custom_self_cast_only;
-
-        // SpellCustomizations::SetOnShapeshiftChange - 2 spells
-        bool custom_apply_on_shapeshift_change;
-
-        // set in Hackfixes.cpp - 3 spells
-        // set in SpellCustomizations::SetMeleeSpellBool based on school and effect
-        bool custom_is_melee_spell;
-
-        // set in Hackfixes.cpp - 1 spells (2094)
-        // set in SpellCustomizations::SetRangedSpellBool based on school and dmg type
-        bool custom_is_ranged_spell;
-
-        // set in HackFixes.cpp for all spells, based on school
-        uint32_t custom_SchoolMask;
-
-        // SpellCustomizations::SetCustomFlags - 1 spell (781)
-        uint32_t CustomFlags;
-
-        // from MySQL table spell_effects_override - 374 spells
-        uint32_t EffectCustomFlag[MAX_SPELL_EFFECTS];
-#else
-
-        //////////////////////////////////////////////////////////////////////////////////////////
-        // Applied values from DBC
-        uint32_t Id;
-        uint32_t Attributes;
-        uint32_t AttributesEx;
-        uint32_t AttributesExB;
-        uint32_t AttributesExC;
-        uint32_t AttributesExD;
-        uint32_t AttributesExE;
-        uint32_t AttributesExF;
-        uint32_t AttributesExG;
-        uint32_t AttributesExH;
-        uint32_t AttributesExI;
-        uint32_t AttributesExJ;
-        uint32_t CastingTimeIndex;
-        uint32_t DurationIndex;
-        int32_t powerType;            // uint32_t  error: case value evaluates to -2, which cannot be narrowed to type 'uint32' (aka 'unsigned int') [-Wc++11-narrowing]
-        uint32_t rangeIndex;
-        float speed;
-        uint32_t SpellVisual;
-        uint32_t field114;
-        uint32_t spellIconID;
-        uint32_t activeIconID;
-        std::string Name;
-        std::string Rank;
-        std::string Description;
-        std::string BuffDescription;
-        uint32_t School;
-        uint32_t RuneCostID;
-        //uint32_t SpellMissileID;
-        //uint32_t spellDescriptionVariableID;
-        uint32_t SpellDifficultyID;
-
-        //dbc links
-        uint32_t SpellScalingId;                              // SpellScaling.dbc
-        uint32_t SpellAuraOptionsId;                          // SpellAuraOptions.dbc
-        uint32_t SpellAuraRestrictionsId;                     // SpellAuraRestrictions.dbc
-        uint32_t SpellCastingRequirementsId;                  // SpellCastingRequirements.dbc
-        uint32_t SpellCategoriesId;                           // SpellCategories.dbc
-        uint32_t SpellClassOptionsId;                         // SpellClassOptions.dbc
-        uint32_t SpellCooldownsId;                            // SpellCooldowns.dbc
-        uint32_t SpellEquippedItemsId;                        // SpellEquippedItems.dbc
-        uint32_t SpellInterruptsId;                           // SpellInterrupts.dbc
-        uint32_t SpellLevelsId;                               // SpellLevels.dbc
-        uint32_t SpellPowerId;                                // SpellPower.dbc
-        uint32_t SpellReagentsId;                             // SpellReagents.dbc
-        uint32_t SpellShapeshiftId;                           // SpellShapeshift.dbc
-        uint32_t SpellTargetRestrictionsId;                   // SpellTargetRestrictions.dbc
-        uint32_t SpellTotemsId;                               // SpellTotems.dbc
-
-        // data from SpellScaling.dbc
-        // data from SpellAuraOptions.dbc
-        uint32_t maxstack;
-        uint32_t procChance;
-        uint32_t procCharges;
-        uint32_t procFlags;
-
-        // data from SpellAuraRestrictions.dbc
-        uint32_t CasterAuraState;
-        uint32_t TargetAuraState;
-        uint32_t CasterAuraStateNot;
-        uint32_t TargetAuraStateNot;
-        uint32_t casterAuraSpell;
-        uint32_t targetAuraSpell;
-        uint32_t casterAuraSpellNot;
-        uint32_t targetAuraSpellNot;
-
-        // data from SpellCastingRequirements.dbc
-        uint32_t FacingCasterFlags;
-        int32_t RequiresAreaId;
-        uint32_t RequiresSpellFocus;
-
-        // data from SpellCategories.dbc
-        uint32_t Category;
-        uint32_t DispelType;
-        uint32_t Spell_Dmg_Type;
-        uint32_t MechanicsType;
-        uint32_t PreventionType;
-        uint32_t StartRecoveryCategory;
-
-        // data from SpellClassOptions.dbc
-        uint32_t SpellGroupType[3];
-        uint32_t SpellFamilyName;
-
-        // data from SpellCooldowns.dbc
-        uint32_t CategoryRecoveryTime;
-        uint32_t RecoveryTime;
-        uint32_t StartRecoveryTime;
-
-        // data from SpellEquippedItems.dbc
-        int32_t EquippedItemClass;
-        int32_t EquippedItemInventoryTypeMask;
-        int32_t EquippedItemSubClass;
-
-        // data from SpellInterrupts.dbc
-        uint32_t AuraInterruptFlags;
-        uint32_t ChannelInterruptFlags;
-        uint32_t InterruptFlags;
-
-        // data from SpellLevels.dbc
-        uint32_t baseLevel;
-        uint32_t maxLevel;
-        uint32_t spellLevel;
-
-        // data from SpellPower.dbc
-        uint32_t manaCost;
-        uint32_t manaCostPerlevel;
-        uint32_t ManaCostPercentage;
-        uint32_t manaPerSecond;
-        uint32_t manaPerSecondPerLevel;
-
-        // data from SpellReagents.dbc
-        uint32_t Reagent[MAX_SPELL_REAGENTS];
-        uint32_t ReagentCount[MAX_SPELL_REAGENTS];
-
-        // data from SpellShapeshift.dbc
-        uint32_t RequiredShapeShift;
-        uint32_t ShapeshiftExclude;
-
-        // data from SpellTargetRestrictions.dbc
-        uint32_t MaxTargets;
-        uint32_t MaxTargetLevel;
-        uint32_t TargetCreatureType;
-        uint32_t Targets;
-
-        // data from SpellTotems.dbc
-        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];
-        uint32_t Totem[MAX_SPELL_TOTEMS];
-
-        // data from SpellEffect.dbc
-        uint32_t Effect[MAX_SPELL_EFFECTS];
-        float EffectMultipleValue[MAX_SPELL_EFFECTS];
-        uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];
-        uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];
-        int32_t EffectBasePoints[MAX_SPELL_EFFECTS];
-        float EffectBonusMultiplier[MAX_SPELL_EFFECTS];
-        float dmg_multiplier[MAX_SPELL_EFFECTS];
-        uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];
-        int32_t EffectDieSides[MAX_SPELL_EFFECTS];
-        uint32_t EffectItemType[MAX_SPELL_EFFECTS];
-        uint32_t EffectMechanic[MAX_SPELL_EFFECTS];
-        int32_t EffectMiscValue[MAX_SPELL_EFFECTS];
-        int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];
-        float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];
-        uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];
-        uint32_t EffectRadiusMaxIndex[MAX_SPELL_EFFECTS];
-        float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];
-        uint32_t EffectSpellClassMask[MAX_SPELL_EFFECTS];
-        uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];
-        uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];
-        uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];
-        uint32_t EffectSpellId[MAX_SPELL_EFFECTS];
-        uint32_t EffectIndex[MAX_SPELL_EFFECTS];
-
-        //////////////////////////////////////////////////////////////////////////////////////////
-        // custom values
-        uint32_t custom_proc_interval;
-        uint32_t custom_BGR_one_buff_on_target;
-        uint32_t custom_c_is_flags;
-        uint32_t custom_RankNumber;
-        uint32_t custom_NameHash;
-        uint32_t custom_ThreatForSpell;
-        float custom_ThreatForSpellCoef;
-        uint32_t custom_spell_coef_flags;
-        float custom_base_range_or_radius_sqr;
-        float cone_width;
-        float casttime_coef;
-        float fixed_dddhcoef;
-        float fixed_hotdotcoef;
-        float Dspell_coef_override;
-        float OTspell_coef_override;
-        int ai_target_type;
-        bool custom_self_cast_only;
-        bool custom_apply_on_shapeshift_change;
-        bool custom_is_melee_spell;
-        bool custom_is_ranged_spell;
-        bool CheckLocation(uint32_t map_id, uint32_t zone_id, uint32_t area_id, Player* player = NULL);
-        uint32_t custom_SchoolMask;
-        uint32_t CustomFlags;
-        uint32_t EffectCustomFlag[MAX_SPELL_EFFECTS];
+#if VERSION_STRING >= Cata
+    // DBC links
+    uint32_t SpellScalingId;                              // SpellScaling.dbc
+    uint32_t SpellAuraOptionsId;                          // SpellAuraOptions.dbc
+    uint32_t SpellAuraRestrictionsId;                     // SpellAuraRestrictions.dbc
+    uint32_t SpellCastingRequirementsId;                  // SpellCastingRequirements.dbc
+    uint32_t SpellCategoriesId;                           // SpellCategories.dbc
+    uint32_t SpellClassOptionsId;                         // SpellClassOptions.dbc
+    uint32_t SpellCooldownsId;                            // SpellCooldowns.dbc
+    uint32_t SpellEquippedItemsId;                        // SpellEquippedItems.dbc
+    uint32_t SpellInterruptsId;                           // SpellInterrupts.dbc
+    uint32_t SpellLevelsId;                               // SpellLevels.dbc
+    uint32_t SpellPowerId;                                // SpellPower.dbc
+    uint32_t SpellReagentsId;                             // SpellReagents.dbc
+    uint32_t SpellShapeshiftId;                           // SpellShapeshift.dbc
+    uint32_t SpellTargetRestrictionsId;                   // SpellTargetRestrictions.dbc
+    uint32_t SpellTotemsId;                               // SpellTotems.dbc
 #endif
-        void* (*SpellFactoryFunc);
-        void* (*AuraFactoryFunc);
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //custom values
+    
+    // from MySQL table spell_proc - 1887 spells
+    uint32_t custom_proc_interval;
+
+    // from MySQL table spell_custom_assign - 1970 spells
+    uint32_t custom_BGR_one_buff_on_target;
+
+    // from MySQL table spell_custom_assign - 353 spells
+    // also flags added in SpellCustomizations::SetMissingCIsFlags
+    uint32_t custom_c_is_flags;
+
+    // from MySQL table spell_ranks - 6546 spells
+    uint32_t custom_RankNumber;
+
+    // set in HackFixes.cpp for all Dummy Trigger
+    uint32_t custom_NameHash;
+
+    // from MySQL table ai_threattospellid - 144 spells
+    int32_t custom_ThreatForSpell;
+
+    // from MySQL table ai_threattospellid - 118 spells
+    float custom_ThreatForSpellCoef;
+
+    // from MySQL table spell_coef_flags - 16499 spells
+    uint32_t custom_spell_coef_flags;
+
+    // set in HackFixes.cpp for all spells
+    float custom_base_range_or_radius_sqr;
+
+    // set in HackFixes.cpp - 1 spell (26029)
+    float cone_width;
+
+    // set in HackFixes.cpp for all spells
+    float casttime_coef;
+
+    // set in HackFixes.cpp for most spells
+    float fixed_dddhcoef;
+
+    // set in HackFixes.cpp for most spells
+    float fixed_hotdotcoef;
+
+    // from MySQL table spell_coef_override - 151 spells
+    float Dspell_coef_override;
+
+    // from MySQL table spell_coef_override - 151 spells
+    float OTspell_coef_override;
+
+    // set in HackFixes.cpp for all spells
+    // check out SpellInfo::aiTargetType
+    int ai_target_type;
+
+    // set in Hackfixes.cpp - 5 spells
+    // from MySQL table spell_custom_assign - 6 spells
+    bool custom_self_cast_only;
+
+    // SpellCustomizations::SetOnShapeshiftChange - 2 spells
+    bool custom_apply_on_shapeshift_change;
+
+    // set in Hackfixes.cpp - 3 spells
+    // set in SpellCustomizations::SetMeleeSpellBool based on school and effect
+    bool custom_is_melee_spell;
+
+    // set in Hackfixes.cpp - 1 spells (2094)
+    // set in SpellCustomizations::SetRangedSpellBool based on school and dmg type
+    bool custom_is_ranged_spell;
+
+    // set in HackFixes.cpp for all spells, based on school
+    uint32_t custom_SchoolMask;
+
+    // SpellCustomizations::SetCustomFlags - 1 spell (781)
+    uint32_t CustomFlags;
+
+    // from MySQL table spell_effects_override - 374 spells
+    uint32_t EffectCustomFlag[MAX_SPELL_EFFECTS];
+
+    void* (*SpellFactoryFunc);
+    void* (*AuraFactoryFunc);
 };

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -348,14 +348,14 @@ bool SpellArea::IsFitToRequirements(Player* player, uint32 newZone, uint32 newAr
     return true;
 }
 
-bool SpellInfo::CheckLocation(uint32_t /*map_id*/, uint32_t zone_id, uint32_t area_id, Player* player)
+bool SpellInfo::checkLocation(uint32_t /*map_id*/, uint32_t zone_id, uint32_t area_id, Player* player) const
 {
 #if VERSION_STRING > TBC
     // normal case
-    if (RequiresAreaId > 0)
+    if (AreaGroupId > 0)
     {
         bool found = false;
-        auto area_group = sAreaGroupStore.LookupEntry(RequiresAreaId);
+        auto area_group = sAreaGroupStore.LookupEntry(AreaGroupId);
         while (area_group)
         {
             for (uint8 i = 0; i < 6; ++i)

--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -51,9 +51,9 @@ bool SpellProc::CanDelete(uint32 spellId, uint64 casterGuid, uint64 /*misc*/)
 bool SpellProc::CheckClassMask(Unit* /*victim*/, SpellInfo* CastingSpell)
 {
     if ((mProcClassMask[0] == 0 && mProcClassMask[1] == 0 && mProcClassMask[2] == 0) ||
-        mProcClassMask[0] & CastingSpell->getSpellGroupType(0) ||
-        mProcClassMask[1] & CastingSpell->getSpellGroupType(1) ||
-        mProcClassMask[2] & CastingSpell->getSpellGroupType(2))
+        mProcClassMask[0] & CastingSpell->getSpellFamilyFlags(0) ||
+        mProcClassMask[1] & CastingSpell->getSpellFamilyFlags(1) ||
+        mProcClassMask[2] & CastingSpell->getSpellFamilyFlags(2))
         return true;
     
     return false;

--- a/src/world/Spell/SpellProc_ClassScripts.cpp
+++ b/src/world/Spell/SpellProc_ClassScripts.cpp
@@ -349,7 +349,7 @@ public:
     // Allow proc on ability cast (like eviscerate, envenom, fan of knives, rupture)
     bool CanProcOnTriggered(Unit* /*victim*/, SpellInfo* castingSpell)
     {
-        if (castingSpell != nullptr && (castingSpell->getSpellGroupType(0) & 0x120000 || castingSpell->getSpellGroupType(1) & 0x240008))
+        if (castingSpell != nullptr && (castingSpell->getSpellFamilyFlags(0) & 0x120000 || castingSpell->getSpellFamilyFlags(1) & 0x240008))
             return true;
 
         return false;
@@ -430,8 +430,8 @@ public:
             // Duration of 5 combo maximum
             int32 dur = 21 * MSTIME_SECOND;
 
-            spellModFlatIntValue(mTarget->SM_FDur, &dur, aura->GetSpellInfo()->getSpellGroupType());
-            spellModPercentageIntValue(mTarget->SM_PDur, &dur, aura->GetSpellInfo()->getSpellGroupType());
+            spellModFlatIntValue(mTarget->SM_FDur, &dur, aura->GetSpellInfo()->getSpellFamilyFlags());
+            spellModPercentageIntValue(mTarget->SM_PDur, &dur, aura->GetSpellInfo()->getSpellFamilyFlags());
 
             // Set new aura's duration, reset event timer and set client visual aura
             aura->SetDuration(dur);
@@ -622,7 +622,7 @@ public:
         if (castingSpell == nullptr)
             return true;
 
-        if (!castingSpell->HasEffect(SPELL_EFFECT_HEAL))
+        if (!castingSpell->hasEffect(SPELL_EFFECT_HEAL))
             return true;
 
         dmgOverwrite[0] = dmg * (mOrigSpell->getEffectBasePoints(0) + 1) / 100;
@@ -835,7 +835,7 @@ public:
     bool DoEffect(Unit* /*victim*/, SpellInfo* castingSpell, uint32 /*flag*/, uint32 /*dmg*/, uint32 /*abs*/, int* /*dmgOverwrite*/, uint32 /*weaponDamageType*/)
     {
         // If spell is not Mind Blast (by SpellGroupType) or player is not on shadowform, don't proc
-        if (!(castingSpell->getSpellGroupType(0) & mProcClassMask[0] && mTarget->IsPlayer() && static_cast<Player*>(mTarget)->getShapeShiftForm() == FORM_SHADOW))
+        if (!(castingSpell->getSpellFamilyFlags(0) & mProcClassMask[0] && mTarget->IsPlayer() && static_cast<Player*>(mTarget)->getShapeShiftForm() == FORM_SHADOW))
             return true;
 
         return false;
@@ -1120,15 +1120,9 @@ public:
     {
         mProcFlags = PROC_ON_CAST_SPELL;
 
-#if VERSION_STRING != Cata
         mProcClassMask[0] = mOrigSpell->getEffectSpellClassMask(0, 0);
         mProcClassMask[1] = mOrigSpell->getEffectSpellClassMask(0, 1);
         mProcClassMask[2] = mOrigSpell->getEffectSpellClassMask(0, 2);
-#else
-        mProcClassMask[0] = mOrigSpell->EffectSpellClassMask[0];
-        mProcClassMask[1] = mOrigSpell->EffectSpellClassMask[1];
-        mProcClassMask[2] = mOrigSpell->EffectSpellClassMask[2];
-#endif
 
         dk = static_cast<DeathKnight*>(mTarget);
     }

--- a/src/world/Spell/SpellTarget.cpp
+++ b/src/world/Spell/SpellTarget.cpp
@@ -257,7 +257,7 @@ void Spell::AddChainTargets(uint32 i, uint32 targetType, float /*r*/, uint32 /*m
     //range
     range /= jumps; //hacky, needs better implementation!
 
-    ascemu::World::Spell::Helpers::spellModFlatIntValue(u_caster->SM_FAdditionalTargets, (int32*)&jumps, m_spellInfo->getSpellGroupType());
+    ascemu::World::Spell::Helpers::spellModFlatIntValue(u_caster->SM_FAdditionalTargets, (int32*)&jumps, m_spellInfo->getSpellFamilyFlags());
 
     AddTarget(i, targetType, firstTarget);
 

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -3694,8 +3694,8 @@ uint32 AIInterface::_CalcThreat(uint32 damage, SpellInfo* sp, Unit* Attacker)
 
     if (sp != nullptr)
     {
-        ascemu::World::Spell::Helpers::spellModFlatIntValue(Attacker->SM_FThreat, &mod, sp->getSpellGroupType());
-        ascemu::World::Spell::Helpers::spellModPercentageIntValue(Attacker->SM_PThreat, &mod, sp->getSpellGroupType());
+        ascemu::World::Spell::Helpers::spellModFlatIntValue(Attacker->SM_FThreat, &mod, sp->getSpellFamilyFlags());
+        ascemu::World::Spell::Helpers::spellModPercentageIntValue(Attacker->SM_PThreat, &mod, sp->getSpellFamilyFlags());
     }
 
     if (Attacker->getClass() == ROGUE)

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -435,9 +435,9 @@ bool Pet::CreateAsSummon(uint32 entry, CreatureProperties const* ci, Creature* c
 
         if (created_by_spell != NULL)
         {
-            if (created_by_spell->HasEffect(SPELL_EFFECT_SUMMON_PET) ||
-                created_by_spell->HasEffect(SPELL_EFFECT_TAME_CREATURE) ||
-                created_by_spell->HasEffect(SPELL_EFFECT_TAMECREATURE))
+            if (created_by_spell->hasEffect(SPELL_EFFECT_SUMMON_PET) ||
+                created_by_spell->hasEffect(SPELL_EFFECT_TAME_CREATURE) ||
+                created_by_spell->hasEffect(SPELL_EFFECT_TAMECREATURE))
                 SetNameForEntry(entry);
 
             setCreatedBySpellId(created_by_spell->getId());
@@ -779,7 +779,7 @@ void Pet::InitializeSpells()
         SpellInfo* info = itr->first;
 
         // Check that the spell isn't passive
-        if (info->IsPassive())
+        if (info->isPassive())
         {
             // Cast on self..
             Spell* sp = sSpellFactoryMgr.NewSpell(this, info, true, NULL);
@@ -1388,7 +1388,7 @@ void Pet::AddSpell(SpellInfo* sp, bool learning, bool showLearnSpell)
     if (sp == NULL)
         return;
 
-    if (sp->IsPassive())        // Cast on self if we're a passive spell
+    if (sp->isPassive())        // Cast on self if we're a passive spell
     {
         if (IsInWorld())
         {

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -2466,10 +2466,11 @@ void Player::addSpell(uint32 spell_id)
     {
         // miscvalue1==777 for mounts, 778 for pets
         // make sure it's a companion pet, not some other summon-type spell
-        if (strncmp(spell->getDescription().c_str(), "Right Cl", 8) == 0) // "Right Click to summon and dismiss " ...
-        {
+        // temporary solution since spell description is no longer loaded -Appled
+        const auto creatureEntry = spell->getEffectMiscValue(0);
+        auto creatureProperties = sMySQLStore.getCreatureProperties(creatureEntry);
+        if (creatureProperties != nullptr && creatureProperties->Type == UNIT_TYPE_NONCOMBAT_PET)
             m_achievementMgr.UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS, 778, 0, 0);
-        }
     }
 #endif
 }
@@ -7268,8 +7269,8 @@ int32 Player::CanShootRangedWeapon(uint32 spellid, Unit* target, bool autoshot)
     float dist = CalcDistance(this, target);
     float maxr = GetMaxRange(spell_range) + 2.52f;
 
-    spellModFlatFloatValue(this->SM_FRange, &maxr, spell_info->getSpellGroupType());
-    spellModPercentageFloatValue(this->SM_PRange, &maxr, spell_info->getSpellGroupType());
+    spellModFlatFloatValue(this->SM_FRange, &maxr, spell_info->getSpellFamilyFlags());
+    spellModPercentageFloatValue(this->SM_PRange, &maxr, spell_info->getSpellFamilyFlags());
 
     //float bonusRange = 0;
     // another hackfix: bonus range from hunter talent hawk eye: +2/4/6 yard range to ranged weapons
@@ -10355,7 +10356,7 @@ void Player::CompleteLoading()
         spellInfo = sSpellCustomizations.GetSpellInfo(*itr);
 
         if (spellInfo != nullptr
-            && (spellInfo->IsPassive())  // passive
+            && (spellInfo->isPassive())  // passive
             && !(spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET))
         {
             if (spellInfo->getRequiredShapeShift())
@@ -11590,7 +11591,7 @@ void Player::_LearnSkillSpells(uint32 SkillLine, uint32 curr_sk)
                         removeSpell(removeSpellId, true, true, skill_line_ability->next);
                     }
                     // if passive spell, apply it now
-                    if (sp->IsPassive())
+                    if (sp->isPassive())
                     {
                         SpellCastTargets targets;
                         targets.m_unitTarget = this->getGuid();
@@ -12192,8 +12193,8 @@ void Player::Cooldown_Add(SpellInfo* pSpell, Item* pItemCaster)
     uint32 spell_category_recovery_time = pSpell->getCategoryRecoveryTime();
     if (spell_category_recovery_time > 0 && category_id)
     {
-        spellModFlatIntValue(SM_FCooldownTime, &cool_time, pSpell->getSpellGroupType());
-        spellModPercentageIntValue(SM_PCooldownTime, &cool_time, pSpell->getSpellGroupType());
+        spellModFlatIntValue(SM_FCooldownTime, &cool_time, pSpell->getSpellFamilyFlags());
+        spellModPercentageIntValue(SM_PCooldownTime, &cool_time, pSpell->getSpellFamilyFlags());
 
         AddCategoryCooldown(category_id, spell_category_recovery_time + mstime, spell_id, pItemCaster ? pItemCaster->getItemProperties()->ItemId : 0);
     }
@@ -12201,8 +12202,8 @@ void Player::Cooldown_Add(SpellInfo* pSpell, Item* pItemCaster)
     uint32 spell_recovery_t = pSpell->getRecoveryTime();
     if (spell_recovery_t > 0)
     {
-        spellModFlatIntValue(SM_FCooldownTime, &cool_time, pSpell->getSpellGroupType());
-        spellModPercentageIntValue(SM_PCooldownTime, &cool_time, pSpell->getSpellGroupType());
+        spellModFlatIntValue(SM_FCooldownTime, &cool_time, pSpell->getSpellFamilyFlags());
+        spellModPercentageIntValue(SM_PCooldownTime, &cool_time, pSpell->getSpellFamilyFlags());
 
         _Cooldown_Add(COOLDOWN_TYPE_SPELL, spell_id, spell_recovery_t + mstime, spell_id, pItemCaster ? pItemCaster->getItemProperties()->ItemId : 0);
     }
@@ -12221,8 +12222,8 @@ void Player::Cooldown_AddStart(SpellInfo* pSpell)
     else
         atime = float2int32(pSpell->getStartRecoveryTime() * GetCastSpeedMod());
 
-    spellModFlatIntValue(SM_FGlobalCooldown, &atime, pSpell->getSpellGroupType());
-    spellModPercentageIntValue(SM_PGlobalCooldown, &atime, pSpell->getSpellGroupType());
+    spellModFlatIntValue(SM_FGlobalCooldown, &atime, pSpell->getSpellFamilyFlags());
+    spellModPercentageIntValue(SM_PGlobalCooldown, &atime, pSpell->getSpellFamilyFlags());
 
     if (atime < 0)
         return;
@@ -13427,7 +13428,7 @@ void Player::LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
                 }
             }
 
-            if (spellInfo->IsPassive() || ((spellInfo->getEffect(0) == SPELL_EFFECT_LEARN_SPELL ||
+            if (spellInfo->isPassive() || ((spellInfo->getEffect(0) == SPELL_EFFECT_LEARN_SPELL ||
                 spellInfo->getEffect(1) == SPELL_EFFECT_LEARN_SPELL ||
                 spellInfo->getEffect(2) == SPELL_EFFECT_LEARN_SPELL)
                 && ((spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET) == 0 || ((spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET) && GetSummon()))))
@@ -13604,12 +13605,12 @@ void Player::LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
             }
 
             int32 ss = getShapeShiftMask();
-            if (spellInfo->RequiredShapeShift == 0 || (ss & spellInfo->RequiredShapeShift) != 0)
+            if (spellInfo->getRequiredShapeShift() == 0 || (ss & spellInfo->getRequiredShapeShift()) != 0)
             {
-                if (spellInfo->IsPassive()
-                     || (spellInfo->Effect[0] == SPELL_EFFECT_LEARN_SPELL ||
-                         spellInfo->Effect[1] == SPELL_EFFECT_LEARN_SPELL ||
-                         spellInfo->Effect[2] == SPELL_EFFECT_LEARN_SPELL))
+                if (spellInfo->isPassive()
+                     || (spellInfo->getEffect(0) == SPELL_EFFECT_LEARN_SPELL ||
+                         spellInfo->getEffect(1) == SPELL_EFFECT_LEARN_SPELL ||
+                         spellInfo->getEffect(2) == SPELL_EFFECT_LEARN_SPELL))
                 {
                     Spell* sp = sSpellFactoryMgr.NewSpell(this, spellInfo, true, nullptr);
                     SpellCastTargets tgt;
@@ -15302,7 +15303,7 @@ void Player::CastSpellArea()
     {
         if (m_auras[i] != nullptr)
         {
-            if (m_auras[i]->GetSpellInfo()->CheckLocation(GetMapId(), ZoneId, AreaId, this) == false)
+            if (m_auras[i]->GetSpellInfo()->checkLocation(GetMapId(), ZoneId, AreaId, this) == false)
             {
                 SpellAreaMapBounds sab = sSpellFactoryMgr.GetSpellAreaMapBounds(m_auras[i]->GetSpellId());
                 if (sab.first != sab.second)

--- a/src/world/Units/Summons/TotemSummon.cpp
+++ b/src/world/Units/Summons/TotemSummon.cpp
@@ -140,11 +140,11 @@ void TotemSummon::SetupSpells()
     // Set up AI, depending on our spells.
     bool castingtotem = true;
 
-    if (TotemSpell->HasEffect(SPELL_EFFECT_SUMMON) ||
-        TotemSpell->HasEffect(SPELL_EFFECT_APPLY_GROUP_AREA_AURA) ||
-        TotemSpell->HasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||
-        TotemSpell->HasEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA) ||
-        (TotemSpell->HasEffect(SPELL_EFFECT_APPLY_AURA) && TotemSpell->appliesAreaAura(SPELL_AURA_PERIODIC_TRIGGER_SPELL)))
+    if (TotemSpell->hasEffect(SPELL_EFFECT_SUMMON) ||
+        TotemSpell->hasEffect(SPELL_EFFECT_APPLY_GROUP_AREA_AURA) ||
+        TotemSpell->hasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||
+        TotemSpell->hasEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA) ||
+        (TotemSpell->hasEffect(SPELL_EFFECT_APPLY_AURA) && TotemSpell->appliesAreaAura(SPELL_AURA_PERIODIC_TRIGGER_SPELL)))
         castingtotem = false;
 
     if (!castingtotem)
@@ -156,7 +156,7 @@ void TotemSummon::SetupSpells()
         Spell* pSpell = sSpellFactoryMgr.NewSpell(this, TotemSpell, true, 0);
         SpellCastTargets targets;
 
-        if (!TotemSpell->HasEffect(SPELL_AURA_PERIODIC_TRIGGER_SPELL))
+        if (!TotemSpell->hasEffect(SPELL_AURA_PERIODIC_TRIGGER_SPELL))
         {
             targets.setDestination(GetPosition());
             targets.m_targetMask = TARGET_FLAG_DEST_LOCATION;

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -1432,7 +1432,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
             }
         }
 
-        spellModFlatIntValue(SM_FChanceOfSuccess, (int32*)&proc_Chance, ospinfo->getSpellGroupType());
+        spellModFlatIntValue(SM_FChanceOfSuccess, (int32*)&proc_Chance, ospinfo->getSpellFamilyFlags());
         if (!Rand(proc_Chance))
             continue;
 
@@ -5892,7 +5892,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                     if (CastingSpell == NULL)
                         continue;
 
-                    switch (CastingSpell->GetAreaAuraEffectId())
+                    switch (CastingSpell->getAreaAuraEffect())
                     {
                         //SPELL_HASH_SHIELD_SLAM
                         case 8242:
@@ -6524,7 +6524,7 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellInfo* CastingSpell, bool
                         break;
                         case 14177: // Cold blood will get removed on offensive spell
                         {
-                            if (!(CastingSpell->getSpellGroupType(0) & 0x6820206 || CastingSpell->getSpellGroupType(1) & 0x240009))
+                            if (!(CastingSpell->getSpellFamilyFlags(0) & 0x6820206 || CastingSpell->getSpellFamilyFlags(1) & 0x240009))
                                 continue;
                         }
                         break;
@@ -7152,7 +7152,7 @@ uint32 Unit::GetSpellDidHitResult(Unit* pVictim, uint32 weapon_damage_type, Spel
 
     if (ability != nullptr)
     {
-        spellModFlatFloatValue(SM_FHitchance, &hitchance, ability->getSpellGroupType());
+        spellModFlatFloatValue(SM_FHitchance, &hitchance, ability->getSpellFamilyFlags());
     }
 
     if (ability && ability->getAttributes() & ATTRIBUTES_CANT_BE_DPB)
@@ -7477,8 +7477,8 @@ void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, 
 
     if (ability != nullptr)
     {
-        spellModFlatFloatValue(SM_CriticalChance, &crit, ability->getSpellGroupType());
-        spellModFlatFloatValue(SM_FHitchance, &hitchance, ability->getSpellGroupType());
+        spellModFlatFloatValue(SM_CriticalChance, &crit, ability->getSpellFamilyFlags());
+        spellModFlatFloatValue(SM_FHitchance, &hitchance, ability->getSpellFamilyFlags());
     }
 
     // by ratings
@@ -7725,7 +7725,7 @@ void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, 
                 else
                 {
                     if (weapon_damage_type == MELEE && ability)
-                        dmg.full_damage = CalculateDamage(this, pVictim, MELEE, ability->getSpellGroupType(), ability);
+                        dmg.full_damage = CalculateDamage(this, pVictim, MELEE, ability->getSpellFamilyFlags(), ability);
                     else
                         dmg.full_damage = CalculateDamage(this, pVictim, weapon_damage_type, 0, ability);
                 }
@@ -7904,7 +7904,7 @@ void Unit::Strike(Unit* pVictim, uint32 weapon_damage_type, SpellInfo* ability, 
                         if (ability != nullptr)
                         {
                             int32 dmg_bonus_pct = 100;
-                            spellModFlatIntValue(SM_PCriticalDamage, &dmg_bonus_pct, ability->getSpellGroupType());
+                            spellModFlatIntValue(SM_PCriticalDamage, &dmg_bonus_pct, ability->getSpellFamilyFlags());
                             dmgbonus = dmgbonus * dmg_bonus_pct / 100;
                         }
 
@@ -8554,8 +8554,8 @@ void Unit::AddAura(Aura* aur)
                 Unit* ucaster = aur->GetUnitCaster();
                 if (ucaster != nullptr)
                 {
-                    spellModFlatIntValue(ucaster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
-                    spellModPercentageIntValue(ucaster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
+                    spellModFlatIntValue(ucaster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
+                    spellModPercentageIntValue(ucaster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
                 }
                 maxStack = charges;
             }
@@ -9151,8 +9151,8 @@ void Unit::AddAura(Aura* aur)
                 Unit* ucaster = aur->GetUnitCaster();
                 if (ucaster != nullptr)
                 {
-                    spellModFlatIntValue(ucaster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
-                    spellModPercentageIntValue(ucaster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellGroupType());
+                    spellModFlatIntValue(ucaster->SM_FCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
+                    spellModPercentageIntValue(ucaster->SM_PCharges, &charges, aur->GetSpellInfo()->getSpellFamilyFlags());
                 }
                 maxStack = charges;
             }
@@ -9966,7 +9966,7 @@ int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg
                 if (caster->IsPlayer())
                 {
                     int32 durmod = 0;
-                    spellModFlatIntValue(caster->SM_FDur, &durmod, spellInfo->getSpellGroupType());
+                    spellModFlatIntValue(caster->SM_FDur, &durmod, spellInfo->getSpellFamilyFlags());
                     plus_damage += static_cast<float>(plus_damage * durmod / 15000);
                 }
             }
@@ -10115,12 +10115,12 @@ int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellInfo* spellInfo, int32 base_dmg
 
 
         int32 bonus_damage = 0;
-        spellModFlatIntValue(caster->SM_FPenalty, &bonus_damage, spellInfo->getSpellGroupType());
-        spellModFlatIntValue(caster->SM_FDamageBonus, &bonus_damage, spellInfo->getSpellGroupType());
+        spellModFlatIntValue(caster->SM_FPenalty, &bonus_damage, spellInfo->getSpellFamilyFlags());
+        spellModFlatIntValue(caster->SM_FDamageBonus, &bonus_damage, spellInfo->getSpellFamilyFlags());
 
         int32 dmg_bonus_pct = 0;
-        spellModFlatIntValue(caster->SM_PPenalty, &dmg_bonus_pct, spellInfo->getSpellGroupType());
-        spellModFlatIntValue(caster->SM_PDamageBonus, &dmg_bonus_pct, spellInfo->getSpellGroupType());
+        spellModFlatIntValue(caster->SM_PPenalty, &dmg_bonus_pct, spellInfo->getSpellFamilyFlags());
+        spellModFlatIntValue(caster->SM_PDamageBonus, &dmg_bonus_pct, spellInfo->getSpellFamilyFlags());
 
         plus_damage += static_cast<float>((base_dmg + bonus_damage) * dmg_bonus_pct / 100);
 
@@ -13878,7 +13878,7 @@ bool Unit::IsCriticalDamageForSpell(Object* victim, SpellInfo* spell)
                 CritChance += static_cast<float>(static_cast<Player*>(this)->m_RootedCritChanceBonus);
         }
 
-        spellModFlatFloatValue(SM_CriticalChance, &CritChance, spell->getSpellGroupType());
+        spellModFlatFloatValue(SM_CriticalChance, &CritChance, spell->getSpellFamilyFlags());
 
         if (victim->IsPlayer())
             resilience_type = PCR_SPELL_CRIT_RESILIENCE;
@@ -13966,7 +13966,7 @@ bool Unit::IsCriticalDamageForSpell(Object* victim, SpellInfo* spell)
 float Unit::GetCriticalDamageBonusForSpell(Object* victim, SpellInfo* spell, float amount)
 {
     int32 critical_bonus = 100;
-    spellModFlatIntValue(SM_PCriticalDamage, &critical_bonus, spell->getSpellGroupType());
+    spellModFlatIntValue(SM_PCriticalDamage, &critical_bonus, spell->getSpellFamilyFlags());
 
     if (critical_bonus > 0)
     {
@@ -14055,7 +14055,7 @@ bool Unit::IsCriticalHealForSpell(Object* victim, SpellInfo* spell)
         }
     }
 
-    spellModFlatIntValue(this->SM_CriticalChance, &crit_chance, spell->getSpellGroupType());
+    spellModFlatIntValue(this->SM_CriticalChance, &crit_chance, spell->getSpellFamilyFlags());
 
     return Rand(crit_chance);
 }
@@ -14063,7 +14063,7 @@ bool Unit::IsCriticalHealForSpell(Object* victim, SpellInfo* spell)
 float Unit::GetCriticalHealBonusForSpell(Object* /*victim*/, SpellInfo* spell, float amount)
 {
     int32 critical_bonus = 100;
-    spellModFlatIntValue(this->SM_PCriticalDamage, &critical_bonus, spell->getSpellGroupType());
+    spellModFlatIntValue(this->SM_PCriticalDamage, &critical_bonus, spell->getSpellFamilyFlags());
 
     if (critical_bonus > 0)
     {

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -1121,7 +1121,7 @@ bool Unit::hasAuraWithAuraEffect(AuraEffect type) const
     {
         if (m_auras[i] == nullptr)
             continue;
-        if (m_auras[i]->GetSpellInfo()->HasEffectApplyAuraName(type))
+        if (m_auras[i]->GetSpellInfo()->hasEffectApplyAuraName(type))
             return true;
     }
     return false;
@@ -1135,7 +1135,7 @@ bool Unit::hasAuraState(AuraState state, SpellInfo* spellInfo, Unit* caster) con
         {
             if (caster->m_auras[i] == nullptr)
                 continue;
-            if (!caster->m_auras[i]->GetSpellInfo()->HasEffectApplyAuraName(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
+            if (!caster->m_auras[i]->GetSpellInfo()->hasEffectApplyAuraName(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
                 continue;
             if (caster->m_auras[i]->GetSpellInfo()->isAffectingSpell(spellInfo))
                 return true;
@@ -1152,15 +1152,15 @@ void Unit::addAuraStateAndAuras(AuraState state)
         if (IsPlayer())
         {
             // Activate passive spells which require this aurastate
-            auto playerSpellMap = static_cast<Player*>(this)->mSpells;
+            const auto playerSpellMap = static_cast<Player*>(this)->mSpells;
             for (auto spellId : playerSpellMap)
             {
                 // Skip deleted spells, i.e. spells with lower rank than the current rank
                 auto deletedSpell = static_cast<Player*>(this)->mDeletedSpells.find(spellId);
                 if ((deletedSpell != static_cast<Player*>(this)->mDeletedSpells.end()))
                     continue;
-                SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
-                if (spellInfo == nullptr || !spellInfo->IsPassive())
+                SpellInfo const* spellInfo = sSpellCustomizations.GetSpellInfo(spellId);
+                if (spellInfo == nullptr || !spellInfo->isPassive())
                     continue;
                 if (spellInfo->getCasterAuraState() == uint32_t(state))
                     CastSpell(this, spellId, true);
@@ -1184,7 +1184,7 @@ void Unit::removeAuraStateAndAuras(AuraState state)
                 continue;
             if (m_auras[i]->GetSpellInfo()->getCasterAuraState() != uint32_t(state))
                 continue;
-            if (m_auras[i]->GetSpellInfo()->IsPassive() || state != AURASTATE_FLAG_ENRAGED)
+            if (m_auras[i]->GetSpellInfo()->isPassive() || state != AURASTATE_FLAG_ENRAGED)
                 RemoveAura(m_auras[i]);
         }
     }
@@ -1210,7 +1210,7 @@ Aura* Unit::getAuraWithAuraEffect(AuraEffect aura_effect)
     for (uint32_t i = MAX_TOTAL_AURAS_START; i < MAX_TOTAL_AURAS_END; ++i)
     {
         Aura* aura = m_auras[i];
-        if (aura != nullptr && aura->GetSpellInfo()->HasEffectApplyAuraName(aura_effect))
+        if (aura != nullptr && aura->GetSpellInfo()->hasEffectApplyAuraName(aura_effect))
             return aura;
     }
 


### PR DESCRIPTION
- Verify fields in spell related DBC files and remove unused fields from all versions (credits to CMaNGOS for classic DBC structure)
- Use same names for DBC fields between different versions to avoid '#if VERSION_STRING' checks in source
- Apply codestyle to SpellInfo class

SpellInfo class has all fields from Cataclysm DBC files initialized and assigned to null (see https://github.com/Appled/AscEmu/blob/d715b8ee06f3840add215b2dd5278a6f71dd652b/src/world/Spell/SpellInfo.cpp#L15). I could've only initialized and assigned the fields used by the selected expansion and skip rest, but this reduces '#if VERSION_STRING' checks in source as well. Only fields which exist in the chosen expansion are loaded though (see https://github.com/Appled/AscEmu/blob/d715b8ee06f3840add215b2dd5278a6f71dd652b/src/world/Spell/Customization/SpellCustomizations.cpp#L42).