### PR TITLE
Rewrite talent system

### DIFF
--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -4235,7 +4235,7 @@ class LuaUnit
     static int ResetAllTalents(lua_State* /*L*/, Unit* ptr)
     {
         TEST_PLAYER()
-            static_cast<Player*>(ptr)->Reset_Talents();
+            static_cast<Player*>(ptr)->Reset_AllTalents();
         return 0;
     }
 
@@ -5410,31 +5410,16 @@ class LuaUnit
     {
         TEST_PLAYER()
             Player* plr = static_cast<Player*>(ptr);
-        plr->Reset_Talents();
+        plr->resetTalents();
         return 0;
     }
 
     static int SetTalentPoints(lua_State* L, Unit* ptr)
     {
         TEST_PLAYER()
-#if VERSION_STRING != Cata
-#ifdef FT_DUAL_SPEC
-        uint32 spec = static_cast<uint32>(luaL_checkinteger(L, 1)); //0 or 1
-        uint32 points = static_cast<uint32>(luaL_checkinteger(L, 2));
-        static_cast<Player*>(ptr)->m_specs[spec].SetTP(points);
-        if (spec == static_cast<Player*>(ptr)->m_talentActiveSpec)
-            static_cast<Player*>(ptr)->setUInt32Value(PLAYER_CHARACTER_POINTS1, points);
-#else
-        uint32 spec = static_cast<uint32>(luaL_checkinteger(L, 1)); //0 or 1
-        uint32 points = static_cast<uint32>(luaL_checkinteger(L, 2));
-        static_cast<Player*>(ptr)->getActiveSpec().SetTP(points);
-        static_cast<Player*>(ptr)->setUInt32Value(PLAYER_CHARACTER_POINTS1, points);
-#endif
-
-        static_cast<Player*>(ptr)->smsg_TalentsInfo(false);
-#else
-            if (L != nullptr && ptr != nullptr) { return 0; }
-#endif
+        const auto forBothSpecs = CHECK_BOOL(L, 1);
+        const auto points = static_cast<uint32_t>(luaL_checkinteger(L, 2));
+        static_cast<Player*>(ptr)->setTalentPoints(points, forBothSpecs);
         return 0;
     }
 

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -1103,7 +1103,7 @@ bool ChatHandler::HandleCharResetTalentsCommand(const char* /*args*/, WorldSessi
     if (selected_player == nullptr)
         return true;
 
-    selected_player->Reset_Talents();
+    selected_player->resetTalents();
 
     if (selected_player != m_session->GetPlayer())
     {

--- a/src/world/GameCata/Handlers/SkillHandler.cpp
+++ b/src/world/GameCata/Handlers/SkillHandler.cpp
@@ -26,7 +26,8 @@ void WorldSession::HandleLearnTalentOpcode(WorldPacket& recv_data)
     recv_data >> talent_id;
     recv_data >> requested_rank;
 
-    _player->LearnTalent(talent_id, requested_rank);
+    _player->learnTalent(talent_id, requested_rank);
+    _player->smsg_TalentsInfo(false);
 }
 
 void WorldSession::HandleLearnPreviewTalentsOpcode(WorldPacket& recv_data)
@@ -45,7 +46,7 @@ void WorldSession::HandleLearnPreviewTalentsOpcode(WorldPacket& recv_data)
         recv_data >> talent_id;
         recv_data >> talent_rank;
 
-        _player->LearnTalent(talent_id, talent_rank, true);
+        _player->learnTalent(talent_id, talent_rank);
     }
 
     _player->smsg_TalentsInfo(false);
@@ -59,26 +60,26 @@ void WorldSession::HandleUnlearnTalents(WorldPacket& /*recvData*/)
 
     GetPlayer()->SetTalentResetTimes(GetPlayer()->GetTalentResetTimes() + 1);
     GetPlayer()->ModGold(-(int32_t)price);
-    GetPlayer()->Reset_Talents();
+    GetPlayer()->resetTalents();
 }
 
 void WorldSession::HandleUnlearnSkillOpcode(WorldPacket& recv_data)
 {
     uint32_t skill_line_id;
-    uint32_t points_remaining = _player->GetPrimaryProfessionPoints();
+    uint32_t points_remaining = _player->getFreePrimaryProfessionPoints();
 
     recv_data >> skill_line_id;
 
     _player->RemoveSpellsFromLine(skill_line_id);
     _player->_RemoveSkillLine(skill_line_id);
 
-    if (points_remaining == _player->GetPrimaryProfessionPoints())
+    if (points_remaining == _player->getFreePrimaryProfessionPoints())
     {
         auto skill_line = sSkillLineStore.LookupEntry(skill_line_id);
         if (!skill_line)
             return;
 
         if (skill_line->type == SKILL_TYPE_PROFESSION && points_remaining < 2)
-            _player->SetPrimaryProfessionPoints(points_remaining + 1);
+            _player->setFreePrimaryProfessionPoints(points_remaining + 1);
     }
 }

--- a/src/world/GameCata/Management/QuestMgr.Cata.cpp
+++ b/src/world/GameCata/Management/QuestMgr.Cata.cpp
@@ -345,7 +345,6 @@ void QuestMgr::BuildRequestItems(WorldPacket* data, QuestProperties const* qst, 
 void QuestMgr::BuildQuestComplete(Player* plr, QuestProperties const* qst)
 {
     uint32_t xp;
-    uint32_t currtalentpoints = plr->GetCurrentTalentPoints();
     uint32_t rewardtalents = qst->rewardtalents;
     uint32_t playerlevel = plr->getLevel();
 
@@ -359,9 +358,11 @@ void QuestMgr::BuildQuestComplete(Player* plr, QuestProperties const* qst)
         plr->GiveXP(xp, 0, false);
     }
 
-    if (currtalentpoints <= (playerlevel - 9 - rewardtalents))
+    // Bonus talents
+    if (rewardtalents > 0)
     {
-        plr->AddTalentPointsToAllSpec(rewardtalents);
+        plr->setTalentPointsFromQuests(plr->getTalentPointsFromQuests() + rewardtalents);
+        plr->setInitialTalentPoints();
     }
 
     // Reward title

--- a/src/world/GameCata/Storage/DBCStores.cpp
+++ b/src/world/GameCata/Storage/DBCStores.cpp
@@ -117,6 +117,7 @@ SERVER_DECL DBC::DBCStorage<DBC::Structures::MailTemplateEntry> sMailTemplateSto
 SERVER_DECL DBC::DBCStorage<DBC::Structures::WMOAreaTableEntry> sWMOAreaTableStore(DBC::Structures::wmo_area_table_format);
 SERVER_DECL DBC::DBCStorage<DBC::Structures::SummonPropertiesEntry> sSummonPropertiesStore(DBC::Structures::summon_properties_format);
 SERVER_DECL DBC::DBCStorage<DBC::Structures::NameGenEntry> sNameGenStore(DBC::Structures::name_gen_format);
+SERVER_DECL DBC::DBCStorage<DBC::Structures::NumTalentsAtLevel> sNumTalentsAtLevel(DBC::Structures::num_talents_at_level_format);
 SERVER_DECL DBC::DBCStorage<DBC::Structures::PhaseEntry> sPhaseStore(DBC::Structures::phase_entry_format);
 SERVER_DECL DBC::DBCStorage<DBC::Structures::LFGDungeonEntry> sLFGDungeonStore(DBC::Structures::lfg_dungeon_entry_format);
 SERVER_DECL DBC::DBCStorage<DBC::Structures::LiquidTypeEntry> sLiquidTypeStore(DBC::Structures::liquid_type_entry_format);
@@ -337,6 +338,7 @@ bool LoadDBCs()
     }
     DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sSummonPropertiesStore, dbc_path, "SummonProperties.dbc");
     DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sNameGenStore, dbc_path, "NameGen.dbc");
+    DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sNumTalentsAtLevel, dbc_path, "NumTalentsAtLevel.dbc");
     DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sPhaseStore, dbc_path, "Phase.dbc");
     DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sLFGDungeonStore, dbc_path, "LFGDungeons.dbc");
     DBC::LoadDBC(available_dbc_locales, bad_dbc_files, sLiquidTypeStore, dbc_path, "LiquidType.dbc");

--- a/src/world/GameCata/Storage/DBCStores.h
+++ b/src/world/GameCata/Storage/DBCStores.h
@@ -139,6 +139,7 @@ extern SERVER_DECL DBC::DBCStorage<DBC::Structures::MailTemplateEntry> sMailTemp
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::WMOAreaTableEntry> sWMOAreaTableStore;
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::SummonPropertiesEntry> sSummonPropertiesStore;
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::NameGenEntry> sNameGenStore;
+extern SERVER_DECL DBC::DBCStorage<DBC::Structures::NumTalentsAtLevel> sNumTalentsAtLevel;
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::PhaseEntry> sPhaseStore;
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::LFGDungeonEntry> sLFGDungeonStore;
 extern SERVER_DECL DBC::DBCStorage<DBC::Structures::LiquidTypeEntry> sLiquidTypeStore;

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -277,7 +277,7 @@ namespace DBC
             //char const mount_type_format[] = "niiiiiiiiiiiiiiiiiiiiiiii"; new
             //char const movie_entry_format[] = "nxxx"; new
             char const name_gen_format[] = "nsii";
-            //char const num_talents_at_level_format[] = "df"; new
+            char const num_talents_at_level_format[] = "df";
             //char const override_spell_data_format[] = "niiiiiiiiiixx"; new
             char const phase_entry_format[] = "nii";
             //char const power_display_format[] = "nixxxx"; new
@@ -1346,6 +1346,12 @@ namespace DBC
             char* Name;                         // 1
             uint32_t unk1;                      // 2
             uint32_t type;                      // 3
+        };
+
+        struct NumTalentsAtLevel
+        {
+            //uint32_t level;                   // 0
+            float talentPoints;                 // 1
         };
 
         struct PhaseEntry

--- a/src/world/Management/Gossip/Gossip.cpp
+++ b/src/world/Management/Gossip/Gossip.cpp
@@ -735,7 +735,6 @@ void Arcemu::Gossip::ClassTrainer::OnSelectOption(Object* pObject, Player* Plr, 
                 Gossip::Menu::Complete(Plr);
                 Plr->ModGold(-10000000);
                 Plr->m_talentSpecsCount = 2;
-                Plr->Reset_Talents();
                 Plr->CastSpell(Plr, 63624, true); // Show activate spec buttons
                 Plr->CastSpell(Plr, 63706, true); // Allow primary spec to be activated
                 Plr->CastSpell(Plr, 63707, true); // Allow secondary spec to be activated

--- a/src/world/Management/QuestMgr.cpp
+++ b/src/world/Management/QuestMgr.cpp
@@ -615,7 +615,6 @@ void QuestMgr::BuildRequestItems(WorldPacket* data, QuestProperties const* qst, 
 void QuestMgr::BuildQuestComplete(Player* plr, QuestProperties const* qst)
 {
     uint32 xp;
-    uint32 currtalentpoints = plr->GetCurrentTalentPoints();
     uint32 rewardtalents = qst->rewardtalents;
     uint32 playerlevel = plr->getLevel();
 
@@ -629,8 +628,12 @@ void QuestMgr::BuildQuestComplete(Player* plr, QuestProperties const* qst)
         plr->GiveXP(xp, 0, false);
     }
 
-    if (currtalentpoints <= (playerlevel - 9 - rewardtalents))
-        plr->AddTalentPointsToAllSpec(rewardtalents);
+    // Bonus talents
+    if (rewardtalents > 0)
+    {
+        plr->setTalentPointsFromQuests(plr->getTalentPointsFromQuests() + rewardtalents);
+        plr->setInitialTalentPoints();
+    }
 
     // Reward title
     if (qst->rewardtitleid > 0)

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -477,7 +477,7 @@ uint8_t WorldSession::trainerGetSpellStatus(TrainerSpell* trainerSpell)
         || (trainerSpell->RequiredSpell && !GetPlayer()->HasSpell(trainerSpell->RequiredSpell))
         || (trainerSpell->Cost && !GetPlayer()->HasGold(trainerSpell->Cost))
         || (trainerSpell->RequiredSkillLine && GetPlayer()->_GetSkillLineCurrent(trainerSpell->RequiredSkillLine, true) < trainerSpell->RequiredSkillLineValue)
-        || (trainerSpell->IsProfession && GetPlayer()->GetPrimaryProfessionPoints() == 0)
+        || (trainerSpell->IsProfession && GetPlayer()->getFreePrimaryProfessionPoints() == 0)
         )
         return TRAINER_STATUS_NOT_LEARNABLE;
     return TRAINER_STATUS_LEARNABLE;

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -860,7 +860,8 @@ void WorldSession::HandleLearnTalentOpcode(WorldPacket& recv_data)
     recv_data >> requested_rank;
     recv_data >> unk;
 
-    _player->LearnTalent(talent_id, requested_rank);
+    _player->learnTalent(talent_id, requested_rank);
+    _player->smsg_TalentsInfo(false);
 }
 
 void WorldSession::HandleUnlearnTalents(WorldPacket& /*recv_data*/)
@@ -872,7 +873,7 @@ void WorldSession::HandleUnlearnTalents(WorldPacket& /*recv_data*/)
 
     GetPlayer()->SetTalentResetTimes(GetPlayer()->GetTalentResetTimes() + 1);
     GetPlayer()->ModGold(-(int32)price);
-    GetPlayer()->Reset_Talents();
+    GetPlayer()->resetTalents();
 }
 
 void WorldSession::HandleUnlearnSkillOpcode(WorldPacket& recv_data)
@@ -880,7 +881,7 @@ void WorldSession::HandleUnlearnSkillOpcode(WorldPacket& recv_data)
     CHECK_INWORLD_RETURN
 
     uint32 skill_line_id;
-    uint32 points_remaining = _player->GetPrimaryProfessionPoints();
+    uint32 points_remaining = _player->getFreePrimaryProfessionPoints();
     recv_data >> skill_line_id;
 
     // Remove any spells within that line that the player has
@@ -891,7 +892,7 @@ void WorldSession::HandleUnlearnSkillOpcode(WorldPacket& recv_data)
 
     // added by Zack : This is probably wrong or already made elsewhere :
     // restore skill learnability
-    if (points_remaining == _player->GetPrimaryProfessionPoints())
+    if (points_remaining == _player->getFreePrimaryProfessionPoints())
     {
         // we unlearned a skill so we enable a new one to be learned
         auto skill_line = sSkillLineStore.LookupEntry(skill_line_id);
@@ -899,7 +900,7 @@ void WorldSession::HandleUnlearnSkillOpcode(WorldPacket& recv_data)
             return;
 
         if (skill_line->type == SKILL_TYPE_PROFESSION && points_remaining < 2)
-            _player->SetPrimaryProfessionPoints(points_remaining + 1);
+            _player->setFreePrimaryProfessionPoints(points_remaining + 1);
     }
 }
 
@@ -938,8 +939,10 @@ void WorldSession::HandleLearnMultipleTalentsOpcode(WorldPacket& recvPacket)
         recvPacket >> talentid;
         recvPacket >> rank;
 
-        _player->LearnTalent(talentid, rank, true);
+        _player->learnTalent(talentid, rank);
     }
+
+    _player->smsg_TalentsInfo(false);
 }
 #endif
 

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -54,30 +54,33 @@ SpellCastResult Spell::canCast(bool tolerate)
             }
         }
 
-        // Out of combat spells should not be able to be casted in combat
-        if (!m_triggeredSpell && requireCombat && (GetSpellInfo()->getAttributes() & ATTRIBUTES_REQ_OOC) && u_caster->CombatStatus.IsInCombat())
-            return SPELL_FAILED_AFFECTING_COMBAT;
-
-        // Caster's aura state requirements
-        if (GetSpellInfo()->getCasterAuraState() && !u_caster->hasAuraState(AuraState(GetSpellInfo()->getCasterAuraState()), GetSpellInfo(), u_caster))
-            return SPELL_FAILED_CASTER_AURASTATE;
-        if (GetSpellInfo()->getCasterAuraStateNot() && u_caster->hasAuraState(AuraState(GetSpellInfo()->getCasterAuraStateNot()), GetSpellInfo(), u_caster))
-            return SPELL_FAILED_CASTER_AURASTATE;
-
-        // Caster's aura spell requirements
-        if (GetSpellInfo()->getCasterAuraSpell() != 0 && !u_caster->HasAura(GetSpellInfo()->getCasterAuraSpell()))
-            return SPELL_FAILED_CASTER_AURASTATE;
-        if (GetSpellInfo()->getCasterAuraSpellNot() != 0)
+        if (!m_triggeredSpell)
         {
-            // TODO: I leave this here for now (from my old work), but this really should be moved to wotlk spellscript -Appled
-            // Paladin's Avenging Wrath / Forbearance thing
-            if (GetSpellInfo()->getCasterAuraSpellNot() == 61988)
+            // Out of combat spells should not be able to be casted in combat
+            if (requireCombat && (GetSpellInfo()->getAttributes() & ATTRIBUTES_REQ_OOC) && u_caster->CombatStatus.IsInCombat())
+                return SPELL_FAILED_AFFECTING_COMBAT;
+
+            // Caster's aura state requirements
+            if (GetSpellInfo()->getCasterAuraState() && !u_caster->hasAuraState(AuraState(GetSpellInfo()->getCasterAuraState()), GetSpellInfo(), u_caster))
+                return SPELL_FAILED_CASTER_AURASTATE;
+            if (GetSpellInfo()->getCasterAuraStateNot() && u_caster->hasAuraState(AuraState(GetSpellInfo()->getCasterAuraStateNot()), GetSpellInfo(), u_caster))
+                return SPELL_FAILED_CASTER_AURASTATE;
+
+            // Caster's aura spell requirements
+            if (GetSpellInfo()->getCasterAuraSpell() != 0 && !u_caster->HasAura(GetSpellInfo()->getCasterAuraSpell()))
+                return SPELL_FAILED_CASTER_AURASTATE;
+            if (GetSpellInfo()->getCasterAuraSpellNot() != 0)
             {
-                if (u_caster->HasAura(61987))
+                // TODO: I leave this here for now (from my old work), but this really should be moved to wotlk spellscript -Appled
+                // Paladin's Avenging Wrath / Forbearance thing
+                if (GetSpellInfo()->getCasterAuraSpellNot() == 61988)
+                {
+                    if (u_caster->HasAura(61987))
+                        return SPELL_FAILED_CASTER_AURASTATE;
+                }
+                else if (u_caster->HasAura(GetSpellInfo()->getCasterAuraSpellNot()))
                     return SPELL_FAILED_CASTER_AURASTATE;
             }
-            else if (u_caster->HasAura(GetSpellInfo()->getCasterAuraSpellNot()))
-                return SPELL_FAILED_CASTER_AURASTATE;
         }
     }
 

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -482,8 +482,16 @@ public:
     uint32_t getXp() const;
     void setXp(uint32_t xp);
 
-    uint32_t getNextLevelXp();
+    uint32_t getNextLevelXp() const;
     void setNextLevelXp(uint32_t xp);
+
+    uint32_t getFreeTalentPoints() const;
+#if VERSION_STRING != Cata
+    void setFreeTalentPoints(uint32_t points);
+#endif
+
+    uint32_t getFreePrimaryProfessionPoints() const;
+    void setFreePrimaryProfessionPoints(uint32_t points);
 
     void setAttackPowerMultiplier(float val);
     void setRangedAttackPowerMultiplier(float val);
@@ -527,18 +535,34 @@ public:
 
     void setInitialDisplayIds(uint8_t gender, uint8_t race);
 
-    //////////////////////////////////////////////////////////////////////////////////////////
-    // Spells
-    bool isSpellFitByClassAndRace(uint32_t spell_id);
-#if VERSION_STRING == Cata
-    uint32_t getFreePrimaryProfessionPoints() const { return getUInt32Value(PLAYER_CHARACTER_POINTS); }
-#endif
-    void updateAutoRepeatSpell();
     bool isTransferPending() const;
     void toggleAfk();
     void toggleDnd();
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Spells
+    bool isSpellFitByClassAndRace(uint32_t spell_id);
+    void updateAutoRepeatSpell();
+
     bool m_FirstCastAutoRepeat;
 
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Talents
+    void learnTalent(uint32_t talentId, uint32_t talentRank);
+    void removeTalent(uint32_t spellId);
+    void resetTalents();
+    void setTalentPoints(uint32_t talentPoints, bool forBothSpecs = true);
+    void addTalentPoints(uint32_t talentPoints, bool forBothSpecs = true);
+    void setInitialTalentPoints(bool talentsResetted = false);
+
+    uint32_t getTalentPointsFromQuests() const;
+    void setTalentPointsFromQuests(uint32_t talentPoints);
+    void smsg_TalentsInfo(bool SendPetTalents); // TODO: classic and tbc
+
+private:
+    uint32_t m_talentPointsFromQuests;
+
+public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Auction
     void sendAuctionCommandResult(Auction* auction, uint32_t Action, uint32_t ErrorCode, uint32_t bidError = 0);
@@ -952,7 +976,6 @@ public:
         bool HasSpell(uint32 spell);
         bool HasDeletedSpell(uint32 spell);
         void smsg_InitialSpells();
-        void smsg_TalentsInfo(bool SendPetTalents);
         void ActivateSpec(uint8 spec);
         void addSpell(uint32 spell_idy);
         void removeSpellByHashName(uint32 hash);
@@ -1369,7 +1392,6 @@ public:
         uint32 m_modblockvaluefromspells;
         void SendInitialLogonPackets();
         void Reset_Spells();
-        void Reset_Talents();
         void Reset_AllTalents();
         // Battlegrounds xD
         CBattleground* m_bg;
@@ -1720,85 +1742,12 @@ public:
         uint64 GetFarsightTarget() { return getUInt64Value(PLAYER_FARSIGHT); }
 
         //\todo fix this
-        void SetTalentPointsForAllSpec(uint32 amt)
-        {
-#ifdef FT_DUAL_SPEC
-            m_specs[0].SetTP(amt);
-            m_specs[1].SetTP(amt);
-#else
-            m_spec.SetTP(amt);
-#endif
-
-#if VERSION_STRING != Cata
-            setUInt32Value(PLAYER_CHARACTER_POINTS1, amt);
-#else
-            setUInt32Value(PLAYER_CHARACTER_POINTS, amt);
-#endif
-            smsg_TalentsInfo(false);
-        }
-
-        void AddTalentPointsToAllSpec(uint32 amt)
-        {
-#ifdef FT_DUAL_SPEC
-            m_specs[0].SetTP(m_specs[0].GetTP() + amt);
-            m_specs[1].SetTP(m_specs[1].GetTP() + amt);
-#else
-            m_spec.SetTP(m_spec.GetTP() + amt);
-#endif
-#if VERSION_STRING != Cata
-            setUInt32Value(PLAYER_CHARACTER_POINTS1, getUInt32Value(PLAYER_CHARACTER_POINTS1) + amt);
-#else
-            setUInt32Value(PLAYER_CHARACTER_POINTS, getUInt32Value(PLAYER_CHARACTER_POINTS) + amt);
-#endif
-            smsg_TalentsInfo(false);
-        }
-
-        void SetCurrentTalentPoints(uint32 points)
-        {
-            getActiveSpec().SetTP(points);
-#if VERSION_STRING != Cata
-            setUInt32Value(PLAYER_CHARACTER_POINTS1, points);
-#else
-            setUInt32Value(PLAYER_CHARACTER_POINTS, points);
-#endif
-            smsg_TalentsInfo(false);
-        }
-
-        uint32 GetCurrentTalentPoints()
-        {
-#if VERSION_STRING != Cata
-            uint32 points = getUInt32Value(PLAYER_CHARACTER_POINTS1);
-#else
-            uint32 points = getUInt32Value(PLAYER_CHARACTER_POINTS);
-#endif
-            Arcemu::Util::ArcemuAssert(points == getActiveSpec().GetTP());
-            return points;
-        }
-
-        //\todo fix this
-        void SetPrimaryProfessionPoints(uint32 amt)
-        {
-#if VERSION_STRING != Cata
-            setUInt32Value(PLAYER_CHARACTER_POINTS2, amt);
-#else
-            if (amt == 0) { return; }
-#endif
-        }
-        //\todo fix this
         void ModPrimaryProfessionPoints(int32 amt)
         {
 #if VERSION_STRING != Cata
             modUInt32Value(PLAYER_CHARACTER_POINTS2, amt);
 #else
             if (amt == 0) { return; }
-#endif
-        }
-        uint32 GetPrimaryProfessionPoints()
-        {
-#if VERSION_STRING != Cata
-            return getUInt32Value(PLAYER_CHARACTER_POINTS2);
-#else
-            return 0;
 #endif
         }
 
@@ -1934,21 +1883,6 @@ public:
         //
         //////////////////////////////////////////////////////////////////////////////////////////
         void HandleSpellLoot(uint32 itemid);
-
-
-        //////////////////////////////////////////////////////////////////////////////////////////
-        // void LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed)
-        // Teaches a talentspell to the Player and decreases the available talent points
-        //
-        // \param uint32 talentid     -   unique numeric identifier of the talent (index of talent.dbc)
-        // \param uint32 rank         -   rank of the talent
-        // \param bool isPreviewed     -   true if called from the preview system
-        //
-        // \return none
-        //
-        //////////////////////////////////////////////////////////////////////////////////////////
-        void LearnTalent(uint32 talentid, uint32 rank, bool isPreviewed = false);
-
 
         void DealDamage(Unit* pVictim, uint32 damage, uint32 targetEvent, uint32 unitEvent, uint32 spellId, bool no_remove_auras = false);
         void TakeDamage(Unit* pAttacker, uint32 damage, uint32 spellid, bool no_remove_auras = false);
@@ -2298,7 +2232,6 @@ public:
         uint8 m_talentActiveSpec;
 #if VERSION_STRING == Cata
         uint32 m_FirstTalentTreeLock;
-        uint32 CalcTalentPointsHaveSpent(uint32 spec);
 #endif
 
 #ifdef FT_DUAL_SPEC

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -1156,7 +1156,7 @@ bool Unit::hasAuraWithAuraEffect(AuraEffect type) const
     return false;
 }
 
-bool Unit::hasAuraState(AuraState state, SpellInfo* spellInfo, Unit* caster) const
+bool Unit::hasAuraState(AuraState state, SpellInfo const* spellInfo, Unit const* caster) const
 {
     if (caster != nullptr && spellInfo != nullptr && caster->hasAuraWithAuraEffect(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
     {

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -520,7 +520,7 @@ public:
     bool hasAurasWithId(uint32_t auraId);
     bool hasAurasWithId(uint32_t* auraId);
     bool hasAuraWithAuraEffect(AuraEffect type) const;
-    bool hasAuraState(AuraState state, SpellInfo *spellInfo = nullptr, Unit* caster = nullptr) const;
+    bool hasAuraState(AuraState state, SpellInfo const* spellInfo = nullptr, Unit const* caster = nullptr) const;
 
     void addAuraStateAndAuras(AuraState state);
     void removeAuraStateAndAuras(AuraState state);


### PR DESCRIPTION
- Death Knights have now their own formula to calculate talent points (Wotlk and Cataclysm)
- Fix talent point amount (Cataclysm)
- Correct glyph slots (Cataclysm)
- Aurastates should not be checked for triggered spells

Known bugs: Learning a talent on Cata freezes your client. I'm guessing there's something wrong with aura packets since everything was fine when passive spells were not added to player. Also mastery spells are still missing from Cata.
Closes https://github.com/AscEmu/AscEmu/issues/570 and https://github.com/AscEmu/AscEmu/issues/580