### PR TITLE
Rewrite stealth and invisibility

### DIFF
--- a/sql/world/updates/201809XX-XX_creature_properties.sql
+++ b/sql/world/updates/201809XX-XX_creature_properties.sql
@@ -1,0 +1,40 @@
+-- Invisibility_type column will be removed or changed in future because almost every invisibility type has its own passive aura
+
+-- Shaman's totem quest npcs (invisibility type 1)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='1';
+
+-- Shade of Jin'do npc (invisibility_type 2)
+-- Only npc with this type, add invisibility aura to the npc
+-- Spell id 24307, Shade of Jin'do Passive
+UPDATE `creature_properties` SET `invisibility_type`='0',`auras`='24307' WHERE `invisibility_type`='2';
+
+-- Quest npc invisibility (invisibility_type 4)
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='4';
+-- Multiple trigger npcs had incorrect invisibility type
+UPDATE `creature_properties` SET `invisibility_type`='15' WHERE `entry`
+IN ('17794', '17795', '18263', '18264','18782','20767','20809','22515');
+
+-- Dungeon Set 2 npcs (invisibility_type 5)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='5';
+
+-- "Pink"/drunk npcs, related to Brewfest (invisibility_type 6)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='6';
+
+-- Quest npc invisibility (invisibility_type 7)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='7';
+
+-- Quest npc invisibility (invisibility_type 8)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='8';
+
+-- Quest npc invisibility (invisibility_type 9)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='9';
+
+-- Quest npc invisibility (invisibility_type 10)
+-- These npcs have already correct aura set
+UPDATE `creature_properties` SET `invisibility_type`='0' WHERE `invisibility_type`='10';

--- a/src/scripts/Battlegrounds/ArathiBasin.cpp
+++ b/src/scripts/Battlegrounds/ArathiBasin.cpp
@@ -951,7 +951,7 @@ bool ArathiBasin::HookSlowLockOpen(GameObject* pGo, Player* pPlayer, Spell* /*pS
     if (cpid == AB_NUM_CONTROL_POINTS)
         return false;
 
-    if (pPlayer->IsStealth() || pPlayer->m_invisible)
+    if (pPlayer->isStealthed() || pPlayer->isInvisible())
         return false;
 
     AssaultControlPoint(pPlayer, cpid);

--- a/src/scripts/Battlegrounds/EyeOfTheStorm.cpp
+++ b/src/scripts/Battlegrounds/EyeOfTheStorm.cpp
@@ -664,7 +664,7 @@ void EyeOfTheStorm::UpdateCPs()
         for (const auto& itr : go->getInRangePlayersSet())
         {
             Player* plr = static_cast<Player*>(itr);
-            if (plr && plr->isAlive() && !(plr->IsStealth()) && !(plr->m_invisible) && !(plr->SchoolImmunityList[0]) && plr->GetDistance2dSq(go) <= EOTS_CAPTURE_DISTANCE)
+            if (plr && plr->isAlive() && !(plr->isStealthed()) && !plr->isInvisible() && !(plr->SchoolImmunityList[0]) && plr->GetDistance2dSq(go) <= EOTS_CAPTURE_DISTANCE)
             {
                 playercounts[plr->GetTeam()]++;
 

--- a/src/scripts/Battlegrounds/IsleOfConquest.cpp
+++ b/src/scripts/Battlegrounds/IsleOfConquest.cpp
@@ -725,7 +725,7 @@ bool IsleOfConquest::HookSlowLockOpen(GameObject* pGo, Player* pPlayer, Spell* /
     if (cpid == IOC_NUM_CONTROL_POINTS)
         return false;
 
-    if (pPlayer->IsStealth() || pPlayer->m_invisible)
+    if (pPlayer->isStealthed() || pPlayer->isInvisible())
         return false;
 
     AssaultControlPoint(pPlayer, cpid);

--- a/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
@@ -331,7 +331,7 @@ public:
             // Make him hidden
             case CN_ARUGAL:
             {
-                pCreature->SetInvisFlag(INVIS_FLAG_TOTAL);
+                pCreature->setVisible(false);
             }break;
             case CN_BLEAK_WORG:
             case CN_SLAVERING_WORG:
@@ -398,7 +398,7 @@ class ArugalAI : public CreatureAIScript
             {
                 case 0:
                 {
-                    getCreature()->SetInvisFlag(INVIS_FLAG_NORMAL);
+                    getCreature()->setVisible(true);
                     getCreature()->CastSpell(getCreature(), SPELL_ARUGAL_SPAWN, true);
                     ModifyAIUpdateEvent(5500);  // call every step after 5.5 seconds
                     if (Creature* pVincent = getNearestCreature(CN_DEATHSTALKER_VINCENT))
@@ -451,7 +451,7 @@ class ArugalAI : public CreatureAIScript
                 {
                     getCreature()->CastSpell(getCreature(), SPELL_ARUGAL_SPAWN, true);
                     SFK_Instance->SetLocaleInstanceData(0, INDEX_ARUGAL_INTRO, Finished);
-                    getCreature()->SetInvisFlag(INVIS_FLAG_TOTAL);
+                    getCreature()->setVisible(false);
                     RemoveAIUpdateEvent();
                 }break;
             }

--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -3323,16 +3323,7 @@ public:
     {
         if (!ptr) return 0;
         bool enabled = CHECK_BOOL(L, 1);
-        if (enabled)
-        {
-            ptr->m_invisFlag = INVIS_FLAG_TOTAL;
-            ptr->m_invisible = true;
-        }
-        else
-        {
-            ptr->m_invisFlag = INVIS_FLAG_NORMAL;
-            ptr->m_invisible = false;
-        }
+        // TODO: remove this
         return 0;
     }
 
@@ -3880,22 +3871,22 @@ public:
     static int SetStealth(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        uint32 stealthlevel = CHECK_ULONG(L, 1);
-        ptr->SetStealth(stealthlevel);
+        // TODO: remove this!
         return 0;
     }
 
     static int GetStealthLevel(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        lua_pushinteger(L, ptr->GetStealthLevel());
+        uint32_t stealthFlag = CHECK_ULONG(L, 1);
+        lua_pushinteger(L, ptr->getStealthLevel(StealthFlag(stealthFlag)));
         return 1;
     }
 
     static int IsStealthed(lua_State* L, Unit* ptr)
     {
         if (!ptr) return 0;
-        if (ptr->IsStealth())
+        if (ptr->isStealthed())
             lua_pushboolean(L, 1);
         else
             lua_pushboolean(L, 0);
@@ -3905,7 +3896,7 @@ public:
     static int RemoveStealth(lua_State* /*L*/, Unit* ptr)
     {
         if (!ptr) return 0;
-        ptr->RemoveStealth();
+        ptr->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
         return 0;
     }
 

--- a/src/world/Chat/Commands/MiscCommands.cpp
+++ b/src/world/Chat/Commands/MiscCommands.cpp
@@ -690,7 +690,6 @@ bool ChatHandler::HandleInvisibleCommand(const char* /*args*/, WorldSession* m_s
     if (selected_player->m_isGmInvisible)
     {
         selected_player->m_isGmInvisible = false;
-        selected_player->m_invisible = false;
         selected_player->bInvincible = false;
 
         selected_player->Social_TellFriendsOnline();
@@ -711,7 +710,6 @@ bool ChatHandler::HandleInvisibleCommand(const char* /*args*/, WorldSession* m_s
     else
     {
         selected_player->m_isGmInvisible = true;
-        selected_player->m_invisible = true;
         selected_player->bInvincible = true;
 
         selected_player->Social_TellFriendsOffline();

--- a/src/world/GameCata/Handlers/LootHandler.cpp
+++ b/src/world/GameCata/Handlers/LootHandler.cpp
@@ -354,14 +354,14 @@ void WorldSession::HandleLootOpcode(WorldPacket& recv_data)
     if (_player->IsDead())
         return;
 
-    if (_player->IsStealth())
-        _player->RemoveStealth();
+    if (_player->isStealthed())
+        _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
 
     if (_player->isCastingSpell())
         _player->interruptSpell();
 
-    if (_player->IsInvisible())
-        _player->RemoveInvisibility();
+    if (_player->isInvisible())
+        _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
 
 
     if (_player->InGroup() && !_player->m_bg)

--- a/src/world/Map/MapMgr.cpp
+++ b/src/world/Map/MapMgr.cpp
@@ -766,7 +766,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
                 {
                     plObj2 = static_cast<Player*>(curObj);
 
-                    if (plObj2->CanSee(obj) && !plObj2->IsVisible(obj->getGuid()))
+                    if (plObj2->canSee(obj) && !plObj2->IsVisible(obj->getGuid()))
                     {
                         CHECK_BUF;
                         count = obj->buildCreateUpdateBlockForPlayer(*buf, plObj2);
@@ -779,7 +779,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
                 {
                     plObj2 = static_cast<Unit*>(curObj)->mPlayerControler;
 
-                    if (plObj2->CanSee(obj) && !plObj2->IsVisible(obj->getGuid()))
+                    if (plObj2->canSee(obj) && !plObj2->IsVisible(obj->getGuid()))
                     {
                         CHECK_BUF;
                         count = obj->buildCreateUpdateBlockForPlayer(*buf, plObj2);
@@ -791,7 +791,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
 
                 if (plObj != nullptr)
                 {
-                    if (plObj->CanSee(curObj) && !plObj->IsVisible(curObj->getGuid()))
+                    if (plObj->canSee(curObj) && !plObj->IsVisible(curObj->getGuid()))
                     {
                         CHECK_BUF;
                         count = curObj->buildCreateUpdateBlockForPlayer(*buf, plObj);
@@ -807,7 +807,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
                 if (curObj->isPlayer())
                 {
                     plObj2 = static_cast<Player*>(curObj);
-                    cansee = plObj2->CanSee(obj);
+                    cansee = plObj2->canSee(obj);
                     isvisible = plObj2->IsVisible(obj->getGuid());
                     if (!cansee && isvisible)
                     {
@@ -826,7 +826,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
                 else if (curObj->isCreatureOrPlayer() && static_cast<Unit*>(curObj)->mPlayerControler != nullptr)
                 {
                     plObj2 = static_cast<Unit*>(curObj)->mPlayerControler;
-                    cansee = plObj2->CanSee(obj);
+                    cansee = plObj2->canSee(obj);
                     isvisible = plObj2->IsVisible(obj->getGuid());
                     if (!cansee && isvisible)
                     {
@@ -845,7 +845,7 @@ void MapMgr::UpdateInRangeSet(Object* obj, Player* plObj, MapCell* cell, ByteBuf
 
                 if (plObj != nullptr)
                 {
-                    cansee = plObj->CanSee(curObj);
+                    cansee = plObj->canSee(curObj);
                     isvisible = plObj->IsVisible(curObj->getGuid());
                     if (!cansee && isvisible)
                     {
@@ -1216,7 +1216,7 @@ void MapMgr::ChangeFarsightLocation(Player* plr, DynamicObject* farsight)
         // We're clearing.
         for (ObjectSet::iterator itr = plr->m_visibleFarsightObjects.begin(); itr != plr->m_visibleFarsightObjects.end(); ++itr)
         {
-            if (plr->IsVisible((*itr)->getGuid()) && !plr->CanSee((*itr)))
+            if (plr->IsVisible((*itr)->getGuid()) && !plr->canSee((*itr)))
             {
                 plr->PushOutOfRange((*itr)->GetNewGUID());      // Send destroy
             }
@@ -1245,7 +1245,7 @@ void MapMgr::ChangeFarsightLocation(Player* plr, DynamicObject* farsight)
                         if (obj == nullptr)
                             continue;
 
-                        if (!plr->IsVisible(obj->getGuid()) && plr->CanSee(obj) && farsight->GetDistance2dSq(obj) <= m_UpdateDistance)
+                        if (!plr->IsVisible(obj->getGuid()) && plr->canSee(obj) && farsight->GetDistance2dSq(obj) <= m_UpdateDistance)
                         {
                             ByteBuffer buf;
                             uint32 count = obj->buildCreateUpdateBlockForPlayer(&buf, plr);

--- a/src/world/Objects/Faction.cpp
+++ b/src/world/Objects/Faction.cpp
@@ -159,7 +159,7 @@ SERVER_DECL bool isAttackable(Object* objA, Object* objB, bool CheckStealth)
         /// we cannot attack shealthed units. Maybe checked in other places too ?
         /// !! warning, this presumes that objA is attacking ObjB
         /// Capt: Added the possibility to disregard this (regarding the spell class)
-        if (static_cast< Unit* >(objB)->IsStealth() && CheckStealth)
+        if (static_cast< Unit* >(objB)->isStealthed() && CheckStealth)
             return false;
     }
 

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -162,7 +162,9 @@ GameObject::GameObject(uint64 guid)
     setScale(1);
     m_summonedGo = false;
     invisible = false;
+    inStealth = false;
     invisibilityFlag = INVIS_FLAG_NORMAL;
+    stealthFlag = STEALTH_FLAG_NORMAL;
     m_summoner = NULL;
     charges = -1;
     gameobject_properties = nullptr;
@@ -894,6 +896,12 @@ void GameObject_Trap::InitAI()
     charges = gameobject_properties->trap.charges;
 
     if (gameobject_properties->trap.stealthed != 0)
+    {
+        inStealth = true;
+        stealthFlag = STEALTH_FLAG_TRAP;
+    }
+
+    if (gameobject_properties->trap.invisible != 0)
     {
         invisible = true;
         invisibilityFlag = INVIS_FLAG_TRAP;

--- a/src/world/Objects/GameObject.h
+++ b/src/world/Objects/GameObject.h
@@ -144,7 +144,7 @@ struct GameObjectProperties
             uint32 server_only;                 // parameter_8
             uint32 stealthed;                   // parameter_9
             uint32 large;                       // parameter_10
-            uint32 stealth_affected;            // parameter_11
+            uint32 invisible;                   // parameter_11 not same as parameter_9
             uint32 open_text_id;                // parameter_12
             uint32 close_text_id;               // parameter_13
             uint32 ignore_totems;               // parameter_14
@@ -428,6 +428,12 @@ public:
     bool isQuestGiver() const;
     bool isFishingNode() const;
 
+    // Trap objects
+    bool invisible;
+    bool inStealth;
+    uint8_t invisibilityFlag;
+    uint8_t stealthFlag;
+
     // MIT End
 
         GameObject(uint64 guid);
@@ -476,8 +482,6 @@ public:
 
         virtual void InitAI();
 
-        bool invisible;     // invisible
-        uint8 invisibilityFlag;
         Unit* m_summoner;
 
         void CallScriptUpdate();

--- a/src/world/Server/Packets/Handlers/MiscHandler.Legacy.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.Legacy.cpp
@@ -444,13 +444,13 @@ void WorldSession::HandleLootOpcode(WorldPacket& recv_data)
     if (_player->IsDead())    // If the player is dead they can't loot!
         return;
 
-    if (_player->IsStealth())    // Check if the player is stealthed
-        _player->RemoveStealth(); // cebernic:RemoveStealth on looting. Blizzlike
+    if (_player->isStealthed())    // Check if the player is stealthed
+        _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH); // cebernic:RemoveStealth on looting. Blizzlike
 
     _player->interruptSpell(); // Cancel spell casting (no need to check is casting, the function does it)
 
-    if (_player->IsInvisible())    // Check if the player is invisible for what ever reason
-        _player->RemoveInvisibility(); // Remove all invisibility
+    if (_player->isInvisible())    // Check if the player is invisible for what ever reason
+        _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY); // Remove all invisibility
 
 
     if (_player->InGroup() && !_player->m_bg)
@@ -1227,7 +1227,7 @@ void WorldSession::HandleGameObjectUse(WorldPacket& recv_data)
     CALL_GO_SCRIPT_EVENT(obj, OnActivate)(_player);
     CALL_INSTANCE_SCRIPT_EVENT(_player->GetMapMgr(), OnGameObjectActivate)(obj, _player);
 
-    _player->RemoveStealth(); // cebernic:RemoveStealth due to GO was using. Blizzlike
+    _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH); // cebernic:RemoveStealth due to GO was using. Blizzlike
 
     SpellCastTargets targets;
     Spell* spell = nullptr;

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -252,7 +252,7 @@ void WorldSession::handleGossipHelloOpcode(WorldPacket& recvPacket)
         if (creature->GetAIInterface())
             creature->GetAIInterface()->StopMovement(30000);
 
-        if (GetPlayer()->IsStealth())
+        if (GetPlayer()->isStealthed())
             GetPlayer()->RemoveAllAuraType(SPELL_AURA_MOD_STEALTH);
 
         GetPlayer()->Reputation_OnTalk(creature->m_factionEntry);

--- a/src/world/Spell/Definitions/AuraEffects.h
+++ b/src/world/Spell/Definitions/AuraEffects.h
@@ -24,7 +24,7 @@ enum AuraEffect
     SPELL_AURA_MOD_DAMAGE_TAKEN = 14,                                   // Mod Damage Taken
     SPELL_AURA_DAMAGE_SHIELD = 15,                                      // Damage Shield
     SPELL_AURA_MOD_STEALTH = 16,                                        // Mod Stealth
-    SPELL_AURA_MOD_DETECT = 17,                                         // Mod Detect
+    SPELL_AURA_MOD_STEALTH_DETECTION = 17,                              // Mod Stealth Detection
     SPELL_AURA_MOD_INVISIBILITY = 18,                                   // Mod Invisibility
     SPELL_AURA_MOD_INVISIBILITY_DETECTION = 19,                         // Mod Invisibility Detection
     SPELL_AURA_MOD_TOTAL_HEALTH_REGEN_PCT = 20,
@@ -215,6 +215,7 @@ enum AuraEffect
     SPELL_AURA_HEALING_STAT_PCT = 220,
     SPELL_AURA_PERIODIC_TRIGGER_DUMMY = 226,
     SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE = 227,                 // Used by Mind Flay etc
+    SPELL_AURA_DETECT_STEALTH = 228,
     SPELL_AURA_REDUCE_AOE_DAMAGE_TAKEN = 229,
     SPELL_AURA_INCREASE_MAX_HEALTH = 230,                               //Used by Commanding Shout
     SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE = 231,

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -960,14 +960,13 @@ uint8 Spell::prepare(SpellCastTargets* targets)
     }
     else
     {
-        if (p_caster != nullptr && p_caster->IsStealth() && !hasAttributeEx(ATTRIBUTESEX_NOT_BREAK_STEALTH) && m_spellInfo->getId() != 1)   // <-- baaaad, baaad hackfix - for some reason some spells were triggering Spell ID #1 and stuffing up the spell system.
+        if (p_caster != nullptr && p_caster->isStealthed() && !hasAttributeEx(ATTRIBUTESEX_NOT_BREAK_STEALTH) && m_spellInfo->getId() != 1)   // <-- baaaad, baaad hackfix - for some reason some spells were triggering Spell ID #1 and stuffing up the spell system.
         {
             /* talents procing - don't remove stealth either */
             if (!hasAttribute(ATTRIBUTES_PASSIVE) &&
                 !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->isPassive()))
             {
-                p_caster->RemoveAura(p_caster->m_stealth);
-                p_caster->m_stealth = 0;
+                p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
             }
         }
 
@@ -1338,14 +1337,13 @@ void Spell::castMe(bool check)
                 }
             }
 
-            if (p_caster->IsStealth() && !hasAttributeEx(ATTRIBUTESEX_NOT_BREAK_STEALTH)
+            if (p_caster->isStealthed() && !hasAttributeEx(ATTRIBUTESEX_NOT_BREAK_STEALTH)
                 && GetSpellInfo()->getId() != 1)  //check spells that get trigger spell 1 after spell loading
             {
                 /* talents procing - don't remove stealth either */
                 if (!hasAttribute(ATTRIBUTES_PASSIVE) && !(pSpellId && sSpellCustomizations.GetSpellInfo(pSpellId)->isPassive()))
                 {
-                    p_caster->RemoveAura(p_caster->m_stealth);
-                    p_caster->m_stealth = 0;
+                    p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
                 }
             }
 
@@ -1360,8 +1358,8 @@ void Spell::castMe(bool check)
                     case 21651:
                     {
                         // Arathi Basin opening spell, remove stealth, invisibility, etc.
-                        p_caster->RemoveStealth();
-                        p_caster->RemoveInvisibility();
+                        p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
+                        p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
 
                         uint32 divineShield[] =
                         {
@@ -1399,8 +1397,8 @@ void Spell::castMe(bool check)
                     case 34976:
                     {
                         // if we're picking up the flag remove the buffs
-                        p_caster->RemoveStealth();
-                        p_caster->RemoveInvisibility();
+                        p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
+                        p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
 
                         uint32 divineShield[] =
                         {
@@ -1879,7 +1877,7 @@ void Spell::finish(bool successful)
         if (!sEventMgr.HasEvent(u_caster, EVENT_CREATURE_RESPAWN))
         {
             // call script
-            Unit* target = u_caster->GetMapMgr()->GetUnit(u_caster->getTargetGuid());
+            Unit* target = u_caster->GetMapMgrUnit(u_caster->getTargetGuid());
             if (target != nullptr)
             {
                 if (target->isCreature())
@@ -4045,7 +4043,7 @@ uint8 Spell::CanCast(bool tolerate)
             // instance & stealth checks
             if (p_caster->GetMapMgr() && p_caster->GetMapMgr()->GetMapInfo() && p_caster->GetMapMgr()->GetMapInfo()->type != INSTANCE_NULL)
                 return SPELL_FAILED_NO_DUELING;
-            if (p_caster->IsStealth())
+            if (p_caster->isStealthed())
                 return SPELL_FAILED_CANT_DUEL_WHILE_STEALTHED;
         }
 

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -213,7 +213,7 @@ class SERVER_DECL Aura : public EventableObject
         void SpellAuraModDamageTaken(bool apply);
         void SpellAuraDamageShield(bool apply);
         void SpellAuraModStealth(bool apply);
-        void SpellAuraModDetect(bool apply);
+        void SpellAuraModStealthDetection(bool apply);
         void SpellAuraModInvisibility(bool apply);
         void SpellAuraModInvisibilityDetection(bool apply);
         void SpellAuraModTotalHealthRegenPct(bool apply);
@@ -373,7 +373,7 @@ class SERVER_DECL Aura : public EventableObject
         void SpellAuraIncreaseRating(bool apply);
         void SpellAuraRegenManaStatPCT(bool apply);
         void SpellAuraSpellHealingStatPCT(bool apply);
-        void SpellAuraModStealthDetection(bool apply);
+        void SpellAuraDetectStealth(bool apply);
         void SpellAuraReduceAOEDamageTaken(bool apply);
         void SpellAuraIncreaseMaxHealth(bool apply);
         void SpellAuraSpiritOfRedemption(bool apply);

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -4918,7 +4918,7 @@ void Spell::SpellEffectDuel(uint8_t /*effectIndex*/) // Duel
     if (!p_caster || !p_caster->isAlive())
         return;
 
-    if (p_caster->IsStealth())
+    if (p_caster->isStealthed())
     {
         SendCastResult(SPELL_FAILED_CANT_DUEL_WHILE_STEALTHED);
         return; // Player is stealth

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -1676,10 +1676,7 @@ void AIInterface::_UpdateCombat(uint32 /*p_time*/)
     {
         if (getNextTarget()->event_GetCurrentInstanceId() == m_Unit->event_GetCurrentInstanceId())
         {
-            if (m_Unit->isCreature())
-                cansee = static_cast< Creature* >(m_Unit)->CanSee(getNextTarget());
-            else
-                cansee = static_cast< Player* >(m_Unit)->CanSee(getNextTarget());
+            cansee = m_Unit->canSee(getNextTarget());
         }
         else
         {
@@ -2289,7 +2286,7 @@ Unit* AIInterface::FindTarget()
             if (tmpPlr->hasUnitFlags(UNIT_FLAG_IGNORE_PLAYER_COMBAT))
                 continue;
 
-            if (tmpPlr->m_invisible)
+            if (tmpPlr->hasAuraWithAuraEffect(SPELL_AURA_MOD_INVISIBILITY))
                 continue;
 
             if (!tmpPlr->hasPlayerFlags(PLAYER_FLAG_PVP_GUARD_ATTACKABLE))    //PvP Guard Attackable.
@@ -2645,7 +2642,7 @@ float AIInterface::_CalcAggroRange(Unit* target)
         lvlDiff = -8;
     }
 
-    if (!static_cast<Creature*>(m_Unit)->CanSee(target))
+    if (!static_cast<Creature*>(m_Unit)->canSee(target))
         return 0;
 
     // Retrieve aggrorange from table
@@ -5002,11 +4999,10 @@ void AIInterface::SetCreatureProtoDifficulty(uint32 entry)
             m_Unit->m_aiInterface->UpdateSpeeds(); // use speed from creature_proto_difficulty.
 
             //invisibility
-            m_Unit->m_invisFlag = static_cast<uint8>(properties_difficulty->invisibility_type);
-            if (m_Unit->m_invisFlag > 0)
-                m_Unit->m_invisible = true;
-            else
-                m_Unit->m_invisible = false;
+            if (properties_difficulty->invisibility_type > INVIS_FLAG_NORMAL)
+                // TODO: currently only invisibility type 15 is used for invisible trigger NPCs
+                // these are always invisible to players
+                m_Unit->modInvisibilityLevel(InvisibilityFlag(properties_difficulty->invisibility_type), 1);
 
             if (m_Unit->isVehicle())
             {

--- a/src/world/Units/Creatures/Creature.h
+++ b/src/world/Units/Creatures/Creature.h
@@ -205,9 +205,6 @@ public:
         void RegenerateMana();
         int BaseAttackType;
 
-        // Invisibility & Stealth Detection - Partha
-        bool CanSee(Unit* obj);
-
         // Looting
         void generateLoot();
         bool HasLootForPlayer(Player* plr);

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -1358,10 +1358,9 @@ void Player::_EventAttack(bool offhand)
             }
         }
 
-        if (this->IsStealth())
+        if (this->isStealthed())
         {
-            RemoveAura(m_stealth);
-            SetStealth(0);
+            removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
         }
 
         if ((GetOnMeleeSpell() == 0) || offhand)
@@ -6599,195 +6598,6 @@ void Player::ApplyPlayerRestState(bool apply)
     UpdateRestState();
 }
 
-#define CORPSE_VIEW_DISTANCE 1600 // 40*40
-
-bool Player::CanSee(Object* obj) // * Invisibility & Stealth Detection - Partha *
-{
-    if (obj == this)
-        return true;
-
-    uint32 object_type = obj->getObjectTypeId();
-
-    if (getDeathState() == CORPSE) // we are dead and we have released our spirit
-    {
-        if (obj->isPlayer())
-        {
-            Player* pObj = static_cast< Player* >(obj);
-
-            if (myCorpseInstanceId == GetInstanceID() && obj->getDistanceSq(myCorpseLocation) <= CORPSE_VIEW_DISTANCE)
-                return !pObj->m_isGmInvisible; // we can see all players within range of our corpse except invisible GMs
-
-            if (m_deathVision) // if we have arena death-vision we can see all players except invisible GMs
-                return !pObj->m_isGmInvisible;
-
-            return (pObj->getDeathState() == CORPSE); // we can only see players that are spirits
-        }
-
-        if (myCorpseInstanceId == GetInstanceID())
-        {
-            if (obj->isCorpse() && static_cast< Corpse* >(obj)->getOwnerGuid() == getGuid())
-                return true;
-
-            if (obj->getDistanceSq(myCorpseLocation) <= CORPSE_VIEW_DISTANCE)
-                return true; // we can see everything within range of our corpse
-        }
-
-        if (m_deathVision) // if we have arena death-vision we can see everything
-            return true;
-
-        if (obj->isCreature() && static_cast<Creature*>(obj)->isSpiritHealer())
-            return true; // we can see spirit healers
-
-        return false;
-    }
-    //------------------------------------------------------------------
-
-    if (!(m_phase & obj->m_phase))  //What you can't see, you can't see, no need to check things further.
-        return false;
-
-    switch (object_type) // we are alive or we haven't released our spirit yet
-    {
-        case TYPEID_PLAYER:
-        {
-            Player* pObj = static_cast< Player* >(obj);
-
-            if (pObj->m_invisible) // Invisibility - Detection of Players
-            {
-                if (pObj->getDeathState() == CORPSE)
-                    return (hasPlayerFlags(PLAYER_FLAG_GM) != 0); // only GM can see players that are spirits
-
-                if (GetGroup() && pObj->GetGroup() == GetGroup() // can see invisible group members except when dueling them
-                    && DuelingWith != pObj)
-                    return true;
-
-                if (pObj->stalkedby == getGuid()) // Hunter's Mark / MindVision is visible to the caster
-                    return true;
-
-                if (m_invisDetect[INVIS_FLAG_NORMAL] < 1 // can't see invisible without proper detection
-                    || pObj->m_isGmInvisible) // can't see invisible GM
-                    return (hasPlayerFlags(PLAYER_FLAG_GM) != 0); // GM can see invisible players
-            }
-
-            if (m_invisible && pObj->m_invisDetect[m_invisFlag] < 1)   // Invisible - can see those that detect, but not others
-                return m_isGmInvisible;
-
-            if (pObj->IsStealth()) // Stealth Detection (I Hate Rogues :P)
-            {
-                if (GetGroup() && pObj->GetGroup() == GetGroup() // can see stealthed group members except when dueling them
-                    && DuelingWith != pObj)
-                    return true;
-
-                if (pObj->stalkedby == getGuid()) // Hunter's Mark / MindVision is visible to the caster
-                    return true;
-
-                if (isInFront(pObj)) // stealthed player is in front of us
-                {
-                    // Detection Range = 5yds + (Detection Skill - Stealth Skill)/5
-                    detectRange = 5.0f + getLevel() + 0.2f * (float)(GetStealthDetectBonus() - pObj->GetStealthLevel());
-
-                    // Hehe... stealth skill is increased by 5 each level and detection skill is increased by 5 each level too.
-                    // This way, a level 70 should easily be able to detect a level 4 rogue (level 4 because that's when you get stealth)
-                    //    detectRange += 0.2f * (getLevel() - pObj->getLevel());
-                    if (detectRange < 1.0f)
-                        detectRange = 1.0f;     // Minimum Detection Range = 1yd
-                }
-                else // stealthed player is behind us
-                {
-                    if (GetStealthDetectBonus() > 1000)
-                        return true;            // immune to stealth
-                    else
-                        detectRange = 0.0f;
-                }
-
-                detectRange += getBoundingRadius(); // adjust range for size of player
-                detectRange += pObj->getBoundingRadius(); // adjust range for size of stealthed player
-                //LogDefault("Player::CanSee(%s): detect range = %f yards (%f ingame units), cansee = %s , distance = %f" , pObj->GetName() , detectRange , detectRange * detectRange , (GetDistance2dSq(pObj) > detectRange * detectRange) ? "yes" : "no" , getDistanceSq(pObj));
-                if (getDistanceSq(pObj) > detectRange * detectRange)
-                    return (hasPlayerFlags(PLAYER_FLAG_GM) != 0); // GM can see stealthed players
-            }
-
-            return !pObj->m_isGmInvisible;
-        }
-        //------------------------------------------------------------------
-
-        case TYPEID_UNIT:
-        {
-            Unit* uObj = static_cast< Unit* >(obj);
-
-            // can't see spirit-healers when alive
-            if (uObj->isCreature() && static_cast<Creature*>(uObj)->isSpiritHealer())
-                return false;
-
-            // always see our units
-            if (getGuid() == uObj->getCreatedByGuid())
-                return true;
-
-            // unit is invisible
-            if (uObj->m_invisible)
-            {
-                // gms can see invisible units
-                /// \todo is invis detection missing here?
-                if (hasPlayerFlags(PLAYER_FLAG_GM))
-                    return true;
-                else
-                    return false;
-            }
-
-            if (uObj->GetAIInterface()->faction_visibility == 1)
-                if (IsTeamHorde())
-                    return true;
-                else
-                    return false;
-
-            if (uObj->GetAIInterface()->faction_visibility == 2)
-                if (IsTeamHorde())
-                    return false;
-                else
-                    return true;
-
-
-            /*if (uObj->m_invisible  // Invisibility - Detection of Units
-                && m_invisDetect[uObj->m_invisFlag] < 1) // can't see invisible without proper detection
-                return (hasPlayerFlags(PLAYER_FLAG_GM) != 0); // GM can see invisible units
-
-            if (m_invisible && uObj->m_invisDetect[m_invisFlag] < 1)   // Invisible - can see those that detect, but not others
-                return m_isGmInvisible;*/
-
-            return true;
-        }
-        //------------------------------------------------------------------
-
-        case TYPEID_GAMEOBJECT:
-        {
-            GameObject* gObj = static_cast< GameObject* >(obj);
-
-            if (gObj->invisible) // Invisibility - Detection of GameObjects
-            {
-                uint64 owner = gObj->getCreatedByGuid();
-
-                if (getGuid() == owner) // the owner of an object can always see it
-                    return true;
-
-                if (GetGroup())
-                {
-                    PlayerInfo* inf = objmgr.GetPlayerInfo((uint32)owner);
-                    if (inf && GetGroup()->HasMember(inf))
-                        return true;
-                }
-
-                if (m_invisDetect[gObj->invisibilityFlag] < 1) // can't see invisible without proper detection
-                    return (hasPlayerFlags(PLAYER_FLAG_GM) != 0); // GM can see invisible objects
-            }
-
-            return true;
-        }
-        //------------------------------------------------------------------
-
-        default:
-            return true;
-    }
-}
-
 void Player::addToInRangeObjects(Object* pObj)
 {
     //Send taxi move if we're on a taxi
@@ -6915,9 +6725,9 @@ void Player::SetDrunkValue(uint16 newDrunkenValue, uint32 itemId)
 
     // special drunk invisibility detection
     if (newDrunkenState >= DRUNKEN_DRUNK)
-        m_invisDetect[INVIS_FLAG_UNKNOWN6] = 100;
+        modInvisibilityDetection(INVIS_FLAG_DRUNK, 100);
     else
-        m_invisDetect[INVIS_FLAG_UNKNOWN6] = 0;
+        modInvisibilityDetection(INVIS_FLAG_DRUNK, -getInvisibilityDetection(INVIS_FLAG_DRUNK));
 
     UpdateVisibility();
 

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -1267,3 +1267,8 @@ void Player::delayMeleeAttackTimer(int32_t delay)
     setAttackTimer(MELEE, getAttackTimer(MELEE) + delay);
     setAttackTimer(OFFHAND, getAttackTimer(OFFHAND) + delay);
 }
+
+int32_t Player::getMyCorpseInstanceId() const
+{
+    return myCorpseInstanceId;
+}

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -626,6 +626,8 @@ public:
     bool hasOffHandWeapon();
     void delayMeleeAttackTimer(int32_t delay);
 
+    int32_t getMyCorpseInstanceId() const;
+
 public:
     //MIT End
     //AGPL Start
@@ -1378,7 +1380,6 @@ public:
         uint32 m_UnderwaterTime;
         uint32 m_UnderwaterState;
         // Visible objects
-        bool CanSee(Object* obj);
         bool IsVisible(uint64 pObj) { return !(m_visibleObjects.find(pObj) == m_visibleObjects.end()); }
         void addToInRangeObjects(Object* pObj);
         void onRemoveInRangeObject(Object* pObj);

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -542,18 +542,17 @@ Unit::Unit() : m_currentSpeedWalk(2.5f),
     CreatureAttackPowerMod[11] = 0;
     CreatureRangedAttackPowerMod[11] = 0;
 
-    m_invisibility = 0;
-    m_invisible = false;
-    m_invisFlag = INVIS_FLAG_NORMAL;
-
     for (i = 0; i < INVIS_FLAG_TOTAL; i++)
     {
-        m_invisDetect[i] = 0;
+        m_invisibilityLevel[i] = 0;
+        m_invisibilityDetection[i] = 0;
     }
 
-    m_stealthLevel = 0;
-    m_stealthDetectBonus = 0;
-    m_stealth = 0;
+    for (i = 0; i < STEALTH_FLAG_TOTAL; ++i)
+    {
+        m_stealthLevel[i] = 0;
+        m_stealthDetection[i] = 0;
+    }
     m_can_stealth = true;
 
     for (i = 0; i < 5; i++)
@@ -608,7 +607,6 @@ Unit::Unit() : m_currentSpeedWalk(2.5f),
         m_detectRangeMOD[i] = 0;
     }
 
-    detectRange = 0;
     trackStealth = false;
 
     m_threatModifyer = 0;
@@ -685,7 +683,6 @@ Unit::Unit() : m_currentSpeedWalk(2.5f),
     m_noFallDamage = false;
     z_axisposition = 0.0f;
     m_safeFall = 0;
-    detectRange = 0.0f;
     m_cTimer = 0;
     m_temp_summon = false;
     m_meleespell_ecn = 0;
@@ -9012,7 +9009,7 @@ void Unit::AddAura(Aura* aur)
         if (pCaster)
         {
             pCaster->RemoveStealth();
-            pCaster->RemoveInvisibility();
+            pCaster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
 
             uint32 iceBlock[] =
             {
@@ -9590,8 +9587,8 @@ void Unit::AddAura(Aura* aur)
         Unit* pCaster = aur->GetUnitCaster();
         if (pCaster)
         {
-            pCaster->RemoveStealth();
-            pCaster->RemoveInvisibility();
+            pCaster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
+            pCaster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
 
             uint32 iceBlock[] =
             {
@@ -12132,7 +12129,7 @@ void Unit::UpdateVisibility()
             {
                 pObj = itr2;
 
-                can_see = plr->CanSee(pObj);
+                can_see = plr->canSee(pObj);
                 is_visible = plr->IsVisible(pObj->getGuid());
                 if (can_see)
                 {
@@ -12156,7 +12153,7 @@ void Unit::UpdateVisibility()
                 if (pObj->isPlayer())
                 {
                     pl = static_cast<Player*>(pObj);
-                    can_see = pl->CanSee(plr);
+                    can_see = pl->canSee(plr);
                     is_visible = pl->IsVisible(plr->getGuid());
                     if (can_see)
                     {
@@ -12187,7 +12184,7 @@ void Unit::UpdateVisibility()
             Player* p = static_cast<Player*>(it2);
             if (p)
             {
-                can_see = p->CanSee(this);
+                can_see = p->canSee(this);
                 is_visible = p->IsVisible(this->getGuid());
                 if (!can_see)
                 {

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -1438,6 +1438,377 @@ void Unit::removeSingleTargetGuidForAura(uint32_t spellId)
         m_singleTargetAura.erase(itr);
 }
 
+void Unit::removeAllAurasByAuraEffect(AuraEffect effect)
+{
+    for (auto i = MAX_TOTAL_AURAS_START; i < MAX_TOTAL_AURAS_END; ++i)
+    {
+        if (m_auras[i] == nullptr)
+            continue;
+        if (m_auras[i]->GetSpellInfo()->hasEffectApplyAuraName(effect))
+            RemoveAura(m_auras[i]);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Visibility system
+bool Unit::canSee(Object* const obj)
+{
+    if (obj == nullptr)
+        return false;
+
+    if (this == obj)
+        return true;
+
+    if (!obj->IsInWorld() || GetMapId() != obj->GetMapId())
+        return false;
+
+    // Unit cannot see objects from different phases
+    if ((GetPhase() & obj->GetPhase()) == 0)
+        return false;
+
+    // Unit cannot see invisible Game Masters unless he/she has Game Master flag on
+    if (obj->isPlayer() && static_cast<Player*>(obj)->m_isGmInvisible)
+        return isPlayer() && HasFlag(PLAYER_FLAGS, PLAYER_FLAG_GM);
+
+    uint64_t ownerGuid = 0;
+    if (getCharmedByGuid() != 0)
+        ownerGuid = getCharmedByGuid();
+    else
+        ownerGuid = getSummonedByGuid();
+
+    // Unit can always see its master
+    if (ownerGuid == obj->getGuid())
+        return true;
+
+    // Player is dead and has released spirit
+    if (isPlayer() && getDeathState() == CORPSE)
+    {
+        const auto corpseViewDistance = 1600.f; // 40*40 yards
+        const auto playerMe = static_cast<Player*>(this);
+        // If object is another player
+        if (obj->isPlayer())
+        {
+            // Dead player can see all players in arena regardless of range
+            if (playerMe->m_deathVision)
+                return true;
+
+            // Player can see all friendly and unfriendly players within 40 yards from his/her corpse
+            const auto playerObj = static_cast<Player*>(obj);
+            if (playerMe->getMyCorpseInstanceId() == playerMe->GetInstanceID() &&
+                playerObj->getDistanceSq(playerMe->getMyCorpseLocation()) <= corpseViewDistance)
+                return true;
+
+            // Otherwise player can only see other players who have released their spirits as well
+            return playerObj->getDeathState() == CORPSE;
+        }
+
+        // Dead player can also see all objects in arena regardless of range
+        if (playerMe->m_deathVision)
+            return true;
+
+        if (playerMe->getMyCorpseInstanceId() == GetInstanceID())
+        {
+            // Player can see his/her own corpse
+            if (obj->isCorpse() && static_cast<Corpse*>(obj)->getOwnerGuid() == getGuid())
+                return true;
+
+            // Player can see all objects within 40 yards from his/her own corpse
+            if (obj->getDistanceSq(playerMe->getMyCorpseLocation()) <= corpseViewDistance)
+                return true;
+        }
+
+        // Player can see Spirit Healers
+        if (obj->isCreature() && static_cast<Creature*>(obj)->isSpiritHealer())
+            return true;
+
+        return false;
+    }
+
+    // Unit is alive or player hasn't released spirit yet
+    // Do checks based on object's type
+    switch (obj->getObjectTypeId())
+    {
+        case TYPEID_PLAYER:
+        {
+            const auto playerObj = static_cast<Player*>(obj);
+            if (playerObj->getDeathState() == CORPSE)
+            {
+                if (isPlayer())
+                {
+                    // If players are from same group, they can see each other normally
+                    const auto playerMe = static_cast<Player*>(this);
+                    if (playerMe->GetGroup() != nullptr && playerMe->GetGroup() == playerObj->GetGroup())
+                        return true;
+
+                    // Game Masters can see all dead players
+                    return HasFlag(PLAYER_FLAGS, PLAYER_FLAG_GM);
+                }
+                else
+                    // Non-player units cannot see dead players
+                    return false;
+            }
+            break;
+        }
+        case TYPEID_UNIT:
+        {
+            // Unit cannot see Spirit Healers when unit's alive
+            // unless unit is a Game Master
+            if (obj->isCreature() && static_cast<Creature*>(obj)->isSpiritHealer())
+                return isPlayer() && HasFlag(PLAYER_FLAGS, PLAYER_FLAG_GM);
+
+            const auto unitObj = static_cast<Unit*>(obj);
+
+            if (unitObj->getCharmedByGuid() != 0)
+                ownerGuid = unitObj->getCharmedByGuid();
+            else
+                ownerGuid = unitObj->getSummonedByGuid();
+
+            // Unit can always see their own summoned units
+            if (getGuid() == ownerGuid)
+                return true;
+
+            if (isPlayer())
+            {
+                // Group members can see each other's summoned units
+                // unless they are dueling, then it's based on detection
+                const auto objectOwner = GetMapMgrPlayer(ownerGuid);
+                if (objectOwner != nullptr)
+                {
+                    if (objectOwner->GetGroup() != nullptr && objectOwner->GetGroup()->HasMember(static_cast<Player*>(this)))
+                    {
+                        if (objectOwner->DuelingWith != static_cast<Player*>(this))
+                            return true;
+                    }
+                }
+
+                // If object is only visible to either faction
+                if (unitObj->GetAIInterface()->faction_visibility == 1)
+                    return static_cast<Player*>(this)->IsTeamHorde() ? true : false;
+                if (unitObj->GetAIInterface()->faction_visibility == 2)
+                    return static_cast<Player*>(this)->IsTeamHorde() ? false : true;
+            }
+            break;
+        }
+        case TYPEID_GAMEOBJECT:
+        {
+            const auto gameObjectObj = static_cast<GameObject*>(obj);
+            // Stealthed / invisible gameobjects
+            if (gameObjectObj->inStealth || gameObjectObj->invisible)
+            {
+                const auto ownerGuid = gameObjectObj->getCreatedByGuid();
+                // Unit can always see their own created gameobjects
+                if (getGuid() == ownerGuid)
+                    return true;
+
+                // Group members can see each other's created gameobjects
+                // unless they are dueling, then it's based on detection
+                const auto objectOwner = GetMapMgrPlayer(ownerGuid);
+                if (objectOwner != nullptr && isPlayer())
+                {
+                    if (objectOwner->GetGroup() != nullptr && objectOwner->GetGroup()->HasMember(static_cast<Player*>(this)))
+                    {
+                        if (objectOwner->DuelingWith != static_cast<Player*>(this))
+                            return true;
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // Game Masters can see invisible and stealthed objects
+    if (isPlayer() && HasFlag(PLAYER_FLAGS, PLAYER_FLAG_GM))
+        return true;
+
+    // Hunter Marked units are always visible to caster
+    if (obj->isCreatureOrPlayer() && static_cast<Unit*>(obj)->stalkedby == getGuid())
+        return true;
+
+    // Pets and summoned units don't have detection, they rely on their master's detection
+    auto meUnit = this;
+    if (getCharmedByGuid() != 0)
+    {
+        const auto summoner = GetMapMgrUnit(getCharmedByGuid());
+        if (summoner != nullptr)
+            meUnit = summoner;
+    }
+    else if (getSummonedByGuid() != 0)
+    {
+        const auto summoner = GetMapMgrUnit(getSummonedByGuid());
+        if (summoner != nullptr)
+            meUnit = summoner;
+    }
+
+    const auto unitTarget = static_cast<Unit*>(obj);
+    const auto gobTarget = static_cast<GameObject*>(obj);
+
+    ////////////////////////////
+    // Invisibility detection
+
+    for (auto i = 0; i < INVIS_FLAG_TOTAL; ++i)
+    {
+        auto unitInvisibilityValue = meUnit->getInvisibilityLevel(InvisibilityFlag(i));
+        auto unitInvisibilityDetection = meUnit->getInvisibilityDetection(InvisibilityFlag(i));
+        auto objectInvisibilityValue = 0;
+        auto objectInvisibilityDetection = 0;
+
+        if (obj->isCreatureOrPlayer())
+        {
+            objectInvisibilityValue = unitTarget->getInvisibilityLevel(InvisibilityFlag(i));
+            objectInvisibilityDetection = unitTarget->getInvisibilityDetection(InvisibilityFlag(i));
+
+            // When unit is invisible, unit can only see those objects which have enough detection value
+            if ((unitInvisibilityValue > objectInvisibilityDetection) ||
+            // When object is invisible, unit can only see it if unit has enough detection value
+                (objectInvisibilityValue > unitInvisibilityDetection))
+                return false;
+        }
+        else if (obj->isGameObject() && gobTarget->invisible && i == INVIS_FLAG_TRAP)
+        {
+            // Base value for invisible traps seems to be 300 according to spell id 2836
+            objectInvisibilityValue = 300;
+            if (objectInvisibilityValue > unitInvisibilityDetection)
+                return false;
+        }
+    }
+
+    ////////////////////////////
+    // Stealth detection
+
+    if ((obj->isCreatureOrPlayer() && unitTarget->isStealthed()) || (obj->isGameObject() && gobTarget->inStealth))
+    {
+        // Get absolute distance
+        const auto distance = meUnit->CalcDistance(obj);
+        const auto combatReach = meUnit->getCombatReach();
+        if (obj->isCreatureOrPlayer())
+        {
+            // Shadow Sight buff in arena makes unit detect stealth regardless of distance and facing
+            if (meUnit->hasAuraWithAuraEffect(SPELL_AURA_DETECT_STEALTH))
+                return true;
+
+            // Normally units not in front cannot be detected
+            if (!meUnit->isInFront(obj))
+                return false;
+
+            // If object is closer than unit's combat reach
+            if (distance < combatReach)
+                return true;
+        }
+
+        // Objects outside of Line of Sight cannot be detected
+        if (worldConfig.terrainCollision.isCollisionEnabled)
+        {
+            if (!meUnit->IsWithinLOSInMap(obj))
+                return false;
+        }
+
+        // In unit cases base stealth level and base stealth detection increases by 5 points per unit's level
+        // Stealth detection base points start from 30ish, exact value unknown
+        int detectionValue = 30 + meUnit->getLevel() * 5;
+
+        // Apply modifiers which increases unit's stealth detection
+        if (obj->isCreatureOrPlayer())
+            detectionValue += meUnit->getStealthDetection(STEALTH_FLAG_NORMAL);
+        else if (obj->isGameObject())
+            detectionValue += meUnit->getStealthDetection(STEALTH_FLAG_TRAP);
+
+        // Subtract object's stealth level from detection value
+        if (obj->isCreatureOrPlayer())
+            detectionValue -= unitTarget->getStealthLevel(STEALTH_FLAG_NORMAL);
+        else if (obj->isGameObject())
+        {
+            // Base value for stealthed gameobjects seems to be 70 according to spell id 2836
+            detectionValue -= 70;
+            if (gobTarget->getCreatedByGuid() != 0)
+            {
+                // If trap has an owner, subtract owner's stealth level (unit level * 5) from detection value
+                const auto summoner = gobTarget->GetMapMgrUnit(gobTarget->getCreatedByGuid());
+                if (summoner != nullptr)
+                    detectionValue -= summoner->getLevel() * 5;
+            }
+            else
+                // If trap has no owner, subtract trap's level from detection value
+                detectionValue -= gobTarget->GetGameObjectProperties()->trap.level * 5;
+        }
+
+        auto visibilityRange = float_t(detectionValue * 0.3f + combatReach);
+        if (visibilityRange <= 0.0f)
+            return false;
+
+        // Players cannot see stealthed objects from further than 30 yards
+        if (meUnit->isPlayer() && visibilityRange > 30.0f)
+            visibilityRange = 30.0f;
+
+        // Object is further than unit's visibility range
+        if (distance > visibilityRange)
+            return false;
+    }
+    return true;
+}
+
+int32_t Unit::getStealthLevel(StealthFlag flag) const
+{
+    return m_stealthLevel[flag];
+}
+
+int32_t Unit::getStealthDetection(StealthFlag flag) const
+{
+    return m_stealthDetection[flag];
+}
+
+void Unit::modStealthLevel(StealthFlag flag, const int32_t amount)
+{
+    m_stealthLevel[flag] += amount;
+}
+
+void Unit::modStealthDetection(StealthFlag flag, const int32_t amount)
+{
+    m_stealthDetection[flag] += amount;
+}
+
+bool Unit::isStealthed() const
+{
+    return hasAuraWithAuraEffect(SPELL_AURA_MOD_STEALTH);
+}
+
+int32_t Unit::getInvisibilityLevel(InvisibilityFlag flag) const
+{
+    return m_invisibilityLevel[flag];
+}
+
+int32_t Unit::getInvisibilityDetection(InvisibilityFlag flag) const
+{
+    return m_invisibilityDetection[flag];
+}
+
+void Unit::modInvisibilityLevel(InvisibilityFlag flag, const int32_t amount)
+{
+    m_invisibilityLevel[flag] += amount;
+}
+
+void Unit::modInvisibilityDetection(InvisibilityFlag flag, const int32_t amount)
+{
+    m_invisibilityDetection[flag] += amount;
+}
+
+bool Unit::isInvisible() const
+{
+    return hasAuraWithAuraEffect(SPELL_AURA_MOD_INVISIBILITY);
+}
+
+void Unit::setVisible(const bool visible)
+{
+    if (!visible)
+        modInvisibilityLevel(INVIS_FLAG_NEVER_VISIBLE, 1);
+    else
+        modInvisibilityLevel(INVIS_FLAG_NEVER_VISIBLE, -getInvisibilityLevel(INVIS_FLAG_NEVER_VISIBLE));
+    UpdateVisibility();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Misc
 void Unit::setAttackTimer(WeaponDamageType type, int32_t time)
 {
     // TODO: getModCastSpeed() is no longer used here, is it required?

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -545,12 +545,43 @@ public:
     void setSingleTargetGuidForAura(uint32_t spellId, uint64_t guid);
     void removeSingleTargetGuidForAura(uint32_t spellId);
 
+    void removeAllAurasByAuraEffect(AuraEffect effect);
+
 #ifdef AE_TBC
     uint32_t addAuraVisual(uint32_t spell_id, uint32_t count, bool positive);
     uint32_t addAuraVisual(uint32_t spell_id, uint32_t count, bool positive, bool &skip_client_update);
     void setAuraSlotLevel(uint32_t slot, bool positive);
 #endif
 
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Visibility system
+    bool canSee(Object* const obj);
+
+    // Stealth
+    int32_t getStealthLevel(StealthFlag flag) const;
+    int32_t getStealthDetection(StealthFlag flag) const;
+    void modStealthLevel(StealthFlag flag, const int32_t amount);
+    void modStealthDetection(StealthFlag flag, const int32_t amount);
+    bool isStealthed() const;
+
+    // Invisibility
+    int32_t getInvisibilityLevel(InvisibilityFlag flag) const;
+    int32_t getInvisibilityDetection(InvisibilityFlag flag) const;
+    void modInvisibilityLevel(InvisibilityFlag flag, const int32_t amount);
+    void modInvisibilityDetection(InvisibilityFlag flag, const int32_t amount);
+    bool isInvisible() const;
+
+    void setVisible(const bool visible);
+
+ private:
+     // Stealth
+     int32_t m_stealthLevel[STEALTH_FLAG_TOTAL];
+     int32_t m_stealthDetection[STEALTH_FLAG_TOTAL];
+     // Invisibility
+     int32_t m_invisibilityLevel[INVIS_FLAG_TOTAL];
+     int32_t m_invisibilityDetection[INVIS_FLAG_TOTAL];
+
+public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
     void setAttackTimer(WeaponDamageType type, int32_t time);
@@ -639,29 +670,6 @@ public:
     bool IsDazed();
     //this function is used for creatures to get chance to daze for another unit
     float get_chance_to_daze(Unit* target);
-
-    // Stealth
-    int32 GetStealthLevel() { return m_stealthLevel; }
-    int32 GetStealthDetectBonus() { return m_stealthDetectBonus; }
-    void SetStealth(uint32 id) { m_stealth = id; }
-    bool IsStealth() { return (m_stealth != 0 ? true : false); }
-    float detectRange;
-
-    // Invisibility
-    void SetInvisibility(uint32 id) { m_invisibility = id; }
-    bool IsInvisible() { return (m_invisible != 0 ? true : false); }
-    uint32 m_invisibility;
-    bool m_invisible;
-    uint8 m_invisFlag;
-    int32 m_invisDetect[INVIS_FLAG_TOTAL];
-    void SetInvisFlag(uint8 pInvisFlag)
-    {
-        m_invisFlag = pInvisFlag;
-        m_invisible = pInvisFlag != INVIS_FLAG_NORMAL;
-
-        UpdateVisibility();
-    }
-    uint8 GetInvisFlag() { return m_invisFlag; }
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // AURAS
@@ -1090,25 +1098,6 @@ public:
     // Escort Quests
     void MoveToWaypoint(uint32 wp_id);
 
-    void RemoveStealth()
-    {
-        if (m_stealth != 0)
-        {
-            RemoveAura(m_stealth);
-            m_stealth = 0;
-        }
-    }
-
-    void RemoveInvisibility()
-    {
-        if (m_invisibility != 0)
-        {
-            RemoveAura(m_invisibility);
-            m_invisibility = 0;
-        }
-    }
-
-    uint32 m_stealth;
     bool m_can_stealth;
 
     Aura* m_auras[MAX_TOTAL_AURAS_END];
@@ -1350,10 +1339,6 @@ protected:
 
     /// Combat
     DeathState m_deathState;
-
-    // Stealth
-    uint32 m_stealthLevel;
-    uint32 m_stealthDetectBonus;
 
     // DK:pet
 

--- a/src/world/Units/UnitDefines.hpp
+++ b/src/world/Units/UnitDefines.hpp
@@ -21,6 +21,41 @@
 #include "CommonTypes.hpp"
 #include "LocationVector.h"
 
+// APGL Ends
+// MIT Start
+
+enum StealthFlag
+{
+    STEALTH_FLAG_NORMAL,
+    STEALTH_FLAG_TRAP,
+    STEALTH_FLAG_TOTAL
+};
+
+// todo: missing possible cata invisiblility types
+enum InvisibilityFlag
+{
+    INVIS_FLAG_NORMAL,              // Used by players
+    INVIS_FLAG_ELEMENTAL_SPIRIT,    // Shaman totem quests
+    INVIS_FLAG_UNKNOWN_2,           // Used by spell id 24306
+    INVIS_FLAG_TRAP,                // Used by gameobjects only
+    INVIS_FLAG_QUEST_4,             // Used by many quest creatures
+    INVIS_FLAG_DUNGEON_SET_NPC,     // Used by dungeon set 2 npcs
+    INVIS_FLAG_DRUNK,               // These can only be seen when drunk
+    INVIS_FLAG_QUEST_7,             // Used by many quest creatures
+    INVIS_FLAG_QUEST_8,             // Used by many quest creatures
+    INVIS_FLAG_QUEST_9,             // Used by many quest creatures
+    INVIS_FLAG_QUEST_10,            // Used by many quest creatures
+    INVIS_FLAG_UNKNOWN_11,          // Used by spell id 49962
+    INVIS_FLAG_UNUSED_12,
+    INVIS_FLAG_UNUSED_13,
+    INVIS_FLAG_UNUSED_14,
+    INVIS_FLAG_NEVER_VISIBLE,       // Used by trigger or placeholder npcs
+    INVIS_FLAG_TOTAL
+};
+
+// MIT End
+// APGL Start
+
 enum DeathState
 {
     ALIVE = 0,  // Unit is alive and well
@@ -808,23 +843,6 @@ enum HitStatus
 
     HITSTATUS_ABSORBED          = HITSTATUS_ABSORB_FULL | HITSTATUS_ABSORB_PARTIAL,
     HITSTATUS_RESIST            = HITSTATUS_RESIST_FULL | HITSTATUS_RESIST_PARTIAL
-};
-
-enum INVIS_FLAG
-{
-    INVIS_FLAG_NORMAL, // players and units with no special invisibility flags
-    INVIS_FLAG_SPIRIT1,
-    INVIS_FLAG_SPIRIT2,
-    INVIS_FLAG_TRAP,
-    INVIS_FLAG_QUEST,
-    INVIS_FLAG_GHOST,
-    INVIS_FLAG_UNKNOWN6,
-    INVIS_FLAG_UNKNOWN7,
-    INVIS_FLAG_SHADOWMOON,
-    INVIS_FLAG_NETHERSTORM,
-    INVIS_FLAG_BASHIR,
-    INVIS_FLAG_UNKNOWN8,
-    INVIS_FLAG_TOTAL
 };
 
 enum FIELD_PADDING//Since this field isn't used you can expand it for you needs


### PR DESCRIPTION
More stuff from my old work:
- Rewrite stealth and invisibility detection
- Correct parameter for trap objects
- Unset invisibility types for creatures in database
- Correct line endings in Player.cpp and Player.h
- Fix random crash in legacy spell system

The creatures which had invisiblity type set have now proper passive aura set.
Only creatures with invisibility type 15 are left. These are trigger or placeholder npcs and should never be seen by players.

Closes https://github.com/AscEmu/AscEmu/issues/104