### PR TITLE
Spells: Correctly reset attack timers instead of delaying on spell cast

### DIFF
--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -780,21 +780,21 @@ void Object::interruptSpellWithSpellType(CurrentSpellType spellType)
 
 bool Object::isCastingSpell(bool skipChanneled /*= false*/, bool skipAutorepeat /*= false*/, bool isAutoshoot /*= false*/) const
 {
-    // Check from generic spells, ignore finished spells
+    // Check generic spell, but ignore finished spells
     if (m_currentSpell[CURRENT_GENERIC_SPELL] != nullptr && m_currentSpell[CURRENT_GENERIC_SPELL]->getState() != SPELL_STATE_FINISHED && m_currentSpell[CURRENT_GENERIC_SPELL]->getCastTimeLeft() > 0 &&
         (!isAutoshoot || !(m_currentSpell[CURRENT_GENERIC_SPELL]->GetSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_NOT_RESET_AUTO_ATTACKS)))
     {
         return true;
     }
 
-    // If not skipped, check from channeled spells
+    // If not skipped, check channeled spell
     if (!skipChanneled && m_currentSpell[CURRENT_CHANNELED_SPELL] != nullptr && m_currentSpell[CURRENT_CHANNELED_SPELL]->getState() != SPELL_STATE_FINISHED &&
         (!isAutoshoot || !(m_currentSpell[CURRENT_CHANNELED_SPELL]->GetSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_NOT_RESET_AUTO_ATTACKS)))
     {
         return true;
     }
 
-    // If not skipped, check from autorepeat spells
+    // If not skipped, check autorepeat spell
     if (!skipAutorepeat && m_currentSpell[CURRENT_AUTOREPEAT_SPELL] != nullptr)
     {
         return true;

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -980,8 +980,8 @@ uint8 Spell::prepare(SpellCastTargets* targets)
 
         if (i_caster == nullptr)
         {
-            if (p_caster != nullptr && m_timer > 0 && !m_triggeredSpell)
-                p_caster->delayMeleeAttackTimer(m_timer + 1000);
+            if (p_caster != nullptr && m_timer > 0 && !m_triggeredSpell && !(GetSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_NOT_RESET_AUTO_ATTACKS))
+                p_caster->resetAttackTimers();
             //p_caster->setAttackTimer(m_timer + 1000, false);
         }
 
@@ -1064,7 +1064,6 @@ void Spell::cancel()
 
                 if (m_timer > 0)
                 {
-                    p_caster->delayMeleeAttackTimer(-m_timer);
                     RemoveItems();
                 }
                 //				p_caster->setAttackTimer(1000, false);
@@ -1772,7 +1771,9 @@ void Spell::AddTime(uint32 type)
             {
                 //				sEventMgr.ModifyEventTimeLeft(p_caster,EVENT_ATTACK_TIMEOUT,attackTimeoutInterval,true);
                 // also add a new delay to offhand and main hand attacks to avoid cutting the cast short
-                p_caster->delayMeleeAttackTimer(delay);
+
+                // TODO: should spell cast time pushback reset swing timers again? -Appled
+                //p_caster->delayMeleeAttackTimer(delay);
             }
         }
         else if (GetSpellInfo()->getChannelInterruptFlags() != 48140)
@@ -1782,8 +1783,9 @@ void Spell::AddTime(uint32 type)
             m_timer -= delay;
             if (m_timer < 0)
                 m_timer = 0;
-            else if (p_caster != nullptr)
-                p_caster->delayMeleeAttackTimer(-delay);
+            //else if (p_caster != nullptr)
+                // TODO: should spell cast time pushback reset swing timers again? -Appled
+                //p_caster->delayMeleeAttackTimer(-delay);
 
             m_Delayed = true;
             if (m_timer > 0)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -1265,12 +1265,6 @@ bool Player::hasOffHandWeapon()
     return offHandItem->getItemProperties()->Class == ITEM_CLASS_WEAPON;
 }
 
-void Player::delayMeleeAttackTimer(int32_t delay)
-{
-    setAttackTimer(MELEE, getAttackTimer(MELEE) + delay);
-    setAttackTimer(OFFHAND, getAttackTimer(OFFHAND) + delay);
-}
-
 int32_t Player::getMyCorpseInstanceId() const
 {
     return myCorpseInstanceId;

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -624,7 +624,6 @@ public:
 
     void unEquipOffHandIfRequired();
     bool hasOffHandWeapon();
-    void delayMeleeAttackTimer(int32_t delay);
 
     int32_t getMyCorpseInstanceId() const;
 

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -1825,3 +1825,11 @@ bool Unit::isAttackReady(WeaponDamageType type) const
 {
     return Util::getMSTime() >= m_attackTimer[type];
 }
+
+void Unit::resetAttackTimers()
+{
+    for (int i = MELEE; i <= RANGED; ++i)
+    {
+        setAttackTimer(WeaponDamageType(i), getBaseAttackTime(i));
+    }
+}

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -587,6 +587,7 @@ public:
     void setAttackTimer(WeaponDamageType type, int32_t time);
     uint32_t getAttackTimer(WeaponDamageType type) const;
     bool isAttackReady(WeaponDamageType type) const;
+    void resetAttackTimers();
 
     // Do not alter anything below this line
     // -------------------------------------


### PR DESCRIPTION
Fix https://github.com/AscEmu/AscEmu/issues/649 properly:

Spell casting should always reset attack timers if spell is not instant cast and has not special attribute preventing the reset.
Also fix some typos in comments.