### PR TITLE
Fix some level 4 warnings from MIT files

### DIFF
--- a/src/world/AI/MovementAI.cpp
+++ b/src/world/AI/MovementAI.cpp
@@ -123,7 +123,6 @@ void MovementAI::sendMovePacket()
     const auto start = m_owner->GetPosition();
 
     auto spline = m_owner->m_movementManager.m_spline;
-    auto splineFlags = spline.GetSplineFlags();
     auto midpoints = m_owner->m_movementManager.m_spline.GetMidPoints();
 
     WorldPacket data(SMSG_MONSTER_MOVE, 60);
@@ -145,7 +144,7 @@ void MovementAI::sendMovePacket()
     m_owner->SendMessageToSet(&data, true);
 }
 
-void MovementAI::stopMoving(bool interrupt)
+void MovementAI::stopMoving(bool /*interrupt*/)
 {
     m_moving = false;
     m_origin_time = 0;

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -413,15 +413,15 @@ bool ChatHandler::HandleDebugSetUnitByteCommand(const char* args, WorldSession* 
     {
         case 0:
         {
-            unit_target->setByteValue(UNIT_FIELD_BYTES_0, offset, value);
+            unit_target->setByteValue(UNIT_FIELD_BYTES_0, static_cast<uint8_t>(offset), static_cast<uint8_t>(value));
         } break;
         case 1:
         {
-            unit_target->setByteValue(UNIT_FIELD_BYTES_1, offset, value);
+            unit_target->setByteValue(UNIT_FIELD_BYTES_1, static_cast<uint8_t>(offset), static_cast<uint8_t>(value));
         } break;
         case 2:
         {
-            unit_target->setByteValue(UNIT_FIELD_BYTES_2, offset, value);
+            unit_target->setByteValue(UNIT_FIELD_BYTES_2, static_cast<uint8_t>(offset), static_cast<uint8_t>(value));
         } break;
         default:
         {
@@ -507,7 +507,7 @@ bool ChatHandler::HandleSendCastFailed(const char* args, WorldSession* m_session
     return true;
 }
 
-bool ChatHandler::HandleDebugSendCreatureMove(const char * args, WorldSession * m_session)
+bool ChatHandler::HandleDebugSendCreatureMove(const char* /*args*/, WorldSession * m_session)
 {
     const auto target = GetSelectedUnit(m_session);
     if (!target)

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -96,7 +96,7 @@ bool ChatHandler::HandleNpcAddAgentCommand(const char* args, WorldSession* m_ses
     return true;
 }
 
-bool ChatHandler::HandleNpcAppearCommand(const char* _, WorldSession* session)
+bool ChatHandler::HandleNpcAppearCommand(const char* /*_*/, WorldSession* session)
 {
     const auto target = GetSelectedCreature(session);
     if (!target) {

--- a/src/world/Management/Guild/GuildDefinitions.h
+++ b/src/world/Management/Guild/GuildDefinitions.h
@@ -167,7 +167,7 @@ enum GuildCommandError
     GC_ERROR_REP_TOO_LOW = 39
 };
 
-enum GuildEvents
+enum GuildEvents : uint8_t
 {
 #if VERSION_STRING == Cata
     GE_PROMOTION = 1,

--- a/src/world/Management/GuildBankTab.cpp
+++ b/src/world/Management/GuildBankTab.cpp
@@ -110,7 +110,7 @@ bool GuildBankTab::writeSlotPacket(WorldPacket& data, uint8_t slotId, bool ignor
         data << uint8_t(enchCount);
         for (uint32_t i = PERM_ENCHANTMENT_SLOT; i < MAX_ENCHANTMENT_SLOT; ++i)
         {
-            if (uint32_t enchId = pItem->getEnchantmentId(EnchantmentSlot(i)))
+            if (uint32_t enchId = pItem->getEnchantmentId(static_cast<uint8_t>(EnchantmentSlot(i))))
             {
                 data << uint8_t(i);
                 data << uint32_t(enchId);

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -257,9 +257,9 @@ void Object::setGuidHigh(uint32_t high) { setGuid(objectData()->guid_parts.low, 
 
 uint32_t Object::getOType() const { return objectData()->type; }
 void Object::setOType(uint32_t type) { write(objectData()->type, type); }
-void Object::setObjectType(uint32_t objectTypeId)
+void Object::setObjectType(uint8_t objectTypeId)
 {
-    uint32_t object_type = TYPE_OBJECT;
+    uint16_t object_type = TYPE_OBJECT;
     switch (objectTypeId)
     {
     case TYPEID_CONTAINER:
@@ -2280,7 +2280,7 @@ void Object::buildValuesUpdate(ByteBuffer* data, UpdateMask* updateMask, Player*
 
                                         for (auto i = 0; i < 4; ++i)
                                         {
-                                            if (quest->required_mob_or_go[i] == this_go->getEntry())
+                                            if (quest->required_mob_or_go[i] == static_cast<int32_t>(this_go->getEntry()))
                                             {
                                                 if (quest_log->GetMobCount(i) < quest->required_mob_or_go_count[i])
                                                 {

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -294,7 +294,7 @@ public:
     //\todo choose one function!
     uint32_t getOType() const;
     void setOType(uint32_t type);
-    void setObjectType(uint32_t objectTypeId);
+    void setObjectType(uint8_t objectTypeId);
 
     void setEntry(uint32_t entry);
     uint32_t getEntry() const;

--- a/src/world/Server/CharacterErrors.h
+++ b/src/world/Server/CharacterErrors.h
@@ -7,7 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "WorldConf.h"
 
-enum CharacterErrorCodes
+enum CharacterErrorCodes : uint8_t
 {
     E_CHAR_CREATE_IN_PROGRESS = 0x2E,
     E_CHAR_CREATE_SUCCESS = 0x2F,

--- a/src/world/Server/Packets/CmsgActivatetaxi.h
+++ b/src/world/Server/Packets/CmsgActivatetaxi.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgActivatetaxiexpress.h
+++ b/src/world/Server/Packets/CmsgActivatetaxiexpress.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAlterAppearance.h
+++ b/src/world/Server/Packets/CmsgAlterAppearance.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAreaSpiritHealerQuery.h
+++ b/src/world/Server/Packets/CmsgAreaSpiritHealerQuery.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAreaSpiritHealerQueue.h
+++ b/src/world/Server/Packets/CmsgAreaSpiritHealerQueue.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAreatrigger.h
+++ b/src/world/Server/Packets/CmsgAreatrigger.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamDisband.h
+++ b/src/world/Server/Packets/CmsgArenaTeamDisband.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamInvite.h
+++ b/src/world/Server/Packets/CmsgArenaTeamInvite.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamLeader.h
+++ b/src/world/Server/Packets/CmsgArenaTeamLeader.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamLeave.h
+++ b/src/world/Server/Packets/CmsgArenaTeamLeave.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamQuery.h
+++ b/src/world/Server/Packets/CmsgArenaTeamQuery.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamRemove.h
+++ b/src/world/Server/Packets/CmsgArenaTeamRemove.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgArenaTeamRoster.h
+++ b/src/world/Server/Packets/CmsgArenaTeamRoster.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAttackSwing.h
+++ b/src/world/Server/Packets/CmsgAttackSwing.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionListIBidderItemse.h
+++ b/src/world/Server/Packets/CmsgAuctionListIBidderItemse.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionListIPendingSales.h
+++ b/src/world/Server/Packets/CmsgAuctionListIPendingSales.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionListItems.h
+++ b/src/world/Server/Packets/CmsgAuctionListItems.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionListOwnerItems.h
+++ b/src/world/Server/Packets/CmsgAuctionListOwnerItems.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionPlaceBid.h
+++ b/src/world/Server/Packets/CmsgAuctionPlaceBid.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionRemoveItem.h
+++ b/src/world/Server/Packets/CmsgAuctionRemoveItem.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAuctionSellItem.h
+++ b/src/world/Server/Packets/CmsgAuctionSellItem.h
@@ -39,7 +39,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAutobankItem.h
+++ b/src/world/Server/Packets/CmsgAutobankItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAutoequipItem.h
+++ b/src/world/Server/Packets/CmsgAutoequipItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAutoequipItemSlot.h
+++ b/src/world/Server/Packets/CmsgAutoequipItemSlot.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAutostoreBagItem.h
+++ b/src/world/Server/Packets/CmsgAutostoreBagItem.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgAutostoreBankItem.h
+++ b/src/world/Server/Packets/CmsgAutostoreBankItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBankerActivate.h
+++ b/src/world/Server/Packets/CmsgBankerActivate.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBattlefieldList.h
+++ b/src/world/Server/Packets/CmsgBattlefieldList.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBattlefieldPort.h
+++ b/src/world/Server/Packets/CmsgBattlefieldPort.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBattlemasterHello.h
+++ b/src/world/Server/Packets/CmsgBattlemasterHello.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBattlemasterJoinArena.h
+++ b/src/world/Server/Packets/CmsgBattlemasterJoinArena.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBinderActivate.h
+++ b/src/world/Server/Packets/CmsgBinderActivate.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBug.h
+++ b/src/world/Server/Packets/CmsgBug.h
@@ -36,7 +36,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBuyBankSlot.h
+++ b/src/world/Server/Packets/CmsgBuyBankSlot.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBuyItem.h
+++ b/src/world/Server/Packets/CmsgBuyItem.h
@@ -36,7 +36,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBuyItemInSlot.h
+++ b/src/world/Server/Packets/CmsgBuyItemInSlot.h
@@ -38,7 +38,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgBuybackItem.h
+++ b/src/world/Server/Packets/CmsgBuybackItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCancelTempEnchantment.h
+++ b/src/world/Server/Packets/CmsgCancelTempEnchantment.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCastSpell.h
+++ b/src/world/Server/Packets/CmsgCastSpell.h
@@ -36,7 +36,7 @@ namespace AscEmu { namespace Packets
             return m_minimum_size;
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChangeSeatsOnControlledVehicle.h
+++ b/src/world/Server/Packets/CmsgChangeSeatsOnControlledVehicle.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelAnnouncements.h
+++ b/src/world/Server/Packets/CmsgChannelAnnouncements.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelBan.h
+++ b/src/world/Server/Packets/CmsgChannelBan.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelDisplayList.h
+++ b/src/world/Server/Packets/CmsgChannelDisplayList.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelInvite.h
+++ b/src/world/Server/Packets/CmsgChannelInvite.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelKick.h
+++ b/src/world/Server/Packets/CmsgChannelKick.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelList.h
+++ b/src/world/Server/Packets/CmsgChannelList.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelModerate.h
+++ b/src/world/Server/Packets/CmsgChannelModerate.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelModerator.h
+++ b/src/world/Server/Packets/CmsgChannelModerator.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelMute.h
+++ b/src/world/Server/Packets/CmsgChannelMute.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelOwner.h
+++ b/src/world/Server/Packets/CmsgChannelOwner.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelPassword.h
+++ b/src/world/Server/Packets/CmsgChannelPassword.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelSetOwner.h
+++ b/src/world/Server/Packets/CmsgChannelSetOwner.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelUnban.h
+++ b/src/world/Server/Packets/CmsgChannelUnban.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelUnmoderator.h
+++ b/src/world/Server/Packets/CmsgChannelUnmoderator.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChannelUnmute.h
+++ b/src/world/Server/Packets/CmsgChannelUnmute.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCharCreate.h
+++ b/src/world/Server/Packets/CmsgCharCreate.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCharCustomize.h
+++ b/src/world/Server/Packets/CmsgCharCustomize.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCharDelete.h
+++ b/src/world/Server/Packets/CmsgCharDelete.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCharFactionChange.h
+++ b/src/world/Server/Packets/CmsgCharFactionChange.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgCharRename.h
+++ b/src/world/Server/Packets/CmsgCharRename.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgChatIgnored.h
+++ b/src/world/Server/Packets/CmsgChatIgnored.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgClearTradeItem.h
+++ b/src/world/Server/Packets/CmsgClearTradeItem.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgComplaint.h
+++ b/src/world/Server/Packets/CmsgComplaint.h
@@ -42,7 +42,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgDestroyItem.h
+++ b/src/world/Server/Packets/CmsgDestroyItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgDismissCritter.h
+++ b/src/world/Server/Packets/CmsgDismissCritter.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgEjectPassenger.h
+++ b/src/world/Server/Packets/CmsgEjectPassenger.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgEmote.h
+++ b/src/world/Server/Packets/CmsgEmote.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override { return false; }
+        bool internalSerialise(WorldPacket& /*packet*/) override { return false; }
 
         bool internalDeserialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/CmsgEnabletaxi.h
+++ b/src/world/Server/Packets/CmsgEnabletaxi.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGameobjReportUse.h
+++ b/src/world/Server/Packets/CmsgGameobjReportUse.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGameobjUse.h
+++ b/src/world/Server/Packets/CmsgGameobjUse.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
     protected:
         size_t expectedSize() const override { return 8; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGetChannelMemberCount.h
+++ b/src/world/Server/Packets/CmsgGetChannelMemberCount.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGmReportLag.h
+++ b/src/world/Server/Packets/CmsgGmReportLag.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGmSurveySubmit.h
+++ b/src/world/Server/Packets/CmsgGmSurveySubmit.h
@@ -39,7 +39,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGmTicketCreate.h
+++ b/src/world/Server/Packets/CmsgGmTicketCreate.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGmTicketUpdateText.h
+++ b/src/world/Server/Packets/CmsgGmTicketUpdateText.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGroupAssistantLeader.h
+++ b/src/world/Server/Packets/CmsgGroupAssistantLeader.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGroupChangeSubGroup.h
+++ b/src/world/Server/Packets/CmsgGroupChangeSubGroup.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGroupSetLeader.h
+++ b/src/world/Server/Packets/CmsgGroupSetLeader.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGroupUninvite.h
+++ b/src/world/Server/Packets/CmsgGroupUninvite.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGroupUninviteGuid.h
+++ b/src/world/Server/Packets/CmsgGroupUninviteGuid.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildAddRank.h
+++ b/src/world/Server/Packets/CmsgGuildAddRank.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankBuyTab.h
+++ b/src/world/Server/Packets/CmsgGuildBankBuyTab.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankDepositMoney.h
+++ b/src/world/Server/Packets/CmsgGuildBankDepositMoney.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankQueryTab.h
+++ b/src/world/Server/Packets/CmsgGuildBankQueryTab.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankQueryText.h
+++ b/src/world/Server/Packets/CmsgGuildBankQueryText.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankSwapItems.h
+++ b/src/world/Server/Packets/CmsgGuildBankSwapItems.h
@@ -49,7 +49,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankUpdateTab.h
+++ b/src/world/Server/Packets/CmsgGuildBankUpdateTab.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankWithdrawMoney.h
+++ b/src/world/Server/Packets/CmsgGuildBankWithdrawMoney.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildBankerActivate.h
+++ b/src/world/Server/Packets/CmsgGuildBankerActivate.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildDelRank.h
+++ b/src/world/Server/Packets/CmsgGuildDelRank.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildDemote.h
+++ b/src/world/Server/Packets/CmsgGuildDemote.h
@@ -41,7 +41,7 @@ namespace AscEmu { namespace Packets
 #endif
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildInfoText.h
+++ b/src/world/Server/Packets/CmsgGuildInfoText.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildInvite.h
+++ b/src/world/Server/Packets/CmsgGuildInvite.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildLeader.h
+++ b/src/world/Server/Packets/CmsgGuildLeader.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildMotd.h
+++ b/src/world/Server/Packets/CmsgGuildMotd.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildPromote.h
+++ b/src/world/Server/Packets/CmsgGuildPromote.h
@@ -41,7 +41,7 @@ namespace AscEmu { namespace Packets
 #endif
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildQuery.h
+++ b/src/world/Server/Packets/CmsgGuildQuery.h
@@ -42,7 +42,7 @@ namespace AscEmu { namespace Packets
         }
 #endif
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildRemove.h
+++ b/src/world/Server/Packets/CmsgGuildRemove.h
@@ -41,7 +41,7 @@ namespace AscEmu { namespace Packets
 #endif
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildSetNote.h
+++ b/src/world/Server/Packets/CmsgGuildSetNote.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildSetOfficerNote.h
+++ b/src/world/Server/Packets/CmsgGuildSetOfficerNote.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildSetPublicNote.h
+++ b/src/world/Server/Packets/CmsgGuildSetPublicNote.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgGuildSetRank.h
+++ b/src/world/Server/Packets/CmsgGuildSetRank.h
@@ -39,7 +39,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }
@@ -55,7 +55,7 @@ namespace AscEmu { namespace Packets
             GuildBankRightsAndSlotsVec rightsAndSlots(MAX_GUILD_BANK_TABS);
             for (uint8_t tabId = 0; tabId < MAX_GUILD_BANK_TABS; ++tabId)
             {
-                uint32_t bankRights;
+                uint8_t bankRights;
                 uint32_t slots;
 
                 packet >> bankRights;

--- a/src/world/Server/Packets/CmsgInitiateTrade.h
+++ b/src/world/Server/Packets/CmsgInitiateTrade.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgInspect.h
+++ b/src/world/Server/Packets/CmsgInspect.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgInspectAchievements.h
+++ b/src/world/Server/Packets/CmsgInspectAchievements.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgItemNameQuery.h
+++ b/src/world/Server/Packets/CmsgItemNameQuery.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgItemTextQuery.h
+++ b/src/world/Server/Packets/CmsgItemTextQuery.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgItemrefundinfo.h
+++ b/src/world/Server/Packets/CmsgItemrefundinfo.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgItemrefundrequest.h
+++ b/src/world/Server/Packets/CmsgItemrefundrequest.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgJoinChannel.h
+++ b/src/world/Server/Packets/CmsgJoinChannel.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLearnTalent.h
+++ b/src/world/Server/Packets/CmsgLearnTalent.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLearnTalentMultiple.h
+++ b/src/world/Server/Packets/CmsgLearnTalentMultiple.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLeaveChannel.h
+++ b/src/world/Server/Packets/CmsgLeaveChannel.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLfgProposalResult.h
+++ b/src/world/Server/Packets/CmsgLfgProposalResult.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLfgSetBootVote.h
+++ b/src/world/Server/Packets/CmsgLfgSetBootVote.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLfgSetRoles.h
+++ b/src/world/Server/Packets/CmsgLfgSetRoles.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLfgTeleport.h
+++ b/src/world/Server/Packets/CmsgLfgTeleport.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLoot.h
+++ b/src/world/Server/Packets/CmsgLoot.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLootMasterGive.h
+++ b/src/world/Server/Packets/CmsgLootMasterGive.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLootMethod.h
+++ b/src/world/Server/Packets/CmsgLootMethod.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLootRelease.h
+++ b/src/world/Server/Packets/CmsgLootRelease.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgLootRoll.h
+++ b/src/world/Server/Packets/CmsgLootRoll.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailCreateTextItem.h
+++ b/src/world/Server/Packets/CmsgMailCreateTextItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailDelete.h
+++ b/src/world/Server/Packets/CmsgMailDelete.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailMarkAsRead.h
+++ b/src/world/Server/Packets/CmsgMailMarkAsRead.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailReturnToSender.h
+++ b/src/world/Server/Packets/CmsgMailReturnToSender.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailTakeItem.h
+++ b/src/world/Server/Packets/CmsgMailTakeItem.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgMailTakeMoney.h
+++ b/src/world/Server/Packets/CmsgMailTakeMoney.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgOfferPetition.h
+++ b/src/world/Server/Packets/CmsgOfferPetition.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgOpenItem.h
+++ b/src/world/Server/Packets/CmsgOpenItem.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgOptOutOfLoot.h
+++ b/src/world/Server/Packets/CmsgOptOutOfLoot.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPageTextQuery.h
+++ b/src/world/Server/Packets/CmsgPageTextQuery.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetAction.h
+++ b/src/world/Server/Packets/CmsgPetAction.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetCancelAura.h
+++ b/src/world/Server/Packets/CmsgPetCancelAura.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetCastSpell.h
+++ b/src/world/Server/Packets/CmsgPetCastSpell.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetLearnTalent.h
+++ b/src/world/Server/Packets/CmsgPetLearnTalent.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetNameQuery.h
+++ b/src/world/Server/Packets/CmsgPetNameQuery.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetRename.h
+++ b/src/world/Server/Packets/CmsgPetRename.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetSetAction.h
+++ b/src/world/Server/Packets/CmsgPetSetAction.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetSpellAutocast.h
+++ b/src/world/Server/Packets/CmsgPetSpellAutocast.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetUnlearn.h
+++ b/src/world/Server/Packets/CmsgPetUnlearn.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetitionBuy.h
+++ b/src/world/Server/Packets/CmsgPetitionBuy.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetitionQuery.h
+++ b/src/world/Server/Packets/CmsgPetitionQuery.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetitionShowSignatures.h
+++ b/src/world/Server/Packets/CmsgPetitionShowSignatures.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetitionShowlist.h
+++ b/src/world/Server/Packets/CmsgPetitionShowlist.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPetitionSign.h
+++ b/src/world/Server/Packets/CmsgPetitionSign.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPlayerLogin.h
+++ b/src/world/Server/Packets/CmsgPlayerLogin.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPlayerVehicleEnter.h
+++ b/src/world/Server/Packets/CmsgPlayerVehicleEnter.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgPushquesttoparty.h
+++ b/src/world/Server/Packets/CmsgPushquesttoparty.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestPoiQuery.h
+++ b/src/world/Server/Packets/CmsgQuestPoiQuery.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestQuery.h
+++ b/src/world/Server/Packets/CmsgQuestQuery.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverAcceptQuest.h
+++ b/src/world/Server/Packets/CmsgQuestgiverAcceptQuest.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverChooseReward.h
+++ b/src/world/Server/Packets/CmsgQuestgiverChooseReward.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverCompleteQuest.h
+++ b/src/world/Server/Packets/CmsgQuestgiverCompleteQuest.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverHello.h
+++ b/src/world/Server/Packets/CmsgQuestgiverHello.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverQueryQuest.h
+++ b/src/world/Server/Packets/CmsgQuestgiverQueryQuest.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverRequestReward.h
+++ b/src/world/Server/Packets/CmsgQuestgiverRequestReward.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestgiverStatusQuery.h
+++ b/src/world/Server/Packets/CmsgQuestgiverStatusQuery.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgQuestlogRemoveQuest.h
+++ b/src/world/Server/Packets/CmsgQuestlogRemoveQuest.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgReadItem.h
+++ b/src/world/Server/Packets/CmsgReadItem.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
 
     protected:
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgReclaimCorpse.h
+++ b/src/world/Server/Packets/CmsgReclaimCorpse.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgRemoveGlyph.h
+++ b/src/world/Server/Packets/CmsgRemoveGlyph.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgRepairItem.h
+++ b/src/world/Server/Packets/CmsgRepairItem.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
 
     protected:
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgRequestPartyMemberStats.h
+++ b/src/world/Server/Packets/CmsgRequestPartyMemberStats.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgRequestVehicleSwitchSeat.h
+++ b/src/world/Server/Packets/CmsgRequestVehicleSwitchSeat.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgResurrectResponse.h
+++ b/src/world/Server/Packets/CmsgResurrectResponse.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSearchLfgJoin.h
+++ b/src/world/Server/Packets/CmsgSearchLfgJoin.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSearchLfgLeave.h
+++ b/src/world/Server/Packets/CmsgSearchLfgLeave.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSellItem.h
+++ b/src/world/Server/Packets/CmsgSellItem.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSendMail.h
+++ b/src/world/Server/Packets/CmsgSendMail.h
@@ -45,7 +45,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetChannelWatch.h
+++ b/src/world/Server/Packets/CmsgSetChannelWatch.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetFactionAtWar.h
+++ b/src/world/Server/Packets/CmsgSetFactionAtWar.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetFactionInactive.h
+++ b/src/world/Server/Packets/CmsgSetFactionInactive.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetGuildBankText.h
+++ b/src/world/Server/Packets/CmsgSetGuildBankText.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetLfgComment.h
+++ b/src/world/Server/Packets/CmsgSetLfgComment.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
+++ b/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         {
         }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetTaxiBenchmarkMode.h
+++ b/src/world/Server/Packets/CmsgSetTaxiBenchmarkMode.h
@@ -26,7 +26,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetTitle.h
+++ b/src/world/Server/Packets/CmsgSetTitle.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetTradeGold.h
+++ b/src/world/Server/Packets/CmsgSetTradeGold.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSetTradeItem.h
+++ b/src/world/Server/Packets/CmsgSetTradeItem.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSocketGems.h
+++ b/src/world/Server/Packets/CmsgSocketGems.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSplitItem.h
+++ b/src/world/Server/Packets/CmsgSplitItem.h
@@ -36,7 +36,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgStableSwapPet.h
+++ b/src/world/Server/Packets/CmsgStableSwapPet.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSummonResponse.h
+++ b/src/world/Server/Packets/CmsgSummonResponse.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSwapInvItem.h
+++ b/src/world/Server/Packets/CmsgSwapInvItem.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgSwapItem.h
+++ b/src/world/Server/Packets/CmsgSwapItem.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgTaxiQueryAvailableNodes.h
+++ b/src/world/Server/Packets/CmsgTaxiQueryAvailableNodes.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgTaxinodeStatusQuery.h
+++ b/src/world/Server/Packets/CmsgTaxinodeStatusQuery.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgTrainerBuySpell.h
+++ b/src/world/Server/Packets/CmsgTrainerBuySpell.h
@@ -30,7 +30,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgTrainerList.h
+++ b/src/world/Server/Packets/CmsgTrainerList.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgTurnInPetition.h
+++ b/src/world/Server/Packets/CmsgTurnInPetition.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgUnlearnSkill.h
+++ b/src/world/Server/Packets/CmsgUnlearnSkill.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgUnstablePet.h
+++ b/src/world/Server/Packets/CmsgUnstablePet.h
@@ -29,7 +29,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgUpdateAccountData.h
+++ b/src/world/Server/Packets/CmsgUpdateAccountData.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgUseItem.h
+++ b/src/world/Server/Packets/CmsgUseItem.h
@@ -41,7 +41,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgWhoIs.h
+++ b/src/world/Server/Packets/CmsgWhoIs.h
@@ -28,7 +28,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgWorldTeleport.h
+++ b/src/world/Server/Packets/CmsgWorldTeleport.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgWrapItem.h
+++ b/src/world/Server/Packets/CmsgWrapItem.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/CmsgZoneupdate.h
+++ b/src/world/Server/Packets/CmsgZoneupdate.h
@@ -27,7 +27,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/Handlers/CharacterHandler.cpp
+++ b/src/world/Server/Packets/Handlers/CharacterHandler.cpp
@@ -567,7 +567,7 @@ void WorldSession::handleCharCustomizeLooksOpcode(WorldPacket& recvPacket)
     const auto loginErrorCode = VerifyName(srlPacket.createStruct.name.c_str(), srlPacket.createStruct.name.length());
     if (loginErrorCode != E_CHAR_NAME_SUCCESS)
     {
-        SendPacket(SmsgCharCustomize(E_CHAR_NAME_NO_NAME).serialise().get());
+        SendPacket(SmsgCharCustomize(loginErrorCode).serialise().get());
         return;
     }
 
@@ -812,8 +812,6 @@ void WorldSession::characterEnumProc(QueryResult* result)
 
     if (result)
     {
-        uint32_t numchar = result->GetRowCount();
-
         do
         {
             Field* fields = result->Fetch();

--- a/src/world/Server/Packets/Handlers/GMTicketHandler.cpp
+++ b/src/world/Server/Packets/Handlers/GMTicketHandler.cpp
@@ -301,7 +301,7 @@ void WorldSession::handleGMTicketGetTicketOpcode(WorldPacket& /*recvPacket*/)
     if (ticket == nullptr)
         SendPacket(SmsgGmTicketGetTicket(GMTNoCurrentTicket, "", 0).serialise().get());
     else
-        SendPacket(SmsgGmTicketGetTicket(GMTCurrentTicketFound, ticket->message, ticket->map).serialise().get());
+        SendPacket(SmsgGmTicketGetTicket(GMTCurrentTicketFound, ticket->message, static_cast<uint8_t>(ticket->map)).serialise().get());
 }
 #else
 void WorldSession::handleGMTicketGetTicketOpcode(WorldPacket& /*recvPacket*/)

--- a/src/world/Server/Packets/Handlers/GuildHandler.cpp
+++ b/src/world/Server/Packets/Handlers/GuildHandler.cpp
@@ -490,7 +490,7 @@ void WorldSession::handleGuildSetRank(WorldPacket& recvPacket)
         return;
 
     if (Guild* guild = _player->GetGuild())
-        guild->handleSetRankInfo(this, srlPacket.newRankId, srlPacket.rankName, srlPacket.newRights, srlPacket.moneyPerDay, srlPacket._rightsAndSlots);
+        guild->handleSetRankInfo(this, static_cast<uint8_t>(srlPacket.newRankId), srlPacket.rankName, srlPacket.newRights, srlPacket.moneyPerDay, srlPacket._rightsAndSlots);
 }
 
 
@@ -501,7 +501,7 @@ void WorldSession::handleCharterShowSignatures(WorldPacket& recvPacket)
         return;
 
     if (Charter* charter = objmgr.GetCharterByItemGuid(srlPacket.itemGuid))
-        _player->GetSession()->SendPacket(SmsgPetitionShowSignatures(srlPacket.itemGuid, charter->GetLeader(), charter->GetID(), charter->SignatureCount,
+        _player->GetSession()->SendPacket(SmsgPetitionShowSignatures(srlPacket.itemGuid, charter->GetLeader(), charter->GetID(), static_cast<uint8_t>(charter->SignatureCount),
             charter->Slots, charter->Signatures).serialise().get());
 }
 
@@ -531,7 +531,7 @@ void WorldSession::handleCharterOffer(WorldPacket& recvPacket)
         return;
     }
 
-    pTarget->GetSession()->SendPacket(SmsgPetitionShowSignatures(srlPacket.itemGuid, pCharter->GetLeader(), pCharter->GetID(), pCharter->SignatureCount,
+    pTarget->GetSession()->SendPacket(SmsgPetitionShowSignatures(srlPacket.itemGuid, pCharter->GetLeader(), pCharter->GetID(), static_cast<uint8_t>(pCharter->SignatureCount),
         pCharter->Slots, pCharter->Signatures).serialise().get());
 }
 

--- a/src/world/Server/Packets/Handlers/LootHandler.cpp
+++ b/src/world/Server/Packets/Handlers/LootHandler.cpp
@@ -246,8 +246,8 @@ void WorldSession::handleAutostoreLootItemOpcode(WorldPacket& recvPacket)
     if (lootGameObject && lootGameObject->getEntry() == GO_FISHING_BOBBER)
     {
         int count = 0;
-        for (const auto& lootItem : loot->items)
-            count += lootItem.iItemsCount;
+        for (const auto& itemFromLoot : loot->items)
+            count += itemFromLoot.iItemsCount;
 
         if (!count)
             lootGameObject->ExpireAndDelete();

--- a/src/world/Server/Packets/MsgBattlegroundPlayerPosition.h
+++ b/src/world/Server/Packets/MsgBattlegroundPlayerPosition.h
@@ -46,7 +46,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/MsgCorpseQuery.h
+++ b/src/world/Server/Packets/MsgCorpseQuery.h
@@ -40,7 +40,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/MsgGuildBankMoneyWithdrawn.h
+++ b/src/world/Server/Packets/MsgGuildBankMoneyWithdrawn.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/MsgMoveTeleportAck.h
+++ b/src/world/Server/Packets/MsgMoveTeleportAck.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/MsgPartyAssign.h
+++ b/src/world/Server/Packets/MsgPartyAssign.h
@@ -31,7 +31,7 @@ namespace AscEmu { namespace Packets
         }
 
     protected:
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/MsgTalentWipeConfirm.h
+++ b/src/world/Server/Packets/MsgTalentWipeConfirm.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgActivatetaxireply.h
+++ b/src/world/Server/Packets/SmsgActivatetaxireply.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgAreaSpiritHealerTime.h
+++ b/src/world/Server/Packets/SmsgAreaSpiritHealerTime.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgAreaTriggerMessage.h
+++ b/src/world/Server/Packets/SmsgAreaTriggerMessage.h
@@ -42,6 +42,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgArenaError.h
+++ b/src/world/Server/Packets/SmsgArenaError.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgAttackStart.h
+++ b/src/world/Server/Packets/SmsgAttackStart.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgAttackStop.h
+++ b/src/world/Server/Packets/SmsgAttackStop.h
@@ -46,6 +46,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgAuctionCommandResult.h
+++ b/src/world/Server/Packets/SmsgAuctionCommandResult.h
@@ -51,6 +51,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgBarberShopResult.h
+++ b/src/world/Server/Packets/SmsgBarberShopResult.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgBinderConfirm.h
+++ b/src/world/Server/Packets/SmsgBinderConfirm.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgBuyBankSlotResult.h
+++ b/src/world/Server/Packets/SmsgBuyBankSlotResult.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgBuyFailed.h
+++ b/src/world/Server/Packets/SmsgBuyFailed.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgBuyItem.h
+++ b/src/world/Server/Packets/SmsgBuyItem.h
@@ -47,6 +47,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCastFailed.h
+++ b/src/world/Server/Packets/SmsgCastFailed.h
@@ -53,6 +53,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCharCreate.h
+++ b/src/world/Server/Packets/SmsgCharCreate.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgCharCustomize.h
+++ b/src/world/Server/Packets/SmsgCharCustomize.h
@@ -51,7 +51,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgCharDelete.h
+++ b/src/world/Server/Packets/SmsgCharDelete.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCharEnum.h
+++ b/src/world/Server/Packets/SmsgCharEnum.h
@@ -181,7 +181,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgCharFactionChange.h
+++ b/src/world/Server/Packets/SmsgCharFactionChange.h
@@ -56,7 +56,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgCharRename.h
+++ b/src/world/Server/Packets/SmsgCharRename.h
@@ -40,7 +40,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgCharacterLoginFailed.h
+++ b/src/world/Server/Packets/SmsgCharacterLoginFailed.h
@@ -35,6 +35,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgClearExtraAuraInfo.h
+++ b/src/world/Server/Packets/SmsgClearExtraAuraInfo.h
@@ -42,7 +42,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgClientControlUpdate.h
+++ b/src/world/Server/Packets/SmsgClientControlUpdate.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgComplainResult.h
+++ b/src/world/Server/Packets/SmsgComplainResult.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgCooldownEvent.h
+++ b/src/world/Server/Packets/SmsgCooldownEvent.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCorpseReclaimDelay.h
+++ b/src/world/Server/Packets/SmsgCorpseReclaimDelay.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCreatureQueryResponse.h
+++ b/src/world/Server/Packets/SmsgCreatureQueryResponse.h
@@ -81,6 +81,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgCrossedInebriationThreshold.h
+++ b/src/world/Server/Packets/SmsgCrossedInebriationThreshold.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgDeathReleaseLoc.h
+++ b/src/world/Server/Packets/SmsgDeathReleaseLoc.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgDestoyObject.h
+++ b/src/world/Server/Packets/SmsgDestoyObject.h
@@ -36,7 +36,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgDismountResult.h
+++ b/src/world/Server/Packets/SmsgDismountResult.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgDuelComplete.h
+++ b/src/world/Server/Packets/SmsgDuelComplete.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgDuelCountdown.h
+++ b/src/world/Server/Packets/SmsgDuelCountdown.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgDuelWinner.h
+++ b/src/world/Server/Packets/SmsgDuelWinner.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgEmote.h
+++ b/src/world/Server/Packets/SmsgEmote.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgEnvironmentalDamageLog.h
+++ b/src/world/Server/Packets/SmsgEnvironmentalDamageLog.h
@@ -43,6 +43,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgEquipmentSetUseResult.h
+++ b/src/world/Server/Packets/SmsgEquipmentSetUseResult.h
@@ -38,7 +38,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgExplorationExperience.h
+++ b/src/world/Server/Packets/SmsgExplorationExperience.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgFeatureSystemStatus.h
+++ b/src/world/Server/Packets/SmsgFeatureSystemStatus.h
@@ -50,7 +50,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgFriendStatus.h
+++ b/src/world/Server/Packets/SmsgFriendStatus.h
@@ -56,7 +56,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgGameobjectQueryResponse.h
+++ b/src/world/Server/Packets/SmsgGameobjectQueryResponse.h
@@ -50,6 +50,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGmTicketCreate.h
+++ b/src/world/Server/Packets/SmsgGmTicketCreate.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGmTicketDeleteTicket.h
+++ b/src/world/Server/Packets/SmsgGmTicketDeleteTicket.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGmTicketGetTicket.h
+++ b/src/world/Server/Packets/SmsgGmTicketGetTicket.h
@@ -43,6 +43,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGmTicketSystemstatus.h
+++ b/src/world/Server/Packets/SmsgGmTicketSystemstatus.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGmTicketUpdateText.h
+++ b/src/world/Server/Packets/SmsgGmTicketUpdateText.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGossipPoi.h
+++ b/src/world/Server/Packets/SmsgGossipPoi.h
@@ -53,6 +53,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGroupDecline.h
+++ b/src/world/Server/Packets/SmsgGroupDecline.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGuildBankMoneyWithdrawn.h
+++ b/src/world/Server/Packets/SmsgGuildBankMoneyWithdrawn.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgGuildBankQueryTextResult.h
+++ b/src/world/Server/Packets/SmsgGuildBankQueryTextResult.h
@@ -39,7 +39,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgGuildCommandResult.h
+++ b/src/world/Server/Packets/SmsgGuildCommandResult.h
@@ -38,6 +38,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGuildEvent.h
+++ b/src/world/Server/Packets/SmsgGuildEvent.h
@@ -50,6 +50,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGuildInfo.h
+++ b/src/world/Server/Packets/SmsgGuildInfo.h
@@ -45,6 +45,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgGuildInvite.h
+++ b/src/world/Server/Packets/SmsgGuildInvite.h
@@ -127,6 +127,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgInstanceDifficulty.h
+++ b/src/world/Server/Packets/SmsgInstanceDifficulty.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgInventoryChangeFailure.h
+++ b/src/world/Server/Packets/SmsgInventoryChangeFailure.h
@@ -48,6 +48,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgItemNameQueryResponse.h
+++ b/src/world/Server/Packets/SmsgItemNameQueryResponse.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgItemPushResult.h
+++ b/src/world/Server/Packets/SmsgItemPushResult.h
@@ -59,6 +59,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgItemTextQueryResponse.h
+++ b/src/world/Server/Packets/SmsgItemTextQueryResponse.h
@@ -41,7 +41,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgLearnedDanceMoves.h
+++ b/src/world/Server/Packets/SmsgLearnedDanceMoves.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgLevelupInfo.h
+++ b/src/world/Server/Packets/SmsgLevelupInfo.h
@@ -59,6 +59,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgLfgOfferContinue.h
+++ b/src/world/Server/Packets/SmsgLfgOfferContinue.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgLfgRoleChosen.h
+++ b/src/world/Server/Packets/SmsgLfgRoleChosen.h
@@ -40,7 +40,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgLfgTeleportDenied.h
+++ b/src/world/Server/Packets/SmsgLfgTeleportDenied.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgLfgUpdateSearch.h
+++ b/src/world/Server/Packets/SmsgLfgUpdateSearch.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgLogXpGain.h
+++ b/src/world/Server/Packets/SmsgLogXpGain.h
@@ -44,6 +44,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgLoginVerifyWorld.h
+++ b/src/world/Server/Packets/SmsgLoginVerifyWorld.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgLootMasterList.h
+++ b/src/world/Server/Packets/SmsgLootMasterList.h
@@ -42,7 +42,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgLootMoneyNotify.h
+++ b/src/world/Server/Packets/SmsgLootMoneyNotify.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgLootReleaseResponse.h
+++ b/src/world/Server/Packets/SmsgLootReleaseResponse.h
@@ -38,6 +38,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgLootRemoved.h
+++ b/src/world/Server/Packets/SmsgLootRemoved.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgMeetingstoneSetQueue.h
+++ b/src/world/Server/Packets/SmsgMeetingstoneSetQueue.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgMonsterMoveTransport.h
+++ b/src/world/Server/Packets/SmsgMonsterMoveTransport.h
@@ -56,6 +56,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgMountResult.h
+++ b/src/world/Server/Packets/SmsgMountResult.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgMountspecialAnim.h
+++ b/src/world/Server/Packets/SmsgMountspecialAnim.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgMoveKnockBack.h
+++ b/src/world/Server/Packets/SmsgMoveKnockBack.h
@@ -74,6 +74,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgNameQueryResponse.h
+++ b/src/world/Server/Packets/SmsgNameQueryResponse.h
@@ -47,6 +47,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgNewWorld.h
+++ b/src/world/Server/Packets/SmsgNewWorld.h
@@ -40,6 +40,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPageTextQueryResponse.h
+++ b/src/world/Server/Packets/SmsgPageTextQueryResponse.h
@@ -40,6 +40,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPartyCommandResult.h
+++ b/src/world/Server/Packets/SmsgPartyCommandResult.h
@@ -48,6 +48,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPartyKillLog.h
+++ b/src/world/Server/Packets/SmsgPartyKillLog.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
+++ b/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
@@ -108,7 +108,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}
-    

--- a/src/world/Server/Packets/SmsgPetActionSound.h
+++ b/src/world/Server/Packets/SmsgPetActionSound.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetNameQuery.h
+++ b/src/world/Server/Packets/SmsgPetNameQuery.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetUnlearnConfirm.h
+++ b/src/world/Server/Packets/SmsgPetUnlearnConfirm.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetitionQueryResponse.h
+++ b/src/world/Server/Packets/SmsgPetitionQueryResponse.h
@@ -62,6 +62,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetitionShowSignatures.h
+++ b/src/world/Server/Packets/SmsgPetitionShowSignatures.h
@@ -58,6 +58,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetitionShowlist.h
+++ b/src/world/Server/Packets/SmsgPetitionShowlist.h
@@ -61,6 +61,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPetitionSignResult.h
+++ b/src/world/Server/Packets/SmsgPetitionSignResult.h
@@ -40,6 +40,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPlayObjectSound.h
+++ b/src/world/Server/Packets/SmsgPlayObjectSound.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPlaySound.h
+++ b/src/world/Server/Packets/SmsgPlaySound.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPlayedTime.h
+++ b/src/world/Server/Packets/SmsgPlayedTime.h
@@ -42,6 +42,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgPowerUpdate.h
+++ b/src/world/Server/Packets/SmsgPowerUpdate.h
@@ -47,7 +47,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgQuestgiverStatus.h
+++ b/src/world/Server/Packets/SmsgQuestgiverStatus.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgQuestgiverStatusMultiple.h
+++ b/src/world/Server/Packets/SmsgQuestgiverStatusMultiple.h
@@ -48,6 +48,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgReadItemFailed.h
+++ b/src/world/Server/Packets/SmsgReadItemFailed.h
@@ -38,6 +38,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgReadItemOk.h
+++ b/src/world/Server/Packets/SmsgReadItemOk.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgRealmSplit.h
+++ b/src/world/Server/Packets/SmsgRealmSplit.h
@@ -37,7 +37,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgResurrectFailed.h
+++ b/src/world/Server/Packets/SmsgResurrectFailed.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSellItem.h
+++ b/src/world/Server/Packets/SmsgSellItem.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSendMailResult.h
+++ b/src/world/Server/Packets/SmsgSendMailResult.h
@@ -80,7 +80,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgSetFlatSpellModifier.h
+++ b/src/world/Server/Packets/SmsgSetFlatSpellModifier.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSetPctSpellModifier.h
+++ b/src/world/Server/Packets/SmsgSetPctSpellModifier.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSetPlayerDeclinedNamesResult.h
+++ b/src/world/Server/Packets/SmsgSetPlayerDeclinedNamesResult.h
@@ -34,7 +34,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgSetProficiency.h
+++ b/src/world/Server/Packets/SmsgSetProficiency.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgShowBank.h
+++ b/src/world/Server/Packets/SmsgShowBank.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgShowTaxiNodes.h
+++ b/src/world/Server/Packets/SmsgShowTaxiNodes.h
@@ -43,6 +43,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSpiritHealerConfirm.h
+++ b/src/world/Server/Packets/SmsgSpiritHealerConfirm.h
@@ -34,6 +34,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgStableResult.h
+++ b/src/world/Server/Packets/SmsgStableResult.h
@@ -35,6 +35,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgStandstateUpdate.h
+++ b/src/world/Server/Packets/SmsgStandstateUpdate.h
@@ -32,7 +32,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgStopMirrorTimer.h
+++ b/src/world/Server/Packets/SmsgStopMirrorTimer.h
@@ -37,6 +37,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgSummonRequest.h
+++ b/src/world/Server/Packets/SmsgSummonRequest.h
@@ -41,6 +41,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTaxinodeStatus.h
+++ b/src/world/Server/Packets/SmsgTaxinodeStatus.h
@@ -38,6 +38,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTextEmote.h
+++ b/src/world/Server/Packets/SmsgTextEmote.h
@@ -48,6 +48,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTitleEarned.h
+++ b/src/world/Server/Packets/SmsgTitleEarned.h
@@ -39,6 +39,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTotemCreated.h
+++ b/src/world/Server/Packets/SmsgTotemCreated.h
@@ -43,6 +43,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTradeStatus.h
+++ b/src/world/Server/Packets/SmsgTradeStatus.h
@@ -38,6 +38,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgTrainerBuySucceeded.h
+++ b/src/world/Server/Packets/SmsgTrainerBuySucceeded.h
@@ -35,7 +35,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Server/Packets/SmsgUpdateAccountDataComplete.h
+++ b/src/world/Server/Packets/SmsgUpdateAccountDataComplete.h
@@ -39,7 +39,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
 #endif
     };
 }}

--- a/src/world/Server/Packets/SmsgUpdateObject.h
+++ b/src/world/Server/Packets/SmsgUpdateObject.h
@@ -37,7 +37,7 @@ namespace AscEmu
                 return true;
             }
 
-            bool internalDeserialise(WorldPacket& packet) override
+            bool internalDeserialise(WorldPacket& /*packet*/) override
             {
                 return true;
             }

--- a/src/world/Server/Packets/SmsgWeather.h
+++ b/src/world/Server/Packets/SmsgWeather.h
@@ -36,6 +36,6 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }}

--- a/src/world/Server/Packets/SmsgWorldStateUiTimerUpdate.h
+++ b/src/world/Server/Packets/SmsgWorldStateUiTimerUpdate.h
@@ -33,7 +33,7 @@ namespace AscEmu { namespace Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return false;
         }

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -2023,7 +2023,7 @@ void MySQLDataStore::loadTotemDisplayIdsTable()
 
         MySQLStructure::TotemDisplayIds totemDisplayId;
 
-        totemDisplayId._race = fields[0].GetUInt32();
+        totemDisplayId._race = static_cast<uint8_t>(fields[0].GetUInt32());
         totemDisplayId.display_id = fields[1].GetUInt32();
         totemDisplayId.race_specific_id = fields[2].GetUInt32();
 

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -7796,7 +7796,6 @@ void Player::ClearCooldownForSpell(uint32 spell_id)
     data << uint64_t(getGuid());
     GetSession()->SendPacket(&data);
 
-    SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spell_id);
     if (SpellInfo* spellInfo = sSpellCustomizations.GetSpellInfo(spell_id))
     {
         for (int i = 0; i < NUM_COOLDOWN_TYPES; ++i)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -1178,7 +1178,7 @@ void Player::updateAutoRepeatSpell()
                 interruptSpellWithSpellType(CURRENT_AUTOREPEAT_SPELL);
             }
             else if (isPlayer())
-                autoRepeatSpell->SendCastResult(canCastAutoRepeatSpell);
+                autoRepeatSpell->SendCastResult(static_cast<uint8_t>(canCastAutoRepeatSpell));
             return;
         }
 
@@ -1399,7 +1399,7 @@ void Player::learnTalent(uint32_t talentId, uint32_t talentRank)
 #endif
 
     // Add the new talent to player talent map
-    getActiveSpec().AddTalent(talentId, talentRank);
+    getActiveSpec().AddTalent(talentId, static_cast<uint8_t>(talentRank));
     setTalentPoints(curTalentPoints - requiredTalentPoints, false);
 }
 

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -174,8 +174,8 @@ class SERVER_DECL PlayerInfo
         uint32 guid;
         uint32 acct;
         char* name;
-        uint32 race;
-        uint32 gender;
+        uint8_t race;
+        uint8_t gender;
         uint8 cl;
         uint32 team;
         uint8 role;

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -395,7 +395,7 @@ Unit::Unit() : m_currentSpeedWalk(2.5f),
     int i;
 
     m_canDualWield = false;
-    for (auto i = 0; i < 3; ++i)
+    for (i = 0; i < 3; ++i)
         m_attackTimer[i] = 0;
 
     m_ignoreArmorPctMaceSpec = 0;


### PR DESCRIPTION
Such as:
- declaration of 'language' hides class member	
- conversion from CharacterErrorCodes to uint8_t, possible loss of data
- conversion from uint32_t to uint8_t, possible loss of data
- local variable is initialized but not referenced
- 'packet': unreferenced formal parameter

etc