### PR TITLE
Core/Scripts: added new scriptable virtual functions for easer data sharing between scripts

### DIFF
--- a/src/world/Server/Script/CreatureAIScript.h
+++ b/src/world/Server/Script/CreatureAIScript.h
@@ -188,6 +188,12 @@ public:
     virtual void OnScriptPhaseChange(uint32_t /*_phaseId*/) {}
     virtual void OnHitBySpell(uint32_t /*_spellId*/, Unit* /*_caster*/) {}
 
+    // Data sharing between scripts
+    virtual void setCreatureData(uint32 /*type*/) {}
+    virtual uint32 getCreatureData(uint32 /*type*/) const { return 0; }
+    virtual void setGuidData(uint32 /*guidType*/, uint64 /*guidData*/) {}
+    virtual uint64 getGuidData(uint32 /*guidType*/) const { return 0; }
+
     virtual void Destroy() { delete this; }
 
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -483,7 +483,7 @@ class SERVER_DECL GameObjectAIScript
 
         // Data sharing between scripts
         virtual void setGameObjectData(uint32 /*type*/) {}
-        virtual uint32 gettGameObjectData(uint32 /*type*/) const { return 0; }
+        virtual uint32 getGameObjectData(uint32 /*type*/) const { return 0; }
         virtual void setGuidData(uint32 /*guidType*/, uint64 /*guidData*/) {}
         virtual uint64 getGuidData(uint32 /*guidType*/) const { return 0; }
 

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -452,6 +452,12 @@ class SERVER_DECL EventScript
         virtual void UpdateEvent() {}
         virtual void Destroy() {}
 
+        // Data sharing between scripts
+        virtual void setInstanceData(uint32 /*dataType*/, uint32 /*value*/) {}
+        virtual uint32 getInstanceData(uint32 /*data*/) const { return 0;  }
+        virtual void setGuidData(uint32 /*guidType*/, uint64 /*guidData*/) {}
+        virtual uint64 getGuidData(uint32 /*guidType*/) const { return 0; }
+
         // UpdateEvent
         void RegisterUpdateEvent(uint32 pFrequency);
         void ModifyUpdateEvent(uint32 pNewFrequency);
@@ -474,6 +480,12 @@ class SERVER_DECL GameObjectAIScript
         virtual void OnDestroyed(){}
         virtual void AIUpdate() {}
         virtual void Destroy() { delete this; }
+
+        // Data sharing between scripts
+        virtual void setGameObjectData(uint32 /*type*/) {}
+        virtual uint32 gettGameObjectData(uint32 /*type*/) const { return 0; }
+        virtual void setGuidData(uint32 /*guidType*/, uint64 /*guidData*/) {}
+        virtual uint64 getGuidData(uint32 /*guidType*/) const { return 0; }
 
         void RegisterAIUpdateEvent(uint32 frequency);
         void ModifyAIUpdateEvent(uint32 newfrequency);


### PR DESCRIPTION
This will reduce amount of scripts where you may need to split into constructor to access specific script data. For example, you have script_A.cpp, script_B.cpp and you need to access data from script_A.cpp in script_B.cpp. You can do such tasks by splitting their script into constructor or using extern keyword. These new functions are scriptable and could be called from any script without splitting into constructor and similar. This will reduce amounts of c++ class casts or c++ constructoring in headers
