### PR TITLE
Improved x64 bit system detection in cmake

### DIFF
--- a/cmake/CheckSystem.cmake
+++ b/cmake/CheckSystem.cmake
@@ -14,18 +14,10 @@ if(USE_PCH)
 endif()
 
 # get architecture type
-if(UNIX)
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "[xX]64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[xX]86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[aA][mM][dD]64" )
-        set(IS_64BIT TRUE)
-    else()
-        set(IS_64BIT FALSE)
-    endif()
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(IS_64BIT TRUE)
 else()
-    if(CMAKE_GENERATOR MATCHES Win64*)
-        set(IS_64BIT TRUE)
-    else()
-        set(IS_64BIT FALSE)
-    endif()
+    set(IS_64BIT FALSE)
 endif()
 
 # set default architecture identifier


### PR DESCRIPTION
Cmake oftenly fails to detect Win64 prefix. This will give more occurate result