### PR TITLE
Fix syntax sql.

### DIFF
--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -586,8 +586,8 @@ void Creature::SaveToDB()
         ss << 0 << ",";
 
     ss << m_phase << ","
-        << "0,"             // event_entry
-        << "0,"             // waypoint_group
+        << "0"  // event_entry
+        << ",0" // waypoint_group
         << ")";
 
     WorldDatabase.Execute(ss.str().c_str());


### PR DESCRIPTION
>test : .npc spawn 28312

> console : Sql query failed due to [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1], Query: [INSERT INTO creature_spawns VALUES(316809,12340,12340,28312,0,1676.62,1677.2,121.67,0,0,25292,35,0,50331648,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,)]