### PR TITLE
Implemented virtual functions for data exchange/handling in instance …

### DIFF
--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -594,7 +594,7 @@ class SERVER_DECL InstanceScript
         virtual void SetInstanceData(uint32_t /*type*/, uint32_t /*data*/) {}
         virtual void SetInstanceData64(uint32_t /*type*/, uint64_t /*data*/) {}
         virtual uint32_t GetInstanceData(uint32_t /*type*/) const { return 0; }
-        virtual uint64_t GetInstanceData(uint32_t /*type*/) const { return 0; }
+        virtual uint64_t GetInstanceData64(uint32_t /*type*/) const { return 0; }
         
         //used for debug
         std::string getDataStateString(uint32_t bossEntry);

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -590,6 +590,12 @@ class SERVER_DECL InstanceScript
         uint32_t getData(uint32_t data);
         bool isDataStateFinished(uint32_t data);
 
+        // used for local instance data (not saved to database, only for scripting)
+        virtual void SetInstanceData(uint32_t /*type*/, uint32_t /*data*/) {}
+        virtual void SetInstanceData64(uint32_t /*type*/, uint64_t /*data*/) {}
+        virtual uint32_t GetInstanceData(uint32_t /*type*/) const { return 0; }
+        virtual uint64_t GetInstanceData(uint32_t /*type*/) const { return 0; }
+        
         //used for debug
         std::string getDataStateString(uint32_t bossEntry);
 


### PR DESCRIPTION
…script to avoid necessary C++ type casts

These scriptable virtual functions will allow to avoid C++ type casting to perform local instance duties, like setting guid data or like setting misc event data. Data setted into these virtual functions will not get saved by default but you can set data with setData function call in overriden functions.

This implementation contains uint32 and uint64 based handling