### PR TITLE
Core/Build: implemented new cmake option "TREAT_WARNINGS_AS_ERRORS".

### DIFF
--- a/cmake/Compilers/msvc.cmake
+++ b/cmake/Compilers/msvc.cmake
@@ -17,11 +17,16 @@ if(NOT IS_64BIT)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
 endif()
 
+if (TREAT_WARNINGS_AS_ERRORS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+endif()
+
 # enable/disable warnings
 # dll warning 4251 disabled by default.
 if (BUILD_WITH_WARNINGS)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX /wd4251")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX /wd4251")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4251")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W0")

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -20,6 +20,7 @@ option(BUILD_LUAENGINE "Build LuaEngine." ON)
 set(ASCEMU_TOOLS_PATH "tools" CACHE PATH "The directory where you want the tools installed.")
 option(BUILD_WITH_WARNINGS "Enable/Disable warnings on compilation" ON)
 option(USE_PCH "Enable precompiled headers - it will reduce compilation time" ON)
+option(TREAT_WARNINGS_AS_ERRORS "Treats warnings as errors" ON)
 
 if(NOT USE_PCH)
     set(ASCEMU_COMMENT_PCH //)


### PR DESCRIPTION
Some dependencies for example maybe aren't updated to recent C++ standarts. With this option we can temporally enable/disable warnings treatment as errors