### PR TITLE
fix gcc/clang compile error with Memory exhausted.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 os: linux
 dist: bionic
-group: edge
-language: cpp
 
-cache:
-  timeout: 1000000
+language: cpp
 
 compiler:
   - gcc
@@ -212,8 +209,9 @@ before_script:
   - cmake --version
 
 script:
+  - "travis_wait 30 sleep 1800 &"
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then 
-    make CXX=$COMPILER -j 4 -k;
+    make CXX=$COMPILER -j 4;
     fi
 
 #after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - zlib1g-dev
             - libssl-dev
@@ -82,7 +82,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - zlib1g-dev
             - libssl-dev
@@ -116,7 +116,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - zlib1g-dev
             - libssl-dev
@@ -150,7 +150,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - zlib1g-dev
             - libssl-dev
@@ -184,7 +184,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - zlib1g-dev
             - libssl-dev
@@ -209,7 +209,6 @@ before_script:
   - cmake --version
 
 script:
-  - "travis_wait 60 sleep 3600 &"
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then 
     make CXX=$COMPILER -j 4;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ group: edge
 language: cpp
 
 cache:
-  timeout: 100000
+  timeout: 1000000
 
 compiler:
   - gcc
@@ -213,7 +213,7 @@ before_script:
 
 script:
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then 
-    make CXX=$COMPILER -j 12;
+    make CXX=$COMPILER -j 4 -k;
     fi
 
 #after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: bionic
-
 language: cpp
 
 compiler:
@@ -19,7 +18,7 @@ env:
 
 before_install:
   - if [ "$COMPILER" = "g++-9" ]; then export CXX="g++-9" CC="gcc-9"; fi
-  - if [ "$COMPILER" = "clang++-9" ]; then export CXX="clang++-9" CC="clang-9"; fi
+  - if [ "$COMPILER" = "clang++-8" ]; then export CXX="clang++-8" CC="clang-8"; fi
     
 jobs:
   #allow_failures:
@@ -56,9 +55,9 @@ jobs:
             - libbz2-dev
             - libmysqlclient-dev
             - libmysql++-dev
-            - clang-9
+            - clang-8
             - g++-9
-      env: ASC_VERSION=Classic COMPILER=clang++-9
+      env: ASC_VERSION=Classic COMPILER=clang++-8
     # tbc
     - os: linux
       compiler: gcc
@@ -90,9 +89,9 @@ jobs:
             - libbz2-dev
             - libmysqlclient-dev
             - libmysql++-dev
-            - clang-9
+            - clang-8
             - g++-9
-      env: ASC_VERSION=TBC COMPILER=clang++-9
+      env: ASC_VERSION=TBC COMPILER=clang++-8
     # wotlk
     - os: linux
       compiler: gcc
@@ -124,9 +123,9 @@ jobs:
             - libbz2-dev
             - libmysqlclient-dev
             - libmysql++-dev
-            - clang-9
+            - clang-8
             - g++-9
-      env: ASC_VERSION=WotLK COMPILER=clang++-9
+      env: ASC_VERSION=WotLK COMPILER=clang++-8
     # Cata
     - os: linux
       compiler: gcc
@@ -158,9 +157,9 @@ jobs:
             - libbz2-dev
             - libmysqlclient-dev
             - libmysql++-dev
-            - clang-9
+            - clang-8
             - g++-9
-      env: ASC_VERSION=Cata COMPILER=clang++-9
+      env: ASC_VERSION=Cata COMPILER=clang++-8
     # MoP
     - os: linux
       compiler: gcc
@@ -192,9 +191,9 @@ jobs:
             - libbz2-dev
             - libmysqlclient-dev
             - libmysql++-dev
-            - clang-9
+            - clang-8
             - g++-9
-      env: ASC_VERSION=Mop COMPILER=clang++-9
+      env: ASC_VERSION=Mop COMPILER=clang++-8
   exclude:
     - env: TRAVIS_EMPTY_JOB_WORKAROUND=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -209,7 +209,7 @@ before_script:
   - cmake --version
 
 script:
-  - "travis_wait 30 sleep 1800 &"
+  - "travis_wait 60 sleep 3600 &"
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then 
     make CXX=$COMPILER -j 4;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 os: linux
 dist: bionic
+group: edge
 language: cpp
+
+cache:
+  timeout: 100000
 
 compiler:
   - gcc
@@ -209,7 +213,7 @@ before_script:
 
 script:
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then 
-    make CXX=$COMPILER -j 4;
+    make CXX=$COMPILER -j 12;
     fi
 
 #after_script:

--- a/src/scripts/InstanceScripts/Instance_Deadmines.cpp
+++ b/src/scripts/InstanceScripts/Instance_Deadmines.cpp
@@ -250,7 +250,7 @@ class MrSmiteAI : public CreatureAIScript
             float XDiff, YDiff;
             XDiff = getCreature()->GetPositionX() - 1.100060f;
             YDiff = getCreature()->GetPositionY() + 780.026367f;
-            float Distance = static_cast<float>(sqrt(XDiff * XDiff + YDiff * YDiff));
+            float Distance = static_cast<float>(std::sqrt(XDiff * XDiff + YDiff * YDiff));
             if (Distance <= 5.0f)
                 return true;
         }

--- a/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
@@ -489,14 +489,14 @@ class AdamantAI : public CreatureAIScript
                 // (currentWP - perviousLocation) *(currentWP - perviousLocation)
                 distanceX = (DeathstalkerAdamantWPS[i].wp_location.x - getCreature()->GetPositionX()) * (DeathstalkerAdamantWPS[i].wp_location.x - getCreature()->GetPositionX());
                 distanceY = (DeathstalkerAdamantWPS[i].wp_location.y - getCreature()->GetPositionY()) * (DeathstalkerAdamantWPS[i].wp_location.y - getCreature()->GetPositionY());
-                distance = sqrt(distanceX - distanceY);
+                distance = std::sqrt(distanceX - distanceY);
             }
             else if (i != adamantWpCount - 1)
             {
                 // (currentWP - perviousWP) *(currentWP - perviousWP)
                 distanceX = (DeathstalkerAdamantWPS[i].wp_location.x - DeathstalkerAdamantWPS[i - 1].wp_location.x) * (DeathstalkerAdamantWPS[i].wp_location.x - DeathstalkerAdamantWPS[i - 1].wp_location.x);
                 distanceY = (DeathstalkerAdamantWPS[i].wp_location.y - DeathstalkerAdamantWPS[i - 1].wp_location.y) * (DeathstalkerAdamantWPS[i].wp_location.y - DeathstalkerAdamantWPS[i - 1].wp_location.y);
-                distance = sqrt(distanceX + distanceY);
+                distance = std::sqrt(distanceX + distanceY);
             }
             waitTime = 1000 * std::abs(DeathstalkerAdamantWPS[i].wp_flag == Movement::WP_MOVE_TYPE_WALK ? distance / walkSpeed : distance / runSpeed);
 

--- a/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
+++ b/src/scripts/InstanceScripts/Instance_TheSteamvault.cpp
@@ -425,7 +425,7 @@ class WarlordKalitreshAI : public CreatureAIScript
                 continue;
 
             pDistiller = Unit2Check;
-            distance = sqrt(Dist2Unit);
+            distance = std::sqrt(Dist2Unit);
             DistillerNumber = i;
         }
 

--- a/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Raid_BlackTemple.cpp
@@ -4513,7 +4513,7 @@ class IllidanStormrageAI : public CreatureAIScript
         float xchange  = Util::getRandomFloat(15.0f);
         float distance = 15.0f;
 
-        float ychange = sqrt(distance * distance - xchange * xchange);
+        float ychange = std::sqrt(distance * distance - xchange * xchange);
 
         if (Util::getRandomUInt(1) == 1)
             xchange *= -1;

--- a/src/scripts/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
+++ b/src/scripts/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
@@ -429,7 +429,7 @@ class DoomfireAI : public CreatureAIScript
                     float y = 0.0f;
 
                     float xchange = Util::getRandomFloat(movedist);
-                    float ychange = sqrt(movedist * movedist - xchange * xchange);
+                    float ychange = std::sqrt(movedist * movedist - xchange * xchange);
 
                     if (Util::getRandomUInt(2) == 1)
                         xchange *= -1;

--- a/src/scripts/InstanceScripts/Raid_Karazhan.cpp
+++ b/src/scripts/InstanceScripts/Raid_Karazhan.cpp
@@ -2788,7 +2788,7 @@ class DorotheeAI : public CreatureAIScript
         float xchange = Util::getRandomFloat(15.0f);
         float distance = 15.0f;
 
-        float ychange = sqrt(distance * distance - xchange * xchange);
+        float ychange = std::sqrt(distance * distance - xchange * xchange);
 
         if (Util::getRandomUInt(1) == 1)
             xchange *= -1;

--- a/src/scripts/InstanceScripts/Raid_Naxxramas.h
+++ b/src/scripts/InstanceScripts/Raid_Naxxramas.h
@@ -2937,7 +2937,7 @@ class SoldierOfTheFrozenWastesAI : public CreatureAIScript
                     float xchange = Util::getRandomFloat(10.0f);
                     float distance = 10.0f;
 
-                    float ychange = sqrt(distance * distance - xchange * xchange);
+                    float ychange = std::sqrt(distance * distance - xchange * xchange);
 
                     if (Util::getRandomUInt(1) == 1)
                         xchange *= -1;
@@ -3041,7 +3041,7 @@ class UnstoppableAbominationAI : public CreatureAIScript
                     float xchange = Util::getRandomFloat(10.0f);
                     float distance = 10.0f;
 
-                    float ychange = sqrt(distance * distance - xchange * xchange);
+                    float ychange = std::sqrt(distance * distance - xchange * xchange);
 
                     if (Util::getRandomUInt(1) == 1)
                         xchange *= -1;
@@ -3134,7 +3134,7 @@ class SoulWeaverAI : public CreatureAIScript
                     float xchange = Util::getRandomFloat(10.0f);
                     float distance = 10.0f;
 
-                    float ychange = sqrt(distance * distance - xchange * xchange);
+                    float ychange = std::sqrt(distance * distance - xchange * xchange);
 
                     if (Util::getRandomUInt(1) == 1)
                         xchange *= -1;
@@ -3225,7 +3225,7 @@ class GuardianOfIcecrownAI : public CreatureAIScript
                     float xchange = Util::getRandomFloat(10.0f);
                     float distance = 10.0f;
 
-                    float ychange = sqrt(distance * distance - xchange * xchange);
+                    float ychange = std::sqrt(distance * distance - xchange * xchange);
 
                     if (Util::getRandomUInt(1) == 1)
                         xchange *= -1;

--- a/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Raid_SerpentshrineCavern.cpp
@@ -276,7 +276,7 @@ class HydrossTheUnstableAI : public CreatureAIScript
             //Switch check
             float distx = getCreature()->GetSpawnX() - getCreature()->GetPositionX();
             float disty = getCreature()->GetSpawnY() - getCreature()->GetPositionY();
-            float dist = sqrt((distx * distx) + (disty * disty));
+            float dist = std::sqrt((distx * distx) + (disty * disty));
             if (dist > 25)
             {
                 //switch to poison form
@@ -360,7 +360,7 @@ class HydrossTheUnstableAI : public CreatureAIScript
             //Switch check
             float distx = getCreature()->GetSpawnX() - getCreature()->GetPositionX();
             float disty = getCreature()->GetSpawnY() - getCreature()->GetPositionY();
-            float dist = sqrt((distx * distx) + (disty * disty));
+            float dist = std::sqrt((distx * distx) + (disty * disty));
             if (dist < 25)
             {
                 //switch to water form

--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -205,7 +205,7 @@ bool DeathGrip(uint8_t effectIndex, Spell* s)
         if (deltaX == 0.0f || deltaY == 0.0f)
             return false;
 
-        float d = sqrt(deltaX * deltaX + deltaY * deltaY) - s->u_caster->getBoundingRadius() - unitTarget->getBoundingRadius();
+        float d = std::sqrt(deltaX * deltaX + deltaY * deltaY) - s->u_caster->getBoundingRadius() - unitTarget->getBoundingRadius();
 
         float alpha = atanf(deltaY / deltaX);
 

--- a/src/shared/LocationVector.h
+++ b/src/shared/LocationVector.h
@@ -39,7 +39,7 @@ class SERVER_DECL LocationVector
     bool isSet() const;
     // MIT End
 
-        // sqrt(dx * dx + dy * dy + dz * dz)
+        // std::sqrt(dx * dx + dy * dy + dz * dz)
         float Distance(const LocationVector & comp)
         {
             float delta_x = comp.x - x;

--- a/src/tools/ToolsCata/vmap_tools/vmap4_extractor/vec3d.h
+++ b/src/tools/ToolsCata/vmap_tools/vmap4_extractor/vec3d.h
@@ -104,7 +104,7 @@ public:
 
     float length() const
     {
-        return sqrt(x*x + y*y + z*z);
+        return std::sqrt(x*x + y*y + z*z);
     }
 
     Vec3D& normalize()
@@ -210,7 +210,7 @@ public:
 
     float length() const
     {
-        return sqrt(x*x + y*y);
+        return std::sqrt(x*x + y*y);
     }
 
     Vec2D& normalize()

--- a/src/tools/ToolsMop/vmap_tools/vmap4_extractor/vec3d.h
+++ b/src/tools/ToolsMop/vmap_tools/vmap4_extractor/vec3d.h
@@ -104,7 +104,7 @@ public:
 
     float length() const
     {
-        return sqrt(x*x + y*y + z*z);
+        return std::sqrt(x*x + y*y + z*z);
     }
 
     Vec3D& normalize()
@@ -210,7 +210,7 @@ public:
 
     float length() const
     {
-        return sqrt(x*x + y*y);
+        return std::sqrt(x*x + y*y);
     }
 
     Vec2D& normalize()

--- a/src/world/Chat/Commands/debugcmds.cpp
+++ b/src/world/Chat/Commands/debugcmds.cpp
@@ -863,7 +863,7 @@ float CalculateDistance(float x1, float y1, float z1, float x2, float y2, float 
     float dx = x1 - x2;
     float dy = y1 - y2;
     float dz = z1 - z2;
-    return sqrt(dx * dx + dy * dy + dz * dz);
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
 }
 
 bool ChatHandler::HandleSimpleDistanceCommand(const char* args, WorldSession* m_session)

--- a/src/world/Management/TaxiMgr.cpp
+++ b/src/world/Management/TaxiMgr.cpp
@@ -54,7 +54,7 @@ void TaxiPath::ComputeLen()
             curmap = itr->second->mapid;
         }
 
-        *curptr += sqrt((itr->second->x - x) * (itr->second->x - x) +
+        *curptr += std::sqrt((itr->second->x - x) * (itr->second->x - x) +
                         (itr->second->y - y) * (itr->second->y - y) +
                         (itr->second->z - z) * (itr->second->z - z));
 
@@ -111,7 +111,7 @@ void TaxiPath::SetPosForTime(float & x, float & y, float & z, uint32_t time, uin
             continue;
         }
 
-        auto len = static_cast<uint32_t>(sqrt((itr->second->x - nx) * (itr->second->x - nx) +
+        auto len = static_cast<uint32_t>(std::sqrt((itr->second->x - nx) * (itr->second->x - nx) +
             (itr->second->y - ny) * (itr->second->y - ny) +
             (itr->second->z - nz) * (itr->second->z - nz)));
 
@@ -191,7 +191,7 @@ void TaxiPath::SendMoveForTime(Player* riding, Player* to, uint32_t time)
             continue;
         }
 
-        auto len = static_cast<uint32_t>(sqrt((itr->second->x - nx) * (itr->second->x - nx) +
+        auto len = static_cast<uint32_t>(std::sqrt((itr->second->x - nx) * (itr->second->x - nx) +
             (itr->second->y - ny) * (itr->second->y - ny) +
             (itr->second->z - nz) * (itr->second->z - nz)));
 

--- a/src/world/Management/TransporterHandler.cpp
+++ b/src/world/Management/TransporterHandler.cpp
@@ -343,7 +343,7 @@ bool Transporter::GenerateWaypoints(uint32 pathid)
         else
         {
             keyFrames[i].distFromPrev =
-                sqrt(pow(keyFrames[i].x - keyFrames[i - 1].x, 2) +
+                std::sqrt(pow(keyFrames[i].x - keyFrames[i - 1].x, 2) +
                 pow(keyFrames[i].y - keyFrames[i - 1].y, 2) +
                 pow(keyFrames[i].z - keyFrames[i - 1].z, 2));
         }
@@ -379,12 +379,12 @@ bool Transporter::GenerateWaypoints(uint32 pathid)
     for (size_t i = 0; i < keyFrames.size(); ++i)
     {
         if (keyFrames[i].distSinceStop < (30 * 30 * 0.5f))
-            keyFrames[i].tFrom = sqrt(2 * keyFrames[i].distSinceStop);
+            keyFrames[i].tFrom = std::sqrt(2 * keyFrames[i].distSinceStop);
         else
             keyFrames[i].tFrom = ((keyFrames[i].distSinceStop - (30 * 30 * 0.5f)) / 30) + 30;
 
         if (keyFrames[i].distUntilStop < (30 * 30 * 0.5f))
-            keyFrames[i].tTo = sqrt(2 * keyFrames[i].distUntilStop);
+            keyFrames[i].tTo = std::sqrt(2 * keyFrames[i].distUntilStop);
         else
             keyFrames[i].tTo = ((keyFrames[i].distUntilStop - (30 * 30 * 0.5f)) / 30) + 30;
 

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -590,7 +590,7 @@ struct QuaternionCompressed
         double z = (double)(m_raw << 43 >> 43) / (double)PACK_COEFF_YZ;
         double w = 1 - (x * x + y * y + z * z);
         ARCEMU_ASSERT(w >= 0);
-        w = sqrt(w);
+        w = std::sqrt(w);
 
         return Quat(float(x), float(y), float(z), float(w));
     }
@@ -938,7 +938,7 @@ void GameObject_Trap::InitAI()
     if (cooldown < 1000)
         cooldown = 1000;
 
-    maxdistance = sqrt(float(gameobject_properties->trap.radius));
+    maxdistance = std::sqrt(float(gameobject_properties->trap.radius));
     if (maxdistance == 0.0f)
         maxdistance = 1.0f;
 

--- a/src/world/Server/Packets/Handlers/MovementHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MovementHandler.cpp
@@ -270,7 +270,7 @@ void WorldSession::handleMovementOpcodes(WorldPacket& recvData)
                 {
                     if (_player->getSpeedRate(TYPE_RUN, true) < 50.f && !_player->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
                     {
-                        sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedRate(TYPE_RUN, true), sqrt(_player->m_position.Distance2DSq({ movement_info.position.x, movement_info.position.y })));
+                        sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedRate(TYPE_RUN, true), std::sqrt(_player->m_position.Distance2DSq({ movement_info.position.x, movement_info.position.y })));
                         Disconnect();
                         return;
                     }
@@ -709,7 +709,7 @@ void WorldSession::handleMovementOpcodes(WorldPacket& recvPacket)
         if (worldConfig.antiHack.isTeleportHackCheckEnabled && _player->m_position.Distance2DSq({ movement_info.position.x, movement_info.position.y }) > 3025.0f
             && _player->getSpeedRate(TYPE_RUN, true) < 50.0f && !_player->obj_movement_info.transport_guid)
         {
-            sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedRate(TYPE_RUN, true), sqrt(_player->m_position.Distance2DSq({ movement_info.position.x, movement_info.position.y })));
+            sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedRate(TYPE_RUN, true), std::sqrt(_player->m_position.Distance2DSq({ movement_info.position.x, movement_info.position.y })));
             Disconnect();
             return;
         }
@@ -1117,7 +1117,7 @@ void WorldSession::handleMovementOpcodes(WorldPacket& recvPacket)
     //        if (sWorld.antihack_teleport && _player->m_position.Distance2DSq(movement_info.position.x, movement_info.position.y) > 3025.0f
     //            && _player->getSpeedForType(TYPE_RUN) < 50.0f && !_player->obj_movement_info.transporter_info.guid)
     //        {
-    //            sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedForType(TYPE_RUN), sqrt(_player->m_position.Distance2DSq(movement_info.position.x, movement_info.position.y)));
+    //            sCheatLog.writefromsession(this, "Disconnected for teleport hacking. Player speed: %f, Distance traveled: %f", _player->getSpeedForType(TYPE_RUN), std::sqrt(_player->m_position.Distance2DSq(movement_info.position.x, movement_info.position.y)));
     //            Disconnect();
     //            return;
     //        }

--- a/src/world/Server/Warden/SpeedDetector.cpp
+++ b/src/world/Server/Warden/SpeedDetector.cpp
@@ -75,7 +75,7 @@ void SpeedCheatDetector::AddSample(float x, float y, int stamp, float player_spe
         //get current speed
         float dif_x = x - last_x;
         float dif_y = y - last_y;
-        float dist = sqrt(dif_x * dif_x + dif_y * dif_y);
+        float dist = std::sqrt(dif_x * dif_x + dif_y * dif_y);
         float cur_speed = dist / (float)time_dif * 1000.0f;
 
         //check if we really got a cheater here

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -3485,7 +3485,7 @@ void Spell::SpellEffectTriggerMissile(uint8_t effectIndex) // Trigger Missile
         d = destination.z - t->GetPositionZ();
         r += d * d;
 
-        if (sqrt(r) > spellRadius) continue;
+        if (std::sqrt(r) > spellRadius) continue;
 
         if (!isAttackable(m_caster, itr))   //Fix Me: only enemy targets?
             continue;

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -852,8 +852,8 @@ AI_Spell* Pet::CreateAISpell(SpellInfo const* info)
     sp->entryId = getEntry();
     sp->floatMisc1 = 0;
     sp->maxrange = GetMaxRange(sSpellRangeStore.LookupEntry(info->getRangeIndex()));
-    if (sp->maxrange < sqrt(info->custom_base_range_or_radius_sqr))
-        sp->maxrange = sqrt(info->custom_base_range_or_radius_sqr);
+    if (sp->maxrange < std::sqrt(info->custom_base_range_or_radius_sqr))
+        sp->maxrange = std::sqrt(info->custom_base_range_or_radius_sqr);
 
     sp->minrange = GetMinRange(sSpellRangeStore.LookupEntry(info->getRangeIndex()));
     sp->Misc2 = 0;

--- a/src/world/Units/Players/PlayerStats.cpp
+++ b/src/world/Units/Players/PlayerStats.cpp
@@ -87,8 +87,8 @@ void Player::updateManaRegeneration()
 
     const auto intellect = getStat(STAT_INTELLECT);
 
-    // From wowwiki: MP5 = 5 * (0.001 + sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
-    float_t regenerateValue = 0.001f + sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
+    // From wowwiki: MP5 = 5 * (0.001 + std::sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
+    float_t regenerateValue = 0.001f + std::sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
 
     // This is per 5 seconds
     float_t mp5 = m_ModInterrMRegen / 5.0f;
@@ -126,8 +126,8 @@ void Player::updateManaRegeneration()
 
     const auto intellect = getStat(STAT_INTELLECT);
 
-    // From wowwiki: MP5 = 5 * (0.001 + sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
-    float_t regenerateValue = 0.001f + sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
+    // From wowwiki: MP5 = 5 * (0.001 + std::sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
+    float_t regenerateValue = 0.001f + std::sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
 
     // This is per 5 seconds
     float_t mp5 = m_ModInterrMRegen / 5.0f;
@@ -165,8 +165,8 @@ void Player::updateManaRegeneration()
 
     const auto intellect = getStat(STAT_INTELLECT);
 
-    // From wowwiki: MP5 = 5 * (0.001 + sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
-    float_t regenerateValue = 0.001f + sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
+    // From wowwiki: MP5 = 5 * (0.001 + std::sqrt(Int) * Spirit * Base_Regen) * 0.60 rounded up
+    float_t regenerateValue = 0.001f + std::sqrt(static_cast<float_t>(intellect)) * spirit * baseRegen * PctPowerRegenModifier[POWER_TYPE_MANA];
 
     // In cata 5 second rule no longer exists
     // Instead you regen 5% of your base mana without modifiers while in combat

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -1216,10 +1216,10 @@ bool Unit::canReachWithAttack(Unit* pVictim)
     // float targetscale = pVictim->getScale();
     // float selfscale = getScale();
 
-    //float distance = sqrt(getDistanceSq(pVictim));
+    //float distance = std::sqrt(getDistanceSq(pVictim));
     float delta_x = pVictim->GetPositionX() - GetPositionX();
     float delta_y = pVictim->GetPositionY() - GetPositionY();
-    float distance = sqrt(delta_x * delta_x + delta_y * delta_y);
+    float distance = std::sqrt(delta_x * delta_x + delta_y * delta_y);
 
 
     // float attackreach = (((targetradius*targetscale) + selfreach) + (((selfradius*selfradius)*selfscale)+1.50f));


### PR DESCRIPTION
**Todo / Checklist**

fix gcc/clang compile error with Memory exhausted.
Use std::sqrt instead of sqrt (just a bit faster)

**Tests Performed:** 
<!--
    Add / Remove lines if necessary
    - 
    - Tested in-game
-->

Build
