### PR TITLE
Changes to ScriptMgr and code cleanup

### DIFF
--- a/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
+++ b/src/scripts/InstanceScripts/Instance_ShadowfangKeep.cpp
@@ -1451,7 +1451,7 @@ class WorlfguardWorgAI : public CreatureAIScript
 // Spell entry: 6421
 bool ashrombeUnlockDummySpell(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Unit* target = pSpell->u_caster;
+    Unit* target = pSpell->getUnitCaster();
     if (!target)
     {
         return false;

--- a/src/scripts/InstanceScripts/Raid_TheEye.cpp
+++ b/src/scripts/InstanceScripts/Raid_TheEye.cpp
@@ -321,7 +321,7 @@ class HighAstromancerSolarianAI : public CreatureAIScript
 
 bool Dummy_Solarian_WrathOfTheAstromancer(uint32_t /*pEffectIndex*/, Spell* pSpell)
 {
-    Unit* Caster = pSpell->u_caster;
+    Unit* Caster = pSpell->getUnitCaster();
     if (!Caster) return true;
 
     Unit* Target = Caster->GetAIInterface()->getNextTarget();

--- a/src/scripts/LuaEngine/SpellFunctions.h
+++ b/src/scripts/LuaEngine/SpellFunctions.h
@@ -162,8 +162,6 @@ LuaSpellEntry luaSpellVars[] =
     { "ai_target_type", 0, offsetof(SpellInfo, ai_target_type) },
     { "self_cast_only", 2, offsetof(SpellInfo, custom_self_cast_only) },
     { "apply_on_shapeshift_change", 2, offsetof(SpellInfo, custom_apply_on_shapeshift_change) },
-    { "is_melee_spell", 2, offsetof(SpellInfo, custom_is_melee_spell) },
-    { "is_ranged_spell", 2, offsetof(SpellInfo, custom_is_ranged_spell) },
     { NULL, 0, 0 },
 };
 
@@ -186,19 +184,19 @@ namespace LuaSpell
         if (!sp)
             return 0;
 
-        if (sp->u_caster)  //unit caster
+        if (sp->getUnitCaster())  //unit caster
         {
-            PUSH_UNIT(L, sp->u_caster);
+            PUSH_UNIT(L, sp->getUnitCaster());
             return 1;
         }
-        else if (sp->g_caster)  //gameobject
+        else if (sp->getGameObjectCaster())  //gameobject
         {
-            PUSH_GO(L, sp->g_caster);
+            PUSH_GO(L, sp->getGameObjectCaster());
             return 1;
         }
-        else if (sp->i_caster)  //item
+        else if (sp->getItemCaster())  //item
         {
-            PUSH_ITEM(L, sp->i_caster);
+            PUSH_ITEM(L, sp->getItemCaster());
             return 1;
         }
         else
@@ -220,7 +218,7 @@ namespace LuaSpell
     {
         if (!sp)
             return 0;
-        lua_pushboolean(L, sp->duelSpell ? 1 : 0);
+        lua_pushboolean(L, sp->wasCastedinDuel() ? 1 : 0);
         return 1;
     }
 
@@ -249,9 +247,9 @@ namespace LuaSpell
 
     int Cancel(lua_State* /*L*/, Spell* sp)
     {
-        if (!sp || !sp->m_caster->IsInWorld())
+        if (!sp || !sp->getCaster()->IsInWorld())
             return 0;
-        sp->m_caster->interruptSpell(sp->getSpellInfo()->getId());
+        sp->getCaster()->interruptSpell(sp->getSpellInfo()->getId());
         return 0;
     }
 
@@ -282,19 +280,19 @@ namespace LuaSpell
 
     int GetTarget(lua_State* L, Spell* sp)
     {
-        if (!sp || !sp->m_caster->IsInWorld())
+        if (!sp || !sp->getCaster()->IsInWorld())
             RET_NIL()
 
             if (sp->m_targets.getUnitTarget())
             {
-                PUSH_UNIT(L, sp->m_caster->GetMapMgr()->GetUnit(sp->m_targets.getUnitTarget()));
+                PUSH_UNIT(L, sp->getCaster()->GetMapMgr()->GetUnit(sp->m_targets.getUnitTarget()));
                 return 1;
             }
             else if (sp->m_targets.getItemTarget())
             {
-                if (!sp->p_caster)
+                if (!sp->getPlayerCaster())
                     RET_NIL()
-                    PUSH_ITEM(L, sp->p_caster->getItemInterface()->GetItemByGUID(sp->m_targets.getItemTarget()));
+                    PUSH_ITEM(L, sp->getPlayerCaster()->getItemInterface()->GetItemByGUID(sp->m_targets.getItemTarget()));
                 return 1;
             }
             else
@@ -451,19 +449,19 @@ namespace LuaSpell
         switch (l.typeId)  //0: int, 1: char*, 2: bool, 3: float
         {
             case 0:
-                GET_SPELLVAR_INT(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_INT(sp->m_spellInfo, l.offset, subindex);
+                GET_SPELLVAR_INT(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_INT(sp->getSpellInfo(), l.offset, subindex);
                 lua_pushboolean(L, 1);
                 break;
             case 1:
-                GET_SPELLVAR_CHAR(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_CHAR(sp->m_spellInfo, l.offset, subindex);
+                GET_SPELLVAR_CHAR(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_CHAR(sp->getSpellInfo(), l.offset, subindex);
                 lua_pushboolean(L, 1);
                 break;
             case 2:
-                GET_SPELLVAR_BOOL(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_BOOL(sp->m_spellInfo, l.offset, subindex);
+                GET_SPELLVAR_BOOL(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_BOOL(sp->getSpellInfo(), l.offset, subindex);
                 lua_pushboolean(L, 1);
                 break;
             case 3:
-                GET_SPELLVAR_FLOAT(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_FLOAT(sp->m_spellInfo, l.offset, subindex);
+                GET_SPELLVAR_FLOAT(sp->getSpellInfo(), l.offset, subindex) = GET_SPELLVAR_FLOAT(sp->getSpellInfo(), l.offset, subindex);
                 lua_pushboolean(L, 1);
                 break;
         }

--- a/src/scripts/QuestScripts/Quest_BoreanTundra.cpp
+++ b/src/scripts/QuestScripts/Quest_BoreanTundra.cpp
@@ -616,7 +616,7 @@ public:
 
 bool PlaceCart(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 

--- a/src/scripts/QuestScripts/Quest_DeathKnight.cpp
+++ b/src/scripts/QuestScripts/Quest_DeathKnight.cpp
@@ -119,7 +119,7 @@ public:
 
 bool PreparationForBattleEffect(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pCaster = pSpell->p_caster;
+    Player* pCaster = pSpell->getPlayerCaster();
     if (pCaster == nullptr)
         return false;
 

--- a/src/scripts/QuestScripts/Quest_Wetlands.cpp
+++ b/src/scripts/QuestScripts/Quest_Wetlands.cpp
@@ -29,12 +29,12 @@ enum
 
 bool BendingShinbone(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster)
+    if (pSpell->getPlayerCaster())
     {
         if (Util::getRandomUInt(100) < 17) // 17% chance
-            pSpell->p_caster->getItemInterface()->AddItemById(ITEM_STURDYSHINBONE, 1, 0); // Sturdy Dragon
+            pSpell->getPlayerCaster()->getItemInterface()->AddItemById(ITEM_STURDYSHINBONE, 1, 0); // Sturdy Dragon
         else
-            pSpell->p_caster->getItemInterface()->AddItemById(ITEM_BROKENSHINBONE, 1, 0);
+            pSpell->getPlayerCaster()->getItemInterface()->AddItemById(ITEM_BROKENSHINBONE, 1, 0);
     }
     return true;
 }

--- a/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
@@ -25,7 +25,7 @@
 
 bool Starfall(uint8_t effectIndex, Spell* pSpell)
 {
-    Unit* m_caster = pSpell->u_caster;
+    Unit* m_caster = pSpell->getUnitCaster();
     if (m_caster == NULL)
         return true;
 
@@ -49,10 +49,10 @@ bool Starfall(uint8_t effectIndex, Spell* pSpell)
 
 bool ImprovedLeaderOfThePack(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == NULL)
+    if (s->getPlayerCaster() == NULL)
         return false;
 
-    s->p_caster->AddProcTriggerSpell(34299, 34299, s->p_caster->getGuid(), 100, PROC_ON_CRIT_ATTACK | static_cast<uint32_t>(PROC_TARGET_SELF), 0, NULL, NULL);
+    s->getPlayerCaster()->AddProcTriggerSpell(34299, 34299, s->getPlayerCaster()->getGuid(), 100, PROC_ON_CRIT_ATTACK | static_cast<uint32_t>(PROC_TARGET_SELF), 0, NULL, NULL);
 
     return true;
 }

--- a/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
@@ -45,17 +45,17 @@ bool Refocus(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Readiness(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
-    pSpell->p_caster->ClearCooldownsOnLine(50, pSpell->getSpellInfo()->getId());//Beast Mastery
-    pSpell->p_caster->ClearCooldownsOnLine(163, pSpell->getSpellInfo()->getId());//Marksmanship
-    pSpell->p_caster->ClearCooldownsOnLine(51, pSpell->getSpellInfo()->getId());//Survival
+    pSpell->getPlayerCaster()->ClearCooldownsOnLine(50, pSpell->getSpellInfo()->getId());//Beast Mastery
+    pSpell->getPlayerCaster()->ClearCooldownsOnLine(163, pSpell->getSpellInfo()->getId());//Marksmanship
+    pSpell->getPlayerCaster()->ClearCooldownsOnLine(51, pSpell->getSpellInfo()->getId());//Survival
     return true;
 }
 
 bool MastersCall(uint8_t effectIndex, Spell* pSpell)
 {
-    Player* caster = pSpell->p_caster;
+    Player* caster = pSpell->getPlayerCaster();
 
     if (caster == NULL)
         return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
@@ -45,17 +45,17 @@ bool BreathOfFire(uint8_t /*effectIndex*/, Spell* /*pSpell*/)
 
 bool GnomishTransporter(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    pSpell->p_caster->EventAttackStop();
-    pSpell->p_caster->SafeTeleport(1, 0, LocationVector(-7169.41f, -3838.63f, 8.72f));
+    pSpell->getPlayerCaster()->EventAttackStop();
+    pSpell->getPlayerCaster()->SafeTeleport(1, 0, LocationVector(-7169.41f, -3838.63f, 8.72f));
     return true;
 }
 
 bool NoggenFoggerElixr(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     uint32_t chance = Util::getRandomUInt(2);
@@ -63,13 +63,13 @@ bool NoggenFoggerElixr(uint8_t /*effectIndex*/, Spell* pSpell)
     switch (chance)
     {
         case 0:
-            pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(16591), true);
+            pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(16591), true);
             break;
         case 1:
-            pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(16593), true);
+            pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(16593), true);
             break;
         case 2:
-            pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(16595), true);
+            pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(16595), true);
             break;
     }
     return true;
@@ -77,7 +77,7 @@ bool NoggenFoggerElixr(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool HallowsEndCandy(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     int newspell = 24924 + Util::getRandomUInt(3);
@@ -85,13 +85,13 @@ bool HallowsEndCandy(uint8_t /*effectIndex*/, Spell* pSpell)
     SpellInfo const* spInfo = sSpellMgr.getSpellInfo(newspell);
     if (!spInfo) return true;
 
-    pSpell->p_caster->castSpell(pSpell->p_caster, spInfo, true);
+    pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), spInfo, true);
     return true;
 }
 
 bool DeviateFish(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     int newspell = 8064 + Util::getRandomUInt(4);
@@ -99,13 +99,13 @@ bool DeviateFish(uint8_t /*effectIndex*/, Spell* pSpell)
     SpellInfo const* spInfo = sSpellMgr.getSpellInfo(newspell);
     if (!spInfo) return true;
 
-    pSpell->p_caster->castSpell(pSpell->p_caster, spInfo, true);
+    pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), spInfo, true);
     return true;
 }
 
 bool CookedDeviateFish(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     int chance = 0;
@@ -128,27 +128,27 @@ bool CookedDeviateFish(uint8_t /*effectIndex*/, Spell* pSpell)
         SpellInfo const* spInfo = sSpellMgr.getSpellInfo(newspell);
         if (!spInfo) return true;
 
-        pSpell->p_caster->castSpell(pSpell->p_caster, spInfo, true);
+        pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), spInfo, true);
     }
     return true;
 }
 
 bool HolidayCheer(uint8_t effectIndex, Spell* pSpell)
 {
-    if (!pSpell->m_caster)
+    if (!pSpell->getCaster())
         return true;
 
     Unit* target;
     float dist = pSpell->GetRadius(effectIndex);
 
-    for (const auto& itr : pSpell->m_caster->getInRangeObjectsSet())
+    for (const auto& itr : pSpell->getCaster()->getInRangeObjectsSet())
     {
         if (itr && itr->isCreatureOrPlayer())
             target = static_cast<Unit*>(itr);
         else
             continue;
 
-        if (pSpell->m_caster->CalcDistance(target) > dist || isAttackable(pSpell->m_caster, target))
+        if (pSpell->getCaster()->CalcDistance(target) > dist || isAttackable(pSpell->getCaster(), target))
             continue;
 
         target->Emote(EMOTE_ONESHOT_LAUGH);
@@ -159,7 +159,7 @@ bool HolidayCheer(uint8_t effectIndex, Spell* pSpell)
 bool NetOMatic(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
-    if (!pSpell->p_caster || !target)
+    if (!pSpell->getPlayerCaster() || !target)
         return true;
 
     SpellInfo const* spInfo = sSpellMgr.getSpellInfo(13099);
@@ -169,15 +169,15 @@ bool NetOMatic(uint8_t /*effectIndex*/, Spell* pSpell)
     int chance = Util::getRandomUInt(99) + 1;
 
     if (chance < 51) // nets target: 50%
-        pSpell->p_caster->castSpell(target, spInfo, true);
+        pSpell->getPlayerCaster()->castSpell(target, spInfo, true);
 
     else if (chance < 76) // nets you instead: 25%
-        pSpell->p_caster->castSpell(pSpell->p_caster, spInfo, true);
+        pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), spInfo, true);
 
     else // nets you and target: 25%
     {
-        pSpell->p_caster->castSpell(pSpell->p_caster, spInfo, true);
-        pSpell->p_caster->castSpell(target, spInfo, true);
+        pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), spInfo, true);
+        pSpell->getPlayerCaster()->castSpell(target, spInfo, true);
     }
     return true;
 }
@@ -185,17 +185,17 @@ bool NetOMatic(uint8_t /*effectIndex*/, Spell* pSpell)
 bool BanishExile(uint8_t effectIndex, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
-    if (!pSpell->p_caster || !target)
+    if (!pSpell->getPlayerCaster() || !target)
         return true;
 
-    pSpell->p_caster->doSpellDamage(target, pSpell->m_spellInfo->getId(), target->getHealth(), effectIndex);
+    pSpell->getPlayerCaster()->doSpellDamage(target, pSpell->getSpellInfo()->getId(), target->getHealth(), effectIndex);
     return true;
 }
 
 bool ForemansBlackjack(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
-    if (!pSpell->p_caster || !target || !target->isCreature())
+    if (!pSpell->getPlayerCaster() || !target || !target->isCreature())
         return true;
 
     // check to see that we have the correct creature
@@ -210,11 +210,11 @@ bool ForemansBlackjack(uint8_t /*effectIndex*/, Spell* pSpell)
     // Remove Zzz aura
     c_target->RemoveAllAuras();
 
-    pSpell->p_caster->sendPlayObjectSoundPacket(c_target->getGuid(), 6197);
+    pSpell->getPlayerCaster()->sendPlayObjectSoundPacket(c_target->getGuid(), 6197);
 
     // send chat message
     char msg[100];
-    sprintf(msg, "Ow! Ok, I'll get back to work, %s", pSpell->p_caster->getName().c_str());
+    sprintf(msg, "Ow! Ok, I'll get back to work, %s", pSpell->getPlayerCaster()->getName().c_str());
     target->SendChatMessage(CHAT_MSG_MONSTER_SAY, LANG_UNIVERSAL, msg);
 
     c_target->Emote(EMOTE_STATE_WORK_CHOPWOOD);
@@ -228,45 +228,45 @@ bool ForemansBlackjack(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool NetherWraithBeacon(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    float SSX = pSpell->p_caster->GetPositionX();
-    float SSY = pSpell->p_caster->GetPositionY();
-    float SSZ = pSpell->p_caster->GetPositionZ();
-    float SSO = pSpell->p_caster->GetOrientation();
+    float SSX = pSpell->getPlayerCaster()->GetPositionX();
+    float SSY = pSpell->getPlayerCaster()->GetPositionY();
+    float SSZ = pSpell->getPlayerCaster()->GetPositionZ();
+    float SSO = pSpell->getPlayerCaster()->GetOrientation();
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(22408, SSX, SSY, SSZ, SSO, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(22408, SSX, SSY, SSZ, SSO, true, false, 0, 0);
     return true;
 }
 
 bool NighInvulnBelt(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     int chance = Util::getRandomUInt(99) + 1;
 
     if (chance > 10)    // Buff - Nigh-Invulnerability - 30456
-        pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(30456), true);
+        pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(30456), true);
     else                // Malfunction - Complete Vulnerability - 30457
-        pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(30457), true);
+        pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(30457), true);
 
     return true;
 }
 
 bool ReindeerTransformation(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    if (pSpell->p_caster->getMountDisplayId() != 0)
+    if (pSpell->getPlayerCaster()->getMountDisplayId() != 0)
     {
         /*Zyres: This is not correct!
-        if (pSpell->p_caster->m_setflycheat)
-            pSpell->p_caster->setMountDisplayId(22724);
+        if (pSpell->getPlayerCaster()->m_setflycheat)
+            pSpell->getPlayerCaster()->setMountDisplayId(22724);
         else*/
-        pSpell->p_caster->setMountDisplayId(15902);
+        pSpell->getPlayerCaster()->setMountDisplayId(15902);
     }
     return true;
 }
@@ -303,7 +303,7 @@ bool WinterWondervolt(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ScryingCrystal(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* player = pSpell->p_caster;
+    Player* player = pSpell->getPlayerCaster();
     LocationVector pos = player->GetPosition();
     if (player->GetMapMgr()->GetInterface()->GetGameObjectNearestCoords(pos.x, pos.y, pos.z, 300078))
     {
@@ -321,7 +321,7 @@ bool ScryingCrystal(uint8_t /*effectIndex*/, Spell* pSpell)
 bool MinionsOfGurok(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
-    if (!pSpell->p_caster || !target || !target->isCreature() || target->getEntry() != 17157)
+    if (!pSpell->getPlayerCaster() || !target || !target->isCreature() || target->getEntry() != 17157)
         return true;
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
@@ -331,9 +331,9 @@ bool MinionsOfGurok(uint8_t /*effectIndex*/, Spell* pSpell)
     float SSZ = target->GetPositionZ();
     float SSO = target->GetOrientation();
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(18181, SSX + Util::getRandomUInt(8) - 4, SSY + Util::getRandomUInt(8) - 4, SSZ, SSO, true, false, 0, 0);
 
     return true;
 }
@@ -344,10 +344,10 @@ bool PurifyBoarMeat(uint8_t /*effectIndex*/, Spell* pSpell)
     switch (bormeat)
     {
         case 0:
-            pSpell->p_caster->castSpell(pSpell->p_caster, 29277, true);
+            pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), 29277, true);
             break;
         case 1:
-            pSpell->p_caster->castSpell(pSpell->p_caster, 29278, true);
+            pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), 29278, true);
             break;
     }
 
@@ -356,15 +356,15 @@ bool PurifyBoarMeat(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool WarpRiftGenerator(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    float SSX = pSpell->p_caster->GetPositionX();
-    float SSY = pSpell->p_caster->GetPositionY();
-    float SSZ = pSpell->p_caster->GetPositionZ();
-    float SSO = pSpell->p_caster->GetOrientation();
+    float SSX = pSpell->getPlayerCaster()->GetPositionX();
+    float SSY = pSpell->getPlayerCaster()->GetPositionY();
+    float SSZ = pSpell->getPlayerCaster()->GetPositionZ();
+    float SSO = pSpell->getPlayerCaster()->GetOrientation();
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(16939, SSX, SSY, SSZ, SSO, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(16939, SSX, SSY, SSZ, SSO, true, false, 0, 0);
 
     return true;
 }
@@ -506,7 +506,7 @@ bool Poultryizer(uint8_t /*effectIndex*/, Spell* s)
     if (!unitTarget || !unitTarget->isAlive())
         return false;
 
-    s->u_caster->castSpell(unitTarget->getGuid(), 30501, true);
+    s->getUnitCaster()->castSpell(unitTarget->getGuid(), 30501, true);
 
     return true;
 }
@@ -522,7 +522,7 @@ bool SixDemonBag(uint8_t /*effectIndex*/, Spell* s)
     uint32_t randid = Util::getRandomUInt(5);
     uint32_t spelltocast = ClearSpellId[randid];
 
-    s->u_caster->castSpell(unitTarget, spelltocast, true);
+    s->getUnitCaster()->castSpell(unitTarget, spelltocast, true);
 
     return true;
 }
@@ -533,10 +533,10 @@ bool ExtractGas(uint8_t /*effectIndex*/, Spell* s)
     uint32_t cloudtype = 0;
     Creature* creature = nullptr;
 
-    if (!s->p_caster)
+    if (!s->getPlayerCaster())
         return false;
 
-    for (const auto& itr : s->p_caster->getInRangeObjectsSet())
+    for (const auto& itr : s->getPlayerCaster()->getInRangeObjectsSet())
     {
         if (itr && itr->isCreature())
         {
@@ -545,9 +545,9 @@ bool ExtractGas(uint8_t /*effectIndex*/, Spell* s)
 
             if (cloudtype == 24222 || cloudtype == 17408 || cloudtype == 17407 || cloudtype == 17378)
             {
-                if (s->p_caster->GetDistance2dSq(itr) < 400)
+                if (s->getPlayerCaster()->GetDistance2dSq(itr) < 400)
                 {
-                    s->p_caster->SetSelection(creature->getGuid());
+                    s->getPlayerCaster()->SetSelection(creature->getGuid());
                     check = true;
                     break;
                 }
@@ -572,7 +572,7 @@ bool ExtractGas(uint8_t /*effectIndex*/, Spell* s)
     if (cloudtype == 17378)
         item = 22578; //-water
 
-    s->p_caster->getItemInterface()->AddItemById(item, count, 0);
+    s->getPlayerCaster()->getItemInterface()->AddItemById(item, count, 0);
     creature->Despawn(3500, creature->GetCreatureProperties()->RespawnTime);
 
     return true;
@@ -580,11 +580,11 @@ bool ExtractGas(uint8_t /*effectIndex*/, Spell* s)
 
 bool BrittleArmor(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->u_caster == NULL)
+    if (s->getUnitCaster() == NULL)
         return false;
 
     for (uint8_t j = 0; j < 20; j++)
-        s->u_caster->castSpell(s->u_caster, 24575, true);
+        s->getUnitCaster()->castSpell(s->getUnitCaster(), 24575, true);
 
     return true;
 }
@@ -610,13 +610,13 @@ bool RequiresNoAmmo(uint8_t effectIndex, Aura* a, bool apply)
 //////////////////////////////////////////////////////////////////////////////////////////
 bool NitroBoosts(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == NULL)
+    if (s->getPlayerCaster() == NULL)
         return true;
 
-    uint32_t engineeringskill = s->p_caster->_GetSkillLineCurrent(SKILL_ENGINEERING);
+    uint32_t engineeringskill = s->getPlayerCaster()->_GetSkillLineCurrent(SKILL_ENGINEERING);
 
     if (engineeringskill >= 400)
-        s->p_caster->castSpell(s->p_caster, 54861, true);
+        s->getPlayerCaster()->castSpell(s->getPlayerCaster(), 54861, true);
 
     return true;
 }
@@ -639,7 +639,7 @@ bool NitroBoosts(uint8_t /*effectIndex*/, Spell* s)
 //////////////////////////////////////////////////////////////////////////////////////////
 bool ShrinkRay(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == NULL)
+    if (s->getPlayerCaster() == NULL)
         return true;
 
     uint32_t spellids[] =
@@ -657,7 +657,7 @@ bool ShrinkRay(uint8_t /*effectIndex*/, Spell* s)
     if (!malfunction)
     {
 
-        s->p_caster->castSpell(s->GetUnitTarget(), spellids[1], true);
+        s->getPlayerCaster()->castSpell(s->GetUnitTarget(), spellids[1], true);
 
     }
     else
@@ -670,46 +670,46 @@ bool ShrinkRay(uint8_t /*effectIndex*/, Spell* s)
 
             case 0:  // us
             {
-                s->p_caster->castSpell(s->p_caster, spellids[spellindex], true);
+                s->getPlayerCaster()->castSpell(s->getPlayerCaster(), spellids[spellindex], true);
             }
             break;
 
             case 1:  // them
             {
                 // if it's a malfunction it will only grow the target, since shrinking is normal
-                s->p_caster->castSpell(s->GetUnitTarget(), spellids[0], true);
+                s->getPlayerCaster()->castSpell(s->GetUnitTarget(), spellids[0], true);
             }
             break;
 
             case 2:  // our party
             {
-                for (const auto& itr : s->p_caster->getInRangePlayersSet())
+                for (const auto& itr : s->getPlayerCaster()->getInRangePlayersSet())
                 {
                     if (!itr)
                         continue;
 
                     Player* p = static_cast<Player*>(itr);
-                    if ((p->GetPhase() & s->p_caster->GetPhase()) == 0)
+                    if ((p->GetPhase() & s->getPlayerCaster()->GetPhase()) == 0)
                         continue;
 
-                    if (p->GetGroup()->GetID() != s->p_caster->GetGroup()->GetID())
+                    if (p->GetGroup()->GetID() != s->getPlayerCaster()->GetGroup()->GetID())
                         continue;
 
-                    s->p_caster->castSpell(p, spellids[spellindex], true);
+                    s->getPlayerCaster()->castSpell(p, spellids[spellindex], true);
                 }
             }
             break;
 
             case 3:  // every attacking enemy
             {
-                for (const auto& itr : s->p_caster->getInRangeOppositeFactionSet())
+                for (const auto& itr : s->getPlayerCaster()->getInRangeOppositeFactionSet())
                 {
                     if(!itr)
                         continue;
 
                     Object* o = itr;
 
-                    if ((o->GetPhase() & s->p_caster->GetPhase()) == 0)
+                    if ((o->GetPhase() & s->getPlayerCaster()->GetPhase()) == 0)
                         continue;
 
                     if (!o->isCreature())
@@ -717,13 +717,13 @@ bool ShrinkRay(uint8_t /*effectIndex*/, Spell* s)
 
                     Unit* u = static_cast<Unit*>(o);
 
-                    if (u->getTargetGuid() != s->p_caster->getGuid())
+                    if (u->getTargetGuid() != s->getPlayerCaster()->getGuid())
                         continue;
 
-                    if (!isAttackable(s->p_caster, u))
+                    if (!isAttackable(s->getPlayerCaster(), u))
                         continue;
 
-                    s->p_caster->castSpell(u, spellids[spellindex], true);
+                    s->getPlayerCaster()->castSpell(u, spellids[spellindex], true);
                 }
             }
             break;
@@ -776,7 +776,7 @@ bool ChampioningTabards(uint8_t /*effectIndex*/, Aura* a, bool apply)
 //////////////////////////////////////////////////////////////////////////////////////////
 bool Spinning(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
 
     if (p_caster == NULL)
         return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/MageSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/MageSpells.cpp
@@ -24,10 +24,10 @@
 
 bool Cold_Snap(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    pSpell->p_caster->ClearCooldownsOnLine(6, pSpell->getSpellInfo()->getId());
+    pSpell->getPlayerCaster()->ClearCooldownsOnLine(6, pSpell->getSpellInfo()->getId());
     return true;
 }
 
@@ -61,7 +61,7 @@ bool HotStreak(uint8_t effectIndex, Aura* pAura, bool apply)
 
 bool SummonWaterElemental(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Unit* caster = pSpell->u_caster;
+    Unit* caster = pSpell->getUnitCaster();
     if (caster == NULL)
         return true;
 

--- a/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
@@ -84,14 +84,14 @@ bool MoltenShields(uint8_t /*effectIndex*/, Spell* s)
 
 bool Cannibalize(uint8_t effectIndex, Spell* s)
 {
-    if (!s->p_caster)
+    if (!s->getPlayerCaster())
         return false;
 
     bool check = false;
     float rad = s->GetRadius(effectIndex);
     rad *= rad;
 
-    for (const auto& itr : s->p_caster->getInRangeObjectsSet())
+    for (const auto& itr : s->getPlayerCaster()->getInRangeObjectsSet())
     {
         if (itr && itr->isCreature())
         {
@@ -100,7 +100,7 @@ bool Cannibalize(uint8_t effectIndex, Spell* s)
                 CreatureProperties const* cn = static_cast<Creature*>(itr)->GetCreatureProperties();
                 if (cn->Type == UNIT_TYPE_HUMANOID || cn->Type == UNIT_TYPE_UNDEAD)
                 {
-                    if (s->p_caster->GetDistance2dSq(itr) < rad)
+                    if (s->getPlayerCaster()->GetDistance2dSq(itr) < rad)
                     {
                         check = true;
                         break;
@@ -112,10 +112,10 @@ bool Cannibalize(uint8_t effectIndex, Spell* s)
 
     if (check)
     {
-        s->p_caster->cannibalize = true;
-        s->p_caster->cannibalizeCount = 0;
-        sEventMgr.AddEvent(s->p_caster, &Player::EventCannibalize, uint32_t(7), EVENT_CANNIBALIZE, 2000, 5, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
-        s->p_caster->setEmoteState(EMOTE_STATE_CANNIBALIZE);
+        s->getPlayerCaster()->cannibalize = true;
+        s->getPlayerCaster()->cannibalizeCount = 0;
+        sEventMgr.AddEvent(s->getPlayerCaster(), &Player::EventCannibalize, uint32_t(7), EVENT_CANNIBALIZE, 2000, 5, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+        s->getPlayerCaster()->setEmoteState(EMOTE_STATE_CANNIBALIZE);
     }
 
     return true;
@@ -123,25 +123,25 @@ bool Cannibalize(uint8_t effectIndex, Spell* s)
 
 bool ArcaniteDragonLing(uint8_t /*effectIndex*/, Spell* s)
 {
-    s->u_caster->castSpell(s->u_caster, 19804, true);
+    s->getUnitCaster()->castSpell(s->getUnitCaster(), 19804, true);
     return true;
 }
 
 bool MithrilMechanicalDragonLing(uint8_t /*effectIndex*/, Spell* s)
 {
-    s->u_caster->castSpell(s->u_caster, 12749, true);
+    s->getUnitCaster()->castSpell(s->getUnitCaster(), 12749, true);
     return true;
 }
 
 bool MechanicalDragonLing(uint8_t /*effectIndex*/, Spell* s)
 {
-    s->u_caster->castSpell(s->u_caster, 4073, true);
+    s->getUnitCaster()->castSpell(s->getUnitCaster(), 4073, true);
     return true;
 }
 
 bool GnomishBattleChicken(uint8_t /*effectIndex*/, Spell* s)
 {
-    s->u_caster->castSpell(s->u_caster, 13166, true);
+    s->getUnitCaster()->castSpell(s->getUnitCaster(), 13166, true);
     return true;
 }
 
@@ -154,7 +154,7 @@ bool GiftOfLife(uint8_t /*effectIndex*/, Spell* s)
 
     SpellCastTargets tgt(playerTarget->getGuid());
     SpellInfo const* inf = sSpellMgr.getSpellInfo(23782);
-    Spell* spe = sSpellMgr.newSpell(s->u_caster, inf, true, NULL);
+    Spell* spe = sSpellMgr.newSpell(s->getUnitCaster(), inf, true, NULL);
     spe->prepare(&tgt);
 
     return true;
@@ -221,7 +221,7 @@ bool NorthRendInscriptionResearch(uint8_t /*effectIndex*/, Spell* s)
                             {
                                 if (glyph_properties->Type == glyphType)
                                 {
-                                    if (!s->p_caster->HasSpell(skill_line_ability->spell))
+                                    if (!s->getPlayerCaster()->HasSpell(skill_line_ability->spell))
                                     {
                                         discoverableGlyphs.push_back(skill_line_ability->spell);
                                     }
@@ -237,7 +237,7 @@ bool NorthRendInscriptionResearch(uint8_t /*effectIndex*/, Spell* s)
         if (discoverableGlyphs.size() > 0)
         {
             uint32_t newGlyph = discoverableGlyphs.at(Util::getRandomUInt(static_cast<uint32_t>(discoverableGlyphs.size() - 1)));
-            s->p_caster->addSpell(newGlyph);
+            s->getPlayerCaster()->addSpell(newGlyph);
         }
     }
 
@@ -360,12 +360,12 @@ bool EatenRecently(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool Temper(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->u_caster == NULL)
+    if (pSpell->getUnitCaster() == NULL)
         return true;
 
-    Unit* pHated = pSpell->u_caster->GetAIInterface()->GetMostHated();
+    Unit* pHated = pSpell->getUnitCaster()->GetAIInterface()->GetMostHated();
 
-    MapScriptInterface* pMap = pSpell->u_caster->GetMapMgr()->GetInterface();
+    MapScriptInterface* pMap = pSpell->getUnitCaster()->GetMapMgr()->GetInterface();
     Creature* pCreature1 = pMap->SpawnCreature(28695, 1335.296265f, -89.237503f, 56.717800f, 1.994538f, true, true, 0, 0, 1);
     if (pCreature1)
         pCreature1->GetAIInterface()->AttackReaction(pHated, 1);
@@ -381,16 +381,16 @@ bool Temper(uint8_t /*effectIndex*/, Spell* pSpell)
 //Chaos blast dummy effect
 bool ChaosBlast(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->u_caster == NULL)
+    if (pSpell->getUnitCaster() == NULL)
         return true;
 
-    pSpell->u_caster->castSpell(pSpell->GetUnitTarget(), 37675, true);
+    pSpell->getUnitCaster()->castSpell(pSpell->GetUnitTarget(), 37675, true);
     return true;
 }
 
 bool Dummy_Solarian_WrathOfTheAstromancer(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Unit* Caster = pSpell->u_caster;
+    Unit* Caster = pSpell->getUnitCaster();
     if (!Caster)
         return true;
 
@@ -409,10 +409,10 @@ bool Dummy_Solarian_WrathOfTheAstromancer(uint8_t /*effectIndex*/, Spell* pSpell
 
 bool PreparationForBattle(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == NULL)
+    if (pSpell->getPlayerCaster() == NULL)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(12842, 0, 0);
 
@@ -421,10 +421,10 @@ bool PreparationForBattle(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool CrystalSpikes(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->u_caster == NULL)
+    if (pSpell->getUnitCaster() == NULL)
         return true;
 
-    Unit* pCaster = pSpell->u_caster;
+    Unit* pCaster = pSpell->getUnitCaster();
 
     for (uint8_t i = 1; i < 6; ++i)
     {
@@ -459,10 +459,10 @@ bool CrystalSpikes(uint8_t /*effectIndex*/, Spell* pSpell)
 ////////////////////////////////////////////////////////////////
 bool ListeningToMusicParent(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == NULL)
+    if (s->getPlayerCaster() == NULL)
         return true;
 
-    s->p_caster->castSpell(s->p_caster, 50493, true);
+    s->getPlayerCaster()->castSpell(s->getPlayerCaster(), 50493, true);
 
     return true;
 }
@@ -484,7 +484,7 @@ bool ListeningToMusicParent(uint8_t /*effectIndex*/, Spell* s)
 ////////////////////////////////////////////////////////////////
 bool TeleportToCoordinates(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return true;
 
     TeleportCoords const* teleport_coord = sMySQLStore.getTeleportCoord(s->getSpellInfo()->getId());
@@ -494,7 +494,7 @@ bool TeleportToCoordinates(uint8_t /*effectIndex*/, Spell* s)
         return true;
     }
 
-    s->HandleTeleport(teleport_coord->x, teleport_coord->y, teleport_coord->z, teleport_coord->mapId, s->p_caster);
+    s->HandleTeleport(teleport_coord->x, teleport_coord->y, teleport_coord->z, teleport_coord->mapId, s->getPlayerCaster());
     return true;
 }
 

--- a/src/scripts/SpellHandlers/LegacyFiles/PaladinSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/PaladinSpells.cpp
@@ -46,7 +46,7 @@ bool HolyShock(uint8_t /*effectIndex*/, Spell* pSpell)
         return true;
     }
 
-    Player* caster = pSpell->p_caster;
+    Player* caster = pSpell->getPlayerCaster();
     if (caster == nullptr)
     {
         return true;
@@ -191,7 +191,7 @@ bool JudgementLightWisdomJustice(uint8_t /*effectIndex*/, Spell* pSpell)
         return true;
     }
 
-    Player* caster = pSpell->p_caster;
+    Player* caster = pSpell->getPlayerCaster();
     if (caster == nullptr)
     {
         return true;
@@ -347,7 +347,7 @@ bool RighteousDefense(uint8_t /*effectIndex*/, Spell* s)
 
     Unit* unitTarget = s->GetUnitTarget();
 
-    if (!unitTarget || !s->u_caster)
+    if (!unitTarget || !s->getUnitCaster())
         return false;
 
     Unit* targets[3];
@@ -374,13 +374,13 @@ bool RighteousDefense(uint8_t /*effectIndex*/, Spell* s)
     {
         //set threat to this target so we are the msot hated
         uint32_t threat_to_him = targets[j]->GetAIInterface()->getThreatByPtr(unitTarget);
-        uint32_t threat_to_us = targets[j]->GetAIInterface()->getThreatByPtr(s->u_caster);
+        uint32_t threat_to_us = targets[j]->GetAIInterface()->getThreatByPtr(s->getUnitCaster());
         int threat_dif = threat_to_him - threat_to_us;
         if (threat_dif > 0) //should nto happen
-            targets[j]->GetAIInterface()->modThreatByPtr(s->u_caster, threat_dif);
+            targets[j]->GetAIInterface()->modThreatByPtr(s->getUnitCaster(), threat_dif);
 
-        targets[j]->GetAIInterface()->AttackReaction(s->u_caster, 1, 0);
-        targets[j]->GetAIInterface()->setNextTarget(s->u_caster);
+        targets[j]->GetAIInterface()->AttackReaction(s->getUnitCaster(), 1, 0);
+        targets[j]->GetAIInterface()->setNextTarget(s->getUnitCaster());
     }
 
     return true;
@@ -388,7 +388,7 @@ bool RighteousDefense(uint8_t /*effectIndex*/, Spell* s)
 
 bool Illumination(uint8_t /*effectIndex*/, Spell* s)
 {
-    switch (s->m_triggeredByAura == NULL ? s->getSpellInfo()->getId() : s->m_triggeredByAura->getSpellId())
+    switch (s->getTriggeredByAura() == NULL ? s->getSpellInfo()->getId() : s->getTriggeredByAura()->getSpellId())
     {
         case 20210:
         case 20212:
@@ -396,10 +396,10 @@ bool Illumination(uint8_t /*effectIndex*/, Spell* s)
         case 20214:
         case 20215:
         {
-            if (s->p_caster == NULL)
+            if (s->getPlayerCaster() == NULL)
                 return false;
-            SpellInfo const* sp = s->p_caster->last_heal_spell ? s->p_caster->last_heal_spell : s->getSpellInfo();
-            s->p_caster->energize(s->p_caster, 20272, 60 * s->u_caster->getBaseMana() * sp->getManaCostPercentage() / 10000, POWER_TYPE_MANA);
+            SpellInfo const* sp = s->getPlayerCaster()->last_heal_spell ? s->getPlayerCaster()->last_heal_spell : s->getSpellInfo();
+            s->getPlayerCaster()->energize(s->getPlayerCaster(), 20272, 60 * s->getPlayerCaster()->getBaseMana() * sp->getManaCostPercentage() / 10000, POWER_TYPE_MANA);
         }
         break;
 
@@ -410,21 +410,21 @@ bool Illumination(uint8_t /*effectIndex*/, Spell* s)
 
 bool JudgementOfTheWise(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (!s->p_caster)
+    if (!s->getPlayerCaster())
         return false;
 
-    s->p_caster->energize(s->p_caster, 31930, uint32_t(0.15f * s->p_caster->getBaseMana()), POWER_TYPE_MANA);
-    s->p_caster->castSpell(s->p_caster, 57669, false);
+    s->getPlayerCaster()->energize(s->getPlayerCaster(), 31930, uint32_t(0.15f * s->getPlayerCaster()->getBaseMana()), POWER_TYPE_MANA);
+    s->getPlayerCaster()->castSpell(s->getPlayerCaster(), 57669, false);
 
     return true;
 }
 
 bool GuardedByTheLight(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (!s->p_caster)
+    if (!s->getPlayerCaster())
         return false;
 
-    if (Aura* aura = s->p_caster->getAuraWithId(54428))
+    if (Aura* aura = s->getPlayerCaster()->getAuraWithId(54428))
         aura->refresh();
 
     return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/PriestSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/PriestSpells.cpp
@@ -25,12 +25,12 @@
 
 bool Penance(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster || !pSpell->p_caster->isAlive() ||
+    if (!pSpell->getPlayerCaster() || !pSpell->getPlayerCaster()->isAlive() ||
         !pSpell->GetUnitTarget() || !pSpell->GetUnitTarget()->isAlive())
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
-    Player* player = pSpell->p_caster;
+    Player* player = pSpell->getPlayerCaster();
 
     // index 0 contains the spell for the first tick, index 1 is the peroidic cast spell.
     uint32_t hostileSpell[] = { 0, 0 };
@@ -192,7 +192,7 @@ bool PainAndSufferingAura(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool PainAndSufferingProc(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* caster = pSpell->p_caster;
+    Player* caster = pSpell->getPlayerCaster();
     if (caster == NULL)
         return true;
 
@@ -249,9 +249,7 @@ bool PainAndSufferingProc(uint8_t /*effectIndex*/, Spell* pSpell)
         return true;
 
     // Set new aura's duration, reset event timer and set client visual aura
-    aura->setTimeLeft(aura->getTimeLeft());
-    sEventMgr.ModifyEventTimeLeft(aura, EVENT_AURA_REMOVE, aura->getTimeLeft());
-    target->sendAuraUpdate(aura, false);
+    aura->refresh(true);
 
     return true;
 }

--- a/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
@@ -36,10 +36,10 @@ enum
 
 bool CleansingVial(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     if (pPlayer->HasQuest(9427) == false)
         return true;
@@ -53,10 +53,10 @@ bool CleansingVial(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SummonCyclonian(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->u_caster == nullptr)
+    if (pSpell->getUnitCaster() == nullptr)
         return true;
 
-    Unit* pUnit = pSpell->u_caster;
+    Unit* pUnit = pSpell->getUnitCaster();
 
     LocationVector unitPos = pUnit->GetPosition();
 
@@ -71,10 +71,10 @@ bool SummonCyclonian(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ElementalPowerExtractor(uint32_t /*i*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     Unit* pUnit = pSpell->GetUnitTarget();
     if (pUnit == nullptr || pUnit->isCreature() == false)
         return true;
@@ -90,10 +90,10 @@ bool ElementalPowerExtractor(uint32_t /*i*/, Spell* pSpell)
 
 bool SummonEkkorash(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -103,10 +103,10 @@ bool SummonEkkorash(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool CallRexxar(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -126,10 +126,10 @@ bool CallRexxar(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool LayWreath(uint8_t /*effectIndex*/, Spell* pSpell)  //Peace at Last quest
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -147,10 +147,10 @@ bool LayWreath(uint8_t /*effectIndex*/, Spell* pSpell)  //Peace at Last quest
 
 bool ScrapReaver(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -165,36 +165,36 @@ bool ScrapReaver(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool RuuanokClaw(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(21767, 3210.960693f, 5348.308594f, 144.537476f, 5.450696f, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(21767, 3210.960693f, 5348.308594f, 144.537476f, 5.450696f, true, false, 0, 0);
     return true;
 }
 
 bool KarangsBanner(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     // Banner Aura
     pPlayer->castSpell(pPlayer, sSpellMgr.getSpellInfo(20746), true);
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(12921, 2231.710205f, -1543.603027f, 90.694946f, 4.700579f, true, false, 0, 0);
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(12921, 2232.534912f, -1556.983276f, 89.744415f, 1.527570f, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(12921, 2231.710205f, -1543.603027f, 90.694946f, 4.700579f, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(12921, 2232.534912f, -1556.983276f, 89.744415f, 1.527570f, true, false, 0, 0);
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(12757, 2239.357178f, -1546.649536f, 89.671097f, 3.530336f, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(12757, 2239.357178f, -1546.649536f, 89.671097f, 3.530336f, true, false, 0, 0);
 
     return true;
 }
 
 bool ADireSituation(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster != nullptr)
+    if (pSpell->getPlayerCaster() != nullptr)
     {
-        pSpell->p_caster->AddQuestKill(10506, 0);
+        pSpell->getPlayerCaster()->AddQuestKill(10506, 0);
     }
 
     return true;
@@ -202,7 +202,7 @@ bool ADireSituation(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool FuryoftheDreghoodElders(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -228,7 +228,7 @@ bool FuryoftheDreghoodElders(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ASpiritAlly(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -280,7 +280,7 @@ bool BalanceMustBePreserved(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool BlessingofIncineratus(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -364,7 +364,7 @@ bool TagMurloc(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool CookingPot(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -381,7 +381,7 @@ bool CookingPot(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool EvilDrawsNear(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -398,10 +398,10 @@ bool EvilDrawsNear(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool UnyieldingBattleHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Creature* creat = pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(19862, -1190.856079f, 2261.246582f, 46.625797f, 1.705882f, true, false, 0, 0);
+    Creature* creat = pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(19862, -1190.856079f, 2261.246582f, 46.625797f, 1.705882f, true, false, 0, 0);
     creat->Despawn(300000, 0); // 5 mins delay
 
     return true;
@@ -409,7 +409,7 @@ bool UnyieldingBattleHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool MeasuringWarpEnergies(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -459,7 +459,7 @@ bool MeasuringWarpEnergies(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool YennikuRelease(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -480,7 +480,7 @@ bool YennikuRelease(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ScrollOfMyzrael(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -505,7 +505,7 @@ bool ScrollOfMyzrael(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Showdown(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* p_caster = pSpell->p_caster;
+    Player* p_caster = pSpell->getPlayerCaster();
     if (p_caster == nullptr)
     {
         return true;
@@ -524,7 +524,7 @@ bool Showdown(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TheBaitforLarkorwi1(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -543,7 +543,7 @@ bool TheBaitforLarkorwi1(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TheBaitforLarkorwi2(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -560,7 +560,7 @@ bool TheBaitforLarkorwi2(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Fumping(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -593,7 +593,7 @@ bool Fumping(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TheBigBoneWorm(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -610,7 +610,7 @@ bool TheBigBoneWorm(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Torgos(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -629,7 +629,7 @@ bool Torgos(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool WelcomingtheWolfSpirit(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -645,7 +645,7 @@ bool WelcomingtheWolfSpirit(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool NaturalRemedies(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -663,10 +663,10 @@ bool NaturalRemedies(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool FloraoftheEcoDomes(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || pSpell->GetUnitTarget() == nullptr || pSpell->GetUnitTarget()->isCreature() == false)
+    if (pSpell->getPlayerCaster() == nullptr || pSpell->GetUnitTarget() == nullptr || pSpell->GetUnitTarget()->isCreature() == false)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     Creature* normal = static_cast<Creature*>(pSpell->GetUnitTarget());
 
@@ -687,7 +687,7 @@ bool FloraoftheEcoDomes(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TheCleansingMustBeStopped(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -743,7 +743,7 @@ bool AdministreringtheSalve(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool ZappedGiants(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -800,10 +800,10 @@ bool ZappedGiants(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool BuildingAPerimeter(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     GameObject* pEast = pPlayer->GetMapMgr()->GetInterface()->GetGameObjectNearestCoords(2257.0f, 2465.0f, 101.0f, 183947);
     if (pEast != nullptr && pPlayer->CalcDistance(pPlayer, pEast) < 30)
@@ -831,7 +831,7 @@ bool BuildingAPerimeter(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool RodofPurification(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -853,7 +853,7 @@ bool RodofPurification(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool AnUnusualPatron(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -897,7 +897,7 @@ bool MagnetoCollector(uint8_t /*effectIndex*/, Aura* pAura, bool /*apply*/)
 
 bool TemporalPhaseModulator(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -982,12 +982,12 @@ bool TemporalPhaseModulator(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool EmblazonRuneblade(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     pPlayer->SendChatMessageToPlayer(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, "Player check", pPlayer);
 
     QuestLogEntry* qle = pPlayer->GetQuestLogForEntry(12619);
@@ -1003,10 +1003,10 @@ bool EmblazonRuneblade(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool WyrmcallersHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -1022,10 +1022,10 @@ bool WyrmcallersHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool RaeloraszSpark(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     if (plr == nullptr)
         return true;
 
@@ -1044,7 +1044,7 @@ bool RaeloraszSpark(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool RuneOfDistortion(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     if (plr == nullptr)
         return true;
 
@@ -1061,7 +1061,7 @@ bool RuneOfDistortion(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool GoreBladder(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1072,7 +1072,7 @@ bool GoreBladder(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     pPlayer->AddQuestKill(12810, 0, 0);
 
     return true;
@@ -1080,7 +1080,7 @@ bool GoreBladder(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool PlagueSpray(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
@@ -1089,7 +1089,7 @@ bool PlagueSpray(uint8_t /*effectIndex*/, Spell* pSpell)
     else if (!target || target->getEntry() != 23652 || !target->HasAura(40467))
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11307, 0, 0);
 
@@ -1098,25 +1098,25 @@ bool PlagueSpray(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool GoblinWeatherMachine(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
     uint32_t Weather = 46736 + Util::getRandomUInt(4);
 
-    pSpell->p_caster->castSpell(pSpell->p_caster, sSpellMgr.getSpellInfo(Weather), true);
+    pSpell->getPlayerCaster()->castSpell(pSpell->getPlayerCaster(), sSpellMgr.getSpellInfo(Weather), true);
     return true;
 }
 
 bool PurifiedAshes(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
     if (!target || target->getEntry() != 26633 || !target->isDead())
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     int entry;
 
     if (pPlayer->isTeamHorde())
@@ -1131,7 +1131,7 @@ bool PurifiedAshes(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool DISMEMBER(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
@@ -1140,7 +1140,7 @@ bool DISMEMBER(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 300000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     int entry;
 
     if (pPlayer->isTeamHorde())
@@ -1159,7 +1159,7 @@ bool DISMEMBER(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool CraftyBlaster(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1170,7 +1170,7 @@ bool CraftyBlaster(uint8_t /*effectIndex*/, Spell* pSpell)
         return true;
     }
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11653, 0, 0);
 
@@ -1179,7 +1179,7 @@ bool CraftyBlaster(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool RagefistTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1192,7 +1192,7 @@ bool RagefistTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11593, 0, 0);
 
@@ -1201,29 +1201,29 @@ bool RagefistTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SummonShadra(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    LocationVector pos = pSpell->p_caster->GetPosition();
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(2707, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
+    LocationVector pos = pSpell->getPlayerCaster()->GetPosition();
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(2707, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
 
     return true;
 }
 
 bool SummonEcheyakee(uint8_t effectIndex, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || effectIndex != 1)  //Effect_1 = SEND_EVENT,Effect_2 = DUMMY
+    if (pSpell->getPlayerCaster() == nullptr || effectIndex != 1)  //Effect_1 = SEND_EVENT,Effect_2 = DUMMY
         return true;
 
-    LocationVector pos = pSpell->p_caster->GetPosition();
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(3475, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
+    LocationVector pos = pSpell->getPlayerCaster()->GetPosition();
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(3475, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
 
     return true;
 }
 
 bool HodirsHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
@@ -1232,7 +1232,7 @@ bool HodirsHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(12977, 0, 0);
 
@@ -1241,7 +1241,7 @@ bool HodirsHorn(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TelluricPoultice(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1254,7 +1254,7 @@ bool TelluricPoultice(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(12937, 0, 0);
 
@@ -1263,7 +1263,7 @@ bool TelluricPoultice(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Screwdriver(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1276,7 +1276,7 @@ bool Screwdriver(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11730, 0, 0);
 
@@ -1285,7 +1285,7 @@ bool Screwdriver(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool IncineratingOil(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -1298,7 +1298,7 @@ bool IncineratingOil(uint8_t /*effectIndex*/, Spell* pSpell)
 
     static_cast<Creature*>(target)->Despawn(500, 360000);
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(12568, 0, 0);
 
@@ -1307,26 +1307,26 @@ bool IncineratingOil(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SummonAquementas(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    LocationVector pos = pSpell->p_caster->GetPosition();
+    LocationVector pos = pSpell->getPlayerCaster()->GetPosition();
 
-    pSpell->p_caster->GetMapMgr()->GetInterface()->SpawnCreature(9453, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
+    pSpell->getPlayerCaster()->GetMapMgr()->GetInterface()->SpawnCreature(9453, pos.x, pos.y, pos.z, pos.o, true, false, 0, 0);
 
     return true;
 }
 
 bool PrayerBeads(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
     Unit* target = pSpell->GetUnitTarget();
     if (!target || target->getEntry() != 22431)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(10935, 0, 0);
 
@@ -1335,7 +1335,7 @@ bool PrayerBeads(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool CleansingVialDND(uint32_t /*i*/, Spell* s)
 {
-    QuestLogEntry* en = s->p_caster->GetQuestLogForEntry(9427);
+    QuestLogEntry* en = s->getPlayerCaster()->GetQuestLogForEntry(9427);
     if (en == nullptr)
         return true;
 
@@ -1388,10 +1388,10 @@ bool HunterTamingQuest(uint8_t /*effectIndex*/, Aura* a, bool apply)
                 if (m_target->isCreature())
                 {
                     Creature* tamed = static_cast<Creature*>(m_target);
-                    tamed->GetAIInterface()->HandleEvent(EVENT_LEAVECOMBAT, p_caster, 0);
+                    tamed->GetAIInterface()->HandleEvent(EVENT_LEAVECOMBAT, getPlayerCaster(), 0);
 
                     Pet* pPet = sObjectMgr.CreatePet(tamed->getEntry());
-                    if (!pPet->CreateAsSummon(tamed->getEntry(), tamed->GetCreatureProperties(), tamed, p_caster, triggerspell, 2, 900000))
+                    if (!pPet->CreateAsSummon(tamed->getEntry(), tamed->GetCreatureProperties(), tamed, getPlayerCaster(), triggerspell, 2, 900000))
                     {
                         pPet->DeleteMe();//CreateAsSummon() returns false if an error occurred.
                         pPet = NULL;
@@ -1399,7 +1399,7 @@ bool HunterTamingQuest(uint8_t /*effectIndex*/, Aura* a, bool apply)
 
                     tamed->Despawn(1, 0); //we despawn the tamed creature once we are out of Aura::Remove()
 
-                    QuestLogEntry* qle = p_caster->GetQuestLogForEntry(tamequest->id);
+                    QuestLogEntry* qle = getPlayerCaster()->GetQuestLogForEntry(tamequest->id);
                     if (qle != nullptr)
                     {
                         qle->SetMobCount(0, 1);
@@ -1411,7 +1411,7 @@ bool HunterTamingQuest(uint8_t /*effectIndex*/, Aura* a, bool apply)
             }
             else
             {
-                p_caster->sendCastFailedPacket(triggerspell->getId(), SPELL_FAILED_TRY_AGAIN, 0, 0);
+                getPlayerCaster()->sendCastFailedPacket(triggerspell->getId(), SPELL_FAILED_TRY_AGAIN, 0, 0);
             }*/
         }
     }
@@ -1517,14 +1517,14 @@ bool ToLegionHold(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool CenarionMoondust(uint8_t /*effectIndex*/, Spell* pSpell) // Body And Heart (Alliance)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    if (!pSpell->p_caster->IsInWorld())
+    if (!pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
     const float pos[] = { 6335.2329f, 144.0811f, 24.0068f, 5.701f }; // x, y, z, o
-    Player* p_caster = pSpell->p_caster;
+    Player* p_caster = pSpell->getPlayerCaster();
 
     //Moonkin Stone aura
     p_caster->GetMapMgr()->CreateAndSpawnGameObject(177644, 6331.01f, 88.245f, 22.6522f, 2.01455f, 1.0);
@@ -1564,14 +1564,14 @@ bool CenarionMoondust(uint8_t /*effectIndex*/, Spell* pSpell) // Body And Heart 
 
 bool CenarionLunardust(uint8_t /*effectIndex*/, Spell* pSpell)  // Body And Heart (Horde)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
         return true;
 
-    if (!pSpell->p_caster->IsInWorld())
+    if (!pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
     const float pos[] = { -2443.9711f, -1642.8002f, 92.5129f, 1.71f }; // x, y, z, o
-    Player* p_caster = pSpell->p_caster;
+    Player* p_caster = pSpell->getPlayerCaster();
 
     //Moonkin Stone aura
     p_caster->GetMapMgr()->CreateAndSpawnGameObject(177644, -2499.54f, -1633.03f, 91.8121f, 0.262894f, 1.0);
@@ -1609,7 +1609,7 @@ bool CenarionLunardust(uint8_t /*effectIndex*/, Spell* pSpell)  // Body And Hear
 
 bool CurativeAnimalSalve(uint8_t /*effectIndex*/, Spell* pSpell) // Curing the Sick
 {
-    Player* caster = pSpell->p_caster;
+    Player* caster = pSpell->getPlayerCaster();
     if (caster == NULL)
         return true;
 
@@ -1650,10 +1650,10 @@ bool CurativeAnimalSalve(uint8_t /*effectIndex*/, Spell* pSpell) // Curing the S
 // Trial Of The Lake
 bool TrialOfTheLake(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == NULL)
+    if (pSpell->getPlayerCaster() == NULL)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(28, 0, 0);
     pPlayer->AddQuestKill(29, 0, 0);
@@ -1663,7 +1663,7 @@ bool TrialOfTheLake(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SymbolOfLife(uint8_t /*effectIndex*/, Spell* pSpell) // Alliance ress. quests
 {
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     if (plr == nullptr)
         return true;
 
@@ -1724,10 +1724,10 @@ bool SymbolOfLife(uint8_t /*effectIndex*/, Spell* pSpell) // Alliance ress. ques
 
 bool FilledShimmeringVessel(uint8_t /*effectIndex*/, Spell* pSpell) // Blood Elf ress. quest
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     WoWGuid wowGuid;
     wowGuid.Init(plr->GetSelection());
@@ -1757,10 +1757,10 @@ bool FilledShimmeringVessel(uint8_t /*effectIndex*/, Spell* pSpell) // Blood Elf
 
 bool DouseEternalFlame(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     QuestLogEntry* qle = plr->GetQuestLogForEntry(9737);
     if (qle == nullptr)
@@ -1787,22 +1787,22 @@ bool DouseEternalFlame(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool Triage(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster || pSpell->GetUnitTarget() == nullptr)
+    if (!pSpell->getPlayerCaster() || pSpell->GetUnitTarget() == nullptr)
         return true;
 
-    pSpell->p_caster->castSpell(pSpell->GetUnitTarget(), sSpellMgr.getSpellInfo(746), true);
+    pSpell->getPlayerCaster()->castSpell(pSpell->GetUnitTarget(), sSpellMgr.getSpellInfo(746), true);
 
-    pSpell->p_caster->AddQuestKill(6624, 0, 0);
+    pSpell->getPlayerCaster()->AddQuestKill(6624, 0, 0);
 
     return true;
 }
 
 bool NeutralizingTheCauldrons(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || !pSpell->p_caster->IsInWorld())
+    if (pSpell->getPlayerCaster() == nullptr || !pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -1818,17 +1818,17 @@ bool NeutralizingTheCauldrons(uint8_t /*effectIndex*/, Spell* pSpell)
 
     if (posX == 3747.07f)
     {
-        pSpell->p_caster->AddQuestKill(11647, 0, 0);
+        pSpell->getPlayerCaster()->AddQuestKill(11647, 0, 0);
     }
 
     if (posX == 4023.5f)
     {
-        pSpell->p_caster->AddQuestKill(11647, 1, 0);
+        pSpell->getPlayerCaster()->AddQuestKill(11647, 1, 0);
     }
 
     if (posX == 4126.12f)
     {
-        pSpell->p_caster->AddQuestKill(11647, 2, 0);
+        pSpell->getPlayerCaster()->AddQuestKill(11647, 2, 0);
     }
 
     return true;
@@ -1838,10 +1838,10 @@ bool NeutralizingTheCauldrons(uint8_t /*effectIndex*/, Spell* pSpell)
 // Stop the Plague
 bool HighmessasCleansingSeeds(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || !pSpell->p_caster->IsInWorld())
+    if (pSpell->getPlayerCaster() == nullptr || !pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11677, 0, 0);
 
@@ -1852,10 +1852,10 @@ bool HighmessasCleansingSeeds(uint8_t /*effectIndex*/, Spell* pSpell)
 // There's Something Going On In Those Caves
 bool BixiesInhibitingPowder(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || !pSpell->p_caster->IsInWorld())
+    if (pSpell->getPlayerCaster() == nullptr || !pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(11694, 0, 0);
 
@@ -1866,10 +1866,10 @@ bool BixiesInhibitingPowder(uint8_t /*effectIndex*/, Spell* pSpell)
 // Leading the Ancestors Home
 bool CompleteAncestorRitual(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || !pSpell->p_caster->IsInWorld())
+    if (pSpell->getPlayerCaster() == nullptr || !pSpell->getPlayerCaster()->IsInWorld())
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(11610);
     if (!pQuest)
         return true;
@@ -1899,10 +1899,10 @@ bool CompleteAncestorRitual(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool PoweringOurDefenses(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     plr->AddQuestKill(8490, 0, 0);
 
@@ -1928,7 +1928,7 @@ bool TestingTheAntidote(uint8_t /*effectIndex*/, Spell* pSpell)
 
     target->Despawn(0, 300000);
 
-    spawned->GetAIInterface()->setNextTarget(pSpell->u_caster);
+    spawned->GetAIInterface()->setNextTarget(pSpell->getUnitCaster());
 
     return true;
 }
@@ -1937,7 +1937,7 @@ bool TestingTheAntidote(uint8_t /*effectIndex*/, Spell* pSpell)
 // Zeth'Gor Must Burn!
 bool ZethGorMustBurnHorde(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -2040,7 +2040,7 @@ bool ZethGorMustBurnHorde(uint8_t /*effectIndex*/, Spell* pSpell)
 // Laying Waste to the Unwanted
 bool LayingWasteToTheUnwantedAlliance(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -2124,10 +2124,10 @@ bool LayingWasteToTheUnwantedAlliance(uint8_t /*effectIndex*/, Spell* pSpell)
 // Burn It Up... For the Horde!
 bool BurnItUp(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(10087);
     if (pQuest == nullptr)
@@ -2176,10 +2176,10 @@ bool BurnItUp(uint8_t /*effectIndex*/, Spell* pSpell)
 // The Seer's Relic
 bool TheSeersRelic(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     QuestLogEntry* qle = pPlayer->GetQuestLogForEntry(9545);
     if (qle == nullptr || qle->getMobCountByIndex(0) >= qle->getQuestProperties()->required_mob_or_go_count[0])
         return true;
@@ -2208,10 +2208,10 @@ bool TheSeersRelic(uint8_t /*effectIndex*/, Spell* pSpell)
 // Disrupt Their Reinforcements
 bool DisruptTheirReinforcements(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     QuestLogEntry* pQuestA = pPlayer->GetQuestLogForEntry(10144);
     QuestLogEntry* pQuestH = pPlayer->GetQuestLogForEntry(10208);
 
@@ -2295,10 +2295,10 @@ bool DisruptTheirReinforcements(uint8_t /*effectIndex*/, Spell* pSpell)
 //Arzeth's Demise
 bool FuryOfTheDreghoodElders(uint32_t /*i*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     Unit* pUnit = pSpell->GetUnitTarget();
     if (pUnit == nullptr || !pUnit->isCreature() || pUnit->getEntry() != 19354)
@@ -2318,10 +2318,10 @@ bool FuryOfTheDreghoodElders(uint32_t /*i*/, Spell* pSpell)
 // War is Hell
 bool WarIsHell(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -2351,10 +2351,10 @@ bool WarIsHell(uint8_t /*effectIndex*/, Spell* pSpell)
 // A Lesson in Fear
 bool PlantForsakenBanner(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(11282);
     if (pQuest == nullptr)
@@ -2393,7 +2393,7 @@ bool PlantForsakenBanner(uint8_t /*effectIndex*/, Spell* pSpell)
 // Erratic Behavior
 bool ConvertingSentry(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pCaster = pSpell->p_caster;
+    Player* pCaster = pSpell->getPlayerCaster();
     if (pCaster == nullptr)
         return true;
 
@@ -2422,10 +2422,10 @@ bool ConvertingSentry(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool OrbOfMurlocControl(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(11541);
     if (pQuest == nullptr)
@@ -2433,14 +2433,14 @@ bool OrbOfMurlocControl(uint8_t /*effectIndex*/, Spell* pSpell)
 
     Creature* pTarget;
 
-    for (const auto& itr : pSpell->m_caster->getInRangeObjectsSet())
+    for (const auto& itr : pSpell->getCaster()->getInRangeObjectsSet())
     {
         if (itr && itr->isCreatureOrPlayer() && static_cast<Unit*>(itr)->isCreature())
             pTarget = static_cast<Creature*>(itr);
         else
             continue;
 
-        if (pSpell->m_caster->CalcDistance(pTarget) > 5)
+        if (pSpell->getCaster()->CalcDistance(pTarget) > 5)
             continue;
 
         if (pTarget->getEntry() == 25084)
@@ -2465,7 +2465,7 @@ bool OrbOfMurlocControl(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ShipBombing(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -2549,10 +2549,10 @@ bool ShipBombing(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ImpaleEmissary(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -2580,10 +2580,10 @@ bool ImpaleEmissary(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool LeyLine(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -2609,7 +2609,7 @@ bool LeyLine(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool ManaRemnants(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return false;
 
@@ -2639,10 +2639,10 @@ bool ManaRemnants(uint8_t /*effectIndex*/, Spell* pSpell)
 // Stopping the Spread
 bool StoppingTheSpread(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -2676,10 +2676,10 @@ bool StoppingTheSpread(uint8_t /*effectIndex*/, Spell* pSpell)
 //Ruthless Cunning
 bool RuthlessCunning(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -2699,10 +2699,10 @@ bool RuthlessCunning(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool FindingTheKeymaster(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     plr->AddQuestKill(10256, 0, 0);
 
@@ -2711,10 +2711,10 @@ bool FindingTheKeymaster(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool TheFleshLies(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     LocationVector pos = plr->GetPosition();
 
@@ -2744,10 +2744,10 @@ bool TheFleshLies(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SurveyingtheRuins(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(10335);
     if (pQuest == nullptr)
@@ -2800,10 +2800,10 @@ bool SurveyingtheRuins(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool CrystalOfDeepShadows(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming a Shadoweave Tailor
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     QuestLogEntry* qle = plr->GetQuestLogForEntry(10833);
 
     if (qle == nullptr)
@@ -2818,10 +2818,10 @@ bool CrystalOfDeepShadows(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming a 
 
 bool Carcass(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming a Shadoweave Tailor
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     LocationVector pos = pPlayer->GetPosition();
 
@@ -2853,10 +2853,10 @@ bool Carcass(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming a Shadoweave Ta
 
 bool ForceofNeltharakuSpell(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming a Shadoweave Tailor
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     WoWGuid wowGuid;
     wowGuid.Init(pPlayer->GetSelection());
@@ -2885,10 +2885,10 @@ bool ForceofNeltharakuSpell(uint8_t /*effectIndex*/, Spell* pSpell) // Becoming 
 
 bool UnlockKarynakuChains(uint32_t /*i*/, Spell* pSpell) // Becoming a Shadoweave Tailor
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(10872, 0, 0);
 
@@ -2898,10 +2898,10 @@ bool UnlockKarynakuChains(uint32_t /*i*/, Spell* pSpell) // Becoming a Shadoweav
 
 bool ShatariTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     WoWGuid wowGuid;
     wowGuid.Init(plr->GetSelection());
     Creature* target = plr->GetMapMgr()->GetCreature(wowGuid.getGuidLowPart());
@@ -2956,10 +2956,10 @@ bool ShatariTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool SpragglesCanteen(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
     WoWGuid wowGuid;
     wowGuid.Init(plr->GetSelection());
 
@@ -2990,7 +2990,7 @@ bool SpragglesCanteen(uint8_t /*effectIndex*/, Spell* pSpell)
 // Finding the Source
 bool FindingTheSource(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     if (pPlayer == nullptr)
         return true;
 
@@ -3040,10 +3040,10 @@ bool FindingTheSource(uint8_t /*effectIndex*/, Spell* pSpell)
 // quest 5163 - Are We There, Yeti?
 bool ReleaseUmisYeti(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || pSpell->GetUnitTarget() == nullptr || !pSpell->GetUnitTarget()->isCreature())
+    if (pSpell->getPlayerCaster() == nullptr || pSpell->GetUnitTarget() == nullptr || !pSpell->GetUnitTarget()->isCreature())
         return true;
 
-    QuestLogEntry* qLogEntry = pSpell->p_caster->GetQuestLogForEntry(5163);
+    QuestLogEntry* qLogEntry = pSpell->getPlayerCaster()->GetQuestLogForEntry(5163);
     if (qLogEntry == nullptr)
         return true;
 
@@ -3053,7 +3053,7 @@ bool ReleaseUmisYeti(uint8_t /*effectIndex*/, Spell* pSpell)
     {
         if (target->getEntry() == friends[j] && qLogEntry->getMobCountByIndex(j) < qLogEntry->getQuestProperties()->required_mob_or_go_count[j])
         {
-            pSpell->p_caster->AddQuestKill(5163, j, 0);
+            pSpell->getPlayerCaster()->AddQuestKill(5163, j, 0);
             return true;
         }
     }
@@ -3065,10 +3065,10 @@ bool ReleaseUmisYeti(uint8_t /*effectIndex*/, Spell* pSpell)
 // Healing The Lake
 bool HealingTheLake(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
 
     pPlayer->AddQuestKill(9294, 0, 0);
 
@@ -3078,10 +3078,10 @@ bool HealingTheLake(uint8_t /*effectIndex*/, Spell* pSpell)
 // Protecting Our Own
 bool ProtectingOurOwn(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* plr = pSpell->p_caster;
+    Player* plr = pSpell->getPlayerCaster();
 
     plr->AddQuestKill(10488, 0, 0);
 
@@ -3104,10 +3104,10 @@ bool ProtectingOurOwn(uint8_t /*effectIndex*/, Spell* pSpell)
 /////////////////////////////////////////////////////////////////
 bool CastFishingNet(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr || pSpell->GetGameObjectTarget() == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr || pSpell->GetGameObjectTarget() == nullptr)
         return true;
 
-    Player* pPlayer = pSpell->p_caster;
+    Player* pPlayer = pSpell->getPlayerCaster();
     QuestLogEntry* pQuest = pPlayer->GetQuestLogForEntry(9452); //Red Snapper - Very Tasty
     if (pQuest == nullptr)
         return true;
@@ -3135,10 +3135,10 @@ bool CastFishingNet(uint8_t /*effectIndex*/, Spell* pSpell)
 
 bool InducingVision(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (pSpell->p_caster == nullptr)
+    if (pSpell->getPlayerCaster() == nullptr)
         return true;
 
-    Player* mTarget = pSpell->p_caster;
+    Player* mTarget = pSpell->getPlayerCaster();
     if (mTarget == nullptr || mTarget->GetMapMgr() == nullptr || mTarget->GetMapMgr()->GetInterface() == nullptr)
         return true;
 

--- a/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
@@ -31,23 +31,23 @@
 
 bool Preparation(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster) return true;
+    if (!pSpell->getPlayerCaster()) return true;
 
-    pSpell->p_caster->ClearCooldownForSpell(5277);          // Evasion Rank 1
-    pSpell->p_caster->ClearCooldownForSpell(26669);         // Evasion Rank 2
-    pSpell->p_caster->ClearCooldownForSpell(2983);          // Sprint Rank 1
-    pSpell->p_caster->ClearCooldownForSpell(8696);          // Sprint Rank 2
-    pSpell->p_caster->ClearCooldownForSpell(11305);         // Sprint Rank 3
-    pSpell->p_caster->ClearCooldownForSpell(1856);          // Vanish Rank 1
-    pSpell->p_caster->ClearCooldownForSpell(1857);          // Vanish Rank 2
-    pSpell->p_caster->ClearCooldownForSpell(26889);         // Vanish Rank 3
-    pSpell->p_caster->ClearCooldownForSpell(14177);         // Cold Blood
-    pSpell->p_caster->ClearCooldownForSpell(36554);         // Shadowstep
-    if (pSpell->p_caster->HasAura(56819))                   // Glyph of Preparation item = 42968 casts 57127 that apply aura 56819.
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(5277);          // Evasion Rank 1
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(26669);         // Evasion Rank 2
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(2983);          // Sprint Rank 1
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(8696);          // Sprint Rank 2
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(11305);         // Sprint Rank 3
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(1856);          // Vanish Rank 1
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(1857);          // Vanish Rank 2
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(26889);         // Vanish Rank 3
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(14177);         // Cold Blood
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(36554);         // Shadowstep
+    if (pSpell->getPlayerCaster()->HasAura(56819))                   // Glyph of Preparation item = 42968 casts 57127 that apply aura 56819.
     {
-        pSpell->p_caster->ClearCooldownForSpell(13877);     // Blade Flurry
-        pSpell->p_caster->ClearCooldownForSpell(51722);     // Dismantle
-        pSpell->p_caster->ClearCooldownForSpell(1766);      // Kick
+        pSpell->getPlayerCaster()->ClearCooldownForSpell(13877);     // Blade Flurry
+        pSpell->getPlayerCaster()->ClearCooldownForSpell(51722);     // Dismantle
+        pSpell->getPlayerCaster()->ClearCooldownForSpell(1766);      // Kick
     }
     return true;
 }
@@ -55,11 +55,11 @@ bool Preparation(uint8_t /*effectIndex*/, Spell* pSpell)
 bool Shiv(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* pTarget = pSpell->GetUnitTarget();
-    if (!pSpell->p_caster || !pTarget) return true;
+    if (!pSpell->getPlayerCaster() || !pTarget) return true;
 
-    pSpell->p_caster->castSpell(pTarget->getGuid(), 5940, true);
+    pSpell->getPlayerCaster()->castSpell(pTarget->getGuid(), 5940, true);
 
-    Item* it = pSpell->p_caster->getItemInterface()->GetInventoryItem(EQUIPMENT_SLOT_OFFHAND);
+    Item* it = pSpell->getPlayerCaster()->getItemInterface()->GetInventoryItem(EQUIPMENT_SLOT_OFFHAND);
     if (!it)
         return true;
 
@@ -76,7 +76,7 @@ bool Shiv(uint8_t /*effectIndex*/, Spell* pSpell)
 
                 if (sp->custom_c_is_flags & SPELL_FLAG_IS_POISON)
                 {
-                    pSpell->p_caster->castSpell(pTarget->getGuid(), Entry->spell[c], true);
+                    pSpell->getPlayerCaster()->castSpell(pTarget->getGuid(), Entry->spell[c], true);
                 }
             }
         }
@@ -281,7 +281,7 @@ bool KillingSpreePeriodicDummy(uint8_t /*effectIndex*/, Aura* a, bool /*apply*/)
 
 bool KillingSpreeEffectDummy(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
 
     if (p_caster == NULL)
         return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/ShamanSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/ShamanSpells.cpp
@@ -48,20 +48,20 @@ bool SkyShatterRegalia(uint8_t /*effectIndex*/, Spell* s)
     // Shaman - Skyshatter Regalia - Two Piece Bonus
     // it checks for earth, air, water, fire totems and triggers Totemic Mastery spell 38437.
 
-    if (!s->p_caster)
+    if (!s->getPlayerCaster())
         return false;
 
-    if (s->p_caster->summonhandler.HasSummonInSlot(0) &&
-        s->p_caster->summonhandler.HasSummonInSlot(1) &&
-        s->p_caster->summonhandler.HasSummonInSlot(2) &&
-        s->p_caster->summonhandler.HasSummonInSlot(3))
+    if (s->getPlayerCaster()->summonhandler.HasSummonInSlot(0) &&
+        s->getPlayerCaster()->summonhandler.HasSummonInSlot(1) &&
+        s->getPlayerCaster()->summonhandler.HasSummonInSlot(2) &&
+        s->getPlayerCaster()->summonhandler.HasSummonInSlot(3))
     {
-        Aura* aur = sSpellMgr.newAura(sSpellMgr.getSpellInfo(38437), 5000, s->p_caster, s->p_caster, true);
+        Aura* aur = sSpellMgr.newAura(sSpellMgr.getSpellInfo(38437), 5000, s->getPlayerCaster(), s->getPlayerCaster(), true);
 
         for (uint8_t j = 0; j < 3; j++)
             aur->addAuraEffect(static_cast<AuraEffect>(aur->getSpellInfo()->getEffectRadiusIndex(j)), aur->getSpellInfo()->getEffectBasePoints(j) + 1, aur->getSpellInfo()->getEffectMiscValue(j), j);
 
-        s->p_caster->addAura(aur);
+        s->getPlayerCaster()->addAura(aur);
     }
 
     return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/WarlockSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarlockSpells.cpp
@@ -40,7 +40,7 @@
  /////////////////////////////////////////////////////////////
 bool SoulLinkParent(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
     {
         return true;
     }
@@ -60,7 +60,7 @@ bool LifeTap(uint8_t effectIndex, Spell* s)
 {
     Player* playerTarget = s->GetPlayerTarget();
 
-    if (!s->p_caster || !playerTarget)
+    if (!s->getPlayerCaster() || !playerTarget)
     {
         return false;
     }
@@ -82,9 +82,9 @@ bool LifeTap(uint8_t effectIndex, Spell* s)
     if (damage >= playerTarget->getHealth())
         return false;
 
-    s->p_caster->DealDamage(playerTarget, damage, 0, 0, s->getSpellInfo()->getId());
+    s->getPlayerCaster()->DealDamage(playerTarget, damage, 0, 0, s->getSpellInfo()->getId());
     damage = damage * (100 + playerTarget->m_lifetapbonus) / 100;    // Apply improved life tap
-    s->p_caster->energize(playerTarget, s->getSpellInfo()->getId(), damage, POWER_TYPE_MANA);
+    s->getPlayerCaster()->energize(playerTarget, s->getSpellInfo()->getId(), damage, POWER_TYPE_MANA);
 
     return true;
 }
@@ -93,22 +93,22 @@ bool SoulShatter(uint8_t /*effectIndex*/, Spell* s)
 {
     Unit* unitTarget = s->GetUnitTarget();
 
-    if (!s->u_caster || !s->u_caster->isAlive() || !unitTarget || !unitTarget->isAlive())
+    if (!s->getPlayerCaster() || !s->getPlayerCaster()->isAlive() || !unitTarget || !unitTarget->isAlive())
         return false;
 
-    s->u_caster->castSpell(unitTarget, 32835, false);
+    s->getPlayerCaster()->castSpell(unitTarget, 32835, false);
 
     return true;
 }
 
 bool MinorHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18692))
+    if (s->getPlayerCaster()->HasSpell(18692))
         s->CreateItem(19004);
-    else if (s->p_caster->HasSpell(18693))
+    else if (s->getPlayerCaster()->HasSpell(18693))
         s->CreateItem(19005);
     else
         s->CreateItem(5512);
@@ -118,26 +118,26 @@ bool MinorHealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool LesserHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(19007);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(19006);
     else
-        s->p_caster->getItemInterface()->AddItemById(5511, 1, 0);
+        s->getPlayerCaster()->getItemInterface()->AddItemById(5511, 1, 0);
     return true;
 }
 
 bool HealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(19009);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(19008);
     else
         s->CreateItem(5509);
@@ -147,12 +147,12 @@ bool HealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool GreaterHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(19011);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(19010);
     else
         s->CreateItem(5510);
@@ -162,12 +162,12 @@ bool GreaterHealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool MajorHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(19013);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(19012);
     else
         s->CreateItem(9421);
@@ -177,12 +177,12 @@ bool MajorHealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool MasterHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(22105);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(22104);
     else
         s->CreateItem(22103);
@@ -192,12 +192,12 @@ bool MasterHealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool DemonicHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(36891);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(36890);
     else
         s->CreateItem(36889);
@@ -207,12 +207,12 @@ bool DemonicHealthStone(uint8_t /*effectIndex*/, Spell* s)
 
 bool FelHealthStone(uint8_t /*effectIndex*/, Spell* s)
 {
-    if (s->p_caster == nullptr)
+    if (s->getPlayerCaster() == nullptr)
         return false;
 
-    if (s->p_caster->HasSpell(18693))    // Improved Healthstone (2)
+    if (s->getPlayerCaster()->HasSpell(18693))    // Improved Healthstone (2)
         s->CreateItem(36894);
-    else if (s->p_caster->HasSpell(18692))    // Improved Healthstone (1)
+    else if (s->getPlayerCaster()->HasSpell(18692))    // Improved Healthstone (1)
         s->CreateItem(36893);
     else
         s->CreateItem(36892);
@@ -224,7 +224,7 @@ bool MasterDemonologist1(uint8_t /*effectIndex*/, Spell* s)
 {
     Unit* unitTarget = s->GetUnitTarget();
 
-    if (!s->p_caster || !unitTarget)
+    if (!s->getPlayerCaster() || !unitTarget)
         return false; //can't imagine how this talent got to anybody else then a player casting on pet
 
     uint32_t casted_spell_id = 0;
@@ -252,8 +252,8 @@ bool MasterDemonologist1(uint8_t /*effectIndex*/, Spell* s)
     if (casted_spell_id)
     {
         //for self
-        Spell* sp = sSpellMgr.newSpell(s->p_caster, sSpellMgr.getSpellInfo(casted_spell_id), true, NULL);
-        SpellCastTargets tgt(s->p_caster->getGuid());
+        Spell* sp = sSpellMgr.newSpell(s->getPlayerCaster(), sSpellMgr.getSpellInfo(casted_spell_id), true, NULL);
+        SpellCastTargets tgt(s->getPlayerCaster()->getGuid());
         sp->prepare(&tgt);
 
         //for pet
@@ -265,8 +265,8 @@ bool MasterDemonologist1(uint8_t /*effectIndex*/, Spell* s)
     if (inc_resist_by_level_spell)
     {
         //for self
-        Spell* sp = sSpellMgr.newSpell(s->p_caster, sSpellMgr.getSpellInfo(inc_resist_by_level_spell), true, NULL);
-        SpellCastTargets tgt(s->p_caster->getGuid());
+        Spell* sp = sSpellMgr.newSpell(s->getPlayerCaster(), sSpellMgr.getSpellInfo(inc_resist_by_level_spell), true, NULL);
+        SpellCastTargets tgt(s->getPlayerCaster()->getGuid());
         sp->prepare(&tgt);
         //for pet
         sp = sSpellMgr.newSpell(unitTarget, sSpellMgr.getSpellInfo(inc_resist_by_level_spell), true, NULL);
@@ -279,7 +279,7 @@ bool MasterDemonologist1(uint8_t /*effectIndex*/, Spell* s)
 
 bool MasterDemonologist2(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
     Unit* unitTarget = s->GetUnitTarget();
 
     if (!p_caster || !unitTarget)
@@ -336,7 +336,7 @@ bool MasterDemonologist2(uint8_t /*effectIndex*/, Spell* s)
 
 bool MasterDemonologist3(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
     Unit* unitTarget = s->GetUnitTarget();
 
     if (!p_caster || !unitTarget)
@@ -392,7 +392,7 @@ bool MasterDemonologist3(uint8_t /*effectIndex*/, Spell* s)
 
 bool MasterDemonologist4(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
     Unit* unitTarget = s->GetUnitTarget();
 
     if (!p_caster || !unitTarget)
@@ -448,7 +448,7 @@ bool MasterDemonologist4(uint8_t /*effectIndex*/, Spell* s)
 
 bool MasterDemonologist5(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
     Unit* unitTarget = s->GetUnitTarget();
 
     if (!p_caster || !unitTarget)
@@ -509,11 +509,11 @@ bool SummonSuccubusQuest(uint8_t /*effectIndex*/, Spell* s)
     if (cp == nullptr)
         return false;
 
-    Creature* pCreature = s->p_caster->GetMapMgr()->CreateCreature(cp->Id);
-    pCreature->Load(cp, s->p_caster->GetPositionX(), s->p_caster->GetPositionY(), s->p_caster->GetPositionZ());
+    Creature* pCreature = s->getPlayerCaster()->GetMapMgr()->CreateCreature(cp->Id);
+    pCreature->Load(cp, s->getPlayerCaster()->GetPositionX(), s->getPlayerCaster()->GetPositionY(), s->getPlayerCaster()->GetPositionZ());
     pCreature->GetAIInterface()->Init(pCreature, AI_SCRIPT_AGRO, Movement::WP_MOVEMENT_SCRIPT_NONE);
-    pCreature->GetAIInterface()->taunt(s->p_caster, true);
-    pCreature->PushToWorld(s->p_caster->GetMapMgr());
+    pCreature->GetAIInterface()->taunt(s->getPlayerCaster(), true);
+    pCreature->PushToWorld(s->getPlayerCaster()->GetMapMgr());
     pCreature->Despawn(60000, 0);
 
     return true;
@@ -521,7 +521,7 @@ bool SummonSuccubusQuest(uint8_t /*effectIndex*/, Spell* s)
 
 bool SummonVoidWalkerQuest(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
 
     CreatureProperties const* cp = sMySQLStore.getCreatureProperties(5676);
     if (cp == nullptr)
@@ -539,7 +539,7 @@ bool SummonVoidWalkerQuest(uint8_t /*effectIndex*/, Spell* s)
 
 bool SummonFelHunterQuest(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
 
     CreatureProperties const* cp = sMySQLStore.getCreatureProperties(6268);
     if (cp == nullptr)

--- a/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
@@ -25,12 +25,12 @@
 
 bool Execute(uint8_t effectIndex, Spell* pSpell)
 {
-    if (pSpell->p_caster == NULL || pSpell->GetUnitTarget() == NULL)
+    if (pSpell->getPlayerCaster() == NULL || pSpell->GetUnitTarget() == NULL)
     {
         return true;
     }
 
-    Player* Caster = pSpell->p_caster;
+    Player* Caster = pSpell->getPlayerCaster();
     Unit* Target = pSpell->GetUnitTarget();
 
     uint32_t rage = Caster->getPower(POWER_TYPE_RAGE);
@@ -64,12 +64,12 @@ bool Execute(uint8_t effectIndex, Spell* pSpell)
 
 bool Vigilance(uint8_t /*effectIndex*/, Spell* pSpell)
 {
-    if (!pSpell->p_caster)
+    if (!pSpell->getPlayerCaster())
     {
         return true;
     }
 
-    pSpell->p_caster->ClearCooldownForSpell(355);   // Taunt
+    pSpell->getPlayerCaster()->ClearCooldownForSpell(355);   // Taunt
 
     return true;
 }
@@ -88,7 +88,7 @@ bool DamageShield(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
 
 bool HeroicFury(uint8_t /*effectIndex*/, Spell* s)
 {
-    Player* p_caster = s->p_caster;
+    Player* p_caster = s->getPlayerCaster();
 
     if (!p_caster)
     {
@@ -122,15 +122,15 @@ bool HeroicFury(uint8_t /*effectIndex*/, Spell* s)
 
 bool Charge(uint8_t effectIndex, Spell* s)
 {
-    if (!s->u_caster)
+    if (!s->getUnitCaster())
     {
         return false;
     }
 
     uint32_t rage_to_gen = s->getSpellInfo()->getEffectBasePoints(effectIndex) + 1;
-    if (s->p_caster)
+    if (s->getPlayerCaster())
     {
-        for (std::set<uint32_t>::iterator itr = s->p_caster->mSpells.begin(); itr != s->p_caster->mSpells.end(); ++itr)
+        for (std::set<uint32_t>::iterator itr = s->getPlayerCaster()->mSpells.begin(); itr != s->getPlayerCaster()->mSpells.end(); ++itr)
         {
             if (*itr == 12697)
             {
@@ -145,7 +145,7 @@ bool Charge(uint8_t effectIndex, Spell* s)
     }
 
     // Add the rage to the caster
-    s->u_caster->modPower(POWER_TYPE_RAGE, rage_to_gen);
+    s->getUnitCaster()->modPower(POWER_TYPE_RAGE, rage_to_gen);
 
     return true;
 }
@@ -162,7 +162,7 @@ bool LastStand(uint8_t /*effectIndex*/, Spell* s)
     SpellCastTargets tgt(playerTarget->getGuid());
 
     SpellInfo const* inf = sSpellMgr.getSpellInfo(12976);
-    Spell* spe = sSpellMgr.newSpell(s->u_caster, inf, true, NULL);
+    Spell* spe = sSpellMgr.newSpell(s->getUnitCaster(), inf, true, NULL);
     spe->prepare(&tgt);
 
     return true;

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -1683,7 +1683,7 @@ bool ChatHandler::HandleCharSetTalentpointsCommand(const char* args, WorldSessio
         return true;
 
     uint32 primary_amount = 0;
-    uint32 secondary_amount = 0;
+    [[maybe_unused]]uint32 secondary_amount = 0;
 
     std::stringstream ss(args);
     ss >> primary_amount;

--- a/src/world/Chat/Commands/LookupCommands.cpp
+++ b/src/world/Chat/Commands/LookupCommands.cpp
@@ -18,7 +18,7 @@ This file is released under the MIT license. See README-MIT for more information
 //.lookup achievement criteria string : searches for "string" in achievement criteria name
 //.lookup achievement all string : searches for "string" in achievement name, description, reward, and critiera
 //////////////////////////////////////////////////////////////////////////////////////////
-bool ChatHandler::HandleLookupAchievementCommand(const char* args, WorldSession* m_session)
+bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* args, [[maybe_unused]]WorldSession* m_session)
 {
 #if VERSION_STRING > TBC
     if (!*args)

--- a/src/world/Chat/Commands/debugcmds.cpp
+++ b/src/world/Chat/Commands/debugcmds.cpp
@@ -281,7 +281,7 @@ bool ChatHandler::HandleFaceCommand(const char* args, WorldSession* m_session)
 
 }
 
-bool ChatHandler::HandleSetBytesCommand(const char* args, WorldSession* m_session)
+bool ChatHandler::HandleSetBytesCommand(const char* /*args*/, WorldSession* m_session)
 {
     SystemMessage(m_session, "This command is no longer availabe!");
     /*Object* obj;
@@ -343,7 +343,7 @@ bool ChatHandler::HandleSetBytesCommand(const char* args, WorldSession* m_sessio
     return true;
 }
 
-bool ChatHandler::HandleGetBytesCommand(const char* args, WorldSession* m_session)
+bool ChatHandler::HandleGetBytesCommand(const char* /*args*/, WorldSession* m_session)
 {
     SystemMessage(m_session, "This command is no longer availabe!");
 
@@ -545,7 +545,7 @@ bool ChatHandler::HandleSendItemPushResult(const char* args, WorldSession* m_ses
     return true;
 }
 
-bool ChatHandler::HandleModifyBitCommand(const char* args, WorldSession* m_session)
+bool ChatHandler::HandleModifyBitCommand(const char* /*args*/, WorldSession* m_session)
 {
     SystemMessage(m_session, "This command is no longer availabe!");
 
@@ -605,7 +605,7 @@ bool ChatHandler::HandleModifyBitCommand(const char* args, WorldSession* m_sessi
     return true;
 }
 
-bool ChatHandler::HandleModifyValueCommand(const char* args, WorldSession* m_session)
+bool ChatHandler::HandleModifyValueCommand(const char* /*args*/, WorldSession* m_session)
 {
     SystemMessage(m_session, "This command is no longer availabe!");
 

--- a/src/world/Management/ArenaTeam.cpp
+++ b/src/world/Management/ArenaTeam.cpp
@@ -46,7 +46,7 @@ static const uint32 IdToTeamCount[6] =
     0,
 };
 
-ArenaTeam::ArenaTeam(uint16 Type, uint32 Id)
+ArenaTeam::ArenaTeam(uint8_t Type, uint32 Id)
 {
     m_id = Id;
     m_type = Type;
@@ -61,7 +61,7 @@ ArenaTeam::ArenaTeam(Field* f)
     uint32 z = 0;
 
     m_id = f[z++].GetUInt32();
-    m_type = f[z++].GetUInt16();
+    m_type = f[z++].GetUInt8();
     m_leader = f[z++].GetUInt32();
     m_name = f[z++].GetString();
     m_emblem.emblemStyle = f[z++].GetUInt32();

--- a/src/world/Management/ArenaTeam.h
+++ b/src/world/Management/ArenaTeam.h
@@ -73,7 +73,7 @@ class SERVER_DECL ArenaTeam
 {
     public:
 
-        ArenaTeam(uint16 Type, uint32 Id);
+        ArenaTeam(uint8_t Type, uint32 Id);
         ArenaTeam(Field* f);
         ~ArenaTeam()
         {
@@ -119,7 +119,7 @@ class SERVER_DECL ArenaTeam
         std::vector<ArenaTeamPacketList> getRoosterMembers() const;
 
         uint32 m_id;
-        uint16_t m_type;
+        uint8_t m_type;
         uint32 m_leader;
         uint32 m_slots;
         std::string m_name;

--- a/src/world/Management/AuctionHouse.cpp
+++ b/src/world/Management/AuctionHouse.cpp
@@ -63,7 +63,7 @@ AuctionPacketList Auction::getListMember()
     auctionList.outBid = (highestBid ? getAuctionOutBid() : 0);
     auctionList.buyoutPrice = buyoutPrice;
 
-    auctionList.expireTime = ((expireTime - UNIXTIME) * 1000);
+    auctionList.expireTime = static_cast<uint32_t>(((expireTime - UNIXTIME) * 1000));
     auctionList.highestBidderGuid = highestBidderGuid;
     auctionList.highestBid = highestBid;
 
@@ -327,7 +327,7 @@ void AuctionHouse::sendOwnerListPacket(Player* player, WorldPacket* /*packet*/)
     }
     auctionLock.ReleaseReadLock();
 
-    player->SendPacket(SmsgAuctionOwnerListResult(auctionPacketList.size(), auctionPacketList, auctionPacketList.size()).serialise().get());
+    player->SendPacket(SmsgAuctionOwnerListResult(static_cast<uint32_t>(auctionPacketList.size()), auctionPacketList, static_cast<uint32_t>(auctionPacketList.size())).serialise().get());
 }
 
 void AuctionHouse::updateOwner(uint32_t oldGuid, uint32_t newGuid)
@@ -366,7 +366,7 @@ void AuctionHouse::sendBidListPacket(Player* player, WorldPacket* /*packet*/)
     }
     auctionLock.ReleaseReadLock();
 
-    player->SendPacket(SmsgAuctionBidderListResult(auctionPacketList.size(), auctionPacketList, auctionPacketList.size(), 300).serialise().get());
+    player->SendPacket(SmsgAuctionBidderListResult(static_cast<uint32_t>(auctionPacketList.size()), auctionPacketList, static_cast<uint32_t>(auctionPacketList.size()), 300).serialise().get());
 }
 
 void AuctionHouse::sendAuctionBuyOutNotificationPacket(Auction* auction)
@@ -507,5 +507,5 @@ void AuctionHouse::sendAuctionList(Player* player, AscEmu::Packets::CmsgAuctionL
     }
     auctionLock.ReleaseReadLock();
 
-    player->SendPacket(SmsgAuctionListResult(auctionPacketList.size(), auctionPacketList, auctionPacketList.size(), 300).serialise().get());
+    player->SendPacket(SmsgAuctionListResult(static_cast<uint32_t>(auctionPacketList.size()), auctionPacketList, static_cast<uint32_t>(auctionPacketList.size()), 300).serialise().get());
 }

--- a/src/world/Management/Guild.cpp
+++ b/src/world/Management/Guild.cpp
@@ -1404,7 +1404,7 @@ void Guild::broadcastPacket(WorldPacket* packet) const
     }
 }
 
-void Guild::massInviteToEvent(WorldSession* session, uint32_t minLevel, uint32_t maxLevel, uint32_t minRank)
+void Guild::massInviteToEvent([[maybe_unused]]WorldSession* session, [[maybe_unused]]uint32_t minLevel, [[maybe_unused]]uint32_t maxLevel, [[maybe_unused]]uint32_t minRank)
 {
 #if VERSION_STRING > TBC
     uint32_t count = 0;

--- a/src/world/Management/Item.Legacy.cpp
+++ b/src/world/Management/Item.Legacy.cpp
@@ -698,7 +698,7 @@ void Item::ApplyEnchantmentBonus(uint32 Slot, bool Apply)
                                 continue;
 
                             Spell* spell = sSpellMgr.newSpell(m_owner, sp, true, 0);
-                            spell->i_caster = this;
+                            spell->setItemCaster(this);
                             spell->prepare(&targets);
                         }
                     }
@@ -1091,8 +1091,10 @@ int32 GetStatScalingStatValueColumn(ItemProperties const* proto, uint32 type)
         }
 
         default:
-            return 1;
+            break;
     }
+
+    return 1;
 }
 
 uint32 Item::CountGemsWithLimitId(uint32 LimitId)

--- a/src/world/Management/ItemInterface.cpp
+++ b/src/world/Management/ItemInterface.cpp
@@ -368,7 +368,7 @@ AddItemResult ItemInterface::m_AddItem(Item* item, int8 ContainerSlot, int16 slo
                 uint32 count = item->buildCreateUpdateBlockForPlayer(&buf, m_pOwner);
                 m_pOwner->getUpdateMgr().pushCreationData(&buf, count);
             }
-            m_pOwner->setInventorySlotItemGuid(slot, item->getGuid());
+            m_pOwner->setInventorySlotItemGuid(static_cast<uint8_t>(slot), item->getGuid());
         }
         else
         {
@@ -486,7 +486,7 @@ Item* ItemInterface::SafeRemoveAndRetreiveItemFromSlot(int8 ContainerSlot, int16
         {
             pItem->m_isDirty = true;
 
-            m_pOwner->setInventorySlotItemGuid(slot, 0);
+            m_pOwner->setInventorySlotItemGuid(static_cast<uint8_t>(slot), 0);
 
             if (slot < EQUIPMENT_SLOT_END)
             {
@@ -646,7 +646,7 @@ bool ItemInterface::SafeFullRemoveItemFromSlot(int8 ContainerSlot, int16 slot)
         {
             pItem->m_isDirty = true;
 
-            m_pOwner->setInventorySlotItemGuid(slot, 0);
+            m_pOwner->setInventorySlotItemGuid(static_cast<uint8_t>(slot), 0);
 
             if (slot < EQUIPMENT_SLOT_END)
             {
@@ -2817,7 +2817,7 @@ Item* ItemInterface::GetItemByGUID(uint64 Guid)
 
 void ItemInterface::EmptyBuyBack()
 {
-    for (uint32 j = 0; j < MAX_BUYBACK_SLOT; ++j)
+    for (uint8_t j = 0; j < MAX_BUYBACK_SLOT; ++j)
     {
         if (m_pBuyBack[j] != nullptr)
         {
@@ -2909,7 +2909,7 @@ void ItemInterface::AddBuyBackItem(Item* it, uint32 price)
 
 void ItemInterface::RemoveBuyBackItem(uint32 index)
 {
-    uint32_t j = 0;
+    uint8_t j = 0;
     for (j = index; j < MAX_BUYBACK_SLOT - 1; ++j)
     {
         if (m_pOwner->getVendorBuybackSlot(j) != 0)

--- a/src/world/Management/LootMgr.cpp
+++ b/src/world/Management/LootMgr.cpp
@@ -824,7 +824,7 @@ void LootRoll::PlayerRolled(Player* player, uint8 choice)
     if (m_NeedRolls.find(player->getGuidLow()) != m_NeedRolls.end() || m_GreedRolls.find(player->getGuidLow()) != m_GreedRolls.end())
         return; // don't allow cheaters
 
-    int roll = Util::getRandomUInt(99) + 1;
+    uint8_t roll = Util::getRandomUInt(99) + 1;
     uint8_t rollType = choice;
 
     if (choice == NEED)

--- a/src/world/Management/QuestMgr.cpp
+++ b/src/world/Management/QuestMgr.cpp
@@ -2735,7 +2735,8 @@ void QuestMgr::OnPlayerEmote(Player* plr, uint32 emoteid, uint64 & victimguid)
 
     Unit* victim = plr->GetMapMgr() ? plr->GetMapMgr()->GetUnit(victimguid) : NULL;
 
-    uint32 i, j;
+    uint32 i;
+    uint8_t j;
     uint32 entry = (victim) ? victim->getEntry() : 0;
     QuestLogEntry* qle;
     for (i = 0; i < 25; ++i)

--- a/src/world/Management/TaxiMgr.cpp
+++ b/src/world/Management/TaxiMgr.cpp
@@ -197,9 +197,11 @@ void TaxiPath::SendMoveForTime(Player* riding, Player* to, uint32_t time)
 
         if (len >= traveledLen)
         {
-            float x = (itr->second->x - nx) * (traveledLen / len) + nx;
-            float y = (itr->second->y - ny) * (traveledLen / len) + ny;
-            float z = (itr->second->z - nz) * (traveledLen / len) + nz;
+            // todo: variables are initialized but not referenced -Appled
+
+            //float x = (itr->second->x - nx) * (traveledLen / len) + nx;
+            //float y = (itr->second->y - ny) * (traveledLen / len) + ny;
+            //float z = (itr->second->z - nz) * (traveledLen / len) + nz;
             break;
         }
 

--- a/src/world/Objects/MovementInfo.h
+++ b/src/world/Objects/MovementInfo.h
@@ -19,7 +19,7 @@ struct MovementInfo
         position(0.f, 0.f, 0.f, 0.f),
         transport_guid(0), transport_position(0.f, 0.f, 0.f, 0.f), transport_time(0),
 #if VERSION_STRING == WotLK
-        transport_seat(0), transport_time2(0.f),
+        transport_seat(0), transport_time2(0),
 #endif
         pitch_rate(0.f), fall_time(0), spline_elevation(0.f) {}
 
@@ -86,7 +86,7 @@ struct MovementInfo
 #endif
 
     // transport
-    void setTransportData(ObjectGuid _guid, float x, float y, float z, float o, uint32_t time, int8_t seat)
+    void setTransportData(ObjectGuid _guid, float x, float y, float z, float o, uint32_t time, [[maybe_unused]]int8_t seat)
     {
         transport_guid = _guid;
         transport_position.x = x;

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -629,7 +629,32 @@ int32_t Object::doSpellDamage(Unit* victim, uint32_t spellId, int32_t dmg, uint8
         if (isPeriodic && aur != nullptr)
             bonusDamage *= aur->getStackCount();
 
+        // Get attack power bonus
+        float_t attackPowerBonus = 0.0f;
+        if (isPeriodic && aur != nullptr)
+        {
+            if (spellInfo->spell_ap_coeff_overtime > 0.0f)
+            {
+                attackPowerBonus = aur->getAttackPowerBonus() * spellInfo->spell_ap_coeff_overtime;
+                attackPowerBonus *= aur->getStackCount();
+            }
+        }
+        else
+        {
+            if (isPeriodic)
+            {
+                if (spellInfo->spell_ap_coeff_overtime > 0.0f)
+                    attackPowerBonus = casterUnit->getAttackPower() * spellInfo->spell_ap_coeff_overtime;
+            }
+            else
+            {
+                if (spellInfo->spell_ap_coeff_direct > 0.0f)
+                    attackPowerBonus = casterUnit->getAttackPower() * spellInfo->spell_ap_coeff_direct;
+            }
+        }
+
         damage += bonusDamage;
+        damage += attackPowerBonus;
         if (damage < 0.0f)
             damage = 0.0f;
     }
@@ -954,7 +979,32 @@ void Object::doSpellHealing(Unit* victim, uint32_t spellId, int32_t amt, bool al
         if (isPeriodic && aur != nullptr)
             bonusHeal *= aur->getStackCount();
 
+        // Get attack power bonus
+        float_t attackPowerBonus = 0.0f;
+        if (isPeriodic && aur != nullptr)
+        {
+            if (spellInfo->spell_ap_coeff_overtime > 0.0f)
+            {
+                attackPowerBonus = aur->getAttackPowerBonus() * spellInfo->spell_ap_coeff_overtime;
+                attackPowerBonus *= aur->getStackCount();
+            }
+        }
+        else
+        {
+            if (isPeriodic)
+            {
+                if (spellInfo->spell_ap_coeff_overtime > 0.0f)
+                    attackPowerBonus = casterUnit->getAttackPower() * spellInfo->spell_ap_coeff_overtime;
+            }
+            else
+            {
+                if (spellInfo->spell_ap_coeff_direct > 0.0f)
+                    attackPowerBonus = casterUnit->getAttackPower() * spellInfo->spell_ap_coeff_direct;
+            }
+        }
+
         heal += bonusHeal;
+        heal += attackPowerBonus;
         if (heal < 0.0f)
             heal = 0.0f;
     }
@@ -1564,7 +1614,7 @@ uint32 Object::buildCreateUpdateBlockForPlayer(ByteBuffer* data, Player* target)
     if (!target)
         return 0;
 
-    uint8_t flags = 0, flags2 = 0, update_type = UPDATETYPE_CREATE_OBJECT;
+    uint8_t flags = 0, update_type = UPDATETYPE_CREATE_OBJECT;
     if (m_objectTypeId == TYPEID_CORPSE)
         if (static_cast<Corpse*>(this)->getDisplayId() == 0)
             return 0;
@@ -2805,7 +2855,7 @@ void Unit::BuildHeartBeatMsg(WorldPacket* data)
     BuildMovementPacket(data);
 }
 
-bool Object::SetPosition(const LocationVector & v, bool allowPorting /* = false */)
+bool Object::SetPosition(const LocationVector & v, [[maybe_unused]]bool allowPorting /* = false */)
 {
     bool updateMap = false, result = true;
 
@@ -2832,7 +2882,7 @@ bool Object::SetPosition(const LocationVector & v, bool allowPorting /* = false 
     return result;
 }
 
-bool Object::SetPosition(float newX, float newY, float newZ, float newOrientation, bool allowPorting)
+bool Object::SetPosition(float newX, float newY, float newZ, float newOrientation, [[maybe_unused]]bool allowPorting)
 {
     bool updateMap = false, result = true;
 

--- a/src/world/Objects/ObjectMgr.cpp
+++ b/src/world/Objects/ObjectMgr.cpp
@@ -1600,7 +1600,7 @@ void ObjectMgr::generateDatabaseGossipOptionAndSubMenu(Object* object, Player* p
                 {
                     if (itr->second.onChooseData != 0)
                     {
-                        if (player->GetStanding(itr->second.onChooseData) >= itr->second.onChooseData2)
+                        if (player->GetStanding(itr->second.onChooseData) >= static_cast<int32_t>(itr->second.onChooseData2))
                             player->castSpell(player, sSpellMgr.getSpellInfo(itr->second.onChooseData3), true);
                         else
                             player->BroadcastMessage(player->GetSession()->LocalizedWorldSrv(itr->second.onChooseData4));

--- a/src/world/Server/Packets/CmsgAuctionSellItem.h
+++ b/src/world/Server/Packets/CmsgAuctionSellItem.h
@@ -33,6 +33,7 @@ namespace AscEmu::Packets
         {
         }
 
+#if VERSION_STRING >= Cata
         CmsgAuctionSellItem(uint64_t auctioneerGuid, uint64_t bidMoney, uint64_t buyoutPrice, uint32_t itemsCount, uint32_t expireTime) :
             ManagedPacket(CMSG_AUCTION_SELL_ITEM, 0),
             auctioneerGuid(auctioneerGuid),
@@ -40,6 +41,15 @@ namespace AscEmu::Packets
             buyoutPrice(buyoutPrice),
             itemsCount(itemsCount),
             expireTime(expireTime)
+#else
+        CmsgAuctionSellItem(uint64_t auctioneerGuid, uint32_t bidMoney, uint32_t buyoutPrice, uint32_t itemsCount, uint32_t expireTime) :
+            ManagedPacket(CMSG_AUCTION_SELL_ITEM, 0),
+            auctioneerGuid(auctioneerGuid),
+            bidMoney(bidMoney),
+            buyoutPrice(buyoutPrice),
+            itemsCount(itemsCount),
+            expireTime(expireTime)
+#endif
         {
         }
 

--- a/src/world/Server/Packets/CmsgPlayedTime.h
+++ b/src/world/Server/Packets/CmsgPlayedTime.h
@@ -33,7 +33,7 @@ namespace AscEmu::Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise([[maybe_unused]]WorldPacket& packet) override
         {
 #if VERSION_STRING > TBC
             packet >> displayInUi;

--- a/src/world/Server/Packets/Handlers/ArenaTeamHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ArenaTeamHandler.cpp
@@ -342,7 +342,7 @@ void WorldSession::handleArenaTeamRosterOpcode(WorldPacket& recvPacket)
     if (auto arenaTeam = sObjectMgr.GetArenaTeamById(srlPacket.teamId))
     {
         const auto memberList = arenaTeam->getRoosterMembers();
-        SendPacket(SmsgArenaTeamRooster(arenaTeam->m_id, memberList.size(), arenaTeam->GetPlayersPerTeam(), memberList).serialise().get());
+        SendPacket(SmsgArenaTeamRooster(arenaTeam->m_id, static_cast<uint32_t>(memberList.size()), arenaTeam->GetPlayersPerTeam(), memberList).serialise().get());
     }
 }
 

--- a/src/world/Server/Packets/Handlers/GuildHandler.cpp
+++ b/src/world/Server/Packets/Handlers/GuildHandler.cpp
@@ -658,7 +658,7 @@ void WorldSession::handleCharterTurnInCharter(WorldPacket& recvPacket)
     }
     else
     {
-        uint16_t type;
+        uint8_t type;
 
         switch (charter->CharterType)
         {

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -366,8 +366,8 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
 
                 Spell* spell = sSpellMgr.newSpell(_player, spellInfo, false, nullptr);
                 spell->extra_cast_number = srlPacket.castCount;
-                spell->i_caster = tmpItem;
-                uint8 result = spell->prepare(&targets);
+                spell->setItemCaster(tmpItem);
+                spell->prepare(&targets);
             }
         }
     }
@@ -412,7 +412,7 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
 
     Spell* spell = sSpellMgr.newSpell(_player, spellInfo, false, nullptr);
     spell->extra_cast_number = srlPacket.castCount;
-    spell->i_caster = tmpItem;
+    spell->setItemCaster(tmpItem);
     spell->m_glyphslot = srlPacket.glyphIndex;
 
     // Some spell cast packets include more data
@@ -1043,9 +1043,9 @@ void WorldSession::handleDestroyItemOpcode(WorldPacket& recvPacket)
         for (uint8_t i = 0; i < CURRENT_SPELL_MAX; ++i)
         {
             if (_player->getCurrentSpell(CurrentSpellType(i)) != nullptr
-                && _player->getCurrentSpell(CurrentSpellType(i))->i_caster == pItem)
+                && _player->getCurrentSpell(CurrentSpellType(i))->getItemCaster() == pItem)
             {
-                _player->getCurrentSpell(CurrentSpellType(i))->i_caster = nullptr;
+                _player->getCurrentSpell(CurrentSpellType(i))->setItemCaster(nullptr);
                 _player->interruptSpellWithSpellType(CurrentSpellType(i));
             }
         }

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -2175,7 +2175,7 @@ void WorldSession::sendClientCacheVersion(uint32 version)
 
 void WorldSession::sendAccountDataTimes(uint32 mask)
 {
-    SendPacket(SmsgAccountDataTimes(UNIXTIME, 1, mask, NUM_ACCOUNT_DATA_TYPES).serialise().get());
+    SendPacket(SmsgAccountDataTimes(static_cast<uint32_t>(UNIXTIME), 1, mask, NUM_ACCOUNT_DATA_TYPES).serialise().get());
 }
 
 void WorldSession::sendMOTD()

--- a/src/world/Server/Packets/Handlers/TradeHandler.cpp
+++ b/src/world/Server/Packets/Handlers/TradeHandler.cpp
@@ -337,7 +337,7 @@ void WorldSession::handleAcceptTrade(WorldPacket& /*recvPacket*/)
         playerSpellTargets.addTargetMask(TARGET_FLAG_TRADE_ITEM);
         // Create spell
         playerSpell = sSpellMgr.newSpell(_player, spellInfo, true, nullptr);
-        playerSpell->i_caster = castedFromItem;
+        playerSpell->setItemCaster(castedFromItem);
         playerSpell->m_targets = playerSpellTargets;
 
         // Check if player is able to cast the spell
@@ -371,7 +371,7 @@ void WorldSession::handleAcceptTrade(WorldPacket& /*recvPacket*/)
         traderSpellTargets.addTargetMask(TARGET_FLAG_TRADE_ITEM);
         // Create spell
         traderSpell = sSpellMgr.newSpell(tradeData->getTradeTarget(), spellInfo, true, nullptr);
-        traderSpell->i_caster = castedFromItem;
+        traderSpell->setItemCaster(castedFromItem);
         traderSpell->m_targets = traderSpellTargets;
 
         // Check if trader is able to cast the spell

--- a/src/world/Server/Packets/Movement/CreatureMovement.cpp
+++ b/src/world/Server/Packets/Movement/CreatureMovement.cpp
@@ -13,7 +13,7 @@ namespace Packets::Movement
     void SendMoveToPacket(Unit* pUnit)
     {
         auto spline = pUnit->m_movementManager.m_spline;
-        auto splineFlags = spline.GetSplineFlags();
+        [[maybe_unused]]auto splineFlags = spline.GetSplineFlags();
         auto midpoints = pUnit->m_movementManager.m_spline.GetMidPoints();
 
         WorldPacket data(SMSG_MONSTER_MOVE, 60);

--- a/src/world/Server/Packets/SmsgAttackSwingBadFacing.h
+++ b/src/world/Server/Packets/SmsgAttackSwingBadFacing.h
@@ -25,7 +25,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgAttackSwingNotInRange.h
+++ b/src/world/Server/Packets/SmsgAttackSwingNotInRange.h
@@ -25,7 +25,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgAuthChallenge.h
+++ b/src/world/Server/Packets/SmsgAuthChallenge.h
@@ -52,6 +52,6 @@ namespace AscEmu::Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }

--- a/src/world/Server/Packets/SmsgAuthResponse.h
+++ b/src/world/Server/Packets/SmsgAuthResponse.h
@@ -218,6 +218,6 @@ namespace AscEmu::Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override { return false; }
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
     };
 }

--- a/src/world/Server/Packets/SmsgCancelCombat.h
+++ b/src/world/Server/Packets/SmsgCancelCombat.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise([[maybe_unused]]WorldPacket& packet) override
         {
 #if VERSION_STRING == Mop
             packet << uint64_t(0);

--- a/src/world/Server/Packets/SmsgChannelList.h
+++ b/src/world/Server/Packets/SmsgChannelList.h
@@ -33,7 +33,7 @@ namespace AscEmu::Packets
             unknown(1),
             channelName(channelName),
             members(members),
-            membersCount(members.size())
+            membersCount(static_cast<uint32_t>(members.size()))
         {
         }
 

--- a/src/world/Server/Packets/SmsgContactList.h
+++ b/src/world/Server/Packets/SmsgContactList.h
@@ -36,7 +36,7 @@ namespace AscEmu::Packets
         SmsgContactList(uint32_t socialFlag, const std::vector<SmsgContactListMember> contactMemberList) :
             ManagedPacket(SMSG_CONTACT_LIST, 500),
             socialFlag(socialFlag),
-            listCount(contactMemberList.size()),
+            listCount(static_cast<uint32_t>(contactMemberList.size())),
             contactMemberList(contactMemberList)
         {
         }

--- a/src/world/Server/Packets/SmsgControlVehicle.h
+++ b/src/world/Server/Packets/SmsgControlVehicle.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgDefenseMessage.h
+++ b/src/world/Server/Packets/SmsgDefenseMessage.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
 
         SmsgDefenseMessage(uint32_t zoneId, const std::string message) :
             ManagedPacket(SMSG_DEFENSE_MESSAGE, 4 + 4 + message.size()),
-            zoneId(zoneId), message(message), messageSize(message.size())
+            zoneId(zoneId), message(message), messageSize(static_cast<uint32_t>(message.size()))
         {
         }
 

--- a/src/world/Server/Packets/SmsgDuelInbounds.h
+++ b/src/world/Server/Packets/SmsgDuelInbounds.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgDurabilityDamageDeath.h
+++ b/src/world/Server/Packets/SmsgDurabilityDamageDeath.h
@@ -26,7 +26,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise([[maybe_unused]]WorldPacket& packet) override
         {
 #if VERSION_STRING > WotLK
             packet << percent;

--- a/src/world/Server/Packets/SmsgEnableBarberShop.h
+++ b/src/world/Server/Packets/SmsgEnableBarberShop.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgFishEscaped.h
+++ b/src/world/Server/Packets/SmsgFishEscaped.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgFishNotHooked.h
+++ b/src/world/Server/Packets/SmsgFishNotHooked.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgGossipComplete.h
+++ b/src/world/Server/Packets/SmsgGossipComplete.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgGroupDestroyed.h
+++ b/src/world/Server/Packets/SmsgGroupDestroyed.h
@@ -22,7 +22,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgGuildMemberDailyReset.h
+++ b/src/world/Server/Packets/SmsgGuildMemberDailyReset.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgLogoutCancelAck.h
+++ b/src/world/Server/Packets/SmsgLogoutCancelAck.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgLogoutComplete.h
+++ b/src/world/Server/Packets/SmsgLogoutComplete.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgMotd.h
+++ b/src/world/Server/Packets/SmsgMotd.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
         SmsgMotd(std::vector<std::string> motdLines) :
             ManagedPacket(SMSG_MOTD, 50),
             motdLines(motdLines),
-            lineCount(motdLines.size())
+            lineCount(static_cast<uint32_t>(motdLines.size()))
         {
         }
 

--- a/src/world/Server/Packets/SmsgNewTaxiPath.h
+++ b/src/world/Server/Packets/SmsgNewTaxiPath.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgQuestLogFull.h
+++ b/src/world/Server/Packets/SmsgQuestLogFull.h
@@ -23,7 +23,7 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override { return m_minimum_size; }
 
-        bool internalSerialise(WorldPacket& packet) override
+        bool internalSerialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/Packets/SmsgResurrectRequest.h
+++ b/src/world/Server/Packets/SmsgResurrectRequest.h
@@ -30,7 +30,7 @@ namespace AscEmu::Packets
         SmsgResurrectRequest(uint64_t casterGuid, std::string casterName, uint8_t isSicknessAffected, uint8_t overrideTimer = 0, uint32_t spellId = 0) :
             ManagedPacket(SMSG_RESURRECT_REQUEST, 8 + 4 + casterName.size() + 1 + 1 + 1),
             casterGuid(casterGuid),
-            stringSize(casterName.size() + 1),
+            stringSize(static_cast<uint32_t>(casterName.size() + 1)),
             casterName(casterName),
             isSicknessAffected(isSicknessAffected),
             overrideTimer(overrideTimer),

--- a/src/world/Server/Packets/SmsgSetForceReactions.h
+++ b/src/world/Server/Packets/SmsgSetForceReactions.h
@@ -20,7 +20,7 @@ namespace AscEmu::Packets
 
         SmsgSetForceReactions(const std::map<uint32_t, uint32_t>& reactionMap) :
             ManagedPacket(SMSG_SET_FORCED_REACTIONS, 4 + reactionMap.size() * 2 * 4),
-            mapSize(reactionMap.size()),
+            mapSize(static_cast<uint32_t>(reactionMap.size())),
             reactionMap(reactionMap)
         {
         }

--- a/src/world/Server/Packets/SmsgSpellDispellLog.h
+++ b/src/world/Server/Packets/SmsgSpellDispellLog.h
@@ -33,7 +33,7 @@ namespace AscEmu::Packets
             targetGuid(targetGuid),
             spellId(spellId),
             unk1(0),
-            displellCount(dispellSpells.size()),
+            displellCount(static_cast<uint32_t>(dispellSpells.size())),
             dispellSpells(std::move(dispellSpells))
         {
         }

--- a/src/world/Server/Packets/SmsgSpellStealLog.h
+++ b/src/world/Server/Packets/SmsgSpellStealLog.h
@@ -33,7 +33,7 @@ namespace AscEmu::Packets
             targetGuid(targetGuid),
             spellId(spellId),
             unk1(0),
-            stealedCount(stealedSpells.size()),
+            stealedCount(static_cast<uint32_t>(stealedSpells.size())),
             stealedSpells(std::move(stealedSpells))
         {
         }

--- a/src/world/Spell/Customization/HackFixes.cpp
+++ b/src/world/Spell/Customization/HackFixes.cpp
@@ -649,7 +649,7 @@ void SpellMgr::applyHackFixes()
 
     SpellInfo* sp = nullptr;
 
-    for (const auto it : mSpellInfoMapStore)
+    for (const auto& it : mSpellInfoMapStore)
     {
         // Read every SpellEntry row
         sp = sSpellMgr.getMutableSpellInfo(it.first);
@@ -1336,11 +1336,6 @@ void SpellMgr::applyHackFixes()
 
     // Insert paladin spell fixes here
 
-    //Paladin - Seal of Command - Holy damage, but melee mechanics (crit damage, chance, etc)
-    sp = getMutableSpellInfo(20424);
-    if (sp != nullptr)
-        sp->custom_is_melee_spell = true;
-
     //Paladin - Hammer of the Righteous
     sp = getMutableSpellInfo(53595);
     if (sp != nullptr)
@@ -1742,14 +1737,6 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(18461);
     if (sp != nullptr)
         sp->addAttributesEx(ATTRIBUTESEX_NOT_BREAK_STEALTH);
-
-    // rogue - Blind (Make it able to miss!)
-    sp = getMutableSpellInfo(2094);
-    if (sp != nullptr)
-    {
-        sp->setDmgClass(SPELL_DMG_TYPE_RANGED);
-        sp->custom_is_ranged_spell = true;
-    }
 
     //rogue - Shadowstep
     sp = getMutableSpellInfo(36563);
@@ -3116,13 +3103,11 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
     {
         sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_UNUSED2);
-        sp->custom_is_melee_spell = true;
     }
     sp = getMutableSpellInfo(49802);
     if (sp != nullptr)
     {
         sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_UNUSED2);
-        sp->custom_is_melee_spell = true;
     }
 
     sp = getMutableSpellInfo(20719); //feline grace

--- a/src/world/Spell/Customization/SpellCustomizations.cpp
+++ b/src/world/Spell/Customization/SpellCustomizations.cpp
@@ -851,45 +851,6 @@ void SpellMgr::setSpellEffectAmplitude(SpellInfo* sp)
     }
 }
 
-void SpellMgr::setSpellMeleeSpellBool(SpellInfo* sp)
-{
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
-        if (sp->getEffect(i) == SPELL_EFFECT_SCHOOL_DAMAGE && sp->getDmgClass() == SPELL_DMG_TYPE_MELEE)
-        {
-            sp->custom_is_melee_spell = true;
-            continue;
-        }
-
-        switch (sp->getEffect(i))
-        {
-        case SPELL_EFFECT_WEAPON_DAMAGE:
-        case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-        case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-        case SPELL_EFFECT_DUMMYMELEE:
-            sp->custom_is_melee_spell = true;
-            break;
-        default:
-            continue;
-        }
-    }
-
-    if (sp->custom_is_melee_spell)
-        LogDebugFlag(LF_DB_TABLES, "SpellMgr::setSpellMeleeSpellBool : custom_is_melee_spell is true for spell %s (%u)", sp->getName().c_str(), sp->getId());
-}
-
-void SpellMgr::setSpellRangedSpellBool(SpellInfo* sp)
-{
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
-        if (sp->getEffect(i) == SPELL_EFFECT_SCHOOL_DAMAGE && sp->getDmgClass() == SPELL_DMG_TYPE_RANGED)
-            sp->custom_is_ranged_spell = true;
-    }
-
-    if (sp->custom_is_ranged_spell)
-        LogDebugFlag(LF_DB_TABLES, "SpellMgr::setSpellRangedSpellBool : custom_is_ranged_spell is true for spell %s (%u)", sp->getName().c_str(), sp->getId());
-}
-
 void SpellMgr::setSpellMissingCIsFlags(SpellInfo* sp)
 {
     // Zyres: Special cases, not handled in spell_custom_assign!

--- a/src/world/Spell/Definitions/AuraRemoveMode.h
+++ b/src/world/Spell/Definitions/AuraRemoveMode.h
@@ -1,0 +1,16 @@
+/*
+Copyright (c) 2014-2020 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+enum AuraRemoveMode : uint8_t
+{
+    AURA_REMOVE_BY_SERVER   = 0, // Internal stuff
+    AURA_REMOVE_ON_EXPIRE   = 1,
+    AURA_REMOVE_ON_DISPEL   = 2,
+    AURA_REMOVE_ON_STEAL    = 3  // Spell steal
+};

--- a/src/world/Spell/Definitions/CMakeLists.txt
+++ b/src/world/Spell/Definitions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PATH_PREFIX Spell/Definitions)
 set(SRC_SPELL_DEFINITIONS_FILES
     ${PATH_PREFIX}/AuraEffects.h
     ${PATH_PREFIX}/AuraInterruptFlags.h
+    ${PATH_PREFIX}/AuraRemoveMode.h
     ${PATH_PREFIX}/AuraStates.h
     ${PATH_PREFIX}/CastInterruptFlags.h
     ${PATH_PREFIX}/ChannelInterruptFlags.h

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -1294,15 +1294,16 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
             if (areaEntry == nullptr)
                 return SPELL_FAILED_NOT_HERE;
 
+            const auto requireAreaId = static_cast<uint32_t>(getSpellInfo()->getRequiresAreaId());
 #if VERSION_STRING == TBC
-            if (getSpellInfo()->getRequiresAreaId() != areaEntry->id && getSpellInfo()->getRequiresAreaId() != areaEntry->zone)
+            if (requireAreaId != areaEntry->id && requireAreaId != areaEntry->zone)
             {
                 *parameter1 = getSpellInfo()->getRequiresAreaId();
                 return SPELL_FAILED_REQUIRES_AREA;
             }
 #elif VERSION_STRING >= WotLK
             auto found = false;
-            auto areaGroup = sAreaGroupStore.LookupEntry(getSpellInfo()->getRequiresAreaId());
+            auto areaGroup = sAreaGroupStore.LookupEntry(requireAreaId);
             while (areaGroup != nullptr)
             {
                 for (const auto& i : areaGroup->AreaId)
@@ -4248,12 +4249,53 @@ uint32_t Spell::calculatePowerCost() const
 
     return static_cast<uint32_t>(powerCost);
 }
+//////////////////////////////////////////////////////////////////////////////////////////
+// Caster
+Object* Spell::getCaster() const
+{
+    return m_caster;
+}
+
+Unit* Spell::getUnitCaster() const
+{
+    return u_caster;
+}
+
+Player* Spell::getPlayerCaster() const
+{
+    return p_caster;
+}
+
+GameObject* Spell::getGameObjectCaster() const
+{
+    return g_caster;
+}
+
+Item* Spell::getItemCaster() const
+{
+    return i_caster;
+}
+
+void Spell::setItemCaster(Item* itemCaster)
+{
+    i_caster = itemCaster;
+}
+
+bool Spell::wasCastedinDuel() const
+{
+    return duelSpell;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Misc
 SpellInfo const* Spell::getSpellInfo() const
 {
     return m_spellInfo_override != nullptr ? m_spellInfo_override : m_spellInfo;
+}
+
+Aura* Spell::getTriggeredByAura() const
+{
+    return m_triggeredByAura;
 }
 
 bool Spell::canAttackCreatureType(Creature* target) const

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -940,6 +940,8 @@ void Aura::spellAuraEffectPeriodicHealPct(AuraEffectModifier* aurEff, bool apply
 {
     if (apply)
     {
+        aurEff->mDamage = static_cast<int32_t>(std::ceil(getOwner()->getMaxHealth() * (aurEff->mBaseDamage / 100.0f))) * getStackCount();
+
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->effIndex] == 0)
             m_periodicTimer[aurEff->effIndex] = aurEff->mAmplitude;
@@ -960,6 +962,9 @@ void Aura::spellAuraEffectPeriodicPowerPct(AuraEffectModifier* aurEff, bool appl
 
     if (apply)
     {
+        const auto powerType = static_cast<PowerType>(aurEff->miscValue);
+        aurEff->mDamage = static_cast<int32_t>(std::ceil(getOwner()->getMaxPower(powerType) * (aurEff->mBaseDamage / 100.0f))) * getStackCount();
+
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->effIndex] == 0)
             m_periodicTimer[aurEff->effIndex] = aurEff->mAmplitude;
@@ -1165,6 +1170,8 @@ void Aura::spellAuraEffectPeriodicDamagePercent(AuraEffectModifier* aurEff, bool
 {
     if (apply)
     {
+        aurEff->mDamage = static_cast<int32_t>(std::ceil(aurEff->mBaseDamage / 100.0f * getOwner()->getMaxHealth())) * getStackCount();
+
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->effIndex] == 0)
             m_periodicTimer[aurEff->effIndex] = aurEff->mAmplitude;
@@ -1181,6 +1188,10 @@ void Aura::spellAuraEffectPeriodicDamagePercent(AuraEffectModifier* aurEff, bool
 void Aura::spellAuraEffectPeriodicPowerBurn(AuraEffectModifier* aurEff, bool apply)
 {
     if (aurEff->miscValue < POWER_TYPE_MANA || aurEff->miscValue >= TOTAL_PLAYER_POWER_TYPES)
+        return;
+
+    const auto powerType = static_cast<PowerType>(aurEff->miscValue);
+    if (getOwner()->getMaxPower(powerType) == 0)
         return;
 
     if (apply)

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "Definitions/AuraEffects.h"
+#include "Definitions/AuraRemoveMode.h"
 #include "Definitions/SpellEffects.h"
 #include "Management/Item.h"
 #include "Objects/Object.h"
@@ -100,7 +101,8 @@ enum AuraUpdateFlags : uint8_t
 struct AuraEffectModifier
 {
     AuraEffect mAuraEffect;     // Effect type
-    int32_t mDamage;            // Effect amount
+    int32_t mDamage;            // Effect calculated amount
+    int32_t mBaseDamage;        // Effect base amount
     int32_t mFixedDamage;       // For example used with auras that increase your spell power by % of some stat
     int32_t miscValue;          // Misc Value
     int32_t mAmplitude;         // Effect amplitude
@@ -123,7 +125,7 @@ class SERVER_DECL Aura : public EventableObject
         int32_t getEffectDamage(uint8_t effIndex) const;
         int32_t getEffectDamageByEffect(AuraEffect auraEffect) const;
 
-        void removeAura();
+        void removeAura(AuraRemoveMode mode = AURA_REMOVE_BY_SERVER);
 
         bool canPeriodicEffectCrit();
 
@@ -147,6 +149,7 @@ class SERVER_DECL Aura : public EventableObject
         float_t getCritChance() const;
         int32_t getSpellPowerBonus() const;
         int32_t getHealPowerBonus() const;
+        uint32_t getAttackPowerBonus() const;
 
         Unit* getOwner() const;
         Player* getPlayerOwner() const;
@@ -400,12 +403,14 @@ class SERVER_DECL Aura : public EventableObject
         // Following values are calculated only on aura apply, not on every tick
         void _calculateCritChance();
         void _calculateSpellPowerBonus();
+        void _calculateAttackPowerBonus();
         void _calculateSpellHaste();
         void _calculateEffectAmplitude(uint8_t effIndex);
         bool _canHasteAffectDuration();
         float_t m_critChance = 0.0f;
         int32_t m_spellPowerBonus = 0;
         int32_t m_healPowerBonus = 0;
+        uint32_t m_attackPowerBonus = 0;
         float_t m_spellHaste = 0.0f;
 
         // Computes if aura is positive or negative at aura constructor based on SpellInfo

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -1448,13 +1448,13 @@ void Spell::SpellEffectSchoolDMG(uint8_t effectIndex) // dmg school
 
     if (getSpellInfo()->getSpeed() > 0 && m_triggeredSpell == false)
     {
-        m_caster->doSpellDamage(unitTarget, getSpellInfo()->getId(), dmg, effectIndex, pSpellId == 0, static_damage);
+        m_caster->doSpellDamage(unitTarget, getSpellInfo()->getId(), dmg, effectIndex, pSpellId == 0, isEffectDamageStatic[effectIndex]);
     }
     else
     {
         if (GetType() == SPELL_DMG_TYPE_MAGIC)
         {
-            m_caster->doSpellDamage(unitTarget, getSpellInfo()->getId(), dmg, effectIndex, !m_triggeredSpell, static_damage);
+            m_caster->doSpellDamage(unitTarget, getSpellInfo()->getId(), dmg, effectIndex, !m_triggeredSpell, isEffectDamageStatic[effectIndex]);
         }
         else
         {
@@ -3947,7 +3947,7 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
 
                     dispelledSpells.push_back(aursp->getId());
 
-                    unitTarget->RemoveAura(aur);
+                    aur->removeAura(AURA_REMOVE_ON_DISPEL);
                     AuraRemoved = true;
 
                     if (--damage <= 0)
@@ -3959,7 +3959,7 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
 
                     dispelledSpells.push_back(aursp->getId());
 
-                    unitTarget->removeAllAurasByIdForGuid(aursp->getId(), aur->getCasterGuid());
+                    aur->removeAura(AURA_REMOVE_ON_DISPEL);
                     AuraRemoved = true;
 
                     if (--damage <= 0)

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -3,7 +3,6 @@ Copyright (c) 2014-2020 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
-#include "Definitions/PowerType.h"
 #include "Definitions/School.h"
 #include "Definitions/SpellEffects.h"
 #include "Definitions/SpellEffectTarget.h"
@@ -14,71 +13,20 @@ This file is released under the MIT license. See README-MIT for more information
 
 SpellInfo::SpellInfo()
 {
-    Id = 0;
-    Category = 0;
-    DispelType = 0;
-    MechanicsType = 0;
-    Attributes = 0;
-    AttributesEx = 0;
-    AttributesExB = 0;
-    AttributesExC = 0;
-    AttributesExD = 0;
-    AttributesExE = 0;
-    AttributesExF = 0;
-    AttributesExG = 0;
-    AttributesExH = 0;
-    AttributesExI = 0;
-    AttributesExJ = 0;
-    Shapeshifts = 0;
-    ShapeshiftsExcluded = 0;
-    Targets = 0;
-    TargetCreatureType = 0;
-    RequiresSpellFocus = 0;
-    FacingCasterFlags = 0;
-    CasterAuraState = 0;
-    TargetAuraState = 0;
-    CasterAuraStateNot = 0;
-    TargetAuraStateNot = 0;
-    casterAuraSpell = 0;
-    targetAuraSpell = 0;
-    casterAuraSpellNot = 0;
-    targetAuraSpellNot = 0;
-    CastingTimeIndex = 0;
-    RecoveryTime = 0;
-    CategoryRecoveryTime = 0;
-    InterruptFlags = 0;
-    AuraInterruptFlags = 0;
-    ChannelInterruptFlags = 0;
-    procFlags = 0;
-    procChance = 0;
-    procCharges = 0;
-    maxLevel = 0;
-    baseLevel = 0;
-    spellLevel = 0;
-    DurationIndex = 0;
-    powerType = POWER_TYPE_MANA;
-    manaCost = 0;
-    manaCostPerlevel = 0;
-    manaPerSecond = 0;
-    manaPerSecondPerLevel = 0;
-    rangeIndex = 0;
-    speed = 0;
-    MaxStackAmount = 0;
-    for (auto i = 0; i < MAX_SPELL_TOTEMS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_TOTEMS; ++i)
         Totem[i] = 0;
-    for (auto i = 0; i < MAX_SPELL_REAGENTS; ++i)
+
+    for (uint8_t i = 0; i < MAX_SPELL_REAGENTS; ++i)
     {
         Reagent[i] = 0;
         ReagentCount[i] = 0;
     }
-    EquippedItemClass = -1;
-    EquippedItemSubClass = 0;
-    EquippedItemInventoryTypeMask = 0;
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         Effect[i] = 0;
         EffectDieSides[i] = 0;
-        EffectRealPointsPerLevel[i] = 0;
+        EffectRealPointsPerLevel[i] = 0.0f;
         EffectBasePoints[i] = 0;
         EffectMechanic[i] = 0;
         EffectImplicitTargetA[i] = 0;
@@ -86,14 +34,14 @@ SpellInfo::SpellInfo()
         EffectRadiusIndex[i] = 0;
         EffectApplyAuraName[i] = 0;
         EffectAmplitude[i] = 0;
-        EffectMultipleValue[i] = 0;
+        EffectMultipleValue[i] = 0.0f;
         EffectChainTarget[i] = 0;
         EffectItemType[i] = 0;
         EffectMiscValue[i] = 0;
         EffectMiscValueB[i] = 0;
         EffectTriggerSpell[i] = 0;
-        EffectPointsPerComboPoint[i] = 0;
-        for (auto u = 0; u < MAX_SPELL_EFFECTS; ++u)
+        EffectPointsPerComboPoint[i] = 0.0f;
+        for (uint8_t u = 0; u < MAX_SPELL_EFFECTS; ++u)
             EffectSpellClassMask[i][u] = 0;
 #if VERSION_STRING >= Cata
         EffectRadiusMaxIndex[i] = 0;
@@ -101,91 +49,26 @@ SpellInfo::SpellInfo()
         EffectIndex[i] = 0;
 #endif
         SpellFamilyFlags[i] = 0;
-        EffectDamageMultiplier[i] = 0;
-        EffectBonusMultiplier[i] = 0;
+        EffectDamageMultiplier[i] = 0.0f;
+        EffectBonusMultiplier[i] = 0.0f;
     }
+
     for (uint8_t i = 0; i < 2; ++i)
         SpellVisual[i] = 0;
-    spellIconID = 0;
-    activeIconID = 0;
-    spellPriority = 0;
-    Name = "";
-    Rank = "";
-    ManaCostPercentage = 0;
-    StartRecoveryCategory = 0;
-    StartRecoveryTime = 0;
-    MaxTargetLevel = 0;
-    SpellFamilyName = 0;
-    MaxTargets = 0;
-    DmgClass = 0;
-    PreventionType = 0;
+
 #if VERSION_STRING > Classic
-    for (auto i = 0; i < MAX_SPELL_TOTEM_CATEGORIES; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_TOTEM_CATEGORIES; ++i)
         TotemCategory[i] = 0;
 #endif
-    AreaGroupId = 0;
-    SchoolMask = 0;
-    RuneCostID = 0;
-    SpellDifficultyId = 0;
     
-#if VERSION_STRING >= Cata
-    // DBC links
-    SpellScalingId = 0;
-    SpellAuraOptionsId = 0;
-    SpellAuraRestrictionsId = 0;
-    SpellCastingRequirementsId = 0;
-    SpellCategoriesId = 0;
-    SpellClassOptionsId = 0;
-    SpellCooldownsId = 0;
-    SpellEquippedItemsId = 0;
-    SpellInterruptsId = 0;
-    SpellLevelsId = 0;
-    SpellPowerId = 0;
-    SpellReagentsId = 0;
-    SpellShapeshiftId = 0;
-    SpellTargetRestrictionsId = 0;
-    SpellTotemsId = 0;
-#endif
-    // Coefficient values
-    spell_coeff_direct = -1;
-    spell_coeff_overtime = -1;
-    spell_coeff_direct_override = -1;
-    spell_coeff_overtime_override = -1;
-
     // Custom values
-    custom_proc_interval = 0;
-    custom_BGR_one_buff_on_target = 0;
-    custom_c_is_flags = 0;
-    custom_RankNumber = 0;
-    custom_NameHash = 0;
-    custom_ThreatForSpell = 0;
-    custom_ThreatForSpellCoef = 0;
-    custom_base_range_or_radius_sqr = 0;
-    cone_width = 0;
-    ai_target_type = 0;
-
-    custom_self_cast_only = false;
-    custom_apply_on_shapeshift_change = false;
-    custom_is_melee_spell = false;
-    custom_is_ranged_spell = false;
-
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
         EffectCustomFlag[i] = 0;
-
-    // Script linkers
-    spellScriptLink = nullptr;
-    auraScriptLink = nullptr;
-
-    // New script system
-    spellScript = nullptr;
 }
-
-SpellInfo::~SpellInfo() {}
-
 
 bool SpellInfo::hasEffect(uint32_t effect) const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == effect)
             return true;
@@ -196,7 +79,7 @@ bool SpellInfo::hasEffect(uint32_t effect) const
 
 bool SpellInfo::hasEffectApplyAuraName(uint32_t auraType) const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] != SPELL_EFFECT_APPLY_AURA && Effect[i] != SPELL_EFFECT_PERSISTENT_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_ENEMY_AREA_AURA &&
             Effect[i] != SPELL_EFFECT_APPLY_FRIEND_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_GROUP_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_OWNER_AREA_AURA &&
@@ -253,7 +136,7 @@ bool SpellInfo::isHealingSpell() const
 
 int SpellInfo::firstBeneficialEffect() const
 {
-    for (auto i = 0; i < 3; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         switch (Effect[i])
         {
@@ -436,7 +319,7 @@ uint32_t SpellInfo::getSpellDefaultDuration(Unit const* caster) const
 
 bool SpellInfo::hasTargetType(uint32_t type) const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (EffectImplicitTargetA[i] == type ||
             EffectImplicitTargetB[i] == type)
@@ -546,11 +429,11 @@ bool SpellInfo::isPassive() const
 
 bool SpellInfo::isProfession() const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_SKILL)
         {
-            auto skill = EffectMiscValue[i];
+            const auto skill = EffectMiscValue[i];
 
             //Profession skill
             if (skill == SKILL_FISHING || skill == SKILL_COOKING || skill == SKILL_FIRST_AID)
@@ -565,11 +448,11 @@ bool SpellInfo::isProfession() const
 
 bool SpellInfo::isPrimaryProfession() const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_SKILL)
         {
-            auto skill = EffectMiscValue[i];
+            const auto skill = EffectMiscValue[i];
             if (isPrimaryProfessionSkill(skill))
                 return true;
         }
@@ -579,7 +462,7 @@ bool SpellInfo::isPrimaryProfession() const
 
 bool SpellInfo::isPrimaryProfessionSkill(uint32_t skill_id) const
 {
-    if (auto skill_line = sSkillLineStore.LookupEntry(skill_id))
+    if (const auto skill_line = sSkillLineStore.LookupEntry(skill_id))
     {
         if (skill_line && skill_line->type == SKILL_TYPE_PROFESSION)
             return true;
@@ -610,7 +493,7 @@ bool SpellInfo::isOnNextMeleeAttack() const
 
 bool SpellInfo::appliesAreaAura(uint32_t auraType) const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         switch (Effect[i])
         {
@@ -634,7 +517,7 @@ bool SpellInfo::appliesAreaAura(uint32_t auraType) const
 
 uint32_t SpellInfo::getAreaAuraEffect() const
 {
-    for (auto i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] == SPELL_EFFECT_APPLY_GROUP_AREA_AURA ||
             Effect[i] == SPELL_EFFECT_APPLY_RAID_AREA_AURA ||

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -22,7 +22,7 @@ class SERVER_DECL SpellInfo
 {
 public:
     SpellInfo();
-    ~SpellInfo();
+    ~SpellInfo() = default;
 
     friend class SpellMgr;
 
@@ -458,8 +458,6 @@ public:
     int getAi_target_type() const { return ai_target_type; }
     bool getCustom_self_cast_only() const { return custom_self_cast_only; }
     bool getCustom_apply_on_shapeshift_change() const { return custom_apply_on_shapeshift_change; }
-    bool getCustom_is_melee_spell() const { return custom_is_melee_spell; }
-    bool getCustom_is_ranged_spell() const { return custom_is_ranged_spell; }
 
     uint32_t getEffectCustomFlag(uint8_t idx) const
     {
@@ -882,80 +880,80 @@ private:
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Applied values from DBC
-    uint32_t Id;
+    uint32_t Id = 0;
     // Data from SpellCategories.dbc (in Cataclysm)
-    uint32_t Category;
-    uint32_t DispelType;
-    uint32_t MechanicsType;
+    uint32_t Category = 0;
+    uint32_t DispelType = 0;
+    uint32_t MechanicsType = 0;
     // Data from Spell.dbc (in Cataclysm)
-    uint32_t Attributes;
-    uint32_t AttributesEx;
-    uint32_t AttributesExB;
-    uint32_t AttributesExC;
-    uint32_t AttributesExD;
-    uint32_t AttributesExE;
-    uint32_t AttributesExF;
-    uint32_t AttributesExG;
-    uint32_t AttributesExH;
-    uint32_t AttributesExI;
-    uint32_t AttributesExJ;
+    uint32_t Attributes = 0;
+    uint32_t AttributesEx = 0;
+    uint32_t AttributesExB = 0;
+    uint32_t AttributesExC = 0;
+    uint32_t AttributesExD = 0;
+    uint32_t AttributesExE = 0;
+    uint32_t AttributesExF = 0;
+    uint32_t AttributesExG = 0;
+    uint32_t AttributesExH = 0;
+    uint32_t AttributesExI = 0;
+    uint32_t AttributesExJ = 0;
     // Data from SpellShapeshift.dbc (in Cataclysm)
-    uint32_t Shapeshifts;
-    uint32_t ShapeshiftsExcluded;
+    uint32_t Shapeshifts = 0;
+    uint32_t ShapeshiftsExcluded = 0;
     // Data from SpellTargetRestrictions.dbc (in Cataclysm)
-    uint32_t Targets;
-    uint32_t TargetCreatureType;
+    uint32_t Targets = 0;
+    uint32_t TargetCreatureType = 0;
     // Data from SpellCastingRequirements.dbc (in Cataclysm)
-    uint32_t RequiresSpellFocus;
-    uint32_t FacingCasterFlags;
+    uint32_t RequiresSpellFocus = 0;
+    uint32_t FacingCasterFlags = 0;
     // Data from SpellAuraRestrictions.dbc (in Cataclysm)
-    uint32_t CasterAuraState;
-    uint32_t TargetAuraState;
-    uint32_t CasterAuraStateNot;
-    uint32_t TargetAuraStateNot;
-    uint32_t casterAuraSpell;
-    uint32_t targetAuraSpell;
-    uint32_t casterAuraSpellNot;
-    uint32_t targetAuraSpellNot;
+    uint32_t CasterAuraState = 0;
+    uint32_t TargetAuraState = 0;
+    uint32_t CasterAuraStateNot = 0;
+    uint32_t TargetAuraStateNot = 0;
+    uint32_t casterAuraSpell = 0;
+    uint32_t targetAuraSpell = 0;
+    uint32_t casterAuraSpellNot = 0;
+    uint32_t targetAuraSpellNot = 0;
     // Data from Spell.dbc (in Cataclysm)
-    uint32_t CastingTimeIndex;
+    uint32_t CastingTimeIndex = 0;
     // Data from SpellCooldowns.dbc (in Cataclysm)
-    uint32_t RecoveryTime;
-    uint32_t CategoryRecoveryTime;
+    uint32_t RecoveryTime = 0;
+    uint32_t CategoryRecoveryTime = 0;
     // Data from SpellInterrupts.dbc (in Cataclysm)
-    uint32_t InterruptFlags;
-    uint32_t AuraInterruptFlags;
-    uint32_t ChannelInterruptFlags;
+    uint32_t InterruptFlags = 0;
+    uint32_t AuraInterruptFlags = 0;
+    uint32_t ChannelInterruptFlags = 0;
     // Data from SpellAuraOptions.dbc (in Cataclysm)
-    uint32_t procFlags;
-    uint32_t procChance;
-    uint32_t procCharges;
+    uint32_t procFlags = 0;
+    uint32_t procChance = 0;
+    uint32_t procCharges = 0;
     // Data from SpellLevels.dbc (in Cataclysm)
-    uint32_t maxLevel;
-    uint32_t baseLevel;
-    uint32_t spellLevel;
+    uint32_t maxLevel = 0;
+    uint32_t baseLevel = 0;
+    uint32_t spellLevel = 0;
     // Data from Spell.dbc (in Cataclysm)
-    uint32_t DurationIndex;
-    PowerType powerType;
+    uint32_t DurationIndex = 0;
+    PowerType powerType = POWER_TYPE_MANA;
     // Data from SpellPower.dbc (in Cataclysm)
-    uint32_t manaCost;
-    uint32_t manaCostPerlevel;
-    uint32_t manaPerSecond;
-    uint32_t manaPerSecondPerLevel;
+    uint32_t manaCost = 0;
+    uint32_t manaCostPerlevel = 0;
+    uint32_t manaPerSecond = 0;
+    uint32_t manaPerSecondPerLevel = 0;
     // Data from Spell.dbc (in Cataclysm)
-    uint32_t rangeIndex;
-    float speed;
+    uint32_t rangeIndex = 0;
+    float speed = 0.0f;
     // Data from SpellAuraOptions.dbc (in Cataclysm)
-    uint32_t MaxStackAmount;
+    uint32_t MaxStackAmount = 0;
     // Data from SpellTotems.dbc (in Cataclysm)
     uint32_t Totem[MAX_SPELL_TOTEMS];
     // Data from SpellReagents.dbc (in Cataclysm)
     int32_t Reagent[MAX_SPELL_REAGENTS];
     uint32_t ReagentCount[MAX_SPELL_REAGENTS];
     // Data from SpellEquippedItems.dbc (in Cataclysm)
-    int32_t EquippedItemClass;
-    int32_t EquippedItemSubClass;
-    int32_t EquippedItemInventoryTypeMask;
+    int32_t EquippedItemClass = -1;
+    int32_t EquippedItemSubClass = 0;
+    int32_t EquippedItemInventoryTypeMask = 0;
     // Data from SpellEffect.dbc (in Cataclysm)
     uint32_t Effect[MAX_SPELL_EFFECTS];
     int32_t EffectDieSides[MAX_SPELL_EFFECTS];
@@ -982,27 +980,27 @@ private:
 #endif
     // Data from Spell.dbc (in Cataclysm)
     uint32_t SpellVisual[2];
-    uint32_t spellIconID;
-    uint32_t activeIconID;
-    uint32_t spellPriority;
-    std::string Name;
-    std::string Rank;
+    uint32_t spellIconID = 0;
+    uint32_t activeIconID = 0;
+    uint32_t spellPriority = 0;
+    std::string Name = "";
+    std::string Rank = "";
     // Data from SpellPower.dbc (in Cataclysm)
-    uint32_t ManaCostPercentage;
+    uint32_t ManaCostPercentage = 0;
     // Data from SpellCategories.dbc (in Cataclysm)
-    uint32_t StartRecoveryCategory;
+    uint32_t StartRecoveryCategory = 0;
     // Data from SpellCooldowns.dbc (in Cataclysm)
-    uint32_t StartRecoveryTime;
+    uint32_t StartRecoveryTime = 0;
     // Data from SpellTargetRestrictions.dbc (in Cataclysm)
-    uint32_t MaxTargetLevel;
+    uint32_t MaxTargetLevel = 0;
     // Data from SpellClassOptions.dbc (in Cataclysm)
-    uint32_t SpellFamilyName;
+    uint32_t SpellFamilyName = 0;
     uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];
     // Data from SpellTargetRestrictions.dbc (in Cataclysm)
-    uint32_t MaxTargets;
+    uint32_t MaxTargets = 0;
     // Data from SpellCategories.dbc (in Cataclysm)
-    uint32_t DmgClass;
-    uint32_t PreventionType;
+    uint32_t DmgClass = 0;
+    uint32_t PreventionType = 0;
     // Data from SpellEffect.dbc (in Cataclysm)
     float EffectDamageMultiplier[MAX_SPELL_EFFECTS];
 #if VERSION_STRING > Classic
@@ -1010,106 +1008,98 @@ private:
     uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];     // not used!
 #endif
     // Data from SpellCastingRequirements.dbc (in Cataclysm)
-    int32_t AreaGroupId;
+    int32_t AreaGroupId = 0;
     // Data from Spell.dbc (in Cataclysm)
-    uint32_t SchoolMask;
-    uint32_t RuneCostID;
+    uint32_t SchoolMask = 0;
+    uint32_t RuneCostID = 0;
     // Data from SpellEffect.dbc (in Cataclysm)
     float EffectBonusMultiplier[MAX_SPELL_EFFECTS];
     // Data from SpellDifficulty.dbc (in Cataclysm)
-    uint32_t SpellDifficultyId;
+    uint32_t SpellDifficultyId = 0;
 
-    // Script links
-    void* (*spellScriptLink);
-    void* (*auraScriptLink);
+    // Script links (Legacy)
+    void* (*spellScriptLink) = nullptr;
+    void* (*auraScriptLink) = nullptr;
 
 public:
 #if VERSION_STRING >= Cata
     // DBC links
-    uint32_t SpellScalingId;                              // SpellScaling.dbc
-    uint32_t SpellAuraOptionsId;                          // SpellAuraOptions.dbc
-    uint32_t SpellAuraRestrictionsId;                     // SpellAuraRestrictions.dbc
-    uint32_t SpellCastingRequirementsId;                  // SpellCastingRequirements.dbc
-    uint32_t SpellCategoriesId;                           // SpellCategories.dbc
-    uint32_t SpellClassOptionsId;                         // SpellClassOptions.dbc
-    uint32_t SpellCooldownsId;                            // SpellCooldowns.dbc
-    uint32_t SpellEquippedItemsId;                        // SpellEquippedItems.dbc
-    uint32_t SpellInterruptsId;                           // SpellInterrupts.dbc
-    uint32_t SpellLevelsId;                               // SpellLevels.dbc
-    uint32_t SpellPowerId;                                // SpellPower.dbc
-    uint32_t SpellReagentsId;                             // SpellReagents.dbc
-    uint32_t SpellShapeshiftId;                           // SpellShapeshift.dbc
-    uint32_t SpellTargetRestrictionsId;                   // SpellTargetRestrictions.dbc
-    uint32_t SpellTotemsId;                               // SpellTotems.dbc
+    uint32_t SpellScalingId = 0;                              // SpellScaling.dbc
+    uint32_t SpellAuraOptionsId = 0;                          // SpellAuraOptions.dbc
+    uint32_t SpellAuraRestrictionsId = 0;                     // SpellAuraRestrictions.dbc
+    uint32_t SpellCastingRequirementsId = 0;                  // SpellCastingRequirements.dbc
+    uint32_t SpellCategoriesId = 0;                           // SpellCategories.dbc
+    uint32_t SpellClassOptionsId = 0;                         // SpellClassOptions.dbc
+    uint32_t SpellCooldownsId = 0;                            // SpellCooldowns.dbc
+    uint32_t SpellEquippedItemsId = 0;                        // SpellEquippedItems.dbc
+    uint32_t SpellInterruptsId = 0;                           // SpellInterrupts.dbc
+    uint32_t SpellLevelsId = 0;                               // SpellLevels.dbc
+    uint32_t SpellPowerId = 0;                                // SpellPower.dbc
+    uint32_t SpellReagentsId = 0;                             // SpellReagents.dbc
+    uint32_t SpellShapeshiftId = 0;                           // SpellShapeshift.dbc
+    uint32_t SpellTargetRestrictionsId = 0;                   // SpellTargetRestrictions.dbc
+    uint32_t SpellTotemsId = 0;                               // SpellTotems.dbc
 #endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Spell coefficients
 
     // Direct damage or direct heal coefficient
-    float spell_coeff_direct;
+    float_t spell_coeff_direct = -1.0f;
 
     // Damage or healing over-time coefficient (NOTE: This is per tick, not for full duration, unlike the SQL override variable)
-    float spell_coeff_overtime;
+    float_t spell_coeff_overtime = -1.0f;
+
+    // Attack power coefficient (only set in SQL table spell_coefficient_override)
+    float_t spell_ap_coeff_direct = 0.0f;
+    // This is per tick
+    float_t spell_ap_coeff_overtime = 0.0f;
 
     // SQL override coefficients (table spell_coefficient_override)
-    float spell_coeff_direct_override;
-    float spell_coeff_overtime_override;
-
-    //////////////////////////////////////////////////////////////////////////////////////////
-    // Spell Script
-
-    SpellScript* spellScript;
+    float_t spell_coeff_direct_override = -1.0f;
+    float_t spell_coeff_overtime_override = -1.0f;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     //custom values
 
     // from MySQL table spell_proc - 1887 spells
-    uint32_t custom_proc_interval;
+    uint32_t custom_proc_interval = 0;
 
     // from MySQL table spell_custom_assign - 1970 spells
-    uint32_t custom_BGR_one_buff_on_target;
+    uint32_t custom_BGR_one_buff_on_target = 0;
 
     // from MySQL table spell_custom_assign - 353 spells
     // also flags added in SpellCustomizations::SetMissingCIsFlags
-    uint32_t custom_c_is_flags;
+    uint32_t custom_c_is_flags = 0;
 
     // from MySQL table spell_ranks - 6546 spells
-    uint32_t custom_RankNumber;
+    uint32_t custom_RankNumber = 0;
 
     // set in HackFixes.cpp for all Dummy Trigger
-    uint32_t custom_NameHash;
+    uint32_t custom_NameHash = 0;
 
     // from MySQL table ai_threattospellid - 144 spells
-    int32_t custom_ThreatForSpell;
+    int32_t custom_ThreatForSpell = 0;
 
     // from MySQL table ai_threattospellid - 118 spells
-    float custom_ThreatForSpellCoef;
+    float custom_ThreatForSpellCoef = 0.0f;
 
     // set in HackFixes.cpp for all spells
-    float custom_base_range_or_radius_sqr;
+    float custom_base_range_or_radius_sqr = 0.0f;
 
     // set in HackFixes.cpp - 1 spell (26029)
-    float cone_width;
+    float cone_width = 0.0f;
 
     // set in HackFixes.cpp for all spells
     // check out SpellInfo::aiTargetType
-    int ai_target_type;
+    int ai_target_type = 0;
 
     // set in Hackfixes.cpp - 5 spells
     // from MySQL table spell_custom_assign - 6 spells
-    bool custom_self_cast_only;
+    bool custom_self_cast_only = false;
 
     // SpellCustomizations::SetOnShapeshiftChange - 2 spells
-    bool custom_apply_on_shapeshift_change;
-
-    // set in Hackfixes.cpp - 3 spells
-    // set in SpellCustomizations::SetMeleeSpellBool based on school and effect
-    bool custom_is_melee_spell;
-
-    // set in Hackfixes.cpp - 1 spells (2094)
-    // set in SpellCustomizations::SetRangedSpellBool based on school and dmg type
-    bool custom_is_ranged_spell;
+    bool custom_apply_on_shapeshift_change = false;
 
     // from MySQL table spell_effects_override - 374 spells
     uint32_t EffectCustomFlag[MAX_SPELL_EFFECTS];

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -93,8 +93,6 @@ void SpellMgr::startSpellMgr()
         // Custom values
         // todo: if possible, get rid of these
         setSpellEffectAmplitude(spellInfo);
-        setSpellMeleeSpellBool(spellInfo);
-        setSpellRangedSpellBool(spellInfo);
         setSpellMissingCIsFlags(spellInfo);
         setSpellOnShapeshiftChange(spellInfo);
     }
@@ -222,12 +220,13 @@ bool SpellMgr::checkLocation(SpellInfo const* spellInfo, uint32_t zone_id, uint3
     // Normal case
     if (spellInfo->getRequiresAreaId() > 0)
     {
+        const auto requireAreaId = static_cast<uint32_t>(spellInfo->getRequiresAreaId());
 #if VERSION_STRING == TBC
-        if (spellInfo->getRequiresAreaId() != zone_id && spellInfo->getRequiresAreaId() != area_id)
+        if (requireAreaId != zone_id && requireAreaId != area_id)
             return false;
 #elif VERSION_STRING >= WotLK
         auto found = false;
-        auto areaGroup = sAreaGroupStore.LookupEntry(spellInfo->getRequiresAreaId());
+        auto areaGroup = sAreaGroupStore.LookupEntry(requireAreaId);
         while (areaGroup != nullptr)
         {
             for (uint8_t i = 0; i < 6; ++i)
@@ -298,13 +297,13 @@ SpellInfo const* SpellMgr::getSpellInfoByDifficulty(const uint32_t spellDifficul
 
 void SpellMgr::loadSpellInfoData()
 {
-    for (auto i = 0; i < MAX_SPELL_ID; ++i)
+    for (uint32_t i = 0; i < MAX_SPELL_ID; ++i)
     {
-        auto dbcSpellEntry = sSpellStore.LookupEntry(i);
+        const auto dbcSpellEntry = sSpellStore.LookupEntry(i);
         if (dbcSpellEntry == nullptr)
             continue;
 
-        uint32_t spell_id = dbcSpellEntry->Id;
+        auto spell_id = dbcSpellEntry->Id;
         SpellInfo& spellInfo = mSpellInfoMapStore[spell_id];
 
         spellInfo.setId(spell_id);
@@ -673,10 +672,10 @@ void SpellMgr::loadSpellCoefficientOverride()
 
 void SpellMgr::loadSpellCustomOverride()
 {
-    //                                                 0        1          2                       3                     4              5             6                7            8
-    const auto result = WorldDatabase.Query("SELECT spell_id, rank, assign_on_target_flag, assign_self_cast_only, assign_c_is_flag, proc_flags, proc_target_selfs, proc_chance, proc_charges, "
-    //                                      9                       10                           11                         12
-                                      "proc_interval, proc_effect_trigger_spell_0, proc_effect_trigger_spell_1, proc_effect_trigger_spell_2 FROM spell_custom_override");
+    //                                                   0        1               2                       3                        4               5                6                  7              8
+    const auto result = WorldDatabase.Query("SELECT `spell_id`, `rank`, `assign_on_target_flag`, `assign_self_cast_only`, `assign_c_is_flag`, `proc_flags`, `proc_target_selfs`, `proc_chance`, `proc_charges`, "
+    //                                       9                       10                            11                             12
+                                      "`proc_interval`, `proc_effect_trigger_spell_0`, `proc_effect_trigger_spell_1`, `proc_effect_trigger_spell_2` FROM spell_custom_override");
     
     if (result == nullptr)
     {

--- a/src/world/Spell/SpellMgr.h
+++ b/src/world/Spell/SpellMgr.h
@@ -101,8 +101,6 @@ private:
 
     // Custom setters (defined in SpellCustomizations.cpp)
     void setSpellEffectAmplitude(SpellInfo* sp);
-    void setSpellMeleeSpellBool(SpellInfo* sp);
-    void setSpellRangedSpellBool(SpellInfo* sp);
     void setSpellMissingCIsFlags(SpellInfo* sp);
     void setSpellOnShapeshiftChange(SpellInfo* sp);
     // Hacky methods (defined in Hackfixes.cpp)

--- a/src/world/Spell/SpellProc_ClassScripts.cpp
+++ b/src/world/Spell/SpellProc_ClassScripts.cpp
@@ -434,7 +434,6 @@ public:
 
             // Set new aura's duration, reset event timer and set client visual aura
             aura->setTimeLeft(dur);
-            sEventMgr.ModifyEventTimeLeft(aura, EVENT_AURA_REMOVE, aura->getTimeLeft());
             mTarget->sendAuraUpdate(aura, false);
         }
 

--- a/src/world/Spell/SpellScript.h
+++ b/src/world/Spell/SpellScript.h
@@ -5,11 +5,13 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "Definitions/AuraRemoveMode.h"
 #include "Definitions/SpellFailure.h"
 #include "Units/Unit.h"
 
 #include "CommonTypes.hpp"
 
+class Aura;
 class Spell;
 
 enum class SpellScriptExecuteState : uint8_t
@@ -19,15 +21,21 @@ enum class SpellScriptExecuteState : uint8_t
     EXECUTE_PREVENT,            // Spell script is executed but prevent default effect
 };
 
+enum class SpellScriptEffectDamage : uint8_t
+{
+    DAMAGE_DEFAULT = 0,         // Effect damage is using default calculations
+    DAMAGE_FULL_RECALCULATION   // Effect damage is completely recalculated, do not add caster damage modifiers anymore
+};
+
 class SERVER_DECL SpellScript
 {
 public:
 
-    SpellScript() {}
+    SpellScript() = default;
     virtual ~SpellScript() {}
 
     // Called at the end of spell check cast function
-    virtual SpellCastResult onCanCast(Spell* /*spell*/, uint32_t* /*parameter1*/, uint32_t* /*parameter2*/) const { return SPELL_CAST_SUCCESS; }
+    virtual SpellCastResult onCanCast(Spell* /*spell*/, uint32_t* /*parameter1*/, uint32_t* /*parameter2*/) { return SPELL_CAST_SUCCESS; }
     // Called when cast bar is sent to client (NOT called for instant spells)
     virtual void doAtStartCasting(Spell* /*spell*/) {}
     // Called after spell targets for this effect have been initialized
@@ -36,8 +44,25 @@ public:
     virtual void doBeforeEffectHit(Spell* /*spell*/, uint8_t /*effectIndex*/) {}
     // Called after target missed/resisted the spell
     virtual void doAfterSpellMissed(Spell* /*spell*/, Unit* /*unitTarget*/) {}
+    // Called when spell effect is calculated
+    virtual SpellScriptEffectDamage doCalculateEffect(Spell* /*spell*/, uint8_t /*effIndex*/, int32_t* /*damage*/) { return SpellScriptEffectDamage::DAMAGE_DEFAULT; }
     // Called before spell effect type handling
-    virtual SpellScriptExecuteState beforeSpellEffect(Spell* /*spell*/, uint32_t /*effectType*/, uint8_t /*effectId*/) const { return SpellScriptExecuteState::EXECUTE_NOT_HANDLED; }
+    virtual SpellScriptExecuteState beforeSpellEffect(Spell* /*spell*/, uint32_t /*effectType*/, uint8_t /*effectId*/) { return SpellScriptExecuteState::EXECUTE_NOT_HANDLED; }
     // Called after spell effect type handling
     virtual void afterSpellEffect(Spell* /*spell*/, uint32_t /*effectType*/, uint8_t /*effectId*/) {}
+};
+
+class SERVER_DECL AuraScript
+{
+public:
+
+    AuraScript() = default;
+    virtual ~AuraScript() {}
+
+    // Called when aura is created (Aura constructor)
+    virtual void onAuraCreate(Aura* /*aur*/) {}
+    // Called when aura is removed
+    virtual void onAuraRemove(Aura* /*aur*/, AuraRemoveMode /*mode*/) {}
+    // Called when periodic tick happens
+    virtual SpellScriptExecuteState onAuraPeriodicTick(Aura* /*aur*/, AuraEffectModifier* /*aurEff*/, int32_t* /*damage*/) { return SpellScriptExecuteState::EXECUTE_NOT_HANDLED; }
 };

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -1595,7 +1595,7 @@ void Pet::WipeTalents()
     SendSpellsToOwner();
 }
 
-void Pet::RemoveSpell(SpellInfo const* sp, bool showUnlearnSpell)
+void Pet::RemoveSpell(SpellInfo const* sp, [[maybe_unused]]bool showUnlearnSpell)
 {
     mSpells.erase(sp);
     std::map<uint32, AI_Spell*>::iterator itr = m_AISpellStore.find(sp->getId());

--- a/src/world/Units/Creatures/Pet.h
+++ b/src/world/Units/Creatures/Pet.h
@@ -61,7 +61,7 @@ enum PetCommands
     PET_ACTION_CASTING  = 4
 };
 
-enum PetActionFeedback
+enum PetActionFeedback : uint8_t
 {
     PET_FEEDBACK_NONE,
     PET_FEEDBACK_PET_DEAD,

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -296,7 +296,7 @@ Player::Player(uint32 guid)
     m_cache = new PlayerCache;
     m_cache->SetUInt32Value(CACHE_PLAYER_LOWGUID, guid);
     sObjectMgr.AddPlayerCache(guid, m_cache);
-    int i, j;
+    int i;
 
     m_H_regenTimer = 0;
     //////////////////////////////////////////////////////////////////////////
@@ -2844,7 +2844,7 @@ void Player::LoadFromDBProc(QueryResultVector & results)
     for (uint32 z = 0; z < NUM_CHARTER_TYPES; ++z)
         m_charters[z] = sObjectMgr.GetCharterByGuid(getGuid(), (CharterTypes)z);
 
-    for (uint16 z = 0; z < NUM_ARENA_TEAM_TYPES; ++z)
+    for (uint8_t z = 0; z < NUM_ARENA_TEAM_TYPES; ++z)
     {
         m_arenaTeams[z] = sObjectMgr.GetArenaTeamByGuid(getGuidLow(), z);
         if (m_arenaTeams[z] != nullptr)
@@ -3590,7 +3590,6 @@ void Player::OnPushToWorld()
 
     if (m_FirstLogin)
     {
-        uint8 my_class = getClass();
         uint8 start_level = 1;
 
         start_level = static_cast<uint8>(worldConfig.player.playerStartingLevel);
@@ -4585,7 +4584,7 @@ void Player::SpawnCorpseBones()
 
 void Player::DeathDurabilityLoss(double percent)
 {
-    SendPacket(SmsgDurabilityDamageDeath(percent).serialise().get());
+    SendPacket(SmsgDurabilityDamageDeath(static_cast<uint32_t>(percent)).serialise().get());
 
     for (uint8 i = 0; i < EQUIPMENT_SLOT_END; i++)
     {
@@ -5449,7 +5448,7 @@ void Player::SetDrunkValue(uint16 newDrunkenValue, uint32 itemId)
     uint32 oldDrunkenState = GetDrunkenstateByValue(m_drunk);
 
     m_drunk = newDrunkenValue;
-    setDrunkValue(m_drunk);
+    setDrunkValue(static_cast<uint8_t>(m_drunk));
 
     uint32 newDrunkenState = GetDrunkenstateByValue(m_drunk);
 
@@ -10221,7 +10220,7 @@ void Player::SetKnownTitle(RankTitles title, bool set)
     const uint64_t current = getKnownTitles(index);
 
     if (set)
-        setKnownTitles(index, current | 1 << (title % 32));
+        setKnownTitles(index, current | 1ULL << static_cast<uint64_t>((title % 32)));
     else
         setKnownTitles(index, current & ~1 << (title % 32));
 

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -2484,7 +2484,7 @@ void Player::setTalentPointsFromQuests(uint32_t talentPoints)
     m_talentPointsFromQuests = talentPoints;
 }
 
-void Player::smsg_TalentsInfo(bool SendPetTalents)
+void Player::smsg_TalentsInfo([[maybe_unused]]bool SendPetTalents)
 {
     // TODO: classic and tbc
 #if VERSION_STRING >= WotLK
@@ -2525,7 +2525,7 @@ void Player::smsg_TalentsInfo(bool SendPetTalents)
 
             // What kind of glyphs player has
             data << uint8_t(GLYPHS_COUNT);
-            for (auto i = 0; i < GLYPHS_COUNT; ++i)
+            for (uint8_t i = 0; i < GLYPHS_COUNT; ++i)
             {
                 data << uint16_t(GetGlyph(specId, i));
             }
@@ -2535,7 +2535,7 @@ void Player::smsg_TalentsInfo(bool SendPetTalents)
 #endif
 }
 
-void Player::activateTalentSpec(uint8_t specId)
+void Player::activateTalentSpec([[maybe_unused]]uint8_t specId)
 {
 #ifndef FT_DUAL_SPEC
     return;
@@ -2613,7 +2613,7 @@ void Player::setActionButton(uint8_t button, uint32_t action, uint8_t type, uint
     getActiveSpec().mActions[button].Type = type;
 }
 
-void Player::sendActionBars(bool clearBars)
+void Player::sendActionBars([[maybe_unused]]bool clearBars)
 {
 #if VERSION_STRING < Mop
     WorldPacket data(SMSG_ACTION_BUTTONS, PLAYER_ACTION_BUTTON_SIZE + 1);
@@ -2858,7 +2858,7 @@ bool Player::isGMFlagSet()
     return hasPlayerFlags(PLAYER_FLAG_GM);
 }
 
-void Player::sendMovie(uint32_t movieId)
+void Player::sendMovie([[maybe_unused]]uint32_t movieId)
 {
 #if VERSION_STRING > TBC
     m_session->SendPacket(SmsgTriggerMovie(movieId).serialise().get());

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -1461,7 +1461,7 @@ public:
 #if VERSION_STRING > Classic
             const uint8_t index = title / 32;
 
-            return (getKnownTitles(index) & 1 << (title % 32)) != 0;
+            return (getKnownTitles(index) & 1ULL << static_cast<uint64_t>((title % 32))) != 0;
 #else
             return false;
 #endif

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -714,7 +714,6 @@ Unit::Unit() :
     memset(m_diminishAuraCount, 0, DIMINISHING_GROUP_COUNT);
     memset(m_diminishCount, 0, DIMINISHING_GROUP_COUNT * 2);
     memset(m_diminishTimer, 0, DIMINISHING_GROUP_COUNT * 2);
-    memset(m_auraStackCount, 0, MAX_NEGATIVE_VISUAL_AURAS_END);
     memset(m_auravisuals, 0, MAX_NEGATIVE_VISUAL_AURAS_END * sizeof(uint32));
 
     m_diminishActive = false;
@@ -8384,44 +8383,6 @@ void Unit::smsg_AttackStart(Unit* pVictim)
     }
 }
 
-uint8 Unit::FindVisualSlot(uint32 SpellId, bool IsPos)
-{
-    uint32 from, to;
-    uint8 visualslot = 0xFF;
-    if (IsPos)
-    {
-        from = 0;
-        to = MAX_POSITIVE_VISUAL_AURAS_END;
-    }
-    else
-    {
-        from = MAX_NEGATIVE_VISUAL_AURAS_START;
-        to = MAX_NEGATIVE_VISUAL_AURAS_END;
-    }
-    //check for already visual same aura
-    for (uint32 i = from; i < to; i++)
-    {
-        if (m_auravisuals[i] == SpellId)
-        {
-            visualslot = static_cast<uint8>(i);
-            break;
-        }
-    }
-
-    if (visualslot == 0xFF)
-    {
-        for (uint32 i = from; i < to; i++)
-        {
-            if (m_auravisuals[i] == 0)
-            {
-                visualslot = static_cast<uint8>(i);
-                break;
-            }
-        }
-    }
-    return visualslot;
-}
-
 bool Unit::RemoveAura(Aura* aur)
 {
     if (aur == NULL)
@@ -10221,36 +10182,6 @@ bool Unit::IsPoisoned()
             return true;
 
     return false;
-}
-
-void Unit::ModVisualAuraStackCount(Aura* aur, int32 count)
-{
-#if VERSION_STRING == TBC
-    return;
-#endif
-    if (!aur)
-        return;
-
-    uint8 slot = aur->m_visualSlot;
-    if (slot >= MAX_NEGATIVE_VISUAL_AURAS_END)
-        return;
-
-    if (count < 0 && m_auraStackCount[slot] <= -count)
-    {
-        m_auraStackCount[slot] = 0;
-        m_auravisuals[slot] = 0;
-
-        sendAuraUpdate(aur, true);
-    }
-    else
-    {
-        m_auraStackCount[slot] += static_cast<uint8>(count);
-        m_auravisuals[slot] = aur->getSpellId();
-
-        sendAuraUpdate(aur, false);
-    }
-
-    //return m_auraStackCount[slot];
 }
 
 void Unit::RemoveAurasOfSchool(uint32 School, bool Positive, bool Immune)

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -100,7 +100,7 @@ uint8_t Unit::getBytes0ByOffset(uint32_t offset) const
         case 2:
             return getGender();
         case 3:
-            return getPowerType();
+            return static_cast<uint8_t>(getPowerType());
         default:
             LogError("Offset %u is not a valid offset value for byte_0 data (max 3). Returning 0", offset);
             return 0;
@@ -2305,7 +2305,7 @@ void Unit::addAura(Aura* aur)
     // Find a visual slot for aura
     uint8_t visualSlot = 0xFF;
     if (!aur->IsPassive() || aur->getSpellInfo()->getAttributesEx() & ATTRIBUTESEX_NO_INITIAL_AGGRO)
-        visualSlot = findVisualSlotForAura(aur->getSpellId(), !aur->isNegative());
+        visualSlot = findVisualSlotForAura(!aur->isNegative());
 
     aur->m_visualSlot = visualSlot;
     aur->m_auraSlot = auraSlot;
@@ -2413,7 +2413,7 @@ void Unit::addAura(Aura* aur)
 
 }
 
-uint8_t Unit::findVisualSlotForAura(uint32_t spellId, bool isPositive) const
+uint8_t Unit::findVisualSlotForAura(bool isPositive) const
 {
     uint8_t start, end;
     if (isPositive)
@@ -3636,7 +3636,7 @@ uint8_t Unit::getPowerPct(PowerType powerType) const
     return static_cast<uint8_t>(getPower(powerType) * 100 / getMaxPower(powerType));
 }
 
-void Unit::sendPowerUpdate(bool self)
+void Unit::sendPowerUpdate([[maybe_unused]]bool self)
 {
     // Save current power so the same amount is sent to player and everyone else
     const auto powerAmount = getPower(getPowerType());

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -661,7 +661,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Aura
     void addAura(Aura* aur);
-    uint8_t findVisualSlotForAura(uint32_t spellId, bool isPositive) const;
+    uint8_t findVisualSlotForAura(bool isPositive) const;
 
     Aura* getAuraWithId(uint32_t spell_id);
     Aura* getAuraWithId(uint32_t* auraId);
@@ -1345,11 +1345,6 @@ public:
 
     DynamicObject* dynObj;
 
-    //! returns: aura stack count
-    uint8 m_auraStackCount[MAX_NEGATIVE_VISUAL_AURAS_END];
-
-    void ModVisualAuraStackCount(Aura* aur, int32 count);
-    uint8 FindVisualSlot(uint32 SpellId, bool IsPos);
     uint32 m_auravisuals[MAX_NEGATIVE_VISUAL_AURAS_END];
 
     bool bProcInUse;


### PR DESCRIPTION
**Todo / Checklist**
Spells: Include attack power coefficient in spell damage and heal calculations
Scripts: Store spell and aura scripts in ScriptMgr instead of in SpellInfo to reduce memory usage (original work by @sanctum32 )
Scripts: Create AuraScript class and implement few new script hooks
SpellInfo: Get rid of two custom variables; custom_is_melee_spell and custom_is_ranged_spell
SQL: Fix SQL query error with spell_custom_override table in MySQL 8.0
Misc: Fix some codestyle in SpellInfo and Spell class
Misc: Fix ~120 level 3 and level 4 warnings in tbc, wotlk and cata (rest are for you @Zyres 😉 )

**Tests Performed:** 
Tested ingame


