### PR TITLE
Threading: Fix diff in WorldRunnable thread

### DIFF
--- a/src/world/Server/WorldRunnable.cpp
+++ b/src/world/Server/WorldRunnable.cpp
@@ -32,29 +32,26 @@ void WorldRunnable::threadShutdown()
 
 void WorldRunnable::threadRunner(AEThread& /*thread*/)
 {
-    uint32_t lastWorldUpdate = Util::getMSTime();
-    uint32_t lastSessionsUpdate = Util::getMSTime();
-
     ServerState::instance()->update();
-
     uint32_t diff;
-    uint32_t now = Util::getMSTime();
 
-    if (now < lastWorldUpdate)
+    auto now = Util::getMSTime();
+    if (now < m_lastWorldUpdate)
         diff = 50;
     else
-        diff = now - lastWorldUpdate;
+        diff = now - m_lastWorldUpdate;
 
     sWorld.Update(diff);
+    m_lastWorldUpdate = now;
 
     now = Util::getMSTime();
-
-    if (now < lastSessionsUpdate)
+    if (now < m_lastSessionsUpdate)
         diff = 50;
     else
-        diff = now - lastSessionsUpdate;
+        diff = now - m_lastSessionsUpdate;
 
     sWorld.updateGlobalSession(diff);
+    m_lastSessionsUpdate = now;
 }
 
 void WorldRunnable::threadInit()

--- a/src/world/Server/WorldRunnable.h
+++ b/src/world/Server/WorldRunnable.h
@@ -18,4 +18,8 @@ public:
     ~WorldRunnable();
 
     void threadShutdown();
+
+private:
+    uint32_t m_lastWorldUpdate = 0;
+    uint32_t m_lastSessionsUpdate = 0;
 };


### PR DESCRIPTION
**Todo / Checklist**
Diff was always null in WorldRunnable thread because Util::getMSTime() - Util::getMSTime() = 0 ;)
Fixes https://github.com/AscEmu/AscEmu/issues/813

**Tests Performed:** 
Built and tested


