### PR TITLE
Rewrite spell modifiers and aura charges

### DIFF
--- a/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
+++ b/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
@@ -1281,7 +1281,7 @@ void AlteracValley::HookGenerateLoot(Player* plr, Object* pCorpse)
     {
         if (loot_ptr->Faction == -1 || loot_ptr->Faction == static_cast<int8_t>(plr->getTeam()))
         {
-            if (Rand(loot_ptr->Chance * worldConfig.getFloatRate(RATE_DROP0)))
+            if (Util::checkChance(loot_ptr->Chance * worldConfig.getFloatRate(RATE_DROP0)))
             {
                 __LootItem li;
                 ItemProperties const* pProto = sMySQLStore.getItemProperties(loot_ptr->ItemId);

--- a/src/scripts/InstanceScripts/Wotlk/Instance_DrakTharonKeep.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/Instance_DrakTharonKeep.cpp
@@ -223,7 +223,7 @@ class NovosTheSummonerAI : public CreatureAIScript
         }
         if (possible_targets.size() > 0)
         {
-            uint32_t random_player = possible_targets[Rand(uint32_t(possible_targets.size() - 1))];
+            uint32_t random_player = possible_targets[Util::checkChance(uint32_t(possible_targets.size() - 1))];
             return getCreature()->GetMapMgr()->GetPlayer(random_player);
         }
         return nullptr;
@@ -265,7 +265,7 @@ class NovosTheSummonerAI : public CreatureAIScript
             for (uint8_t i = 0; i < INVADERS_COUNT; i++)
             {
                 mob_entry = 0;
-                if (Rand(ELITE_CHANCE))
+                if (Util::checkChance(ELITE_CHANCE))
                     mob_entry = 27597;
                 else
                 {

--- a/src/scripts/InstanceScripts/Wotlk/Raid_Naxxramas.h
+++ b/src/scripts/InstanceScripts/Wotlk/Raid_Naxxramas.h
@@ -1460,7 +1460,7 @@ class RazuviousAI : public CreatureAIScript
 
     void OnTargetDied(Unit* /*mTarget*/) override
     {
-        if (Rand(50.0f))
+        if (Util::checkChance(50.0f))
         {
             getCreature()->SendChatMessage(CHAT_MSG_MONSTER_YELL, LANG_UNIVERSAL, "You should've stayed home!");
             getCreature()->PlaySoundToSet(8862);

--- a/src/scripts/LuaEngine/SpellFunctions.h
+++ b/src/scripts/LuaEngine/SpellFunctions.h
@@ -161,7 +161,7 @@ LuaSpellEntry luaSpellVars[] =
     { "spell_coeff_overtime", 3, offsetof(SpellInfo, spell_coeff_overtime) },
     { "ai_target_type", 0, offsetof(SpellInfo, ai_target_type) },
     { "self_cast_only", 2, offsetof(SpellInfo, custom_self_cast_only) },
-    { "apply_on_shapeshift_change", 2, offsetof(SpellInfo, custom_apply_on_shapeshift_change) },
+    //{ "apply_on_shapeshift_change", 2, offsetof(SpellInfo, custom_apply_on_shapeshift_change) },
     { NULL, 0, 0 },
 };
 
@@ -235,7 +235,7 @@ namespace LuaSpell
         /*
         SPELL_STATE_NULL      = 0,
         SPELL_STATE_PREPARING = 1,
-        SPELL_STATE_CASTING   = 2,
+        SPELL_STATE_CHANNELING   = 2,
         SPELL_STATE_FINISHED  = 3,
         SPELL_STATE_IDLE      = 4
         */

--- a/src/scripts/QuestScripts/Quest_Terrokar_Forest.cpp
+++ b/src/scripts/QuestScripts/Quest_Terrokar_Forest.cpp
@@ -52,7 +52,7 @@ class TheInfestedProtectorsQAI : public CreatureAIScript
             Player * plr = static_cast<Player*>(mKiller);
             if (plr->HasQuest(10896))
             {
-                if (Rand(90))
+                if (Util::checkChance(90))
                 {
                     switch (getCreature()->getEntry())
                     {

--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -100,7 +100,7 @@ bool DeathStrike(uint8_t /*effectIndex*/, Spell* pSpell)
 
         Aura* aur = pSpell->getPlayerCaster()->getAuraWithId(improvedDeathStrike);
         if (aur != nullptr)
-            val += val * (aur->getSpellInfo()->getEffectBasePoints(2) + 1) / 100;
+            val += val * (aur->getSpellInfo()->calculateEffectValue(2)) / 100;
 
         if (val > 0)
             pSpell->getPlayerCaster()->addSimpleHealingBatchEvent(val, pSpell->getPlayerCaster(), pSpell->getSpellInfo());

--- a/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
@@ -38,7 +38,7 @@ bool Starfall(uint8_t effectIndex, Spell* pSpell)
         Unit* Target = static_cast<Unit*>(itr);
         if (isAttackable(Target, m_caster) && m_caster->CalcDistance(itr) <= pSpell->GetRadius(effectIndex))
         {
-            m_caster->castSpell(Target, pSpell->CalculateEffect(effectIndex, Target), true);
+            m_caster->castSpell(Target, pSpell->getSpellInfo()->calculateEffectValue(effectIndex, m_caster), true);
             ++am;
             if (am >= 2)
                 return true;

--- a/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
@@ -190,7 +190,7 @@ bool NorthRendInscriptionResearch(uint8_t /*effectIndex*/, Spell* s)
 
     // What is a "very high chance" ?  90% ?
     float chance = 90.0f;
-    if (Rand(chance))
+    if (Util::checkChance(chance))
     {
         // Type 0 = Major, 1 = Minor
         uint32_t glyphType = (s->getSpellInfo()->getId() == 61177) ? 0 : 1;

--- a/src/scripts/SpellHandlers/LegacyFiles/ShamanSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/ShamanSpells.cpp
@@ -34,7 +34,7 @@ bool FlametongueWeaponPassive(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
     {
         // target is always a player
         Item* item = static_cast<Player*>(target)->getItemInterface()->GetItemByGUID(pAura->itemCasterGUID);
-        target->addProcTriggerSpell(10444, pAura->getSpellInfo()->getId(), pAura->getCasterGuid(), pAura->getSpellInfo()->getProcChance(), PROC_ON_DONE_MELEE_HIT, EXTRA_PROC_NULL, 0, NULL, NULL, item);
+        target->addProcTriggerSpell(10444, pAura->getSpellInfo()->getId(), pAura->getCasterGuid(), pAura->getSpellInfo()->getProcChance(), PROC_ON_DONE_MELEE_HIT, EXTRA_PROC_NULL, NULL, NULL, pAura, item);
     }
     else
         target->removeProcTriggerSpell(10444, pAura->getCasterGuid(), pAura->itemCasterGUID);

--- a/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
@@ -53,7 +53,7 @@ bool Execute(uint8_t effectIndex, Spell* pSpell)
         toadd = (multiple[pSpell->getSpellInfo()->custom_RankNumber] * rage);
     }
 
-    dmg = pSpell->CalculateEffect(effectIndex, pSpell->GetUnitTarget());
+    dmg = pSpell->calculateEffect(effectIndex);
     dmg += Caster->getAttackPower() / 5;
     dmg += toadd;
 

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -25,19 +25,18 @@ class Butchery : public SpellScript
 public:
     SpellScriptCheckDummy onAuraDummyEffect(Aura* aur, AuraEffectModifier* aurEff, bool apply) override
     {
-        if (!apply)
-            return SpellScriptCheckDummy::DUMMY_OK;
-
-        auto spellProc = aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_BUTCHERY_ENERGIZE), aur->getSpellInfo(), aur->getCasterGuid(), 0);
-        if (spellProc != nullptr)
-            spellProc->setOverrideEffectDamage(EFF_INDEX_0, aurEff->getEffectDamage());
+        if (apply)
+        {
+            auto spellProc = aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_BUTCHERY_ENERGIZE), aur, aur->getCasterGuid());
+            if (spellProc != nullptr)
+                spellProc->setOverrideEffectDamage(EFF_INDEX_0, aurEff->getEffectDamage());
+        }
+        else
+        {
+            aur->getOwner()->removeProcTriggerSpell(SPELL_BUTCHERY_ENERGIZE, aur->getCasterGuid());
+        }
 
         return SpellScriptCheckDummy::DUMMY_OK;
-    }
-
-    void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
-    {
-        aur->getOwner()->removeProcTriggerSpell(SPELL_BUTCHERY_ENERGIZE, aur->getCasterGuid());
     }
 };
 #endif
@@ -49,8 +48,8 @@ class DeathRuneMastery : public SpellScript
      void onAuraApply(Aura* aur) override
      {
          // Should proc only on Obliterate and Death Strike
-         uint32_t procFamilyMask[3] = { 0x10, 0x20000, 0 };
-         aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_DEATH_RUNE_MASTERY_BLOOD), aur->getSpellInfo(), aur->getCasterGuid(), 0, procFamilyMask);
+         const uint32_t procFamilyMask[3] = { 0x10, 0x20000, 0 };
+         aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_DEATH_RUNE_MASTERY_BLOOD), aur, aur->getCasterGuid(), procFamilyMask);
      }
 
      void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
@@ -64,16 +63,12 @@ class MarkOfBlood : public SpellScript
 public:
     SpellScriptCheckDummy onAuraDummyEffect(Aura* aur, AuraEffectModifier* /*aurEff*/, bool apply) override
     {
-        if (!apply)
-            return SpellScriptCheckDummy::DUMMY_OK;
+        if (apply)
+            aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_MARK_OF_BLOOD_HEAL), aur, aur->getCasterGuid());
+        else
+            aur->getOwner()->removeProcTriggerSpell(SPELL_MARK_OF_BLOOD_HEAL, aur->getCasterGuid());
 
-        aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_MARK_OF_BLOOD_HEAL), aur->getSpellInfo(), aur->getCasterGuid(), 0);
         return SpellScriptCheckDummy::DUMMY_OK;
-    }
-
-    void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
-    {
-        aur->getOwner()->removeProcTriggerSpell(SPELL_MARK_OF_BLOOD_HEAL, aur->getCasterGuid());
     }
 };
 #endif

--- a/src/scripts/SpellHandlers/Scripts/Items.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Items.cpp
@@ -114,17 +114,13 @@ public:
 
     SpellScriptCheckDummy onAuraDummyEffect(Aura* aur, AuraEffectModifier* /*aurEff*/, bool apply) override
     {
-        if (!apply)
-            return SpellScriptCheckDummy::DUMMY_OK;
-
         // On dummy aura apply make it proc self
-        aur->getOwner()->addProcTriggerSpell(aur->getSpellInfo(), aur->getCasterGuid(), 0);
-        return SpellScriptCheckDummy::DUMMY_OK;
-    }
+        if (apply)
+            aur->getOwner()->addProcTriggerSpell(aur->getSpellInfo(), aur->getCasterGuid(), aur);
+        else
+            aur->getOwner()->removeProcTriggerSpell(aur->getSpellId(), aur->getCasterGuid());
 
-    void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
-    {
-        aur->getOwner()->removeProcTriggerSpell(aur->getSpellId(), aur->getCasterGuid());
+        return SpellScriptCheckDummy::DUMMY_OK;
     }
 
     void onCreateSpellProc(SpellProc* spellProc, Object* obj) override
@@ -252,18 +248,17 @@ class Shadowmourne : public SpellScript
 public:
     SpellScriptCheckDummy onAuraDummyEffect(Aura* aur, AuraEffectModifier* /*aurEff*/, bool apply) override
     {
-        if (!apply)
-            return SpellScriptCheckDummy::DUMMY_OK;
-
         // On dummy aura apply make it proc self
-        aur->getOwner()->addProcTriggerSpell(aur->getSpellInfo(), aur->getCasterGuid(), 0);
+        if (apply)
+            aur->getOwner()->addProcTriggerSpell(aur->getSpellInfo(), aur->getCasterGuid(), aur);
+        else
+            aur->getOwner()->removeProcTriggerSpell(aur->getSpellId(), aur->getCasterGuid());
+
         return SpellScriptCheckDummy::DUMMY_OK;
     }
 
     void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
     {
-        aur->getOwner()->removeProcTriggerSpell(aur->getSpellId(), aur->getCasterGuid());
-
         // Also remove Soul Fragments
         aur->getOwner()->removeAllAurasById(SPELL_SOUL_FRAGMENT);
     }

--- a/src/scripts/SpellHandlers/Scripts/Warlock.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Warlock.cpp
@@ -5,8 +5,97 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Setup.h"
 
+enum WarlockSpells
+{
+    SPELL_BACKLASH_PROC             = 34936,
+    SPELL_NIGHTFALL_R1              = 18094,
+    SPELL_NIGHTFALL_R2              = 18095,
+    SPELL_SHADOW_TRANCE_PROC        = 17941,
+};
+
+#if VERSION_STRING >= TBC
+class Backlash : public SpellScript
+{
+public:
+    void onAuraCreate(Aura* aur) override
+    {
+        // SpellInfo is missing charge count
+        aur->setCharges(1, false);
+    }
+
+    void onCreateSpellProc(SpellProc* proc, Object* /*obj*/) override
+    {
+        // 8 sec cooldown
+        proc->setProcInterval(8000);
+        proc->setCastedOnProcOwner(true);
+    }
+};
+#endif
+
+class NightfallDummy : public SpellScript
+{
+public:
+    SpellScriptCheckDummy onAuraDummyEffect(Aura* aur, AuraEffectModifier* /*aurEff*/, bool apply) override
+    {
+        if (apply)
+        {
+            // Should proc on Corruption and Drain Life
+            const uint32_t procMask[3] = { 0xA, 0, 0 };
+            aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(SPELL_SHADOW_TRANCE_PROC), aur, aur->getCasterGuid(), procMask);
+        }
+        else
+        {
+            aur->getOwner()->removeProcTriggerSpell(SPELL_SHADOW_TRANCE_PROC, aur->getCasterGuid());
+        }
+
+        return SpellScriptCheckDummy::DUMMY_OK;
+    }
+};
+
+class ShadowTrance : public SpellScript
+{
+public:
+    void onAuraCreate(Aura* aur) override
+    {
+        // SpellInfo is missing charge count
+        aur->setCharges(1, false);
+    }
+
+    void onCreateSpellProc(SpellProc* proc, Object* /*obj*/) override
+    {
+        proc->setCastedOnProcOwner(true);
+    }
+
+    bool canProc(SpellProc* proc, Unit* /*victim*/, SpellInfo const* /*castingSpell*/, DamageInfo damageInfo) override
+    {
+        // Cannot proc if warlock already has the aura
+        if (proc->getProcOwner()->HasAura(SPELL_SHADOW_TRANCE_PROC))
+            return false;
+
+        // Should proc only when dealing damage
+        if (damageInfo.realDamage == 0)
+            return false;
+
+        return true;
+    }
+};
+
 void setupWarlockSpells(ScriptMgr* mgr)
 {
     // Call legacy script setup
     SetupLegacyWarlockSpells(mgr);
+
+#if VERSION_STRING >= TBC
+    mgr->register_spell_script(SPELL_BACKLASH_PROC, new Backlash);
+#endif
+
+    uint32_t nightfallIds[] =
+    {
+        SPELL_NIGHTFALL_R1,
+        SPELL_NIGHTFALL_R2,
+        0
+    };
+    mgr->register_spell_script(nightfallIds, new NightfallDummy);
+
+    mgr->register_spell_script(SPELL_SHADOW_TRANCE_PROC, new ShadowTrance);
 }

--- a/src/scripts/SpellHandlers/Scripts/Warrior.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Warrior.cpp
@@ -5,8 +5,101 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Setup.h"
 
+enum WarriorSpells
+{
+    SPELL_FLURRY_DUMMY_R1   = 12319,
+    SPELL_FLURRY_DUMMY_R2   = 12971,
+    SPELL_FLURRY_DUMMY_R3   = 12972,
+    SPELL_FLURRY_DUMMY_R4   = 12973,
+    SPELL_FLURRY_DUMMY_R5   = 12974,
+    SPELL_FLURRY_PROC_R1    = 12966,
+    SPELL_FLURRY_PROC_R2    = 12967,
+    SPELL_FLURRY_PROC_R3    = 12968,
+    SPELL_FLURRY_PROC_R4    = 12969,
+    SPELL_FLURRY_PROC_R5    = 12970,
+};
+
+#if VERSION_STRING < Mop
+class Flurry : public SpellScript
+{
+public:
+    void onCreateSpellProc(SpellProc* proc, Object* /*obj*/) override
+    {
+        proc->setExtraProcFlags(EXTRA_PROC_ON_CRIT_ONLY);
+    }
+
+    void onAuraApply(Aura* aur) override
+    {
+        // Make the proc aura proc its mother spell
+        // This is only needed to consume proc charges from this aura on melee attacks
+        // DBC data also have PROC_ON_DONE_MELEE_HIT flag set so this is not probably far-fetched
+        motherAuraId = aur->pSpellId;
+        spellProc = aur->getOwner()->addProcTriggerSpell(sSpellMgr.getSpellInfo(motherAuraId), aur, aur->getCasterGuid());
+        if (spellProc != nullptr)
+            spellProc->skipOnNextHandleProc(true);
+    }
+
+    void onAuraRefreshOrGainNewStack(Aura* /*aur*/, uint32_t /*newStacks*/, uint32_t /*oldStacks*/) override
+    {
+        // If this proc is not skipped in next ::handleProc event,
+        // the same attack, that created this aura, will consume one proc charge
+        if (spellProc != nullptr)
+            spellProc->skipOnNextHandleProc(true);
+    }
+
+    void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
+    {
+        aur->getOwner()->removeProcTriggerSpell(motherAuraId, aur->getCasterGuid());
+        motherAuraId = 0;
+        spellProc = nullptr;
+    }
+
+private:
+    uint32_t motherAuraId = 0;
+    SpellProc* spellProc = nullptr;
+};
+
+class FlurryDummy : public SpellScript
+{
+    SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* /*spellToProc*/) override
+    {
+        // Do not cast the spell, this is just needed to consume the proc charges from Flurry aura
+        // If the cast is prevented earlier in onDoProcEffect, the proc system assumes the proc did not happen
+        return SpellScriptExecuteState::EXECUTE_PREVENT;
+    }
+};
+#endif
+
 void setupWarriorSpells(ScriptMgr* mgr)
 {
     // Call legacy script setup
     SetupLegacyWarriorSpells(mgr);
+
+#if VERSION_STRING < Mop
+    uint32_t flurryIds[] =
+    {
+        SPELL_FLURRY_PROC_R1,
+        SPELL_FLURRY_PROC_R2,
+        SPELL_FLURRY_PROC_R3,
+#if VERSION_STRING < Cata
+        SPELL_FLURRY_PROC_R4,
+        SPELL_FLURRY_PROC_R5,
+#endif
+        0
+    };
+    mgr->register_spell_script(flurryIds, new Flurry);
+
+    uint32_t flurryDummyIds[] =
+    {
+        SPELL_FLURRY_DUMMY_R1,
+        SPELL_FLURRY_DUMMY_R2,
+        SPELL_FLURRY_DUMMY_R3,
+#if VERSION_STRING < Cata
+        SPELL_FLURRY_DUMMY_R4,
+        SPELL_FLURRY_DUMMY_R5,
+#endif
+        0
+    };
+    mgr->register_spell_script(flurryDummyIds, new FlurryDummy);
+#endif
 }

--- a/src/shared/Util.cpp
+++ b/src/shared/Util.cpp
@@ -396,6 +396,35 @@ namespace Util
         return dist(mt);
     }
 
+    bool checkChance(uint32_t val)
+    {
+        if (val >= 100)
+            return true;
+        if (val == 0)
+            return false;
+
+        return val >= getRandomUInt(100);
+    }
+
+    bool checkChance(int32_t val)
+    {
+        if (val >= 100)
+            return true;
+        if (val <= 0)
+            return false;
+
+        return val >= getRandomInt(100);
+    }
+
+    bool checkChance(float_t val)
+    {
+        if (val >= 100.0f)
+            return true;
+        if (val <= 0.0f)
+            return false;
+
+        return static_cast<uint32_t>(val * 100) >= getRandomUInt(100 * 100);
+    }
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // C++17 filesystem dependent functions

--- a/src/shared/Util.hpp
+++ b/src/shared/Util.hpp
@@ -148,6 +148,12 @@ namespace Util
     float getRandomFloat(float end);
     float getRandomFloat(float start, float end);
 
+    // Gets random number from 1-100 and returns true if val is greater than the number
+    bool checkChance(uint32_t val);
+    // Gets random number from 1-100 and returns true if val is greater than the number
+    bool checkChance(int32_t val);
+    // Gets random number from 1-100 and returns true if val is greater than the number
+    bool checkChance(float_t val);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // C++17 filesystem dependent functions

--- a/src/world/Chat/Commands/debugcmds.cpp
+++ b/src/world/Chat/Commands/debugcmds.cpp
@@ -23,6 +23,7 @@
 #include "VMapFactory.h"
 #include "Storage/MySQLDataStore.hpp"
 #include "Server/MainServerDefines.h"
+#include "Map/Area/AreaStorage.hpp"
 #include "Map/MapMgr.h"
 #include "Spell/SpellAuras.h"
 #include "Spell/Definitions/SpellCastTargetFlags.h"

--- a/src/world/Management/Charter.cpp
+++ b/src/world/Management/Charter.cpp
@@ -4,6 +4,9 @@ This file is released under the MIT license. See README-MIT for more information
 */
 
 #include "Charter.hpp"
+#include "Objects/ObjectMgr.h"
+
+#include "shared/Database/Field.hpp"
 
 Charter::Charter(Field* fields)
 {

--- a/src/world/Management/Item.Legacy.cpp
+++ b/src/world/Management/Item.Legacy.cpp
@@ -668,20 +668,20 @@ void Item::ApplyEnchantmentBonus(uint32 Slot, bool Apply)
                             {
                                 // 'Chance on hit' enchantments in main hand should only proc from main hand hits
                                 case EQUIPMENT_SLOT_MAINHAND:
-                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_ON_MAIN_HAND_HIT_ONLY, 0, nullptr, nullptr, this);
+                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_ON_MAIN_HAND_HIT_ONLY, nullptr, nullptr, nullptr, this);
                                     break;
                                 // 'Chance on hit' enchantments in off hand should only proc from off hand hits
                                 case EQUIPMENT_SLOT_OFFHAND:
-                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_OFFHAND_ATTACK), EXTRA_PROC_ON_OFF_HAND_HIT_ONLY, 0, nullptr, nullptr, this);
+                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_OFFHAND_ATTACK), EXTRA_PROC_ON_OFF_HAND_HIT_ONLY, nullptr, nullptr, nullptr, this);
                                     break;
                                 // 'Chance on hit' enchantments in ranged slot should only proc from ranged attacks
                                 ///\ todo: does this enchantment type even have ranged spells?
                                 case EQUIPMENT_SLOT_RANGED:
-                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, 0, nullptr, nullptr, this);
+                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, nullptr, nullptr, nullptr, this);
                                     break;
                                 // In any other slot, proc on any melee hit
                                 default:
-                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_NULL, 0, nullptr, nullptr, this);
+                                    m_owner->addProcTriggerSpell(Entry->spell[c], 0, m_owner->getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_NULL, nullptr, nullptr, nullptr, this);
                                     break;
                             }
                         }

--- a/src/world/Management/LootMgr.cpp
+++ b/src/world/Management/LootMgr.cpp
@@ -40,27 +40,6 @@ struct loot_tb
     float chance;
 };
 
-bool Rand(float chance)
-{
-    int32 val = Util::getRandomUInt(10000);
-    int32 p = int32(chance * 100.0f);
-    return p >= val;
-}
-
-bool Rand(uint32 chance)
-{
-    int32 val = Util::getRandomUInt(10000);
-    int32 p = int32(chance * 100);
-    return p >= val;
-}
-
-bool Rand(int32 chance)
-{
-    int32 val = Util::getRandomUInt(10000);
-    int32 p = chance * 100;
-    return p >= val;
-}
-
 template <class T> // works for anything that has the field 'chance' and is stored in plain array
 const T & RandomChoice(const T* variant, int count)
 {
@@ -397,7 +376,7 @@ void LootMgr::PushLoot(StoreLootList* list, Loot* loot, uint8 type)
                 continue;
 
             ItemProperties const* itemproto = list->items[x].item.itemproto;
-            if (Rand(chance * worldConfig.getFloatRate((WorldConfigRates)(RATE_DROP0 + itemproto->Quality)))) //|| itemproto->Class == ITEM_CLASS_QUEST)
+            if (Util::checkChance(chance * worldConfig.getFloatRate((WorldConfigRates)(RATE_DROP0 + itemproto->Quality)))) //|| itemproto->Class == ITEM_CLASS_QUEST)
             {
                 if (list->items[x].mincount == list->items[x].maxcount)
                     count = list->items[x].maxcount;

--- a/src/world/Management/TransporterHandler.cpp
+++ b/src/world/Management/TransporterHandler.cpp
@@ -610,7 +610,7 @@ void ObjectMgr::LoadTransportForPlayers(Player* player)
 {
     auto tset = m_TransportersByMap[player->GetInstanceID()];
     ByteBuffer transData(10000);
-    uint32 count;
+    uint32 count = 0;
 
     if (tset.size() == 0)
         return;

--- a/src/world/Map/MapMgr.cpp
+++ b/src/world/Map/MapMgr.cpp
@@ -27,6 +27,7 @@
 #include "CThreads.h"
 #include "Management/WorldStatesHandler.h"
 #include "Management/Item.h"
+#include "Map/Area/AreaStorage.hpp"
 #include "CrashHandler.h"
 #include "Units/Summons/Summon.h"
 #include "Units/Summons/GuardianSummon.h"
@@ -45,6 +46,8 @@
 #include "Units/Creatures/Pet.h"
 #include "Server/Packets/SmsgUpdateWorldState.h"
 #include "Server/Packets/SmsgDefenseMessage.h"
+
+#include "shared/WoWGuid.h"
 
 using namespace AscEmu::Packets;
 

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -1005,7 +1005,6 @@ void GameObject_Trap::Update(unsigned long time_passed)
                 if (m_summoner != NULL)
                 {
                     m_summoner->HandleProc(PROC_ON_TRAP_ACTIVATION, reinterpret_cast<Unit*>(o), spell, DamageInfo(), false);
-                    m_summoner->m_procCounter = 0;
                 }
 
                 if (charges != 0)
@@ -1221,7 +1220,7 @@ void GameObject_FishingNode::onUse(Player* player)
             school->CatchFish();
 
         }
-        else if (maxskill != 0 && Rand(((player->_GetSkillLineCurrent(SKILL_FISHING, true) - minskill) * 100) / maxskill))
+        else if (maxskill != 0 && Util::checkChance(((player->_GetSkillLineCurrent(SKILL_FISHING, true) - minskill) * 100) / maxskill))
         {
             sLootMgr.FillFishingLoot(&this->loot, zone);
             player->SendLoot(getGuid(), LOOT_FISHING, GetMapId());

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -131,7 +131,6 @@ protected:
     const WoWObject* objectData() const { return wow_data; }
 
 public:
-
     bool write(const uint8_t& member, uint8_t val);
     bool write(const uint16_t& member, uint16_t val);
     bool write(const float& member, float val);
@@ -181,11 +180,9 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Object Type Id
 protected:
-
     uint8_t m_objectTypeId;
 
 public:
-
     uint8_t getObjectTypeId() const;
 
     bool isCreatureOrPlayer() const;
@@ -213,11 +210,12 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Spell functions
 private:
-
     Spell* m_currentSpell[CURRENT_SPELL_MAX];
 
-public:
+    std::map<Spell*, bool> m_travelingSpells;
+    std::list<Spell*> m_garbageSpells;
 
+public:
     Spell* getCurrentSpell(CurrentSpellType spellType) const;
     Spell* getCurrentSpellById(uint32_t spellId) const;
     void setCurrentSpell(Spell* curSpell);
@@ -232,23 +230,28 @@ public:
 
     // Deals magic damage to target with proper logging, used with periodic damage effects and direct damage effects
     // Returns damage info structure
-    DamageInfo doSpellDamage(Unit* victim, uint32_t spellId, float_t damage, uint8_t effIndex, bool isTriggered = false, bool isPeriodic = false, bool isLeech = false, bool forceCrit = false, Aura* aur = nullptr, AuraEffectModifier* aurEff = nullptr);
+    DamageInfo doSpellDamage(Unit* victim, uint32_t spellId, float_t damage, uint8_t effIndex, bool isTriggered = false, bool isPeriodic = false, bool isLeech = false, bool forceCrit = false, Spell* spell = nullptr, Aura* aur = nullptr, AuraEffectModifier* aurEff = nullptr);
     // Heals target with proper logging, used with periodic heal effects and direct healing
-    DamageInfo doSpellHealing(Unit* victim, uint32_t spellId, float_t heal, bool isTriggered = false, bool isPeriodic = false, bool isLeech = false, bool forceCrit = false, Aura* aur = nullptr, AuraEffectModifier* aurEff = nullptr);
+    DamageInfo doSpellHealing(Unit* victim, uint32_t spellId, float_t heal, bool isTriggered = false, bool isPeriodic = false, bool isLeech = false, bool forceCrit = false, Spell* spell = nullptr, Aura* aur = nullptr, AuraEffectModifier* aurEff = nullptr);
 
     void _UpdateSpells(uint32_t time);
+
+    void addTravelingSpell(Spell* spell);
+    void removeTravelingSpell(Spell* spell);
+    void addGarbageSpell(Spell* spell);
+    void removeGarbageSpells();
+
+    void removeSpellModifierFromCurrentSpells(AuraEffectModifier const* aur);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // InRange sets
 private:
-
     std::vector<Object*> mInRangeObjectsSet;
     std::vector<Object*> mInRangePlayersSet;
     std::vector<Object*> mInRangeOppositeFactionSet;
     std::vector<Object*> mInRangeSameFactionSet;
 
 public:
-
     // general
     virtual void clearInRangeSets();
     virtual void addToInRangeObjects(Object* pObj);
@@ -530,11 +533,6 @@ public:
 
     uint32 GetPhase() { return m_phase; }
         virtual void Phase(uint8 command = PHASE_SET, uint32 newphase = 1);
-
-        virtual bool IsCriticalDamageForSpell(Object* /*victim*/, SpellInfo const* /*spell*/) { return false; }
-        virtual float GetCriticalDamageBonusForSpell(Object* /*victim*/, SpellInfo const* /*spell*/, float /*amount*/) { return 0; }
-        virtual bool IsCriticalHealForSpell(Object* /*victim*/, SpellInfo const* /*spell*/) { return false; }
-        virtual float GetCriticalHealBonusForSpell(Object* /*victim*/, SpellInfo const* /*spell*/, float /*amount*/) { return 0; }
 
         // SpellLog packets just to keep the code cleaner and better to read
         void SendSpellLog(Object* Caster, Object* Target, uint32 Ability, uint8 SpellLogType);

--- a/src/world/Server/Script/CreatureAIScript.h
+++ b/src/world/Server/Script/CreatureAIScript.h
@@ -159,7 +159,7 @@ public:
     virtual void OnCombatStart(Unit* /*_target*/) {}
     virtual void OnCombatStop(Unit* /*_target*/) {}
     virtual void OnDamageTaken(Unit* /*_attacker*/, uint32_t /*_amount*/) {}
-    virtual void DamageTaken(Unit* _attacker, uint32_t* damage) {} // Warning triggers before dmg applied, you can modify the damage done here
+    virtual void DamageTaken(Unit* /*_attacker*/, uint32_t* /*damage*/) {} // Warning triggers before dmg applied, you can modify the damage done here
     virtual void OnCastSpell(uint32_t /*_spellId*/) {}
     virtual void OnTargetParried(Unit* /*_target*/) {}
     virtual void OnTargetDodged(Unit* /*_target*/) {}

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -259,13 +259,13 @@ bool ScriptMgr::callScriptedSpellCanProcOnTriggered(SpellProc* spellProc, Unit* 
     return spellScript->canProcOnTriggered(spellProc, victim, castingSpell, triggeredFromAura);
 }
 
-void ScriptMgr::callScriptedSpellProcCastSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc)
+SpellScriptExecuteState ScriptMgr::callScriptedSpellProcCastSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc)
 {
     const auto spellScript = getSpellScript(spellProc->getSpell()->getId());
     if (spellScript == nullptr)
-        return;
+        return SpellScriptExecuteState::EXECUTE_NOT_HANDLED;
 
-    spellScript->onCastProcSpell(spellProc, caster, victim, spellToProc);
+    return spellScript->onCastProcSpell(spellProc, caster, victim, spellToProc);
 }
 
 SpellScript* ScriptMgr::getSpellScript(uint32_t spellId) const

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -205,7 +205,7 @@ class SERVER_DECL ScriptMgr
         SpellScriptExecuteState callScriptedSpellProcDoEffect(SpellProc* spellProc, Unit* victim, SpellInfo const* castingSpell, DamageInfo damageInfo) const;
         uint32_t callScriptedSpellCalcProcChance(SpellProc* spellProc, Unit* victim, SpellInfo const* castingSpell) const;
         bool callScriptedSpellCanProcOnTriggered(SpellProc* spellProc, Unit* victim, SpellInfo const* castingSpell, Aura* triggeredFromAura) const;
-        void callScriptedSpellProcCastSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc);
+        SpellScriptExecuteState callScriptedSpellProcCastSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc);
 
         SpellScript* getSpellScript(uint32_t spellId) const;
         void register_spell_script(uint32_t spellId, SpellScript* ss);

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -760,6 +760,7 @@ bool World::setInitialWorldSettings()
     logEntitySize();
 
     sSpellMgr.loadSpellDataFromDatabase();
+    sSpellMgr.calculateSpellCoefficients();
 
 #if VERSION_STRING > TBC
     LogDetail("World : Starting Achievement System...");

--- a/src/world/Spell/Customization/HackFixes.cpp
+++ b/src/world/Spell/Customization/HackFixes.cpp
@@ -1183,28 +1183,6 @@ void SpellMgr::applyHackFixes()
     ////////////////////////////////////////////////////////////
     // Arms
 
-    // Juggernaut
-    sp = getMutableSpellInfo(65156);
-    if (sp != nullptr)
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
-
-    // Warrior - Overpower Rank 1
-    sp = getMutableSpellInfo(7384);
-    if (sp != nullptr)
-        sp->addAttributes(ATTRIBUTES_CANT_BE_DPB);
-    // Warrior - Overpower Rank 2
-    sp = getMutableSpellInfo(7887);
-    if (sp != nullptr)
-        sp->addAttributes(ATTRIBUTES_CANT_BE_DPB);
-    // Warrior - Overpower Rank 3
-    sp = getMutableSpellInfo(11584);
-    if (sp != nullptr)
-        sp->addAttributes(ATTRIBUTES_CANT_BE_DPB);
-    // Warrior - Overpower Rank 4
-    sp = getMutableSpellInfo(11585);
-    if (sp != nullptr)
-        sp->addAttributes(ATTRIBUTES_CANT_BE_DPB);
-
     // Warrior - Tactical Mastery Rank 1
     sp = getMutableSpellInfo(12295);
     if (sp != nullptr)
@@ -1217,13 +1195,6 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(12677);
     if (sp != nullptr)
         sp->setRequiredShapeShift(0x00070000);
-
-    // Warrior - Heroic Throw
-    sp = getMutableSpellInfo(57755);
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_SCHOOL_DAMAGE, 0);
-    }
 
     // Warrior - Rend
     sp = getMutableSpellInfo(772);
@@ -1364,17 +1335,6 @@ void SpellMgr::applyHackFixes()
         sp->setSpeed(0);    //without, no damage is done
     }
 
-    sp = getMutableSpellInfo(53719);
-    if (sp != nullptr)
-    {
-        sp->setDmgClass(SPELL_DMG_TYPE_MAGIC);
-    }
-    sp = getMutableSpellInfo(31893);
-    if (sp != nullptr)
-    {
-        sp->setDmgClass(SPELL_DMG_TYPE_MAGIC);
-    }
-
     //Paladin - Divine Storm
     sp = getMutableSpellInfo(53385);
     if (sp != nullptr)
@@ -1445,25 +1405,6 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
         sp->setTargetAuraSpellNot(25771);
 
-    //Paladin - Art of War
-    sp = getMutableSpellInfo(53486);
-    if (sp != nullptr)
-    {
-        sp->setEffectApplyAuraName(SPELL_AURA_MOD_DAMAGE_DONE, 0);
-    }
-    sp = getMutableSpellInfo(53489);
-    if (sp != nullptr)
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
-
-    sp = getMutableSpellInfo(53488);
-    if (sp != nullptr)
-    {
-        sp->setEffectApplyAuraName(SPELL_AURA_MOD_DAMAGE_DONE, 0);
-    }
-    sp = getMutableSpellInfo(59578);
-    if (sp != nullptr)
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
-
     //Paladin - Hammer of Justice - Interrupt effect
     sp = getMutableSpellInfo(853);
     if (sp != nullptr)
@@ -1495,24 +1436,6 @@ void SpellMgr::applyHackFixes()
     //////////////////////////////////////////
 
     // Insert hunter spell fixes here
-
-    //Hunter - Bestial Wrath
-    sp = getMutableSpellInfo(19574);
-    if (sp != nullptr)
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 2);
-
-    //Hunter - The Beast Within
-    sp = getMutableSpellInfo(34471);
-    if (sp != nullptr)
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 2);
-
-    //Hunter - Go for the Throat
-    sp = getMutableSpellInfo(34952);
-    if (sp != nullptr)
-        sp->setEffectImplicitTargetA(EFF_TARGET_PET, 0);
-    sp = getMutableSpellInfo(34953);
-    if (sp != nullptr)
-        sp->setEffectImplicitTargetA(EFF_TARGET_PET, 0);
 
     // Hunter - Spirit Bond
     sp = getMutableSpellInfo(19578);
@@ -1546,13 +1469,6 @@ void SpellMgr::applyHackFixes()
         sp->setEffectBasePoints(sp->getEffectBasePoints(0), 1);
         sp->setEffectAmplitude(sp->getEffectAmplitude(0), 1);
         sp->setEffectDieSides(sp->getEffectDieSides(0), 1);
-    }
-
-    //Hunter Silencing Shot
-    sp = getMutableSpellInfo(34490);
-    if (sp != nullptr)
-    {
-        sp->setEffectApplyAuraName(SPELL_AURA_MOD_SILENCE, 1);
     }
 
     // Hunter - Ferocious Inspiration
@@ -1599,21 +1515,21 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(34497);
     if (sp != nullptr)
     {
-        sp->setProcChance(sp->getEffectBasePoints(0) + 1);
+        sp->setProcChance(sp->calculateEffectValue(0));
         sp->setEffectApplyAuraName(SPELL_AURA_PROC_TRIGGER_SPELL, 0);
         sp->setEffectTriggerSpell(34720, 0);
     }
     sp = getMutableSpellInfo(34498);
     if (sp != nullptr)
     {
-        sp->setProcChance(sp->getEffectBasePoints(0) + 1);
+        sp->setProcChance(sp->calculateEffectValue(0));
         sp->setEffectApplyAuraName(SPELL_AURA_PROC_TRIGGER_SPELL, 0);
         sp->setEffectTriggerSpell(34720, 0);
     }
     sp = getMutableSpellInfo(34499);
     if (sp != nullptr)
     {
-        sp->setProcChance(sp->getEffectBasePoints(0) + 1);
+        sp->setProcChance(sp->calculateEffectValue(0));
         sp->setEffectApplyAuraName(SPELL_AURA_PROC_TRIGGER_SPELL, 0);
         sp->setEffectTriggerSpell(34720, 0);
     }
@@ -1660,18 +1576,6 @@ void SpellMgr::applyHackFixes()
         sp->setProcChance(sp->getEffectBasePoints(0));
     }
 
-    //Hunter : Pathfinding
-    sp = getMutableSpellInfo(19559);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-    }
-    sp = getMutableSpellInfo(19560);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-    }
-
     // Feed pet
     sp = getMutableSpellInfo(6991);
     if (sp != nullptr)
@@ -1693,23 +1597,6 @@ void SpellMgr::applyHackFixes()
         sp->setEffectImplicitTargetA(EFF_TARGET_SINGLE_ENEMY, 1);
     }
 
-    //rogue - Camouflage.
-    sp = getMutableSpellInfo(13975);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-    }
-    sp = getMutableSpellInfo(14062);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-    }
-    sp = getMutableSpellInfo(14063);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-    }
-
     //rogue - Vanish : Second Trigger Spell
     sp = getMutableSpellInfo(18461);
     if (sp != nullptr)
@@ -1719,7 +1606,7 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(36563);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 2);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 2);
     }
     // Still related to shadowstep - prevent the trigger spells from breaking stealth.
     sp = getMutableSpellInfo(44373);
@@ -1816,46 +1703,6 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
         sp->setEffectImplicitTargetA(EFF_TARGET_SINGLE_FRIEND, 0);
 
-    // Vampiric Embrace heal spell
-    sp = getMutableSpellInfo(15290);
-    if (sp != nullptr)
-    {
-        sp->setEffectBasePoints(2, 0);
-        sp->setEffectBasePoints(14, 1);
-    }
-
-    // Improved Mind Blast
-    sp = getMutableSpellInfo(15273);   //rank 1
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_APPLY_AURA, 1);
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 1);
-    }
-    sp = getMutableSpellInfo(15312);   //rank 2
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_APPLY_AURA, 1);
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 1);
-    }
-    sp = getMutableSpellInfo(15313);   //rank 3
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_APPLY_AURA, 1);
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 1);
-    }
-    sp = getMutableSpellInfo(15314);   //rank 4
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_APPLY_AURA, 1);
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 1);
-    }
-    sp = getMutableSpellInfo(15316);   //rank 5
-    if (sp != nullptr)
-    {
-        sp->setEffect(SPELL_EFFECT_APPLY_AURA, 1);
-        sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 1);
-    }
-
     // Body and soul - fix duration of cleanse poison
     sp = getMutableSpellInfo(64134);
     if (sp != nullptr)
@@ -1874,31 +1721,31 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
     }
     sp = getMutableSpellInfo(14525);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
     }
     sp = getMutableSpellInfo(14526);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
     }
     sp = getMutableSpellInfo(14527);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
     }
     sp = getMutableSpellInfo(14528);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
     }
 
     //Priest - Inspiration proc spell
@@ -1912,12 +1759,6 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
         sp->setRangeIndex(4);
 
-    //priest - surge of light
-    sp = getMutableSpellInfo(33151);
-    if (sp != nullptr)
-    {
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
-    }
     // priest - Reflective Shield
     sp = getMutableSpellInfo(33201);
     if (sp != nullptr)
@@ -1999,15 +1840,6 @@ void SpellMgr::applyHackFixes()
 
     // Insert shaman spell fixes here
 
-    // Elemental Mastery
-    sp = getMutableSpellInfo(16166);
-    if (sp != nullptr)
-    {
-        sp->setEffectMiscValue(SMT_CRITICAL, 0);
-        sp->setEffectMiscValue(SMT_COST, 0);
-        // sp->AuraInterruptFlags = AURA_INTERRUPT_ON_AFTER_CAST_SPELL;
-    }
-
     ////////////////////////////////////////////////////////////
     // Shamanistic Rage
     SpellInfo const*  parentsp = getMutableSpellInfo(30823);
@@ -2080,7 +1912,7 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(43339);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_COST, 0);
+        sp->setEffectMiscValue(SPELLMOD_COST, 0);
     }
 
     //shaman - Improved Chain Heal
@@ -2101,48 +1933,48 @@ void SpellMgr::applyHackFixes()
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 1);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 1);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 1);
     }
     sp = getMutableSpellInfo(29192);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 1);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 0);
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 1);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 0);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 1);
     }
 
     // Shaman - Improved Fire Totems
     sp = getMutableSpellInfo(16544);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_DURATION, 0);
+        sp->setEffectMiscValue(SPELLMOD_DURATION, 0);
     }
     sp = getMutableSpellInfo(16086);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_DURATION, 0);
+        sp->setEffectMiscValue(SPELLMOD_DURATION, 0);
     }
 
     //shaman - Elemental Weapons
     sp = getMutableSpellInfo(29080);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 1);
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 2);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 1);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 2);
     }
     sp = getMutableSpellInfo(29079);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 1);
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 2);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 1);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 2);
     }
     sp = getMutableSpellInfo(16266);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 1);
-        sp->setEffectMiscValue(SMT_DAMAGE_DONE, 2);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 1);
+        sp->setEffectMiscValue(SPELLMOD_DAMAGE_DONE, 2);
     }
 
     ////////////////////////////////////////////////////////////
@@ -2244,13 +2076,13 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(35578);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_CRITICAL_DAMAGE, 0);
+        sp->setEffectMiscValue(SPELLMOD_CRITICAL_DAMAGE, 0);
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
     }
     sp = getMutableSpellInfo(35581);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_CRITICAL_DAMAGE, 0);
+        sp->setEffectMiscValue(SPELLMOD_CRITICAL_DAMAGE, 0);
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
     }
 
@@ -2259,19 +2091,19 @@ void SpellMgr::applyHackFixes()
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_COST, 0);
+        sp->setEffectMiscValue(SPELLMOD_COST, 0);
     }
     sp = getMutableSpellInfo(29439);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_COST, 0);
+        sp->setEffectMiscValue(SPELLMOD_COST, 0);
     }
     sp = getMutableSpellInfo(29440);
     if (sp != nullptr)
     {
         sp->setEffectApplyAuraName(SPELL_AURA_ADD_PCT_MODIFIER, 0);
-        sp->setEffectMiscValue(SMT_COST, 0);
+        sp->setEffectMiscValue(SPELLMOD_COST, 0);
     }
 
     //Mage - Arcane Blast
@@ -2305,17 +2137,17 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(31579);
     if (sp != nullptr)
     {
-        sp->setEffectBasePoints(5 * (sp->getEffectBasePoints(0) + 1), 0);
+        sp->setEffectBasePoints(5 * (sp->calculateEffectValue(0)), 0);
     }
     sp = getMutableSpellInfo(31582);
     if (sp != nullptr)
     {
-        sp->setEffectBasePoints(5 * (sp->getEffectBasePoints(0) + 1), 0);
+        sp->setEffectBasePoints(5 * (sp->calculateEffectValue(0)), 0);
     }
     sp = getMutableSpellInfo(31583);
     if (sp != nullptr)
     {
-        sp->setEffectBasePoints(5 * (sp->getEffectBasePoints(0) + 1), 0);
+        sp->setEffectBasePoints(5 * (sp->calculateEffectValue(0)), 0);
     }
 
     // cebernic: not for self?
@@ -2336,7 +2168,6 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(66);
     if (sp != nullptr)
     {
-        sp->addAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
         sp->setEffect(SPELL_EFFECT_NULL, 1);
         sp->setEffectApplyAuraName(SPELL_AURA_PERIODIC_TRIGGER_SPELL, 2);
         sp->setEffect(SPELL_EFFECT_APPLY_AURA, 2);
@@ -2345,13 +2176,6 @@ void SpellMgr::applyHackFixes()
         sp->setEffectDieSides(1, 2);
         sp->setEffectTriggerSpell(32612, 2);
         sp->setEffectBasePoints(-1, 2);
-    }
-
-    //Invisibility triggered spell, should be removed on cast
-    sp = getMutableSpellInfo(32612);
-    if (sp != nullptr)
-    {
-        sp->addAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
     }
 
     //Arcane Potency procs
@@ -2367,13 +2191,6 @@ void SpellMgr::applyHackFixes()
     {
         sp->setProcFlags(0);
         sp->setAuraInterruptFlags(0);
-    }
-
-    //Hot Streak proc
-    sp = getMutableSpellInfo(48108);
-    if (sp != nullptr)
-    {
-        sp->addAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
     }
 
     //mage - Combustion
@@ -2403,21 +2220,21 @@ void SpellMgr::applyHackFixes()
     sp = getMutableSpellInfo(11175);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 1);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 1);
     }
 
     // Mage - Permafrost Rank 2
     sp = getMutableSpellInfo(12569);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 1);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 1);
     }
 
     // Mage - Permafrost Rank 3
     sp = getMutableSpellInfo(12571);
     if (sp != nullptr)
     {
-        sp->setEffectMiscValue(SMT_MISC_EFFECT, 1);
+        sp->setEffectMiscValue(SPELLMOD_ALL_EFFECTS, 1);
     }
 
     //////////////////////////////////////////
@@ -2487,14 +2304,6 @@ void SpellMgr::applyHackFixes()
 #endif
 
     ////////////////////////////////////////////////////////////
-    // Backlash
-    sp = getMutableSpellInfo(34936);
-    if (sp != nullptr)
-    {
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
-    }
-
-    ////////////////////////////////////////////////////////////
     // Demonic Knowledge
     sp = getMutableSpellInfo(35691);
     if (sp != nullptr)
@@ -2541,13 +2350,6 @@ void SpellMgr::applyHackFixes()
         sp->setEffect(SPELL_EFFECT_APPLY_AURA, 0); //making this only for the visible effect
         sp->setEffectApplyAuraName(SPELL_AURA_DUMMY, 0); //no effect here
         sp->setEffectImplicitTargetA(EFF_TARGET_PET, 0);
-    }
-
-    //Shadow Trance should be removed on the first SB
-    sp = getMutableSpellInfo(17941);
-    if (sp != nullptr)
-    {
-        sp->setAuraInterruptFlags(AURA_INTERRUPT_ON_CAST_SPELL);
     }
 
     //warlock: Empowered Corruption

--- a/src/world/Spell/Customization/SpellCustomizations.cpp
+++ b/src/world/Spell/Customization/SpellCustomizations.cpp
@@ -13,46 +13,6 @@ This file is released under the MIT license. See README-MIT for more information
 //\brief: This file includes all old setted custom values or spell.dbc overwrite values
 // If possible, these should be get rid of or moved under appropriate class (like that diminishing group)
 
-bool SpellMgr::isAlwaysApply(SpellInfo const* spellInfo) const
-{
-    switch (spellInfo->getId())
-    {
-        // SPELL_HASH_BLOOD_FURY
-        case 20572:
-        case 23230:
-        case 24571:
-        case 33697:
-        case 33702:
-        // SPELL_HASH_SHADOWSTEP
-        case 36554:
-        case 36563:
-        case 41176:
-        case 44373:
-        case 45273:
-        case 46463:
-        case 55965:
-        case 55966:
-        case 63790:
-        case 63793:
-        case 66178:
-        case 68759:
-        case 68760:
-        case 68761:
-        case 69087:
-        case 70431:
-        case 72326:
-        case 72327:
-        // SPELL_HASH_PSYCHIC_HORROR
-        case 34984:
-        case 65545:
-        {
-            return true;
-        }
-        default:
-            return false;
-    }
-}
-
 // Calculate the Diminishing Group. This is based on id.
 // this off course is very hacky, but as its made done in a proper way
 // I leave it here.
@@ -862,11 +822,4 @@ void SpellMgr::setSpellMissingCIsFlags(SpellInfo* sp)
         sp->custom_c_is_flags |= SPELL_FLAG_IS_TARGETINGSTEALTHED;
     if (sp->isRequireCooldownSpell())
         sp->custom_c_is_flags |= SPELL_FLAG_IS_REQUIRECOOLDOWNUPDATE;
-}
-
-void SpellMgr::setSpellOnShapeshiftChange(SpellInfo* sp)
-{
-    // Currently only for spell Track Humanoids
-    if (sp->getId() == 5225 || sp->getId() == 19883)
-        sp->custom_apply_on_shapeshift_change = true;
 }

--- a/src/world/Spell/Definitions/SpellModifierType.h
+++ b/src/world/Spell/Definitions/SpellModifierType.h
@@ -5,35 +5,38 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
-enum SPELL_MODIFIER_TYPE
+#include <cstdint>
+
+enum SpellModifierType : uint8_t
 {
-    SMT_DAMAGE_DONE       = 0,
-    SMT_DURATION          = 1,
-    SMT_THREAT_REDUCED    = 2,
-    SMT_EFFECT_1          = 3,
-    SMT_CHARGES           = 4,
-    SMT_RANGE             = 5,
-    SMT_RADIUS            = 6,
-    SMT_CRITICAL          = 7,
-    SMT_MISC_EFFECT       = 8,
-    SMT_NONINTERRUPT      = 9,
-    SMT_CAST_TIME         = 10,
-    SMT_COOLDOWN_DECREASE = 11,
-    SMT_EFFECT_2          = 12,
+    SPELLMOD_DAMAGE_DONE       = 0,
+    SPELLMOD_DURATION          = 1,
+    SPELLMOD_THREAT_REDUCED    = 2,
+    SPELLMOD_EFFECT_1          = 3,
+    SPELLMOD_CHARGES           = 4,
+    SPELLMOD_RANGE             = 5,
+    SPELLMOD_RADIUS            = 6,
+    SPELLMOD_CRITICAL          = 7,
+    SPELLMOD_ALL_EFFECTS       = 8,
+    SPELLMOD_NONINTERRUPT      = 9,
+    SPELLMOD_CAST_TIME         = 10,
+    SPELLMOD_COOLDOWN_DECREASE = 11,
+    SPELLMOD_EFFECT_2          = 12,
     // UNUSED_13
-    SMT_COST              = 14,
-    SMT_CRITICAL_DAMAGE   = 15,
-    SMT_HITCHANCE         = 16,
-    SMT_ADDITIONAL_TARGET = 17,
-    SMT_TRIGGER           = 18,
-    SMT_AMPTITUDE         = 19,
-    SMT_JUMP_REDUCE       = 20,
-    SMT_GLOBAL_COOLDOWN   = 21,
-    SMT_SPELL_VALUE_PCT   = 22,
-    SMT_EFFECT_3          = 23,
-    SMT_PENALTY           = 24,
+    SPELLMOD_COST              = 14,
+    SPELLMOD_CRITICAL_DAMAGE   = 15,
+    SPELLMOD_HITCHANCE         = 16,
+    SPELLMOD_ADDITIONAL_TARGET = 17,
+    SPELLMOD_TRIGGER           = 18,
+    SPELLMOD_AMPTITUDE         = 19,
+    SPELLMOD_JUMP_REDUCE       = 20,
+    SPELLMOD_GLOBAL_COOLDOWN   = 21,
+    SPELLMOD_PERIODIC_DAMAGE   = 22,
+    SPELLMOD_EFFECT_3          = 23,
+    SPELLMOD_PENALTY           = 24,
     // UNUSED_25
     // UNUSED_26
-    SMT_EFFECT_BONUS      = 27,
-    SMT_RESIST_DISPEL     = 28,
+    SPELLMOD_EFFECT_BONUS      = 27,
+    SPELLMOD_RESIST_DISPEL     = 28,
+    MAX_SPELLMOD_TYPE
 };

--- a/src/world/Spell/Definitions/SpellState.h
+++ b/src/world/Spell/Definitions/SpellState.h
@@ -5,11 +5,13 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
-enum SpellState
+#include <cstdint>
+
+enum SpellState : uint8_t
 {
-    SPELL_STATE_NULL      = 0,
-    SPELL_STATE_PREPARING = 1,
-    SPELL_STATE_CASTING   = 2,
-    SPELL_STATE_FINISHED  = 3,
-    SPELL_STATE_IDLE      = 4
+    SPELL_STATE_NULL = 0,
+    SPELL_STATE_PREPARING,
+    SPELL_STATE_CHANNELING,
+    SPELL_STATE_TRAVELING,
+    SPELL_STATE_FINISHED
 };

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -5,7 +5,6 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Spell.h"
 #include "SpellAuras.h"
-#include "SpellHelpers.h"
 #include "SpellTarget.h"
 #include "Definitions/AuraInterruptFlags.h"
 #include "Definitions/AuraStates.h"
@@ -38,21 +37,19 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Objects/GameObject.h"
 #include "Objects/ObjectMgr.h"
 #include "Server/Definitions.h"
+#include "Server/Packets/SmsgCancelCombat.h"
+#include "Server/Packets/MsgChannelUpdate.h"
+#include "Server/Packets/MsgChannelStart.h"
 #include "Storage/MySQLDataStore.hpp"
 #include "Units/Creatures/CreatureDefines.hpp"
 #include "Units/Creatures/Pet.h"
 #include "Units/Players/PlayerClasses.hpp"
 #include "Units/UnitDefines.hpp"
 #include "Util.hpp"
-#include "Server/Packets/MsgChannelUpdate.h"
-#include "Server/Packets/MsgChannelStart.h"
 
 using namespace AscEmu::Packets;
 
-using AscEmu::World::Spell::Helpers::spellModFlatFloatValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageFloatValue;
-using AscEmu::World::Spell::Helpers::spellModFlatIntValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageIntValue;
+extern pSpellEffect SpellEffectsHandler[TOTAL_SPELL_EFFECTS];
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Main control flow
@@ -61,7 +58,7 @@ SpellCastResult Spell::prepare(SpellCastTargets* targets)
     if (!m_caster->IsInWorld())
     {
         LogDebugFlag(LF_SPELL, "Object " I64FMT " is casting spell ID %u while not in world", m_caster->getGuid(), getSpellInfo()->getId());
-        DecRef();
+        delete this;
         return SPELL_FAILED_DONT_REPORT;
     }
 
@@ -71,7 +68,7 @@ SpellCastResult Spell::prepare(SpellCastTargets* targets)
         const auto aiInterface = u_caster->GetAIInterface();
         if (aiInterface->isAiState(AI_STATE_FEAR) || aiInterface->isAiState(AI_STATE_WANDER))
         {
-            DecRef();
+            u_caster->addGarbageSpell(this);
             return SPELL_FAILED_NOT_READY;
         }
     }
@@ -81,7 +78,7 @@ SpellCastResult Spell::prepare(SpellCastTargets* targets)
         // Call Lua script hook
         if (!sHookInterface.OnCastSpell(p_caster, getSpellInfo(), this))
         {
-            DecRef();
+            p_caster->addGarbageSpell(this);
             return SPELL_FAILED_UNKNOWN;
         }
 
@@ -127,8 +124,7 @@ SpellCastResult Spell::prepare(SpellCastTargets* targets)
         if (m_castTime > 0 && u_caster != nullptr)
         {
             // Apply cast time modifiers
-            spellModFlatIntValue(u_caster->SM_FCastTime, &m_castTime, getSpellInfo()->getSpellFamilyFlags());
-            spellModPercentageIntValue(u_caster->SM_PCastTime, &m_castTime, getSpellInfo()->getSpellFamilyFlags());
+            u_caster->applySpellModifiers(SPELLMOD_CAST_TIME, &m_castTime, getSpellInfo(), this);
 
             // Apply haste modifier to non-tradeskill spells
             if (!(getSpellInfo()->getAttributes() & (ATTRIBUTES_ABILITY | ATTRIBUTES_TRADESPELL)))
@@ -211,7 +207,7 @@ SpellCastResult Spell::prepare(SpellCastTargets* targets)
 
         // Send global cooldown
         if (p_caster != nullptr && !p_caster->m_cheats.hasCastTimeCheat)
-            p_caster->addGlobalCooldown(getSpellInfo());
+            p_caster->addGlobalCooldown(getSpellInfo(), this);
 
         // Handle instant and non-channeled spells instantly. Other spells will be handled in ::update on next tick.
         // First autorepeat casts are actually never casted, only set as current spell. Player::updateAutoRepeatSpell handles the shooting.
@@ -274,6 +270,8 @@ void Spell::castMe(const bool doReCheck)
         }
     }
 
+    m_isCasting = true;
+
     // Remove stealth if spell is an instant cast
     if (!m_triggeredSpell && m_castTime == 0 && p_caster != nullptr)
     {
@@ -322,8 +320,6 @@ void Spell::castMe(const bool doReCheck)
         m_magnetTarget = 0;
     }
 
-    m_isCasting = true;
-
     // Send cooldown
     if (p_caster != nullptr && !(getSpellInfo()->getAttributes() & (ATTRIBUTES_PASSIVE | ATTRIBUTES_TRIGGER_COOLDOWN)))
     {
@@ -332,11 +328,11 @@ void Spell::castMe(const bool doReCheck)
         if (getSpellInfo()->getAttributesExC() & ATTRIBUTESEXC_PLAYER_RANGED_SPELLS)
         {
             const auto cooldown = static_cast<int32_t>(p_caster->getBaseAttackTime(RANGED));
-            p_caster->addSpellCooldown(getSpellInfo(), i_caster, cooldown);
+            p_caster->addSpellCooldown(getSpellInfo(), i_caster, this, cooldown);
         }
         else
         {
-            p_caster->addSpellCooldown(getSpellInfo(), i_caster);
+            p_caster->addSpellCooldown(getSpellInfo(), i_caster, this);
         }
     }
 
@@ -453,10 +449,14 @@ void Spell::castMe(const bool doReCheck)
 
         if (channelDuration > 0)
         {
-            m_spellState = SPELL_STATE_CASTING;
+            m_spellState = SPELL_STATE_CHANNELING;
             sendChannelStart(channelDuration);
         }
     }
+
+    // Take cast item after SMSG_SPELL_GO but before effect handling
+    if (!GetSpellFailed())
+        RemoveItems();
 
 #if VERSION_STRING < Cata
     /*
@@ -500,31 +500,30 @@ void Spell::castMe(const bool doReCheck)
         {
             for (const auto& targetGuid : m_effectTargets[i])
             {
-                handleEffectTarget(targetGuid, i);
+                handleHittedTarget(targetGuid, i);
             }
         }
         else
         {
-            handleEffectTarget(0, i);
+            handleHittedTarget(0, i);
         }
     }
 
     // If spell applies an aura, handle it to targets after all effects have been processed
     if (!m_pendingAuras.empty())
     {
-        for (const auto& pendingAur : m_pendingAuras)
+        for (auto itr = m_pendingAuras.begin(); itr != m_pendingAuras.end();)
         {
-            // Check if aura has travel time
-            if (pendingAur.second.first == 0)
+            const auto pendingAur = *itr;
+            // Handle only instant auras here
+            if (pendingAur.second.travelTime > 0)
             {
-                AddRef();
-                HandleAddAura(pendingAur.first);
+                ++itr;
+                continue;
             }
-            else
-            {
-                sEventMgr.AddEvent(this, &Spell::HandleAddAura, pendingAur.first, EVENT_SPELL_HIT, pendingAur.second.first, 1, 0);
-                AddRef();
-            }
+
+            HandleAddAura(pendingAur.first);
+            itr = m_pendingAuras.erase(itr);
         }
     }
 
@@ -542,6 +541,9 @@ void Spell::castMe(const bool doReCheck)
         else if (missedTarget.hitResult == SPELL_DID_HIT_PARRY)
             targetParried = true;
     }
+
+    // Handle used spell modifiers
+    takeUsedSpellModifiers();
 
     if (u_caster != nullptr)
     {
@@ -577,43 +579,136 @@ void Spell::castMe(const bool doReCheck)
         }
     }
 
-    m_isCasting = false;
+    // If spell is not channeled, the spell cast has finished successfully and the spell is traveling
+    // Spells with travel time are also finished on next update tick
+    if (m_spellState != SPELL_STATE_CHANNELING)
+    {
+        m_spellState = SPELL_STATE_TRAVELING;
+        m_caster->addTravelingSpell(this);
+    }
 
-    // If spell is not channeled, the spell cast has finished successfully
-    if (m_spellState != SPELL_STATE_CASTING)
-        finish();
+    m_isCasting = false;
 }
 
-void Spell::handleEffectTarget(const uint64_t targetGuid, uint8_t effIndex)
+void Spell::handleHittedTarget(const uint64_t targetGuid, uint8_t effIndex)
 {
     const auto travelTime = _getSpellTravelTimeForTarget(targetGuid);
     if (travelTime < 0)
         return;
 
+    _updateTargetPointers(targetGuid);
+    const auto effDamage = calculateEffect(effIndex);
+
     // If effect applies an aura, create it instantly but add it later to target
     if (getSpellInfo()->doesEffectApplyAura(effIndex))
     {
-        AddRef();
-        HandleEffects(targetGuid, effIndex);
+        handleHittedEffect(targetGuid, effIndex, effDamage);
 
         // Add travel time to aura
         auto itr = m_pendingAuras.find(targetGuid);
         if (itr != m_pendingAuras.end())
-            itr->second.first = float2int32(travelTime);
+            itr->second.travelTime = float2int32(travelTime);
 
         return;
     }
 
     if (travelTime == 0.0f)
     {
-        AddRef();
-        HandleEffects(targetGuid, effIndex);
+        handleHittedEffect(targetGuid, effIndex, effDamage);
     }
     else
     {
-        sEventMgr.AddEvent(this, &Spell::HandleEffects, targetGuid, effIndex, EVENT_SPELL_HIT, float2int32(travelTime), 1, 0);
-        AddRef();
+        HitSpellEffect hitEffect;
+        hitEffect.damage = effDamage;
+        hitEffect.effIndex = effIndex;
+        hitEffect.travelTime = float2int32(travelTime);
+
+        m_hitEffects.insert(std::make_pair(targetGuid, hitEffect));
     }
+}
+
+void Spell::handleHittedEffect(const uint64_t targetGuid, uint8_t effIndex, int32_t effDamage, bool reCheckTarget/* = false*/)
+{
+    // If duel has ended before spell cast was finished, do not handle this target and effect
+    // but do not cancel entire spell
+    // i.e AoE spells can still hit other targets
+    if (DuelSpellNoMoreValid())
+        return;
+
+    if (reCheckTarget)
+        _updateTargetPointers(targetGuid);
+
+    const auto targetType = getSpellInfo()->getRequiredTargetMaskForEffect(effIndex);
+    // TODO: in the future, consider having two damage variables; one for integer and one for float
+    damage = effDamage;
+
+    // todo: this is not how it should be done
+    if (getUnitCaster() != nullptr && GetUnitTarget() != nullptr && GetUnitTarget()->isCreature()
+        && targetType & SPELL_TARGET_REQUIRE_ATTACKABLE && !(getSpellInfo()->getAttributesEx() & ATTRIBUTESEX_NO_INITIAL_AGGRO))
+    {
+        GetUnitTarget()->GetAIInterface()->AttackReaction(getUnitCaster(), 1, 0);
+        GetUnitTarget()->GetAIInterface()->HandleEvent(EVENT_HOSTILEACTION, getUnitCaster(), 0);
+    }
+
+    // Clear DamageInfo before effect
+    m_targetDamageInfo = DamageInfo();
+    m_targetDamageInfo.schoolMask = SchoolMask(getSpellInfo()->getSchoolMask());
+    isTargetDamageInfoSet = false;
+    isForcedCrit = false;
+
+    const auto effectId = getSpellInfo()->getEffect(effIndex);
+    if (effectId >= TOTAL_SPELL_EFFECTS)
+    {
+        LogError("Spell::handleHittedEffect : Unknown spell effect %u in spell id %u, index %u", effectId, getSpellInfo()->getId(), effIndex);
+        return;
+    }
+
+    LogDebugFlag(LF_SPELL, "Spell::handleHittedEffect : Spell effect %u, spell id %u, damage %d", effectId, getSpellInfo()->getId(), damage);
+
+    const auto scriptResult = sScriptMgr.callScriptedSpellBeforeSpellEffect(this, effIndex);
+
+    // Check if spell is forced to have critical effect on this target
+    for (const auto& critGuid : m_critTargets)
+    {
+        if (critGuid == targetGuid)
+        {
+            isForcedCrit = true;
+            break;
+        }
+    }
+
+    // Call effect handler
+    if (scriptResult != SpellScriptExecuteState::EXECUTE_PREVENT)
+        (*this.*SpellEffectsHandler[effectId])(effIndex);
+
+    sScriptMgr.callScriptedSpellAfterSpellEffect(this, effIndex);
+
+    // Create proc events
+    if (isTargetDamageInfoSet)
+    {
+        // Add the DamageInfo to target vector if it was set
+        for (auto& uniqueTarget : uniqueHittedTargets)
+        {
+            if (uniqueTarget.first == targetGuid)
+                uniqueTarget.second = m_targetDamageInfo;
+        }
+    }
+
+    if (uniqueHittedTargets.size() == 1)
+    {
+        // If spell has only this target, use full DamageInfo for caster's DamageInfo
+        if (isTargetDamageInfoSet)
+            m_casterDamageInfo = m_targetDamageInfo;
+    }
+    else
+    {
+        // If spell has multiple targets, just check if the spell critted for this target
+        if (m_targetDamageInfo.isCritical)
+            m_casterDamageInfo.isCritical = true;
+    }
+
+    // Legacy script hook
+    DoAfterHandleEffect(GetUnitTarget(), effIndex);
 }
 
 void Spell::handleMissedTarget(SpellTargetMod const missedTarget)
@@ -627,14 +722,16 @@ void Spell::handleMissedTarget(SpellTargetMod const missedTarget)
     // If there is no distance between caster and target, handle effect instantly
     if (travelTime == 0.0f)
     {
-        AddRef();
         if (didReflect)
         {
+            const auto guid = m_caster->getGuid();
+            _updateTargetPointers(guid);
+
             // Process each effect from the spell on the original caster
             for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
                 if (getSpellInfo()->getEffect(i) != 0)
-                    HandleEffects(m_caster->getGuid(), i);
+                    handleHittedEffect(guid, i, calculateEffect(i));
             }
         }
         else
@@ -647,6 +744,9 @@ void Spell::handleMissedTarget(SpellTargetMod const missedTarget)
     {
         if (didReflect)
         {
+            const auto guid = m_caster->getGuid();
+            _updateTargetPointers(guid);
+
             // Reflected projectiles move back 4x faster
             travelTime *= 1.25f;
 
@@ -654,15 +754,21 @@ void Spell::handleMissedTarget(SpellTargetMod const missedTarget)
             for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
                 if (getSpellInfo()->getEffect(i) != 0)
-                    sEventMgr.AddEvent(this, &Spell::HandleEffects, m_caster->getGuid(), i, EVENT_SPELL_HIT, float2int32(travelTime), 1, 0);
+                {
+                    HitSpellEffect hitEffect;
+                    hitEffect.damage = calculateEffect(i);
+                    hitEffect.effIndex = i;
+                    hitEffect.travelTime = float2int32(travelTime);
+
+                    m_hitEffects.insert(std::make_pair(guid, hitEffect));
+                }
             }
         }
         else
         {
             // Spell was not reflected and it did not hit target
-            sEventMgr.AddEvent(this, &Spell::handleMissedEffect, missedTarget.targetGuid, EVENT_SPELL_HIT, float2int32(travelTime), 1, 0);
+            m_missEffects.insert(std::make_pair(missedTarget.targetGuid, float2int32(travelTime)));
         }
-        AddRef();
     }
 }
 
@@ -682,45 +788,220 @@ void Spell::handleMissedEffect(const uint64_t targetGuid)
         // Call scripted after spell missed hook
         sScriptMgr.callScriptedSpellAfterMiss(this, targetUnit);
     }
-
-    DecRef();
 }
 
-void Spell::Update(unsigned long timePassed)
+void Spell::finish(bool successful)
 {
-    // Check for moving while casting or channeling
-    // but allow slight error
-    if (u_caster != nullptr &&
-       (std::fabs(u_caster->GetPositionX() - m_castPositionX) > 0.5f ||
-        std::fabs(u_caster->GetPositionY() - m_castPositionY) > 0.5f ||
-        std::fabs(u_caster->GetPositionZ() - m_castPositionZ) > 0.5f))
+    if (getState() == SPELL_STATE_FINISHED)
+        return;
+
+    m_spellState = SPELL_STATE_FINISHED;
+
+    // Caster could be nullptr at this point
+    if (getCaster() == nullptr)
     {
-        // TODO: remove this hackfix when movement is sorted out
-        if (m_spellState == SPELL_STATE_CASTING && !getSpellInfo()->hasEffectApplyAuraName(SPELL_AURA_MOD_POSSESS))
+        delete this;
+        return;
+    }
+
+    // Clear spell cooldown if player has cooldown cheat
+    if (!m_triggeredSpell && getPlayerCaster() != nullptr && getPlayerCaster()->m_cheats.hasCooldownCheat)
+        getPlayerCaster()->clearCooldownForSpell(getSpellInfo()->getId());
+
+    // No need to do anything else on failed spells
+    if (!successful)
+    {
+        getCaster()->removeTravelingSpell(this);
+        return;
+    }
+
+    // Lua spell hooks
+    if (getUnitCaster() != nullptr)
+    {
+        CALL_SCRIPT_EVENT(getUnitCaster(), OnCastSpell)(getSpellInfo()->getId());
+
+        if (!sEventMgr.HasEvent(getUnitCaster(), EVENT_CREATURE_RESPAWN))
         {
-            // Cancel channeled spells which don't have ATTRIBUTESEXE_CAN_MOVE_WHILE_CHANNELING flag
-            if (getSpellInfo()->getChannelInterruptFlags() & CHANNEL_INTERRUPT_ON_MOVEMENT && !(getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_CAN_MOVE_WHILE_CHANNELING))
+            for (const auto& uniqueTarget : uniqueHittedTargets)
             {
-                cancel();
-                return;
+                const auto target = getUnitCaster()->GetMapMgrCreature(uniqueTarget.first);
+                if (target == nullptr)
+                    continue;
+
+                if (target->GetScript())
+                    CALL_SCRIPT_EVENT(target, OnHitBySpell)(getSpellInfo()->getId(), getUnitCaster());
             }
         }
-        ///\ todo: determine which spells can be cast while moving
-        else if (getSpellInfo()->getInterruptFlags() & CAST_INTERRUPT_ON_MOVEMENT)
+
+        u_caster->m_canMove = true;
+    }
+
+    // Recheck used spell modifiers
+    takeUsedSpellModifiers();
+
+    // Set cooldown on item
+    if (getItemCaster() != nullptr && getItemCaster()->getOwner() != nullptr && cancastresult == SPELL_CAST_SUCCESS && !GetSpellFailed())
+    {
+        uint8_t i = 0;
+        for (; i < MAX_ITEM_PROTO_SPELLS; ++i)
         {
-            // Don't cancel on next melee, autorepeat or triggered spells
-            if (!u_caster->HasNoInterrupt() && !m_triggeredSpell && !getSpellInfo()->isOnNextMeleeAttack() && !getSpellInfo()->isRangedAutoRepeat())
+            if (getItemCaster()->getItemProperties()->Spells[i].Trigger == USE)
             {
-                cancel();
-                return;
+                if (getItemCaster()->getItemProperties()->Spells[i].Id != 0)
+                    break;
+            }
+        }
+
+        // Potion cooldown starts after leaving combat
+        if (getItemCaster()->getItemProperties()->Class == ITEM_CLASS_CONSUMABLE && getItemCaster()->getItemProperties()->SubClass == 1)
+        {
+            getItemCaster()->getOwner()->SetLastPotion(getItemCaster()->getItemProperties()->ItemId);
+            if (!getItemCaster()->getOwner()->CombatStatus.IsInCombat())
+                getItemCaster()->getOwner()->UpdatePotionCooldown();
+        }
+        else
+        {
+            if (i < MAX_ITEM_PROTO_SPELLS)
+                getItemCaster()->getOwner()->Cooldown_AddItem(getItemCaster()->getItemProperties(), i);
+        }
+    }
+
+    if (getPlayerCaster() != nullptr)
+    {
+        if (getSpellInfo()->getAttributes() & ATTRIBUTES_STOP_ATTACK && getPlayerCaster()->IsAttacking())
+        {
+            getPlayerCaster()->EventAttackStop();
+            getPlayerCaster()->smsg_AttackStop(getPlayerCaster()->GetMapMgrUnit(getPlayerCaster()->GetSelection()));
+            getPlayerCaster()->SendPacket(SmsgCancelCombat().serialise().get());
+        }
+
+        if (m_Delayed)
+        {
+            auto target = getPlayerCaster()->GetMapMgrUnit(getPlayerCaster()->getChannelObjectGuid());
+            if (target == nullptr)
+                target = getPlayerCaster()->GetMapMgrUnit(getPlayerCaster()->GetSelection());
+
+            if (target != nullptr)
+                target->RemoveAura(getSpellInfo()->getId(), getCaster()->getGuid());
+        }
+
+        if (getSpellInfo()->hasEffect(SPELL_EFFECT_SUMMON_OBJECT))
+            getPlayerCaster()->SetSummonedObject(nullptr);
+
+        // Update combo points before spell procs
+        if (m_requiresCP && !GetSpellFailed())
+        {
+            if (getPlayerCaster()->m_spellcomboPoints > 0)
+            {
+                p_caster->m_comboPoints = p_caster->m_spellcomboPoints;
+                getPlayerCaster()->UpdateComboPoints();
+            }
+            else
+            {
+                getPlayerCaster()->NullComboPoints();
             }
         }
     }
 
-    if (m_cancelled)
+    // Handle procs for each target
+    Unit* targetUnit = nullptr;
+    if (m_targetProcFlags != 0)
     {
-        cancel();
-        return;
+        // Handle each target's procs to caster
+        for (const auto& uniqueTarget : uniqueHittedTargets)
+        {
+            targetUnit = getCaster()->GetMapMgrUnit(uniqueTarget.first);
+            if (targetUnit == nullptr)
+                continue;
+
+            targetUnit->HandleProc(m_targetProcFlags, getUnitCaster(), getSpellInfo(), uniqueTarget.second, m_triggeredSpell, PROC_EVENT_DO_ALL, m_triggeredByAura);
+        }
+    }
+
+    // Handle caster procs
+    if (getUnitCaster() != nullptr && m_casterProcFlags != 0)
+    {
+        // Handle caster's procs to each target
+        for (const auto& uniqueTarget : uniqueHittedTargets)
+        {
+            targetUnit = getCaster()->GetMapMgrUnit(uniqueTarget.first);
+            if (targetUnit == nullptr)
+                continue;
+
+            getUnitCaster()->HandleProc(m_casterProcFlags, targetUnit, getSpellInfo(), uniqueTarget.second, m_triggeredSpell, PROC_EVENT_DO_TARGET_PROCS_ONLY, m_triggeredByAura);
+        }
+
+        // Use victim only if there was one target
+        if (uniqueHittedTargets.size() > 1)
+            targetUnit = nullptr;
+
+        // Handle caster's self procs
+        getUnitCaster()->HandleProc(m_casterProcFlags, targetUnit, getSpellInfo(), m_casterDamageInfo, m_triggeredSpell, PROC_EVENT_DO_CASTER_PROCS_ONLY, m_triggeredByAura);
+    }
+
+    // QuestMgr spell hooks
+    if (getPlayerCaster() != nullptr && getPlayerCaster()->IsInWorld())
+    {
+        // Do not call QuestMgr::OnPlayerCast for 'on next attack' spells
+        // It will be called on the actual spell cast
+        if (!(getSpellInfo()->isOnNextMeleeAttack() && !m_triggeredSpell))
+        {
+            uint32_t targetCount = 0;
+            for (auto& target : uniqueHittedTargets)
+            {
+                WoWGuid wowGuid;
+                wowGuid.Init(target.first);
+                if (wowGuid.isUnit())
+                {
+                    ++targetCount;
+                    sQuestMgr.OnPlayerCast(getPlayerCaster(), getSpellInfo()->getId(), target.first);
+                }
+            }
+
+            if (targetCount == 0)
+            {
+                auto guid = getPlayerCaster()->getTargetGuid();
+                sQuestMgr.OnPlayerCast(getPlayerCaster(), getSpellInfo()->getId(), guid);
+            }
+        }
+    }
+
+    // Spell is finished, remove it from traveling spells and delete it on next update tick
+    getCaster()->removeTravelingSpell(this);
+}
+
+void Spell::update(unsigned long timePassed)
+{
+    // Check for moving while casting or channeling
+    if (m_spellState == SPELL_STATE_PREPARING || m_spellState == SPELL_STATE_CHANNELING)
+    {
+        // but allow slight error
+        if (u_caster != nullptr &&
+            (std::fabs(u_caster->GetPositionX() - m_castPositionX) > 0.5f ||
+                std::fabs(u_caster->GetPositionY() - m_castPositionY) > 0.5f ||
+                std::fabs(u_caster->GetPositionZ() - m_castPositionZ) > 0.5f))
+        {
+            // TODO: remove this hackfix when movement is sorted out
+            if (m_spellState == SPELL_STATE_CHANNELING && !getSpellInfo()->hasEffectApplyAuraName(SPELL_AURA_MOD_POSSESS))
+            {
+                // Cancel channeled spells which don't have ATTRIBUTESEXE_CAN_MOVE_WHILE_CHANNELING flag
+                if (getSpellInfo()->getChannelInterruptFlags() & CHANNEL_INTERRUPT_ON_MOVEMENT && !(getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_CAN_MOVE_WHILE_CHANNELING))
+                {
+                    cancel();
+                    return;
+                }
+            }
+            ///\ todo: determine which spells can be cast while moving
+            else if (getSpellInfo()->getInterruptFlags() & CAST_INTERRUPT_ON_MOVEMENT)
+            {
+                // Don't cancel on next melee, autorepeat or triggered spells
+                if (!u_caster->HasNoInterrupt() && !m_triggeredSpell && !getSpellInfo()->isOnNextMeleeAttack() && !getSpellInfo()->isRangedAutoRepeat())
+                {
+                    cancel();
+                    return;
+                }
+            }
+        }
     }
 
     switch (m_spellState)
@@ -735,8 +1016,7 @@ void Spell::Update(unsigned long timePassed)
                 castMe(m_castTime > 0);
             }
         } break;
-        // Channeling
-        case SPELL_STATE_CASTING:
+        case SPELL_STATE_CHANNELING:
         {
             if (m_timer > 0)
             {
@@ -757,9 +1037,219 @@ void Spell::Update(unsigned long timePassed)
                 finish();
             }
         } break;
+        case SPELL_STATE_TRAVELING:
+        {
+            for (auto hitItr = m_hitEffects.begin(); hitItr != m_hitEffects.end();)
+            {
+                auto& hitEff = *hitItr;
+                if (hitEff.second.travelTime > timePassed)
+                {
+                    hitEff.second.travelTime -= timePassed;
+                    ++hitItr;
+                    continue;
+                }
+
+                handleHittedEffect(hitEff.first, hitEff.second.effIndex, hitEff.second.damage, true);
+                hitItr = m_hitEffects.erase(hitItr);
+            }
+
+            for (auto missItr = m_missEffects.begin(); missItr != m_missEffects.end();)
+            {
+                auto& missEff = *missItr;
+                if (missEff.second > timePassed)
+                {
+                    missEff.second -= timePassed;
+                    ++missItr;
+                    continue;
+                }
+
+                handleMissedEffect(missEff.first);
+                missItr = m_missEffects.erase(missItr);
+            }
+
+            for (auto auraItr = m_pendingAuras.begin(); auraItr != m_pendingAuras.end();)
+            {
+                auto& auraEff = *auraItr;
+                if (auraEff.second.travelTime > timePassed)
+                {
+                    auraEff.second.travelTime -= timePassed;
+                    ++auraItr;
+                    continue;
+                }
+
+                HandleAddAura(auraEff.first);
+                auraItr = m_pendingAuras.erase(auraItr);
+            }
+
+            // If all effects and targets have been processed, finish the spell
+            if (m_hitEffects.empty() && m_missEffects.empty() && m_pendingAuras.empty())
+                finish();
+        } break;
         default:
             break;
     }
+}
+
+void Spell::cancel()
+{
+    switch (getState())
+    {
+        case SPELL_STATE_PREPARING:
+        {
+            if (getPlayerCaster() != nullptr)
+                getPlayerCaster()->clearGlobalCooldown();
+
+            SendInterrupted(0);
+            sendCastResult(SPELL_FAILED_INTERRUPTED);
+        } break;
+        case SPELL_STATE_CHANNELING:
+        {
+            sendChannelUpdate(0);
+            SendInterrupted(0);
+            sendCastResult(SPELL_FAILED_INTERRUPTED);
+
+            if (getUnitCaster() != nullptr)
+            {
+                if (m_timer > 0 || m_Delayed)
+                {
+                    auto channelTarget = getUnitCaster()->GetMapMgrUnit(getUnitCaster()->getChannelObjectGuid());
+                    if (channelTarget == nullptr && getPlayerCaster() != nullptr)
+                        channelTarget = getPlayerCaster()->GetMapMgrUnit(getPlayerCaster()->GetSelection());
+
+                    if (channelTarget != nullptr)
+                        channelTarget->RemoveAura(getSpellInfo()->getId(), getCaster()->getGuid());
+
+                    // Remove dynamic objects (area aura effects from Blizzard, Rain of Fire etc)
+                    if (m_AreaAura)
+                    {
+                        const auto dynObj = getUnitCaster()->GetMapMgrDynamicObject(getUnitCaster()->getChannelObjectGuid());
+                        if (dynObj != nullptr)
+                            dynObj->Remove();
+                    }
+
+                    if (getPlayerCaster() != nullptr && getPlayerCaster()->GetSummonedObject() != nullptr)
+                    {
+                        auto obj = getPlayerCaster()->GetSummonedObject();
+                        if (obj->IsInWorld())
+                            obj->RemoveFromWorld(true);
+
+                        delete obj;
+                        getPlayerCaster()->SetSummonedObject(nullptr);
+                    }
+
+                    if (m_timer > 0)
+                        RemoveItems();
+                }
+
+                getUnitCaster()->RemoveAura(getSpellInfo()->getId(), getCaster()->getGuid());
+            }
+        } break;
+        default:
+        {
+            if (getState() == SPELL_STATE_NULL)
+            {
+                // just in case
+                if (getCaster() != nullptr)
+                    getCaster()->removeTravelingSpell(this);
+                else
+                    delete this;
+            }
+        } return;
+    }
+
+    // If this is true, the spell is somewhere in ::castMe() function
+    // In that case, ::finish() will be called when the spell has hitted targets
+    if (!m_isCasting)
+        finish(false);
+}
+
+int32_t Spell::calculateEffect(uint8_t effIndex)
+{
+    auto value = getSpellInfo()->calculateEffectValue(effIndex, getUnitCaster(), getItemCaster(), forced_basepoints[effIndex]);
+
+    // Legacy script hook
+    value = DoCalculateEffect(effIndex, GetUnitTarget(), value);
+
+    const auto scriptResult = sScriptMgr.callScriptedSpellDoCalculateEffect(this, effIndex, &value);
+
+    // If effect damage was recalculated in script, send static damage in effect handlers
+    // so for example spell power bonus won't get calculated twice
+    isEffectDamageStatic[effIndex] = scriptResult != SpellScriptEffectDamage::DAMAGE_DEFAULT;
+    if (scriptResult == SpellScriptEffectDamage::DAMAGE_FULL_RECALCULATION)
+        return value;
+
+    if (getPlayerCaster() != nullptr)
+    {
+        const auto itr = getPlayerCaster()->mSpellOverrideMap.find(getSpellInfo()->getId());
+        if (itr != getPlayerCaster()->mSpellOverrideMap.end())
+        {
+            for (auto scriptOverride = itr->second->begin(); scriptOverride != itr->second->end(); ++scriptOverride)
+            {
+                value += Util::getRandomUInt((*scriptOverride)->damage);
+            }
+        }
+    }
+
+    if (getUnitCaster() != nullptr)
+    {
+        // Calculate spell and attack power bonus (must be calculated on launch, not on spell hit!)
+        if (!isEffectDamageStatic[effIndex])
+        {
+            switch (getSpellInfo()->getEffect(effIndex))
+            {
+                case SPELL_EFFECT_SCHOOL_DAMAGE:
+                    value = static_cast<int32_t>(std::ceil(getUnitCaster()->applySpellDamageBonus(getSpellInfo(), value, 1.0f, false, this)));
+                    break;
+                case SPELL_EFFECT_HEAL:
+                case SPELL_EFFECT_HEAL_MECHANICAL:
+                    value = static_cast<int32_t>(std::ceil(getUnitCaster()->applySpellHealingBonus(getSpellInfo(), value, 1.0f, false, this)));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Save pct modifiers before applying so they can be readded properly later
+        int32_t spellFlatMods = 0, spellPctMods = 100;
+
+        getUnitCaster()->getTotalSpellModifiers(SPELLMOD_ALL_EFFECTS, value, &spellFlatMods, &spellPctMods, getSpellInfo(), this, nullptr, true);
+        getUnitCaster()->applySpellModifiers(SPELLMOD_ALL_EFFECTS, &value, getSpellInfo(), this);
+
+        getUnitCaster()->getTotalSpellModifiers(SPELLMOD_EFFECT_BONUS, value, &spellFlatMods, &spellPctMods, getSpellInfo(), this, nullptr, true);
+        getUnitCaster()->applySpellModifiers(SPELLMOD_EFFECT_BONUS, &value, getSpellInfo(), this);
+
+        switch (effIndex)
+        {
+            case 0:
+                getUnitCaster()->getTotalSpellModifiers(SPELLMOD_EFFECT_1, value, &spellFlatMods, &spellPctMods, getSpellInfo(), this, nullptr, true);
+                getUnitCaster()->applySpellModifiers(SPELLMOD_EFFECT_1, &value, getSpellInfo(), this);
+                break;
+            case 1:
+                getUnitCaster()->getTotalSpellModifiers(SPELLMOD_EFFECT_2, value, &spellFlatMods, &spellPctMods, getSpellInfo(), this, nullptr, true);
+                getUnitCaster()->applySpellModifiers(SPELLMOD_EFFECT_2, &value, getSpellInfo(), this);
+                break;
+            case 2:
+                getUnitCaster()->getTotalSpellModifiers(SPELLMOD_EFFECT_3, value, &spellFlatMods, &spellPctMods, getSpellInfo(), this, nullptr, true);
+                getUnitCaster()->applySpellModifiers(SPELLMOD_EFFECT_3, &value, getSpellInfo(), this);
+                break;
+            default:
+                break;
+        }
+
+        effectPctModifier[effIndex] = static_cast<float_t>(spellPctMods / 100.0f);
+    }
+    else if (getItemCaster() != nullptr && GetUnitTarget() != nullptr)
+    {
+        // Apply spell modifiers from the item owner
+        const auto itemCreator = GetUnitTarget()->GetMapMgrUnit(getItemCaster()->getCreatorGuid());
+        if (itemCreator != nullptr)
+        {
+            itemCreator->applySpellModifiers(SPELLMOD_ALL_EFFECTS, &value, getSpellInfo(), this);
+            itemCreator->applySpellModifiers(SPELLMOD_EFFECT_BONUS, &value, getSpellInfo(), this);
+        }
+    }
+
+    return value;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1187,7 +1677,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                 return SPELL_FAILED_BAD_TARGETS;
 
             // Line of Sight check
-            if (worldConfig.terrainCollision.isCollisionEnabled)
+            if (!m_triggeredSpell && worldConfig.terrainCollision.isCollisionEnabled)
             {
                 if (m_caster->IsInWorld() && !(getSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_IGNORE_LINE_OF_SIGHT) && !(getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_SKIP_LINE_OF_SIGHT_CHECK) &&
                     (m_caster->GetMapId() != target->GetMapId() || !m_caster->GetMapMgr()->isInLineOfSight(m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), target->GetPositionX(), target->GetPositionY(), target->GetPositionZ())))
@@ -1256,7 +1746,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                 else if (!pet->isAlive())
                     return m_triggeredByAura ? SPELL_FAILED_DONT_REPORT : SPELL_FAILED_TARGETS_DEAD;
                 // Check Line of Sight with pets as well
-                if (worldConfig.terrainCollision.isCollisionEnabled)
+                if (!m_triggeredSpell && worldConfig.terrainCollision.isCollisionEnabled)
                 {
                     if (m_caster->IsInWorld() && !(getSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_IGNORE_LINE_OF_SIGHT) && !(getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_SKIP_LINE_OF_SIGHT_CHECK) &&
                         (m_caster->GetMapId() != pet->GetMapId() || !m_caster->GetMapMgr()->isInLineOfSight(m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), pet->GetPositionX(), pet->GetPositionY(), pet->GetPositionZ())))
@@ -1270,7 +1760,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
     // Area checks
 
     // Check Line of Sight for spells with a destination
-    if (m_targets.hasDestination() && worldConfig.terrainCollision.isCollisionEnabled)
+    if (m_targets.hasDestination() && !m_triggeredSpell && worldConfig.terrainCollision.isCollisionEnabled)
     {
         if (m_caster->IsInWorld() && !(getSpellInfo()->getAttributesExB() & ATTRIBUTESEXB_IGNORE_LINE_OF_SIGHT) && !(getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_SKIP_LINE_OF_SIGHT_CHECK) &&
             !m_caster->GetMapMgr()->isInLineOfSight(m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), m_targets.getDestination().x, m_targets.getDestination().y, m_targets.getDestination().z))
@@ -1618,7 +2108,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                 if (m_targets.getGameObjectTarget() != 0)
                 {
                     const auto objectTarget = p_caster->GetMapMgrGameObject(m_targets.getGameObjectTarget());
-                    if (objectTarget != nullptr)
+                    if (objectTarget != nullptr && objectTarget->getGoType() != GAMEOBJECT_TYPE_QUESTGIVER)
                     {
                         // Get lock id
                         switch (objectTarget->getGoType())
@@ -1733,7 +2223,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                             // If item is used for opening, do not use player's skill level
                             uint32_t skillLevel = i_caster != nullptr || p_caster == nullptr ? 0 : p_caster->_GetSkillLineCurrent(skillId);
                             // Add skill bonuses from the spell
-                            skillLevel += getSpellInfo()->getEffectBasePoints(i);
+                            skillLevel += getSpellInfo()->calculateEffectValue(i);;
 
                             // Check for low skill level
                             if (skillLevel < lockInfo->minlockskill[x])
@@ -2106,7 +2596,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
 #endif
                 }
 
-                if (static_cast<int32_t>(target->getLevel()) > CalculateEffect(i, target))
+                if (static_cast<int32_t>(target->getLevel()) > calculateEffect(i))
                     return SPELL_FAILED_HIGHLEVEL;
             } break;
             case SPELL_AURA_MOD_CHARM:
@@ -2149,7 +2639,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
 #endif
                 }
 
-                if (static_cast<int32_t>(target->getLevel()) > CalculateEffect(i, target))
+                if (static_cast<int32_t>(target->getLevel()) > calculateEffect(i))
                     return SPELL_FAILED_HIGHLEVEL;
 
                 const auto targetCreature = dynamic_cast<Creature*>(target);
@@ -2320,7 +2810,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
     return m_triggeredSpell || ProcedOnSpell != nullptr ? SPELL_CAST_SUCCESS : SpellCastResult(CanCast(secondCheck));
 }
 
-SpellCastResult Spell::checkPower() const
+SpellCastResult Spell::checkPower()
 {
     if (m_powerCost == 0)
         return SPELL_CAST_SUCCESS;
@@ -3349,7 +3839,7 @@ SpellCastResult Spell::checkCasterState() const
     return SPELL_CAST_SUCCESS;
 }
 
-SpellCastResult Spell::checkRange(const bool secondCheck) const
+SpellCastResult Spell::checkRange(const bool secondCheck)
 {
     const auto rangeEntry = sSpellRangeStore.LookupEntry(getSpellInfo()->getRangeIndex());
     if (rangeEntry == nullptr)
@@ -3455,10 +3945,7 @@ SpellCastResult Spell::checkRange(const bool secondCheck) const
 
     // Apply spell modifiers to range
     if (u_caster != nullptr)
-    {
-        spellModFlatFloatValue(u_caster->SM_FRange, &maxRange, getSpellInfo()->getSpellFamilyFlags());
-        spellModPercentageFloatValue(u_caster->SM_PRange, &maxRange, getSpellInfo()->getSpellFamilyFlags());
-    }
+        u_caster->applySpellModifiers(SPELLMOD_RANGE, &maxRange, getSpellInfo(), this);
 
     maxRange += rangeMod;
 
@@ -3489,7 +3976,7 @@ SpellCastResult Spell::checkRange(const bool secondCheck) const
 }
 
 #if VERSION_STRING >= WotLK
-SpellCastResult Spell::checkRunes(bool takeRunes) const
+SpellCastResult Spell::checkRunes(bool takeRunes)
 {
     // Check only for players and for spells which have rune cost
     if (getSpellInfo()->getRuneCostID() > 0 && p_caster != nullptr)
@@ -3509,8 +3996,7 @@ SpellCastResult Spell::checkRunes(bool takeRunes) const
             // Apply modifers
             for (uint8_t i = 0; i < RUNE_DEATH; ++i)
             {
-                spellModFlatIntValue(p_caster->SM_FCost, &runeCost[i], getSpellInfo()->getSpellFamilyFlags());
-                spellModPercentageIntValue(p_caster->SM_FCost, &runeCost[i], getSpellInfo()->getSpellFamilyFlags());
+                p_caster->applySpellModifiers(SPELLMOD_COST, &runeCost[i], getSpellInfo(), this);
             }
 
             if (const auto dkPlayer = dynamic_cast<DeathKnight*>(p_caster))
@@ -4178,7 +4664,7 @@ void Spell::takePower()
     u_caster->modPower(powerType, -static_cast<int32_t>(getPowerCost()));
 }
 
-uint32_t Spell::calculatePowerCost() const
+uint32_t Spell::calculatePowerCost()
 {
     // Null for non-unit casters
     if (u_caster == nullptr)
@@ -4200,8 +4686,7 @@ uint32_t Spell::calculatePowerCost() const
     }
 
     // Apply modifiers
-    spellModFlatIntValue(u_caster->SM_FCost, &powerCost, getSpellInfo()->getSpellFamilyFlags());
-    spellModPercentageIntValue(u_caster->SM_PCost, &powerCost, getSpellInfo()->getSpellFamilyFlags());
+    u_caster->applySpellModifiers(SPELLMOD_COST, &powerCost, getSpellInfo(), this);
 
     // Include power cost multipliers from that school
     powerCost = static_cast<int32_t>(powerCost * (1.0f + u_caster->getPowerCostMultiplier(spellSchool)));
@@ -4258,6 +4743,65 @@ SpellInfo const* Spell::getSpellInfo() const
 Aura* Spell::getTriggeredByAura() const
 {
     return m_triggeredByAura;
+}
+
+void Spell::addUsedSpellModifier(AuraEffectModifier const* aurEff)
+{
+    for (const auto& usedMod : m_usedModifiers)
+    {
+        if (usedMod.first == aurEff)
+            return;
+    }
+
+    m_usedModifiers.insert(std::make_pair(aurEff, false));
+}
+
+void Spell::removeUsedSpellModifier(AuraEffectModifier const* aurEff)
+{
+    for (auto& usedMod : m_usedModifiers)
+    {
+        // Mark the spell modifier as removed to prevent memory corruption
+        if (usedMod.first == aurEff)
+        {
+            usedMod.second = true;
+            break;
+        }
+    }
+
+    // Also, remove the spell modifier from pending auras
+    for (auto& pendingAur : m_pendingAuras)
+    {
+        if (pendingAur.second.aur != nullptr)
+            pendingAur.second.aur->removeUsedSpellModifier(aurEff);
+    }
+}
+
+void Spell::takeUsedSpellModifiers()
+{
+    if (m_usedModifiers.empty())
+        return;
+
+    for (auto itr = m_usedModifiers.begin(); itr != m_usedModifiers.end();)
+    {
+        auto aurEff = (*itr).first;
+        // Check for faulty entry
+        if (aurEff->getAura() == nullptr || (*itr).second)
+        {
+            itr = m_usedModifiers.erase(itr);
+            continue;
+        }
+
+        aurEff->getAura()->removeCharge();
+        itr = m_usedModifiers.erase(itr);
+    }
+}
+
+void Spell::setForceCritOnTarget(Unit const* target)
+{
+    if (target == nullptr || target->GetMapMgr() == nullptr)
+        return;
+
+    m_critTargets.push_back(target->getGuid());
 }
 
 bool Spell::canAttackCreatureType(Creature* target) const
@@ -4330,6 +4874,11 @@ void Spell::removeAmmo()
 
 void Spell::_updateCasterPointers(Object* caster)
 {
+    p_caster = nullptr;
+    u_caster = nullptr;
+    i_caster = nullptr;
+    g_caster = nullptr;
+
     m_caster = caster;
     switch (caster->getObjectTypeId())
     {
@@ -4349,6 +4898,86 @@ void Spell::_updateCasterPointers(Object* caster)
         default:
             LogDebugFlag(LF_SPELL, "Spell::_updateCasterPointers : Incompatible object type (type %u) for spell caster", caster->getObjectTypeId());
             break;
+    }
+}
+
+void Spell::_updateTargetPointers(const uint64_t targetGuid)
+{
+    unitTarget = nullptr;
+    itemTarget = nullptr;
+    gameObjTarget = nullptr;
+    playerTarget = nullptr;
+    corpseTarget = nullptr;
+
+    if (targetGuid == 0)
+    {
+        if (getPlayerCaster() != nullptr)
+        {
+            if (m_targets.getTargetMask() & TARGET_FLAG_ITEM)
+                itemTarget = getPlayerCaster()->getItemInterface()->GetItemByGUID(m_targets.getItemTarget());
+
+            if (m_targets.isTradeItem())
+            {
+                const auto trader = getPlayerCaster()->getTradeTarget();
+                if (trader != nullptr)
+                    itemTarget = trader->getTradeData()->getTradeItem(TradeSlots(m_targets.getItemTarget()));
+            }
+        }
+    }
+    else if (targetGuid == getCaster()->getGuid())
+    {
+        unitTarget = getUnitCaster();
+        itemTarget = getItemCaster();
+        gameObjTarget = getGameObjectCaster();
+        playerTarget = getPlayerCaster();
+    }
+    else
+    {
+        if (!getCaster()->IsInWorld())
+            return;
+
+        if (m_targets.isTradeItem())
+        {
+            if (getPlayerCaster() != nullptr)
+            {
+                const auto trader = getPlayerCaster()->getTradeTarget();
+                if (trader != nullptr)
+                    itemTarget = trader->getTradeData()->getTradeItem(TradeSlots(targetGuid));
+            }
+        }
+        else
+        {
+            WoWGuid wowGuid;
+            wowGuid.Init(targetGuid);
+
+            switch (wowGuid.getHigh())
+            {
+                case HighGuid::Unit:
+                case HighGuid::Vehicle:
+                    unitTarget = getCaster()->GetMapMgr()->GetCreature(wowGuid.getGuidLowPart());
+                    break;
+                case HighGuid::Pet:
+                    unitTarget = getCaster()->GetMapMgr()->GetPet(wowGuid.getGuidLowPart());
+                    break;
+                case HighGuid::Player:
+                    unitTarget = getCaster()->GetMapMgr()->GetPlayer(wowGuid.getGuidLowPart());
+                    playerTarget = dynamic_cast<Player*>(unitTarget);
+                    break;
+                case HighGuid::Item:
+                    if (getPlayerCaster() != nullptr)
+                        itemTarget = getPlayerCaster()->getItemInterface()->GetItemByGUID(targetGuid);
+                    break;
+                case HighGuid::GameObject:
+                    gameObjTarget = getCaster()->GetMapMgr()->GetGameObject(wowGuid.getGuidLowPart());
+                    break;
+                case HighGuid::Corpse:
+                    corpseTarget = sObjectMgr.GetCorpse(wowGuid.getGuidLowPart());
+                    break;
+                default:
+                    LogError("Spell::_updateTargetPointers : Invalid object type for spell target (low guid %u) in spell %u", wowGuid.getGuidLowPart(), getSpellInfo()->getId());
+                    break;
+            }
+        }
     }
 }
 

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -28,6 +28,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Data/Flags.h"
 #include "Management/Battleground/Battleground.h"
 #include "Management/ItemInterface.h"
+#include "Map/Area/AreaManagementGlobals.hpp"
 #include "Map/Area/AreaStorage.hpp"
 #include "Map/MapMgr.h"
 #include "Map/MapScriptInterface.h"
@@ -580,7 +581,7 @@ void Spell::castMe(const bool doReCheck)
     }
 
     // If spell is not channeled, the spell cast has finished successfully and the spell is traveling
-    // Spells with travel time are also finished on next update tick
+    // Spells without travel time are also finished on next update tick
     if (m_spellState != SPELL_STATE_CHANNELING)
     {
         m_spellState = SPELL_STATE_TRAVELING;

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -12,6 +12,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Objects/ObjectMgr.h"
 #include "Storage/MySQLDataStore.hpp"
+#include "Units/Creatures/Pet.h"
 
 pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
 {

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -8,16 +8,10 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Definitions/SpellFamily.h"
 #include "Definitions/SpellIsFlags.h"
 #include "Definitions/SpellTypes.h"
-#include "SpellHelpers.h"
 #include "SpellMgr.h"
 
 #include "Objects/ObjectMgr.h"
 #include "Storage/MySQLDataStore.hpp"
-
-using AscEmu::World::Spell::Helpers::spellModFlatFloatValue;
-using AscEmu::World::Spell::Helpers::spellModFlatIntValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageFloatValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageIntValue;
 
 pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
 {
@@ -128,8 +122,8 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::SpellAuraWaterWalk,                                              // 104 SPELL_AURA_WATER_WALK
     &Aura::SpellAuraFeatherFall,                                            // 105 SPELL_AURA_FEATHER_FALL
     &Aura::SpellAuraHover,                                                  // 106 SPELL_AURA_HOVER
-    &Aura::SpellAuraAddFlatModifier,                                        // 107 SPELL_AURA_ADD_FLAT_MODIFIER
-    &Aura::SpellAuraAddPctMod,                                              // 108 SPELL_AURA_ADD_PCT_MOD
+    &Aura::spellAuraEffectAddModifier,                                      // 107 SPELL_AURA_ADD_FLAT_MODIFIER
+    &Aura::spellAuraEffectAddModifier,                                      // 108 SPELL_AURA_ADD_PCT_MOD
     &Aura::SpellAuraAddClassTargetTrigger,                                  // 109 SPELL_AURA_ADD_CLASS_TARGET_TRIGGER
     &Aura::SpellAuraModPowerRegPerc,                                        // 110 SPELL_AURA_MOD_POWER_REG_PERC
     &Aura::spellAuraEffectNotImplemented,                                   // 111 SPELL_AURA_111
@@ -947,7 +941,7 @@ void Aura::spellAuraEffectPeriodicDamage(AuraEffectModifier* aurEff, bool apply)
                     for (uint8 i = 0; i < 3; ++i)
                     {
                         const auto curVal = aurEff->getEffectDamage();
-                        aurEff->setEffectDamage(curVal + (spell->CalculateEffect(i, m_target) * parentsp->getEffectBasePoints(0) / 100));
+                        aurEff->setEffectDamage(curVal + (spell->calculateEffect(i) * parentsp->getEffectBasePoints(0) / 100));
                     }
                     delete spell;
                     spell = nullptr;
@@ -994,14 +988,7 @@ void Aura::spellAuraEffectPeriodicDamage(AuraEffectModifier* aurEff, bool apply)
 
         // Get bonus damage from spell power and attack power
         if (casterUnit != nullptr && !aurEff->isEffectDamageStatic())
-            damage = casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this);
-
-        // Apply damage over time modifiers
-        if (casterUnit != nullptr)
-        {
-            spellModFlatFloatValue(casterUnit->SM_FDOT, &damage, getSpellInfo()->getSpellFamilyFlags());
-            spellModPercentageFloatValue(casterUnit->SM_PDOT, &damage, getSpellInfo()->getSpellFamilyFlags());
-        }
+            damage = casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this);
 
         if (damage <= 0.0f)
             return;
@@ -1059,15 +1046,7 @@ void Aura::spellAuraEffectPeriodicHeal(AuraEffectModifier* aurEff, bool apply)
         {
             // Get bonus healing from spell power and attack power
             if (!aurEff->isEffectDamageStatic())
-                heal = casterUnit->applySpellHealingBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this);
-
-            // Apply modifiers
-            spellModFlatFloatValue(casterUnit->SM_FDOT, &heal, getSpellInfo()->getSpellFamilyFlags());
-            spellModPercentageFloatValue(casterUnit->SM_PDOT, &heal, getSpellInfo()->getSpellFamilyFlags());
-
-            //\ todo: these are already applied in Spell::CalculateEffect
-            spellModFlatFloatValue(casterUnit->SM_FMiscEffect, &heal, getSpellInfo()->getSpellFamilyFlags());
-            spellModPercentageFloatValue(casterUnit->SM_PMiscEffect, &heal, getSpellInfo()->getSpellFamilyFlags());
+                heal = casterUnit->applySpellHealingBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this);
         }
 
         if (heal <= 0)
@@ -1108,7 +1087,7 @@ void Aura::spellAuraEffectPeriodicHealPct(AuraEffectModifier* aurEff, bool apply
         // Get bonus healing from spell power and attack power
         const auto casterUnit = GetUnitCaster();
         if (casterUnit != nullptr && !aurEff->isEffectDamageStatic())
-            aurEff->setEffectDamage(casterUnit->applySpellHealingBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this));
+            aurEff->setEffectDamage(casterUnit->applySpellHealingBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this));
 
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->getEffectIndex()] == 0)
@@ -1237,8 +1216,9 @@ void Aura::spellAuraEffectModShapeshift(AuraEffectModifier* aurEff, bool apply)
     const auto oldForm = getOwner()->getShapeShiftForm();
     const uint8_t newForm = apply ? static_cast<uint8_t>(aurEff->getEffectMiscValue()) : FORM_NORMAL;
 
-    // Remove previous shapeshift aura
-    getOwner()->removeAllAurasByAuraEffect(SPELL_AURA_MOD_SHAPESHIFT, getSpellId());
+    // Remove previous shapeshift aura on apply
+    if (apply)
+        getOwner()->removeAllAurasByAuraEffect(SPELL_AURA_MOD_SHAPESHIFT, getSpellId());
 
     // Some forms have two additional hidden passive aura
     uint32_t passiveSpellId = 0, secondaryPassiveSpell = 0;
@@ -1570,14 +1550,10 @@ void Aura::spellAuraEffectPeriodicLeech(AuraEffectModifier* aurEff, bool apply)
 
         // Get bonus damage from spell power and attack power
         if (casterUnit != nullptr && !aurEff->isEffectDamageStatic())
-            damage = casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this);
+            damage = casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this);
 
-        // Apply modifiers
         if (casterUnit != nullptr)
         {
-            spellModFlatFloatValue(casterUnit->SM_FDOT, &damage, getSpellInfo()->getSpellFamilyFlags());
-            spellModPercentageFloatValue(casterUnit->SM_PDOT, &damage, getSpellInfo()->getSpellFamilyFlags());
-
             // Hackfix from legacy method
             // Apply bonus from [Warlock] Soul Siphon
             if (casterUnit->m_soulSiphon.amt)
@@ -1715,7 +1691,7 @@ void Aura::spellAuraEffectPeriodicHealthFunnel(AuraEffectModifier* aurEff, bool 
         // Get bonus damage from spell power and attack power
         const auto casterUnit = GetUnitCaster();
         if (casterUnit != nullptr && !aurEff->isEffectDamageStatic())
-            aurEff->setEffectDamage(casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this));
+            aurEff->setEffectDamage(casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this));
 
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->getEffectIndex()] == 0)
@@ -1775,7 +1751,7 @@ void Aura::spellAuraEffectPeriodicDamagePercent(AuraEffectModifier* aurEff, bool
         // Get bonus damage from spell power and attack power
         const auto casterUnit = GetUnitCaster();
         if (casterUnit != nullptr && !aurEff->isEffectDamageStatic())
-            aurEff->setEffectDamage(casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, this));
+            aurEff->setEffectDamage(casterUnit->applySpellDamageBonus(getSpellInfo(), aurEff->getEffectDamage(), aurEff->getEffectPercentModifier(), true, nullptr, this));
 
         // Set periodic timer only if timer was resetted
         if (m_periodicTimer[aurEff->getEffectIndex()] == 0)
@@ -1787,6 +1763,119 @@ void Aura::spellAuraEffectPeriodicDamagePercent(AuraEffectModifier* aurEff, bool
         // Prior to cata periodic timer was resetted on refresh
         m_periodicTimer[aurEff->getEffectIndex()] = 0;
 #endif
+    }
+}
+
+void Aura::spellAuraEffectAddModifier(AuraEffectModifier* aurEff, bool apply)
+{
+    if (aurEff->getEffectMiscValue() >= MAX_SPELLMOD_TYPE)
+    {
+        LogError("Aura::spellAuraEffectAddModifier : Unknown spell modifier type %u in spell %u, skipping", aurEff->getEffectMiscValue(), getSpellId());
+        return;
+    }
+
+    getOwner()->addSpellModifier(aurEff, apply);
+
+    // Attempt to prevent possible memory corruption
+    // Multiple spells could use this same spell modifier, and when the first spell removes this modifier
+    // the second spell has a modifier at invalid memory address
+    // Anyhow, the chance for this to happen is rather low
+    if (!apply)
+    {
+        getOwner()->removeSpellModifierFromCurrentSpells(aurEff);
+        if (getCasterGuid() != getOwner()->getGuid())
+        {
+            const auto casterObj = getCaster();
+            if (casterObj != nullptr)
+                casterObj->removeSpellModifierFromCurrentSpells(aurEff);
+        }
+    }
+
+    if (!getOwner()->isPlayer())
+        return;
+
+    // todo: hackfix (?) from the old effect, handle this in pet system
+    // Hunter's beastmastery talents
+    if (aurEff->getAuraEffectType() == SPELL_AURA_ADD_FLAT_MODIFIER)
+    {
+        const auto pet = getPlayerOwner()->GetSummon();
+        if (pet != nullptr)
+        {
+            switch (getSpellInfo()->getId())
+            {
+                // SPELL_HASH_UNLEASHED_FURY:
+                case 19616:
+                case 19617:
+                case 19618:
+                case 19619:
+                case 19620:
+                    pet->LoadPetAuras(0);
+                    break;
+                // SPELL_HASH_THICK_HIDE:
+                case 16929:
+                case 16930:
+                case 16931:
+                case 19609:
+                case 19610:
+                case 19612:
+                case 50502:
+                    pet->LoadPetAuras(1);
+                    break;
+                // SPELL_HASH_ENDURANCE_TRAINING:
+                case 19583:
+                case 19584:
+                case 19585:
+                case 19586:
+                case 19587:
+                    pet->LoadPetAuras(2);
+                    break;
+                // SPELL_HASH_FERAL_SWIFTNESS:
+                case 17002:
+                case 24866:
+                    pet->LoadPetAuras(3);
+                    break;
+                // SPELL_HASH_BESTIAL_DISCIPLINE:
+                case 19590:
+                case 19592:
+                    pet->LoadPetAuras(4);
+                    break;
+                // SPELL_HASH_FEROCITY:
+                case 4154:
+                case 16934:
+                case 16935:
+                case 16936:
+                case 16937:
+                case 16938:
+                case 19598:
+                case 19599:
+                case 19600:
+                case 19601:
+                case 19602:
+                case 33667:
+                    pet->LoadPetAuras(5);
+                    break;
+                // SPELL_HASH_ANIMAL_HANDLER:
+                case 34453:
+                case 34454:
+                case 68361:
+                    pet->LoadPetAuras(6);
+                    break;
+                // SPELL_HASH_CATLIKE_REFLEXES:
+                case 34462:
+                case 34464:
+                case 34465:
+                    pet->LoadPetAuras(7);
+                    break;
+                // SPELL_HASH_SERPENT_S_SWIFTNESS:
+                case 34466:
+                case 34467:
+                case 34468:
+                case 34469:
+                case 34470:
+                    pet->LoadPetAuras(8);
+                    break;
+            }
+        }
     }
 }
 

--- a/src/world/Spell/SpellAuras.cpp
+++ b/src/world/Spell/SpellAuras.cpp
@@ -168,23 +168,6 @@ void Aura::removeAura(AuraRemoveMode mode/* = AURA_REMOVE_BY_SERVER*/)
 
     m_isGarbage = true;
 
-    for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
-        if (getSpellInfo()->getEffect(i) == 0)
-            continue;
-
-        ///\ todo: verify this
-        if (getSpellInfo()->getEffect(i) == SPELL_EFFECT_TRIGGER_SPELL)
-        {
-            const auto triggerSpell = sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(i));
-            if (triggerSpell != nullptr)
-            {
-                if (triggerSpell->getDurationIndex() < getSpellInfo()->getDurationIndex())
-                    getOwner()->RemoveAura(getSpellInfo()->getEffectTriggerSpell(i));
-            }
-        }
-    }
-
     // Reset diminishing return timer
     getOwner()->removeDiminishingReturnTimer(getSpellInfo());
 
@@ -641,15 +624,14 @@ void Aura::takeUsedSpellModifiers()
     {
         auto aurEff = (*itr).first;
         // Check for faulty entry
-        /*if (aurEff->getAura() == nullptr || (*itr).second)
+        if (aurEff->getAura() == nullptr || (*itr).second)
         {
             itr = m_usedModifiers.erase(itr);
             continue;
-        }*/
+        }
 
         aurEff->getAura()->removeCharge();
-        //itr = m_usedModifiers.erase(itr);
-        ++itr;
+        itr = m_usedModifiers.erase(itr);
     }
 }
 

--- a/src/world/Spell/SpellDefines.hpp
+++ b/src/world/Spell/SpellDefines.hpp
@@ -31,15 +31,6 @@ struct DamageProc
     void* owner;                //mark the owner of this proc to know which one to delete
 };
 
-struct SpellCharge
-{
-    uint32_t spellId;
-    uint32_t count;
-    uint32_t ProcFlag;
-    uint32_t lastproc;
-    uint32_t procdiff;
-};
-
 enum SpellAttributes
 {
     ATTRIBUTES_NULL                                 = 0x00000000,

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -36,6 +36,7 @@
 #include "Storage/MySQLDataStore.hpp"
 #include "Units/Players/PlayerClasses.hpp"
 #include "Server/MainServerDefines.h"
+#include "Map/Area/AreaStorage.hpp"
 #include "Map/MapMgr.h"
 #include "Objects/Faction.h"
 #include "SpellMgr.h"

--- a/src/world/Spell/SpellHelpers.h
+++ b/src/world/Spell/SpellHelpers.h
@@ -7,54 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include <cstdint>
 #include "Units/Unit.h"
 
-// TODO: Move this stuff into a class so it's not global scope
-#define SPELL_GROUP_FOREACH(X) \
-    uint32_t intbit = 0; \
-    uint32_t groupnum = 0; \
-    for (uint32_t bit = 0; bit < SPELL_GROUPS; ++bit, ++intbit) { \
-        if (intbit == 32) { \
-            ++groupnum; \
-            intbit = 0; \
-        } \
-        if ((1 << intbit) & group[groupnum]) \
-            X; \
-    }
-
 namespace AscEmu::World::Spell::Helpers
 {
     inline uint32_t decimalToMask(uint32_t dec) { return (static_cast<uint32_t>(1) << (dec - 1)); }
-
-    inline void spellModFlatFloatValue(int* m, float* v, const uint32_t* group)
-    {
-        if (m == nullptr)
-            return;
-
-        SPELL_GROUP_FOREACH(*v += m[bit]);
-    }
-
-    inline void spellModFlatIntValue(int* m, int* v, const uint32_t* group)
-    {
-        if (m == nullptr)
-            return;
-
-        SPELL_GROUP_FOREACH(*v += m[bit]);
-    }
-
-    inline void spellModPercentageFloatValue(int* m, float* v, const uint32_t* group)
-    {
-        if (m == nullptr)
-            return;
-
-        SPELL_GROUP_FOREACH(*v += ((*v) * m[bit]) / 100.0f);
-    }
-
-    inline void spellModPercentageIntValue(int* m, int* v, const uint32_t* group)
-    {
-        if (m == nullptr)
-            return;
-
-        SPELL_GROUP_FOREACH(*v += ((*v) * m[bit]) / 100);
-    }
 }
-
-#undef SPELL_GROUP_FOREACH

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -12,6 +12,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Management/Skill.h"
 #include "Units/Creatures/AIInterface.h"
+#include "Units/Players/Player.h"
 
 SpellInfo::SpellInfo()
 {

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -806,6 +806,103 @@ bool SpellInfo::isOnNextMeleeAttack() const
     return (Attributes & (ATTRIBUTES_ON_NEXT_ATTACK | ATTRIBUTES_ON_NEXT_SWING_2)) != 0;
 }
 
+int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = nullptr*/, Item* itemCaster/* = nullptr*/, uint32_t forcedBasePoints/* = 0*/) const
+{
+    if (effIndex >= MAX_SPELL_EFFECTS)
+        return 0;
+
+    const float_t basePointsPerLevel = getEffectRealPointsPerLevel(effIndex);
+    const auto randomPoints = getEffectDieSides(effIndex);
+    int32_t basePoints = 0;
+
+    // Random suffix value calculation
+    if (itemCaster != nullptr && static_cast<int32_t>(itemCaster->getRandomPropertiesId()) < 0)
+    {
+        const auto randomSuffix = sItemRandomSuffixStore.LookupEntry(std::abs(static_cast<int32_t>(itemCaster->getRandomPropertiesId())));
+        if (randomSuffix != nullptr)
+        {
+            auto faulty = false;
+            for (uint8_t i = 0; i < 3; ++i)
+            {
+                if (randomSuffix->enchantments[i] == 0)
+                    continue;
+
+                const auto spellItemEnchant = sSpellItemEnchantmentStore.LookupEntry(randomSuffix->enchantments[i]);
+                if (spellItemEnchant == nullptr)
+                    continue;
+
+                for (uint8_t j = 0; j < 3; ++j)
+                {
+                    if (spellItemEnchant->spell[j] != getId())
+                        continue;
+
+                    if (randomSuffix->prefixes[j] == 0)
+                    {
+                        faulty = true;
+                        break;
+                    }
+
+                    basePoints = RANDOM_SUFFIX_MAGIC_CALCULATION(randomSuffix->prefixes[i], itemCaster->getPropertySeed());
+                    if (basePoints == 0)
+                    {
+                        faulty = true;
+                        break;
+                    }
+
+                    // Value OK
+                    return basePoints;
+                }
+
+                if (faulty)
+                    break;
+            }
+        }
+    }
+
+    if (forcedBasePoints > 0)
+    {
+        basePoints = forcedBasePoints;
+    }
+    else
+    {
+#if VERSION_STRING >= Cata
+        basePoints = getEffectBasePoints(effIndex);
+#else
+        basePoints = getEffectBasePoints(effIndex) + 1;
+#endif
+    }
+
+    // Check if value increases with level
+    if (unitCaster != nullptr)
+    {
+        auto diff = -static_cast<int32_t>(getBaseLevel());
+        if (getMaxLevel() != 0 && unitCaster->getLevel() > getMaxLevel())
+            diff += getMaxLevel();
+        else
+            diff += unitCaster->getLevel();
+
+        basePoints += float2int32(diff * basePointsPerLevel);
+    }
+
+    if (randomPoints > 1)
+        basePoints += Util::getRandomUInt(randomPoints);
+
+    // Check if value increases with combo points
+    const auto comboDamage = getEffectPointsPerComboPoint(effIndex);
+    if (comboDamage > 0.0f && unitCaster != nullptr && unitCaster->isPlayer())
+    {
+        const auto plrCaster = static_cast<Player*>(unitCaster);
+        basePoints += static_cast<int32_t>(std::round(comboDamage * plrCaster->m_comboPoints));
+        // TODO: rewrite combo points, here's an old comment from legacy method:
+        //this is ugly so i will explain the case maybe someone ha a better idea :
+        // while casting a spell talent will trigger upon the spell prepare faze
+        // the effect of the talent is to add 1 combo point but when triggering spell finishes it will clear the extra combo point
+        plrCaster->m_spellcomboPoints = 0;
+    }
+
+    return basePoints;
+}
+
 bool SpellInfo::doesEffectApplyAura(uint8_t effIndex) const
 {
     if (effIndex >= MAX_SPELL_EFFECTS)

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -15,6 +15,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include <string>
 #include "Log.hpp"
 
+class Item;
 class Player;
 class Unit;
 
@@ -73,6 +74,8 @@ public:
     bool isChanneled() const;
     bool isRangedAutoRepeat() const;
     bool isOnNextMeleeAttack() const;
+
+    int32_t calculateEffectValue(uint8_t effIndex, Unit* unitCaster = nullptr, Item* itemCaster = nullptr, uint32_t forcedBasePoints = 0) const;
 
     bool doesEffectApplyAura(uint8_t effIndex) const;
 
@@ -463,8 +466,6 @@ public:
     float getCustom_base_range_or_radius_sqr() const { return custom_base_range_or_radius_sqr; }
     float getCone_width() const { return cone_width; }
     int getAi_target_type() const { return ai_target_type; }
-    bool getCustom_self_cast_only() const { return custom_self_cast_only; }
-    bool getCustom_apply_on_shapeshift_change() const { return custom_apply_on_shapeshift_change; }
 
     uint32_t getEffectCustomFlag(uint8_t idx) const
     {
@@ -1097,9 +1098,6 @@ public:
     // set in Hackfixes.cpp - 5 spells
     // from MySQL table spell_custom_assign - 6 spells
     bool custom_self_cast_only = false;
-
-    // SpellCustomizations::SetOnShapeshiftChange - 2 spells
-    bool custom_apply_on_shapeshift_change = false;
 
     // from MySQL table spell_effects_override - 374 spells
     uint32_t EffectCustomFlag[MAX_SPELL_EFFECTS];

--- a/src/world/Spell/SpellMgr.h
+++ b/src/world/Spell/SpellMgr.h
@@ -41,7 +41,6 @@ typedef std::pair<SpellAreaForAuraMap::const_iterator, SpellAreaForAuraMap::cons
 typedef std::pair<SpellAreaForAreaMap::const_iterator, SpellAreaForAreaMap::const_iterator> SpellAreaForAreaMapBounds;
 
 // This class loads spells from Spell.dbc and stores them as SpellInfo objects
-// Also, this class registers spell scripts to spells and aura scripts to auras
 class SERVER_DECL SpellMgr
 {
 private:
@@ -59,14 +58,16 @@ public:
     // todo: Appled should implement a finalize method here
     void startSpellMgr();
     void loadSpellDataFromDatabase();
+    void calculateSpellCoefficients();
+    // Legacy scripts
     void loadSpellScripts();
 
     Spell* newSpell(Object* caster, SpellInfo const* info, bool triggered, Aura* aur);
     Aura* newAura(SpellInfo const* proto, int32_t duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = nullptr);
 
-    // Registering spell scripts
+    // Registering legacy spell scripts (DO NOT USE, use ScriptMgr and SpellScript instead!)
     void addSpellById(uint32_t spellId, SpellScriptLinker spellScript);
-    // Registering aura scripts
+    // Registering legacy aura scripts (DO NOT USE, use ScriptMgr and SpellScript instead!)
     void addAuraById(uint32_t spellId, AuraScriptLinker auraScript);
     
     // Spell area maps
@@ -78,7 +79,6 @@ public:
     bool checkLocation(SpellInfo const* spellInfo, uint32_t zone_id, uint32_t area_id, Player* player) const;
 
     // Custom methods (defined in SpellCustomizations.cpp)
-    bool isAlwaysApply(SpellInfo const* spellInfo) const;
     uint32_t getDiminishingGroup(uint32_t id) const;
 
     SpellInfo const* getSpellInfo(const uint32_t spellId) const;
@@ -102,7 +102,6 @@ private:
     // Custom setters (defined in SpellCustomizations.cpp)
     void setSpellEffectAmplitude(SpellInfo* sp);
     void setSpellMissingCIsFlags(SpellInfo* sp);
-    void setSpellOnShapeshiftChange(SpellInfo* sp);
     // Hacky methods (defined in Hackfixes.cpp)
     void createDummySpell(uint32_t id);
     void modifyEffectBasePoints(SpellInfo* sp);
@@ -124,7 +123,7 @@ private:
 
     SpellInfo* getMutableSpellInfo(const uint32_t spellId);
 
-    // Script registerers
+    // Legacy script registerers
     void addSpellBySpellInfo(SpellInfo* info, SpellScriptLinker spellScript);
     void addAuraBySpellInfo(SpellInfo* info, AuraScriptLinker auraScript);
     void setupSpellScripts();

--- a/src/world/Spell/SpellProc.h
+++ b/src/world/Spell/SpellProc.h
@@ -73,7 +73,6 @@ class SERVER_DECL SpellProc
         float_t getProcsPerMinute() const;
         SpellProcFlags getProcFlags() const;
         SpellExtraProcFlags getExtraProcFlags() const;
-        uint32_t getProcCharges() const;
 
         uint32_t getProcClassMask(uint8_t i) const;
         void setProcClassMask(uint8_t i, uint32_t mask);
@@ -83,8 +82,6 @@ class SERVER_DECL SpellProc
 
         void setProcChance(uint32_t procChance);
         void setProcsPerMinute(float_t ppm);
-
-        void setProcCharges(uint32_t charges);
 
         uint32_t getProcInterval() const;
         void setProcInterval(uint32_t time);
@@ -101,6 +98,13 @@ class SERVER_DECL SpellProc
         int32_t getOverrideEffectDamage(uint8_t effIndex) const;
         int32_t* getOverrideEffectDamages();
         void setOverrideEffectDamage(uint8_t effIndex, int32_t damage);
+
+        Aura* getCreatedByAura() const;
+        void setCreatedByAura(Aura* aur);
+
+        // Indicates that this proc will be skipped on next ::handleProc call
+        void skipOnNextHandleProc(bool);
+        bool isSkippingHandleProc() const;
 
         // Indicates that this object is deleted and should be removed on next iteration
         void deleteProc();
@@ -123,7 +127,6 @@ class SERVER_DECL SpellProc
         float_t mProcsPerMinute = 0.0f;
         SpellProcFlags mProcFlags = PROC_NULL;
         SpellExtraProcFlags mExtraProcFlags = EXTRA_PROC_NULL;
-        uint32_t mProcCharges = 0;
         // In milliseconds
         uint32_t mProcInterval = 0;
 
@@ -148,8 +151,14 @@ class SERVER_DECL SpellProc
 
         int32_t mOverrideEffectDamage[MAX_SPELL_EFFECTS];
 
+        // Indicates that this proc will be skipped on next ::handleProc call
+        // used to avoid some spell procs from procing themselves
+        bool mSkipNextProcUpdate = false;
+
         // Indicate that this object is deleted, and should be remove on next iteration
         bool mDeleted = false;
+
+        Aura* m_createdByAura = nullptr;
 };
 
 class SpellProcMgr
@@ -172,8 +181,8 @@ class SpellProcMgr
         // Registers multiple spell ids to same spell proc script
         void addByIds(uint32_t* spellIds, spell_proc_factory_function spellProc);
 
-        SpellProc* newSpellProc(Unit* owner, uint32_t spellId, uint32_t origSpellId, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t procCharges, uint32_t const* spellFamilyMask, uint32_t const* procClassMask, Object* obj);
-        SpellProc* newSpellProc(Unit* owner, SpellInfo const* spellInfo, SpellInfo const* origSpellInfo, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t procCharges, uint32_t const* spellFamilyMask, uint32_t const* procClassMask, Object* obj);
+        SpellProc* newSpellProc(Unit* owner, uint32_t spellId, uint32_t origSpellId, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t const* spellFamilyMask, uint32_t const* procClassMask, Aura* createdByAura, Object* obj);
+        SpellProc* newSpellProc(Unit* owner, SpellInfo const* spellInfo, SpellInfo const* origSpellInfo, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t const* spellFamilyMask, uint32_t const* procClassMask, Aura* createdByAura, Object* obj);
 
     private:
         SpellProcMap mSpellProc;

--- a/src/world/Spell/SpellProc.h
+++ b/src/world/Spell/SpellProc.h
@@ -9,6 +9,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "SpellDefines.hpp"
 #include "SpellInfo.hpp"
 
+class Aura;
 class Object;
 class SpellInfo;
 class SpellProc;

--- a/src/world/Spell/SpellProc_ClassScripts.cpp
+++ b/src/world/Spell/SpellProc_ClassScripts.cpp
@@ -29,10 +29,6 @@
 #include "Definitions/ProcFlags.h"
 #include "Definitions/SpellIsFlags.h"
 #include "Definitions/SpellEffectTarget.h"
-#include "SpellHelpers.h"
-
-using AscEmu::World::Spell::Helpers::spellModFlatIntValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageIntValue;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Warrior ProcScripts
@@ -54,7 +50,7 @@ public:
     {
         Player* plr = static_cast<Player*>(getProcOwner());
 
-        dmgOverwrite[0] = plr->GetBlockDamageReduction() * (getOriginalSpell()->getEffectBasePoints(0) + 1) / 100;
+        dmgOverwrite[0] = plr->GetBlockDamageReduction() * (getOriginalSpell()->calculateEffectValue(0)) / 100;
 
         // plr->GetBlockDamageReduction() returns ZERO if player has no shield equipped
         if (dmgOverwrite[0] == 0)
@@ -238,7 +234,7 @@ public:
                     case 58792:
                     {
                         wp_speed = item->getItemProperties()->Delay;
-                        damage = (sp->getEffectBasePoints(0) + 1) * wp_speed / 100000;
+                        damage = (sp->calculateEffectValue(0)) * wp_speed / 100000;
                     } break;
                 }
             }
@@ -412,13 +408,13 @@ public:
     bool doEffect(Unit* /*victim*/, SpellInfo const* castingSpell, uint32 /*flag*/, uint32 dmg, uint32 /*abs*/, int* dmgOverwrite, uint32 /*weaponDamageType*/) override
     {
         // Get dmg amt for 1 tick
-        dmg = castingSpell->getEffectBasePoints(0) + 1;
+        dmg = castingSpell->calculateEffectValue(0);
 
         // Get total ticks
         auto amplitude = castingSpell->getEffectAmplitude(0) == 0 ? 1 : castingSpell->getEffectAmplitude(0);
         int ticks = GetDuration(sSpellDurationStore.LookupEntry(castingSpell->getDurationIndex())) / amplitude;
 
-        dmgOverwrite[0] = dmg * ticks * (getOriginalSpell()->getEffectBasePoints(0) + 1) / 100;
+        dmgOverwrite[0] = dmg * ticks * (getOriginalSpell()->calculateEffectValue(0)) / 100;
 
         return false;
     }
@@ -433,13 +429,13 @@ public:
     bool doEffect(Unit* /*victim*/, SpellInfo const* castingSpell, uint32 /*flag*/, uint32 dmg, uint32 /*abs*/, int* dmgOverwrite, uint32 /*weapon_damage_type*/) override
     {
         // Get heal amt for 1 tick
-        dmg = castingSpell->getEffectBasePoints(0) + 1;
+        dmg = castingSpell->calculateEffectValue(0);
 
         // Get total ticks
         int ticks = GetDuration(sSpellDurationStore.LookupEntry(castingSpell->getDurationIndex())) / castingSpell->getEffectAmplitude(0);
 
         // Total periodic effect is a single tick amount multiplied by number of ticks
-        dmgOverwrite[0] = dmg * ticks * (getOriginalSpell()->getEffectBasePoints(0) + 1) / 100;
+        dmgOverwrite[0] = dmg * ticks * (getOriginalSpell()->calculateEffectValue(0)) / 100;
 
         return false;
     }

--- a/src/world/Spell/SpellScript.cpp
+++ b/src/world/Spell/SpellScript.cpp
@@ -97,4 +97,7 @@ bool SpellScript::canProcOnTriggered(SpellProc* spellProc, Unit* /*victim*/, Spe
     return false;
 }
 
-void SpellScript::onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* /*spellToProc*/) {}
+SpellScriptExecuteState SpellScript::onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* /*spellToProc*/)
+{
+    return SpellScriptExecuteState::EXECUTE_NOT_HANDLED;
+}

--- a/src/world/Spell/SpellScript.h
+++ b/src/world/Spell/SpellScript.h
@@ -110,5 +110,5 @@ public:
     virtual bool canProcOnTriggered(SpellProc* spellProc, Unit* victim, SpellInfo const* castingSpell, Aura* triggeredFromAura);
     // Called right before the proc spell is cast
     // Caster is not necessarily the unit who owns this spell proc
-    virtual void onCastProcSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc);
+    virtual SpellScriptExecuteState onCastProcSpell(SpellProc* spellProc, Unit* caster, Unit* victim, Spell* spellToProc);
 };

--- a/src/world/Spell/SpellTarget.Legacy.cpp
+++ b/src/world/Spell/SpellTarget.Legacy.cpp
@@ -30,7 +30,6 @@
 #include "Definitions/SpellCastTargetFlags.h"
 #include "Definitions/SpellDidHitResult.h"
 #include "Definitions/SpellEffectTarget.h"
-#include "SpellHelpers.h"
 #include "Units/Creatures/Pet.h"
 
  // APGL End
@@ -208,7 +207,7 @@ void Spell::AddChainTargets(uint32 i, uint32 targetType, float /*r*/, uint32 /*m
     //range
     range /= jumps; //hacky, needs better implementation!
 
-    AscEmu::World::Spell::Helpers::spellModFlatIntValue(u_caster->SM_FAdditionalTargets, (int32*)&jumps, m_spellInfo->getSpellFamilyFlags());
+    u_caster->applySpellModifiers(SPELLMOD_ADDITIONAL_TARGET, &jumps, getSpellInfo(), this);
 
     AddTarget(i, targetType, firstTarget);
 

--- a/src/world/Spell/Spell_ClassScripts.cpp
+++ b/src/world/Spell/Spell_ClassScripts.cpp
@@ -156,7 +156,7 @@ public:
             return 0;
 
         // Check for proc chance
-        if (Util::getRandomFloat(100.0f) > getSpellInfo()->getEffectBasePoints(0) + 1)
+        if (Util::getRandomFloat(100.0f) > getSpellInfo()->calculateEffectValue(0))
             return 0;
 
         // Check if damage will kill player.
@@ -185,7 +185,7 @@ public:
         getPlayerOwner()->castSpell(getPlayerOwner()->getGuid(), 45182, true);
 
         // Better to add custom cooldown procedure then fucking with entry, or not!!
-        getPlayerOwner()->addSpellCooldown(dSpell, nullptr, 60000);
+        getPlayerOwner()->addSpellCooldown(dSpell, nullptr, nullptr, 60000);
 
         // Calc abs and applying it
         uint32 real_dmg = (cur_hlth > min_hlth ? cur_hlth - min_hlth : 0);
@@ -333,7 +333,7 @@ public:
         {
             uint32 count = target->GetAuraCountWithDispelType(DISPEL_DISEASE, m_caster->getGuid());
             if (count)
-                value += value * count * (getSpellInfo()->getEffectBasePoints(2) + 1) / 200;
+                value += value * count * (getSpellInfo()->calculateEffectValue(2)) / 200;
         }
 
         return value;
@@ -357,7 +357,7 @@ public:
         if (aur == NULL)
             return;
 
-        if (!Rand(aur->getSpellInfo()->getProcChance()))
+        if (!Util::checkChance(aur->getSpellInfo()->getProcChance()))
             return;
 
         p_caster->castSpell(target, 47632, false);
@@ -399,10 +399,8 @@ public:
 
     static Spell* Create(Object* Caster, SpellInfo *info, bool triggered, Aura* aur) { return new RuneStrileSpell(Caster, info, triggered, aur); }
 
-    void HandleEffects(uint64 guid, uint8 i)
+    void DoAfterHandleEffect(Unit* /*target*/, uint32 /*i*/)
     {
-        Spell::HandleEffects(guid, i);
-
         if (u_caster != NULL)
             u_caster->RemoveAura(56817);
     }
@@ -424,14 +422,14 @@ public:
     {
         Player* caster = GetPlayerCaster();
         if (caster != NULL)
-            return caster->getMaxHealth() * (getSpellInfo()->getEffectBasePoints(1) + 1) / 100;
+            return caster->getMaxHealth() * (getSpellInfo()->calculateEffectValue(1)) / 100;
         else
             return aurEff->getEffectDamage();
     }
 
     uint8_t CalcPctDamage()
     {
-        return static_cast<uint8_t>(getSpellInfo()->getEffectBasePoints(0) + 1);
+        return static_cast<uint8_t>(getSpellInfo()->calculateEffectValue(0));
     }
 };
 
@@ -457,7 +455,7 @@ public:
         if (caster == NULL)
             return 0;
 
-        if (!Rand(caster->GetParryChance()))
+        if (!Util::checkChance(caster->GetParryChance()))
             return 0;
 
         uint32 dmg_absorbed = *dmg * getEffectDamage(0) / 100;
@@ -507,7 +505,7 @@ public:
         // "Damage that would take you below $s1% health or taken while you are at $s1% health is reduced by $52284s1%."
         if ((health_pct > 35 && new_health_pct < 35) || health_pct == 35)
         {
-            uint32 dmg_absorbed = *dmg * (getSpellInfo()->getEffectBasePoints(0) + 1) / 100;
+            uint32 dmg_absorbed = *dmg * (getSpellInfo()->calculateEffectValue(0)) / 100;
             *dmg -= dmg_absorbed;
 
             return dmg_absorbed;
@@ -560,7 +558,7 @@ public:
         if (aur == NULL)
             return;
 
-        if (!Rand(aur->getSpellInfo()->getProcChance()))
+        if (!Util::checkChance(aur->getSpellInfo()->getProcChance()))
             return;
 
         p_caster->castSpell(target, 47632, false);

--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -2324,6 +2324,8 @@ void Creature::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
 
     pAttacker->smsg_AttackStop(this);
 
+    getSummonInterface()->removeAllSummons();
+
     GetAIInterface()->OnDeath(pAttacker);
 
     // Add Kills if Player is in Vehicle
@@ -2473,7 +2475,7 @@ void Creature::HandleMonsterSayEvent(MONSTER_SAY_EVENTS Event)
     else
     {
         int choice = 0;
-        if (Rand(npcMonsterSay->chance))
+        if (Util::checkChance(npcMonsterSay->chance))
         {
             choice = (npcMonsterSay->textCount == 1) ? 0 : Util::getRandomUInt(npcMonsterSay->textCount - 1);
         }

--- a/src/world/Units/Creatures/Creature.h
+++ b/src/world/Units/Creatures/Creature.h
@@ -29,10 +29,6 @@
 #include "Objects/Object.h"
 #include "Management/Group.h"
 
-SERVER_DECL bool Rand(float chance);
-SERVER_DECL bool Rand(uint32 chance);
-SERVER_DECL bool Rand(int32 chance);
-
 class CreatureAIScript;
 class GossipScript;
 class AuctionHouse;

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -1902,7 +1902,6 @@ void Pet::LoadPetAuras(int32 id)
        */
 
     static uint32 mod_auras[9] = { 8875, 19580, 19581, 19582, 19589, 19591, 34666, 34667, 34675 }; // Beastmastery Talent's auras.
-    InheritSMMods(m_Owner);
 
     if (id == -1)           //unload all
     {
@@ -1971,7 +1970,7 @@ AI_Spell* Pet::HandleAutoCastEvent()
         ++itr2;
         uint32 size = (uint32)m_autoCastSpells[AUTOCAST_EVENT_ATTACK].size();
         if (size > 1)
-            chance = Rand(100.0f / size);
+            chance = Util::checkChance(100.0f / size);
 
         if ((*itr)->autocast_type == AUTOCAST_EVENT_ATTACK)
         {

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -48,6 +48,8 @@
 #include "Server/Warden/SpeedDetector.h"
 #include "Server/MainServerDefines.h"
 #include "Config/Config.h"
+#include "Map/Area/AreaManagementGlobals.hpp"
+#include "Map/Area/AreaStorage.hpp"
 #include "Map/MapMgr.h"
 #include "Objects/Faction.h"
 #include "Spell/SpellAuras.h"

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -60,7 +60,6 @@
 #include "Spell/Definitions/SpellMechanics.h"
 #include "Spell/Definitions/PowerType.h"
 #include "Spell/Definitions/Spec.h"
-#include "Spell/SpellHelpers.h"
 #include "Spell/SpellMgr.h"
 #include "Units/Creatures/Pet.h"
 #include "Server/Packets/SmsgInitialSpells.h"
@@ -115,11 +114,6 @@
 
 using namespace AscEmu::Packets;
 using namespace MapManagement::AreaManagement;
-
-using AscEmu::World::Spell::Helpers::spellModFlatIntValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageIntValue;
-using AscEmu::World::Spell::Helpers::spellModFlatFloatValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageFloatValue;
 
 UpdateMask Player::m_visibleUpdateMask;
 
@@ -4200,19 +4194,19 @@ void Player::_ApplyItemMods(Item* item, int16 slot, bool apply, bool justdrokedo
                 {
                     // 'Chance on hit' in main hand should only proc from main hand hits
                     case EQUIPMENT_SLOT_MAINHAND:
-                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_ON_MAIN_HAND_HIT_ONLY, 0, nullptr, nullptr, this);
+                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT), EXTRA_PROC_ON_MAIN_HAND_HIT_ONLY, nullptr, nullptr, nullptr, this);
                         break;
                     // 'Chance on hit' in off hand should only proc from off hand hits
                     case EQUIPMENT_SLOT_OFFHAND:
-                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_OFFHAND_ATTACK), EXTRA_PROC_ON_OFF_HAND_HIT_ONLY, 0, nullptr, nullptr, this);
+                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_OFFHAND_ATTACK), EXTRA_PROC_ON_OFF_HAND_HIT_ONLY, nullptr, nullptr, nullptr, this);
                         break;
                     // 'Chance on hit' in ranged slot should only proc from ranged attacks
                     case EQUIPMENT_SLOT_RANGED:
-                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, 0, nullptr, nullptr, this);
+                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, nullptr, nullptr, nullptr, this);
                         break;
                     // In any other slot, proc on any melee or ranged hit
                     default:
-                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, 0, nullptr, nullptr, this);
+                        addProcTriggerSpell(spells, nullptr, getGuid(), procChance, SpellProcFlags(PROC_ON_DONE_MELEE_HIT | PROC_ON_DONE_MELEE_SPELL_HIT | PROC_ON_DONE_RANGED_HIT | PROC_ON_DONE_RANGED_SPELL_HIT), EXTRA_PROC_NULL, nullptr, nullptr, nullptr, this);
                         break;
                 }
             }
@@ -7629,23 +7623,8 @@ void Player::CompleteLoading()
         }
 
         if (sp->getProcCharges() > 0 && (*i).charges > 0)
-        {
-            for (uint32 x = 0; x < (*i).charges - 1; x++)
-            {
-                Aura* a = sSpellMgr.newAura(sp, (*i).dur, this, this, false);
-                this->addAura(a);
-            }
-            if (m_chargeSpells.find(sp->getId()) == m_chargeSpells.end())
-            {
-                SpellCharge charge;
-                charge.count = (*i).charges;
-                charge.spellId = sp->getId();
-                charge.ProcFlag = sp->getProcFlags();
-                charge.lastproc = 0;
-                charge.procdiff = 0;
-                m_chargeSpells.insert(std::make_pair(sp->getId(), charge));
-            }
-        }
+            aura->setCharges(static_cast<uint16_t>((*i).charges), false);
+
         this->addAura(aura);
     }
 
@@ -9853,6 +9832,7 @@ void Player::FullHPMP()
     setHealth(getMaxHealth());
     setPower(POWER_TYPE_MANA, getMaxPower(POWER_TYPE_MANA));
     setPower(POWER_TYPE_ENERGY, getMaxPower(POWER_TYPE_ENERGY));
+    setPower(POWER_TYPE_FOCUS, getMaxPower(POWER_TYPE_FOCUS));
 }
 
 /**********************************************
@@ -11315,7 +11295,7 @@ void Player::RemoteRevive()
     setSpeedRate(TYPE_RUN, getSpeedRate(TYPE_RUN, false), true);
     setSpeedRate(TYPE_SWIM, getSpeedRate(TYPE_SWIM, false), true);
     setMoveLandWalk();
-    setHealth(getMaxHealth());
+    FullHPMP();
 }
 
 void Player::SetMover(Unit* target)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -60,7 +60,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Spell/Spell.h"
 #include "Spell/SpellAuras.h"
 #include "Spell/SpellDefines.hpp"
-#include "Spell/SpellHelpers.h"
 #include "Spell/SpellMgr.h"
 #include "Storage/MySQLDataStore.hpp"
 #include "Units/Creatures/Pet.h"
@@ -70,11 +69,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Server/Packets/SmsgSpellCooldown.h"
 
 using namespace AscEmu::Packets;
-
-using AscEmu::World::Spell::Helpers::spellModFlatIntValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageIntValue;
-using AscEmu::World::Spell::Helpers::spellModFlatFloatValue;
-using AscEmu::World::Spell::Helpers::spellModPercentageFloatValue;
 
 TradeData::TradeData(Player* player, Player* trader)
 {
@@ -2073,7 +2067,7 @@ bool Player::hasSpellGlobalCooldown(SpellInfo const* spellInfo)
     return false;
 }
 
-void Player::addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster, int32_t cooldownTime/* = 0*/)
+void Player::addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster, Spell* castingSpell/* = nullptr*/, int32_t cooldownTime/* = 0*/)
 {
     const auto curTime = Util::getMSTime();
     const auto spellId = spellInfo->getId();
@@ -2083,8 +2077,8 @@ void Player::addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster
     if (spellCategoryCooldown > 0 && spellInfo->getCategory() > 0)
     {
         // Add cooldown modifiers
-        spellModFlatIntValue(SM_FCooldownTime, &spellCategoryCooldown, spellInfo->getSpellFamilyFlags());
-        spellModPercentageIntValue(SM_PCooldownTime, &spellCategoryCooldown, spellInfo->getSpellFamilyFlags());
+        if (castingSpell != nullptr)
+            applySpellModifiers(SPELLMOD_COOLDOWN_DECREASE, &spellCategoryCooldown, spellInfo, castingSpell);
 
         AddCategoryCooldown(spellInfo->getCategory(), spellCategoryCooldown + curTime, spellId, itemCaster != nullptr ? itemCaster->getEntry() : 0);
     }
@@ -2094,8 +2088,8 @@ void Player::addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster
     if (spellCooldown > 0)
     {
         // Add cooldown modifers
-        spellModFlatIntValue(SM_FCooldownTime, &spellCooldown, spellInfo->getSpellFamilyFlags());
-        spellModPercentageIntValue(SM_PCooldownTime, &spellCooldown, spellInfo->getSpellFamilyFlags());
+        if (castingSpell != nullptr)
+            applySpellModifiers(SPELLMOD_COOLDOWN_DECREASE, &spellCooldown, spellInfo, castingSpell);
 
         _Cooldown_Add(COOLDOWN_TYPE_SPELL, spellId, spellCooldown + curTime, spellId, itemCaster != nullptr ? itemCaster->getEntry() : 0);
     }
@@ -2104,7 +2098,7 @@ void Player::addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster
     sendSpellCooldownPacket(spellInfo, spellCooldown > spellCategoryCooldown ? spellCooldown : spellCategoryCooldown, false);
 }
 
-void Player::addGlobalCooldown(SpellInfo const* spellInfo, const bool sendPacket/* = false*/)
+void Player::addGlobalCooldown(SpellInfo const* spellInfo, Spell* castingSpell, const bool sendPacket/* = false*/)
 {
     if (spellInfo->getStartRecoveryTime() == 0 && spellInfo->getStartRecoveryCategory() == 0)
         return;
@@ -2113,8 +2107,7 @@ void Player::addGlobalCooldown(SpellInfo const* spellInfo, const bool sendPacket
     auto gcdDuration = static_cast<int32_t>(spellInfo->getStartRecoveryTime());
 
     // Apply global cooldown modifiers
-    spellModFlatIntValue(SM_FGlobalCooldown, &gcdDuration, spellInfo->getSpellFamilyFlags());
-    spellModPercentageIntValue(SM_PGlobalCooldown, &gcdDuration, spellInfo->getSpellFamilyFlags());
+    applySpellModifiers(SPELLMOD_GLOBAL_COOLDOWN, &gcdDuration, spellInfo, castingSpell);
 
     // Apply haste modifier only to magic spells
     if (spellInfo->getStartRecoveryCategory() == 133 && spellInfo->getDmgClass() == SPELL_DMG_TYPE_MAGIC &&
@@ -2176,11 +2169,19 @@ void Player::clearCooldownForSpell(uint32_t spellId)
     }
 }
 
+void Player::clearGlobalCooldown()
+{
+    m_globalCooldown = Util::getMSTime();
+}
+
 void Player::resetAllCooldowns()
 {
     // Clear spell cooldowns
     for (const auto& spell : mSpells)
         clearCooldownForSpell(spell);
+
+    // Clear global cooldown
+    clearGlobalCooldown();
 
     // Clear other cooldowns, like items
     for (uint8_t i = 0; i < NUM_COOLDOWN_TYPES; ++i)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -12,6 +12,8 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Management/Battleground/Battleground.h"
 #include "Management/Guild/GuildMgr.hpp"
 #include "Management/ItemInterface.h"
+#include "Map/Area/AreaManagementGlobals.hpp"
+#include "Map/Area/AreaStorage.hpp"
 #include "Map/MapMgr.h"
 #include "Objects/GameObject.h"
 #include "Objects/ObjectMgr.h"

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -887,10 +887,11 @@ public:
     bool hasSpellOnCooldown(SpellInfo const* spellInfo);
     bool hasSpellGlobalCooldown(SpellInfo const* spellInfo);
     // Do NOT add cooldownTime if you don't know what you're doing (it's required for spells with dynamic cooldown)
-    void addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster, int32_t cooldownTime = 0);
-    void addGlobalCooldown(SpellInfo const* spellInfo, const bool sendPacket = false);
+    void addSpellCooldown(SpellInfo const* spellInfo, Item const* itemCaster, Spell* castingSpell = nullptr, int32_t cooldownTime = 0);
+    void addGlobalCooldown(SpellInfo const* spellInfo, Spell* castingSpell, const bool sendPacket = false);
     void sendSpellCooldownPacket(SpellInfo const* spellInfo, const uint32_t duration, const bool isGcd);
     void clearCooldownForSpell(uint32_t spellId);
+    void clearGlobalCooldown();
     void resetAllCooldowns();
 
 #if VERSION_STRING >= WotLK

--- a/src/world/Units/Summons/TotemSummon.cpp
+++ b/src/world/Units/Summons/TotemSummon.cpp
@@ -42,8 +42,6 @@ void TotemSummon::Load(CreatureProperties const* creatureProperties, Unit* unitO
     setModCastSpeed(1.0f);
     setDynamicFlags(0);
 
-    InheritSMMods(unitOwner);
-
     for (uint8_t school = 0; school < TOTAL_SPELL_SCHOOLS; school++)
     {
         ModDamageDone[school] = unitOwner->GetDamageDoneMod(school);


### PR DESCRIPTION
**Todo / Checklist**
Spells: Rewrite spell modifiers
Spells: Rewrite spell charges
Spells: Rewrite spell handleEffect, calculate effect, cancel, and finish methods
Spells: Calculate spell damage on spell launch, not on hit
Spells: Remove EventMgr/EventableObject from spell system and update spells via caster
Spells: Do not check line of sight for triggered spells
Spells: Remove couple hackfixes
Spells: Fix crash in summon effects
Commands: .revive command will now also heal player to full health if player was not dead
Misc: Util::checkChance() now replaces old Rand() method
Misc: Fix couple warnings and codestyle issues
Scripts: Cleanup spell scripts
Spells: Add scripts for following spells:
- Hot Streak
- Art of War
- Vengeance (paladin)
- Surge of Light
- Backlash
- Nightfall
- Flurry (warrior)

**Tests Performed:** 
Built and tested ingame in wotlk and tbc


