### PR TITLE
MOP Updated structure for .dbc

### DIFF
--- a/src/world/Chat/Commands/MiscCommands.cpp
+++ b/src/world/Chat/Commands/MiscCommands.cpp
@@ -221,7 +221,7 @@ bool ChatHandler::HandleGoTriggerCommand(const char* args, WorldSession* m_sessi
         return true;
     }
 
-    m_session->GetPlayer()->SafeTeleport(area_trigger_entry->mapid, instance_id, LocationVector(area_trigger_entry->x, area_trigger_entry->y, area_trigger_entry->z, area_trigger_entry->o));
+    m_session->GetPlayer()->SafeTeleport(area_trigger_entry->mapid, instance_id, LocationVector(area_trigger_entry->x, area_trigger_entry->y, area_trigger_entry->z, area_trigger_entry->box_radius));
     BlueSystemMessage(m_session, "Teleported to trigger %u on [%u][%.2f][%.2f][%.2f]", area_trigger_entry->id, area_trigger_entry->mapid, area_trigger_entry->x, area_trigger_entry->y, area_trigger_entry->z);
     return true;
 }

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -827,7 +827,7 @@ namespace DBC::Structures
         //uint32_t state;                                           // 10
     };
 
-    #define OUTFIT_ITEMS 24
+#define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
@@ -1427,11 +1427,11 @@ namespace DBC::Structures
     //    uint32_t Price;                                           // 1
     //};
 
-    //\ todo: confirm effect count
-    #define MAX_SPELL_EFFECTS 3
-    #define MAX_SPELL_REAGENTS 8
-    #define MAX_SPELL_TOTEMS 2
-    #define MAX_SPELL_TOTEM_CATEGORIES 2
+//\ todo: confirm effect count
+#define MAX_SPELL_EFFECTS 3
+#define MAX_SPELL_REAGENTS 8
+#define MAX_SPELL_TOTEMS 2
+#define MAX_SPELL_TOTEM_CATEGORIES 2
 
     // SpellAuraOptions.dbc
     struct SpellAuraOptionsEntry
@@ -1978,7 +1978,7 @@ namespace DBC::Structures
         uint32_t categoryMask;                                      // 3
     };
 
-    #define MAX_VEHICLE_SEATS 8
+#define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -167,2011 +167,2008 @@ enum MapTypes
 #define MAX_RAID_DIFFICULTY        4
 #define MAX_DIFFICULTY             4
 
-namespace DBC
+namespace DBC::Structures
 {
-    namespace Structures
+    namespace
     {
-        namespace
-        {
-            char const achievement_format[] = "niiissiiiiisii";
-            char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
-            char const area_group_format[] = "niiiiiii";
-            char const area_table_entry_format[] = "iiinixxxxxisiiiiixxxxxxxxx";
-            char const area_trigger_entry_format[] = "nifffxxxfffff";
-            //char const armor_location_format[] = "nfffff"; new
-            char const auction_house_format[] = "niiix";
-            char const bank_bag_slot_prices_format[] = "ni";
-            char const barber_shop_style_entry_format[] = "nixxxiii";
-            char const banned_addons_entry_format[] = "nxxxxxxxxxx";
-            //char const battlemaster_list_format[]="niiiiiiiiixsiiiiiiii"; new
-            char const char_start_outfit_format[]="dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxii"; 
-            char const char_titles_format[] = "nxsxix";
-            char const chat_channels_format[] = "iixsx";
-            char const chr_classes_format[] = "nixsxxxixiiiii";
-            char const chr_races_format[] = "nxixiixixxxxixsxxxxxixxx";
-            char const chr_classes_xpower_types_format[]="nii";
-            //char const cinematic_sequences_format[]="nxxxxxxxxx"; new
-            char const creature_display_info_format[]="nixifxxxxxxxxxxxx";
-            char const creature_display_info_extra_format[]="nixxxxxxxxxxxxxxxxxxx";
-            char const creature_family_format[] = "nfifiiiiixsx";
-            //char const creature_model_data_format[] = "nxxxxxxxxxxxxxxffxxxxxxxxxxxxxx"; new
-            char const creature_spell_data_format[] = "niiiiiiii";  //niiiixxxx
-            //char const creature_type_format[]="nxx"; new
-            char const currency_types_format[] = "nisxxxxiiix";
-            //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
-            char const dungeon_encounter_format[] = "niixisxx";
-            char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-            char const durability_quality_format[] = "nf";
-            char const emotes_entry_format[] = "nxxiiixx";
-            char const emotes_text_format[] = "nxixxxxxxxxxxxxxxxx";
-            char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxx";
-            char const faction_template_format[] = "niiiiiiiiiiiii";
-            char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffxxx";
-            char const gem_properties_format[] = "nixxix";
-            char const glyph_properties_format[] = "niii";
-            char const glyph_slot_format[] = "nii";
-            char const gt_barber_shop_cost_format[] = "xf";
-            char const gt_chance_to_melee_crit_format[] = "xf";
-            char const gt_chance_to_melee_crit_base_format[] = "xf";
-            char const gt_chance_to_spell_crit_format[] = "xf";
-            char const gt_chance_to_spell_crit_base_format[] = "xf";
-            char const gt_combat_ratings_format[] = "xf";
-            //char const gt_oct_base_hp_by_class_format[] = "df"; new
-            //char const gt_oct_base_mp_by_class_format[] = "df"; new
-            char const gt_oct_class_combat_rating_scalar_format[] = "df";
-            //char const gt_oct_hp_per_stamina_format[] = "df"; new
-            //char const gt_oct_regen_hp_format[] = "xf";
-            char const gt_oct_regen_mp_format[] = "df";
-            char const gt_regen_hp_per_spt_format[] = "xf";
-            char const gt_regen_mp_per_spt_format[] = "xf";
-            //char const gt_spell_scaling_format[] = "df"; new
-            char const guild_perk_spells_format[] = "xii";
-            char const holidays_format[] = "nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            //char const item_armor_quality_format[] = "nfffffffi"; new
-            //char const item_armor_shield_format[] = "nifffffff"; new
-            //char const item_armor_total_format[] = "niffff"; new
-            //char const item_bag_family_format[] = "nx"; new
-            //char const item_class_format[] = "nixxxs"; new
-            //char const item_damage_format[] = "nfffffffi"; new
-            char const item_random_properties_format[] = "nxiiiiis";
-            char const item_random_suffix_format[] = "nsxiiiiiiiiii";
-            char const item_set_format[] = "dsxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii";
-            char const item_limit_category_format[] = "nxii";
-            char const lfg_dungeon_entry_format[] = "nsiiiiiiiiiisiiisiiii";
-            char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
-            char const mail_template_format[] = "nss";  //nxs
-            char const map_format[] = "nsiiiisissififfiiiii";
-            //char const map_difficulty_entry_format[] = "niisiis"; new
-            //char const mount_capability_format[] = "niiiiiii"; new
-            //char const mount_type_format[] = "niiiiiiiiiiiiiiiiiiiiiiii"; new
-            //char const movie_entry_format[] = "nxxx"; new
-            char const name_gen_format[] = "nsii";
-            char const num_talents_at_level_format[] = "df";
-            //char const override_spell_data_format[] = "niiiiiiiiiixx"; new
-            char const phase_entry_format[] = "nii";
-            //char const power_display_format[] = "nixxxx"; new
-            //char const pvp_difficulty_format[] = "diiiii"; new
-            //char const quest_faction_reward_format[] = "niiiiiiiiii"; new
-            char const quest_sort_entry_format[] = "nx";
-            char const quest_xp_format[] = "niiiiiiiiii";
-            //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
-            char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
-            char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const skill_line_format[] = "nisxixi";
-            char const skill_line_ability_format[] = "niiiixxiiiiiix";
-            //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
-            char const spell_aura_options_format[] = "diiii";
-            char const spell_aura_restrictions_format[] = "diiiiiiii";
-            char const spell_cast_times_format[] = "niii";
-            char const spell_casting_requirements_format[] = "dixxixi";
-            char const spell_categories_format[] = "diiiiii";
-            char const spell_class_options_format[] = "dxiiiix";
-            char const spell_cooldowns_format[] = "diii";
-            char const spell_difficulty_format[] = "niiii";
-            char const spell_duration_format[] = "niii";
-            char const spell_entry_format[] = "niiiiiiiiiiiiiiifiiiissxxiixxixiiiiiiixiiiiiiiix";
-            char const spell_item_enchantment_format[] = "nxiiiiiixxxiiisiiiiiiix";
-            //char const skill_race_class_info_format[] = "diiiiixxx"; new
-            char const spell_radius_format[] = "nfff";
-            char const spell_range_format[] = "nffffixx";
-            char const spell_rune_cost_format[] = "niiii";
-            char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
-            char const spell_effect_format[] = "difiiiffiiiiiifiifiiiiiiiix";
-            char const spell_equipped_items_format[] = "diii";
-            //char const spell_focus_object_format[] = "nx"; new
-            char const spell_interrupts_format[] = "dixixi";
-            //char const spell_item_enchantment_condition_format[] = "nbbbbbxxxxxbbbbbbbbbbiiiiixxxxx"; new
-            char const spell_levels_format[] = "diii";
-            char const spell_power_format[] = "diiiiixf";
-            char const spell_reagents_format[] = "diiiiiiiiiiiiiiii";
-            char const spell_scaling_format[] = "diiiiffffffffffi";
-            char const spell_shapeshift_format[] = "dixixx";
-            char const spell_target_restrictions_format[] = "dfiiii";
-            char const spell_totems_format[] = "diiii";
-            //char const stable_slot_prices_format[] = "ni"; NA
-            char const summon_properties_format[] = "niiiii";
-            char const talent_format[] = "niiiiiiiiixxixxxxxx";
-            char const talent_tab_format[] = "nxxiiixxiii";
-            char const talent_tree_primary_spells_format[] = "iiix";
-            char const taxi_nodes_format[] = "nifffsiixxx";
-            char const taxi_path_format[] = "niii";
-            char const taxi_path_node_format[] = "diiifffiiii";
-            char const totem_category_entry_format[] = "nxii";
-            char const transport_animation_format[] = "diifffx";
-            char const transport_rotation_format[] = "diiffff";
-            char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
-            char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxxxxxxxxxx";
-            char const wmo_area_table_format[] = "niiixxxxxiixxxx";
-            char const world_map_area_entry_format[] = "xinxxxxxixxxxx";
-            char const world_map_overlay_format[] = "nxiiiixxxxxxxxx";
-            //char const world_pvp_area_enrty_format[] = "niiiiii"; new
-            //char const world_safe_locs_entry_format[] = "nifffx"; new
-        }
+        char const achievement_format[] = "niiissiiiiisii";
+        char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
+        char const area_group_format[] = "niiiiiii";
+        char const area_table_entry_format[] = "iiinixxxxxisiiiiixxxxxxxxx";
+        char const area_trigger_entry_format[] = "nifffxxxfffff";
+        //char const armor_location_format[] = "nfffff"; new
+        char const auction_house_format[] = "niiix";
+        char const bank_bag_slot_prices_format[] = "ni";
+        char const barber_shop_style_entry_format[] = "nixxxiii";
+        char const banned_addons_entry_format[] = "nxxxxxxxxxx";
+        //char const battlemaster_list_format[]="niiiiiiiiixsiiiiiiii"; new
+        char const char_start_outfit_format[]="dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxii"; 
+        char const char_titles_format[] = "nxsxix";
+        char const chat_channels_format[] = "iixsx";
+        char const chr_classes_format[] = "nixsxxxixiiiii";
+        char const chr_races_format[] = "nxixiixixxxxixsxxxxxixxx";
+        char const chr_classes_xpower_types_format[]="nii";
+        //char const cinematic_sequences_format[]="nxxxxxxxxx"; new
+        char const creature_display_info_format[]="nixifxxxxxxxxxxxx";
+        char const creature_display_info_extra_format[]="nixxxxxxxxxxxxxxxxxxx";
+        char const creature_family_format[] = "nfifiiiiixsx";
+        //char const creature_model_data_format[] = "nxxxxxxxxxxxxxxffxxxxxxxxxxxxxx"; new
+        char const creature_spell_data_format[] = "niiiiiiii";  //niiiixxxx
+        //char const creature_type_format[]="nxx"; new
+        char const currency_types_format[] = "nisxxxxiiix";
+        //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
+        char const dungeon_encounter_format[] = "niixisxx";
+        char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+        char const durability_quality_format[] = "nf";
+        char const emotes_entry_format[] = "nxxiiixx";
+        char const emotes_text_format[] = "nxixxxxxxxxxxxxxxxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxx";
+        char const faction_template_format[] = "niiiiiiiiiiiii";
+        char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffxxx";
+        char const gem_properties_format[] = "nixxix";
+        char const glyph_properties_format[] = "niii";
+        char const glyph_slot_format[] = "nii";
+        char const gt_barber_shop_cost_format[] = "xf";
+        char const gt_chance_to_melee_crit_format[] = "xf";
+        char const gt_chance_to_melee_crit_base_format[] = "xf";
+        char const gt_chance_to_spell_crit_format[] = "xf";
+        char const gt_chance_to_spell_crit_base_format[] = "xf";
+        char const gt_combat_ratings_format[] = "xf";
+        //char const gt_oct_base_hp_by_class_format[] = "df"; new
+        //char const gt_oct_base_mp_by_class_format[] = "df"; new
+        char const gt_oct_class_combat_rating_scalar_format[] = "df";
+        //char const gt_oct_hp_per_stamina_format[] = "df"; new
+        //char const gt_oct_regen_hp_format[] = "xf";
+        char const gt_oct_regen_mp_format[] = "df";
+        char const gt_regen_hp_per_spt_format[] = "xf";
+        char const gt_regen_mp_per_spt_format[] = "xf";
+        //char const gt_spell_scaling_format[] = "df"; new
+        char const guild_perk_spells_format[] = "xii";
+        char const holidays_format[] = "nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        //char const item_armor_quality_format[] = "nfffffffi"; new
+        //char const item_armor_shield_format[] = "nifffffff"; new
+        //char const item_armor_total_format[] = "niffff"; new
+        //char const item_bag_family_format[] = "nx"; new
+        //char const item_class_format[] = "nixxxs"; new
+        //char const item_damage_format[] = "nfffffffi"; new
+        char const item_random_properties_format[] = "nxiiiiis";
+        char const item_random_suffix_format[] = "nsxiiiiiiiiii";
+        char const item_set_format[] = "dsxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii";
+        char const item_limit_category_format[] = "nxii";
+        char const lfg_dungeon_entry_format[] = "nsiiiiiiiiiisiiisiiii";
+        char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
+        char const mail_template_format[] = "nss";  //nxs
+        char const map_format[] = "nsiiiisissififfiiiii";
+        //char const map_difficulty_entry_format[] = "niisiis"; new
+        //char const mount_capability_format[] = "niiiiiii"; new
+        //char const mount_type_format[] = "niiiiiiiiiiiiiiiiiiiiiiii"; new
+        //char const movie_entry_format[] = "nxxx"; new
+        char const name_gen_format[] = "nsii";
+        char const num_talents_at_level_format[] = "df";
+        //char const override_spell_data_format[] = "niiiiiiiiiixx"; new
+        char const phase_entry_format[] = "nii";
+        //char const power_display_format[] = "nixxxx"; new
+        //char const pvp_difficulty_format[] = "diiiii"; new
+        //char const quest_faction_reward_format[] = "niiiiiiiiii"; new
+        char const quest_sort_entry_format[] = "nx";
+        char const quest_xp_format[] = "niiiiiiiiii";
+        //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
+        char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
+        char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const skill_line_format[] = "nisxixi";
+        char const skill_line_ability_format[] = "niiiixxiiiiiix";
+        //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
+        char const spell_aura_options_format[] = "diiii";
+        char const spell_aura_restrictions_format[] = "diiiiiiii";
+        char const spell_cast_times_format[] = "niii";
+        char const spell_casting_requirements_format[] = "dixxixi";
+        char const spell_categories_format[] = "diiiiii";
+        char const spell_class_options_format[] = "dxiiiix";
+        char const spell_cooldowns_format[] = "diii";
+        char const spell_difficulty_format[] = "niiii";
+        char const spell_duration_format[] = "niii";
+        char const spell_entry_format[] = "niiiiiiiiiiiiiiifiiiissxxiixxixiiiiiiixiiiiiiiix";
+        char const spell_item_enchantment_format[] = "nxiiiiiixxxiiisiiiiiiix";
+        //char const skill_race_class_info_format[] = "diiiiixxx"; new
+        char const spell_radius_format[] = "nfff";
+        char const spell_range_format[] = "nffffixx";
+        char const spell_rune_cost_format[] = "niiii";
+        char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
+        char const spell_effect_format[] = "difiiiffiiiiiifiifiiiiiiiix";
+        char const spell_equipped_items_format[] = "diii";
+        //char const spell_focus_object_format[] = "nx"; new
+        char const spell_interrupts_format[] = "dixixi";
+        //char const spell_item_enchantment_condition_format[] = "nbbbbbxxxxxbbbbbbbbbbiiiiixxxxx"; new
+        char const spell_levels_format[] = "diii";
+        char const spell_power_format[] = "diiiiixf";
+        char const spell_reagents_format[] = "diiiiiiiiiiiiiiii";
+        char const spell_scaling_format[] = "diiiiffffffffffi";
+        char const spell_shapeshift_format[] = "dixixx";
+        char const spell_target_restrictions_format[] = "dfiiii";
+        char const spell_totems_format[] = "diiii";
+        //char const stable_slot_prices_format[] = "ni"; NA
+        char const summon_properties_format[] = "niiiii";
+        char const talent_format[] = "niiiiiiiiixxixxxxxx";
+        char const talent_tab_format[] = "nxxiiixxiii";
+        char const talent_tree_primary_spells_format[] = "iiix";
+        char const taxi_nodes_format[] = "nifffsiixxx";
+        char const taxi_path_format[] = "niii";
+        char const taxi_path_node_format[] = "diiifffiiii";
+        char const totem_category_entry_format[] = "nxii";
+        char const transport_animation_format[] = "diifffx";
+        char const transport_rotation_format[] = "diiffff";
+        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxxxxxxxxxx";
+        char const wmo_area_table_format[] = "niiixxxxxiixxxx";
+        char const world_map_area_entry_format[] = "xinxxxxxixxxxx";
+        char const world_map_overlay_format[] = "nxiiiixxxxxxxxx";
+        //char const world_pvp_area_enrty_format[] = "niiiiii"; new
+        //char const world_safe_locs_entry_format[] = "nifffx"; new
+    }
 
-        #pragma pack(push, 1)
-        struct AchievementCategoryEntry
-        {
-            uint32_t ID;                 // 0
-            uint32_t parentCategory;     // 1 -1 for main category
-            const char* name;          // 2-17
-            uint32_t name_flags;         // 18
-            uint32_t sortOrder;          // 19
-        };
+    #pragma pack(push, 1)
+    struct AchievementCategoryEntry
+    {
+        uint32_t ID;                 // 0
+        uint32_t parentCategory;     // 1 -1 for main category
+        const char* name;          // 2-17
+        uint32_t name_flags;         // 18
+        uint32_t sortOrder;          // 19
+    };
 
-        struct AchievementCriteriaEntry
+    struct AchievementCriteriaEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t referredAchievement;     // 1
+        uint32_t requiredType;            // 2
+        union
         {
-            uint32_t ID;                      // 0
-            uint32_t referredAchievement;     // 1
-            uint32_t requiredType;            // 2
-            union
+            // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
+            ///\todo also used for player deaths..
+            struct
             {
-                // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
-                ///\todo also used for player deaths..
-                struct
-                {
-                    uint32_t creatureID;                             // 3
-                    uint32_t creatureCount;                          // 4
-                } kill_creature;
+                uint32_t creatureID;                             // 3
+                uint32_t creatureCount;                          // 4
+            } kill_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
-                ///\todo there are further criterias instead just winning
-                struct
-                {
-                    uint32_t bgMapID;                                // 3
-                    uint32_t winCount;                               // 4
-                } win_bg;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
+            ///\todo there are further criterias instead just winning
+            struct
+            {
+                uint32_t bgMapID;                                // 3
+                uint32_t winCount;                               // 4
+            } win_bg;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t level;                                  // 4
-                } reach_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t level;                                  // 4
+            } reach_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4
-                } reach_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4
+            } reach_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
-                struct
-                {
-                    uint32_t linkedAchievement;                      // 3
-                } complete_achievement;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
+            struct
+            {
+                uint32_t linkedAchievement;                      // 3
+            } complete_achievement;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t totalQuestCount;                        // 4
-                } complete_quest_count;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t totalQuestCount;                        // 4
+            } complete_quest_count;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfDays;                           // 4
-                } complete_daily_quest_daily;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfDays;                           // 4
+            } complete_daily_quest_daily;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
-                struct
-                {
-                    uint32_t zoneID;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_quests_in_zone;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
+            struct
+            {
+                uint32_t zoneID;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_quests_in_zone;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_daily_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_daily_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } complete_battleground;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } complete_battleground;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } death_at_map;
+            // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } death_at_map;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
-                struct
-                {
-                    uint32_t groupSize;                              // 3 can be 5, 10 or 25
-                } complete_raid;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
+            struct
+            {
+                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+            } complete_raid;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
-                struct
-                {
-                    uint32_t creatureEntry;                          // 3
-                } killed_by_creature;
+            // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
+            struct
+            {
+                uint32_t creatureEntry;                          // 3
+            } killed_by_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t fallHeight;                             // 4
-                } fall_without_dying;
+            // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t fallHeight;                             // 4
+            } fall_without_dying;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
-                struct
-                {
-                    uint32_t questID;                                // 3
-                    uint32_t questCount;                             // 4
-                } complete_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
+            struct
+            {
+                uint32_t questID;                                // 3
+                uint32_t questCount;                             // 4
+            } complete_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t spellCount;                             // 4
-                } be_spell_target;
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t spellCount;                             // 4
+            } be_spell_target;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t castCount;                              // 4
-                } cast_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t castCount;                              // 4
+            } cast_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
-                struct
-                {
-                    uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                    uint32_t killCount;                              // 4
-                } honorable_kill_at_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
+            struct
+            {
+                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                              // 4
+            } honorable_kill_at_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } win_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } win_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } play_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } play_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
-                struct
-                {
-                    uint32_t spellID;                                // 3 Reference to Map.dbc
-                } learn_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
+            struct
+            {
+                uint32_t spellID;                                // 3 Reference to Map.dbc
+            } learn_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } own_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } own_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 4=in a row
-                } win_rated_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 4=in a row
+            } win_rated_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                } highest_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+            } highest_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                    uint32_t teamrating;                             // 4
-                } reach_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamrating;                             // 4
+            } reach_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
-                } learn_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+            } learn_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } use_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } use_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } loot_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } loot_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
-                struct
-                {
-                    uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
-                } explore_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
+            struct
+            {
+                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+            } explore_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
-                struct
-                {
-                    ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                    uint32_t rank;                                   // 3
-                } own_rank;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
+            struct
+            {
+                ///\todo This rank is _NOT_ the index from CharTitles.dbc
+                uint32_t rank;                                   // 3
+            } own_rank;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfSlots;                          // 4
-                } buy_bank_slot;
+            // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfSlots;                          // 4
+            } buy_bank_slot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
-                struct
-                {
-                    uint32_t factionID;                              // 3
-                    uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
-                } gain_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
+            struct
+            {
+                uint32_t factionID;                              // 3
+                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+            } gain_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfExaltedFactions;                // 4
-                } gain_exalted_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfExaltedFactions;                // 4
+            } gain_exalted_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
-                ///\todo where is the required itemlevel stored?
-                struct
-                {
-                    uint32_t itemSlot;                               // 3
-                } equip_epic_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
+            ///\todo where is the required itemlevel stored?
+            struct
+            {
+                uint32_t itemSlot;                               // 3
+            } equip_epic_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
-                struct
-                {
-                    uint32_t rollValue;                              // 3
-                    uint32_t count;                                  // 4
-                } roll_need_on_loot;
+            // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
+            struct
+            {
+                uint32_t rollValue;                              // 3
+                uint32_t count;                                  // 4
+            } roll_need_on_loot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
-                struct
-                {
-                    uint32_t classID;                                // 3
-                    uint32_t count;                                  // 4
-                } hk_class;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
+            struct
+            {
+                uint32_t classID;                                // 3
+                uint32_t count;                                  // 4
+            } hk_class;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
-                struct
-                {
-                    uint32_t raceID;                                 // 3
-                    uint32_t count;                                  // 4
-                } hk_race;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
+            struct
+            {
+                uint32_t raceID;                                 // 3
+                uint32_t count;                                  // 4
+            } hk_race;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
-                ///\todo where is the information about the target stored?
-                struct
-                {
-                    uint32_t emoteID;                                // 3
-                } do_emote;
+            // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
+            ///\todo where is the information about the target stored?
+            struct
+            {
+                uint32_t emoteID;                                // 3
+            } do_emote;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 =3 for battleground healing
-                    uint32_t mapid;                                  // 6
-                } healing_done;
+            // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 =3 for battleground healing
+                uint32_t mapid;                                  // 6
+            } healing_done;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                } equip_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
+            struct
+            {
+                uint32_t itemID;                                 // 3
+            } equip_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
-                struct
-                {
-                    uint32_t unknown;                                 // 3
-                    uint32_t goldInCopper;                            // 4
-                } quest_reward_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
+            struct
+            {
+                uint32_t unknown;                                 // 3
+                uint32_t goldInCopper;                            // 4
+            } quest_reward_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t goldInCopper;                           // 4
-                } loot_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t goldInCopper;                           // 4
+            } loot_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t useCount;                               // 4
-                } use_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t useCount;                               // 4
+            } use_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
-                ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } special_pvp_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
+            ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } special_pvp_kill;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t lootCount;                              // 4
-                } fish_in_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t lootCount;                              // 4
+            } fish_in_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
-                struct
-                {
-                    uint32_t unknown;                                // 3 777=?
-                    uint32_t mountCount;                             // 4
-                } number_of_mounts;
+            // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
+            struct
+            {
+                uint32_t unknown;                                // 3 777=?
+                uint32_t mountCount;                             // 4
+            } number_of_mounts;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t duelCount;                              // 4
-                } win_duel;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t duelCount;                              // 4
+            } win_duel;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
-                struct
-                {
-                    uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
-                } highest_power;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
+            struct
+            {
+                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+            } highest_power;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
-                struct
-                {
-                    uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
-                } highest_stat;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
+            struct
+            {
+                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+            } highest_stat;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
-                struct
-                {
-                    uint32_t spellSchool;                            // 3
-                } highest_spellpower;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
+            struct
+            {
+                uint32_t spellSchool;                            // 3
+            } highest_spellpower;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
-                struct
-                {
-                    uint32_t ratingType;                             // 3
-                } highest_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
+            struct
+            {
+                uint32_t ratingType;                             // 3
+            } highest_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
-                struct
-                {
-                    uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                    uint32_t lootTypeCount;                          // 4
-                } loot_type;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
+            struct
+            {
+                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                          // 4
+            } loot_type;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } cast_spell2;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } cast_spell2;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } learn_skill_line;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } learn_skill_line;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } honorable_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } honorable_kill;
 
-                struct
-                {
-                    uint32_t field3;                                 // 3 main requirement
-                    uint32_t field4;                                 // 4 main requirement count
-                    uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                    uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                    uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                    uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
-                } raw;
-            };
-            //uint32_t unk                      // 9
-            char* name;                         // 10
-            uint32_t completionFlag;            // 11
-            uint32_t groupFlag;                 // 12 timed criteria
-            uint32_t unk1;                      // 13 timed criteria misc id
-            uint32_t timeLimit;                 // 14 time limit in seconds
-            uint32_t index;                     // 15 order
+            struct
+            {
+                uint32_t field3;                                 // 3 main requirement
+                uint32_t field4;                                 // 4 main requirement count
+                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+            } raw;
         };
+        //uint32_t unk                      // 9
+        char* name;                         // 10
+        uint32_t completionFlag;            // 11
+        uint32_t groupFlag;                 // 12 timed criteria
+        uint32_t unk1;                      // 13 timed criteria misc id
+        uint32_t timeLimit;                 // 14 time limit in seconds
+        uint32_t index;                     // 15 order
+    };
 
-        struct AchievementEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
-            int32_t mapID;                      // 2 -1=none
-            uint32_t parentAchievement;         // 3
-            char* name;                         // 4
-            char* description;                  // 5
-            uint32_t categoryId;                // 6
-            uint32_t points;                    // 7 reward points
-            uint32_t orderInCategory;           // 8
-            uint32_t flags;                     // 9
-            uint32_t icon;                      // 10
-            char* rewardName;                   // 11 title/item reward name
-            uint32_t count;                     // 12
-            uint32_t refAchievement;            // 13
-        };
+    struct AchievementEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                      // 2 -1=none
+        uint32_t parentAchievement;         // 3
+        char* name;                         // 4
+        char* description;                  // 5
+        uint32_t categoryId;                // 6
+        uint32_t points;                    // 7 reward points
+        uint32_t orderInCategory;           // 8
+        uint32_t flags;                     // 9
+        uint32_t icon;                      // 10
+        char* rewardName;                   // 11 title/item reward name
+        uint32_t count;                     // 12
+        uint32_t refAchievement;            // 13
+    };
 
-        struct AreaGroupEntry
-        {
-            uint32_t AreaGroupId;               // 0
-            uint32_t AreaId[6];                 // 1-6
-            uint32_t next_group;                // 7
-        };
+    struct AreaGroupEntry
+    {
+        uint32_t AreaGroupId;               // 0
+        uint32_t AreaId[6];                 // 1-6
+        uint32_t next_group;                // 7
+    };
 
-        struct AreaTableEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t map_id;                    // 1
-            uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
-            uint32_t explore_flag;              // 3, main index
-            uint32_t flags;                     // 4, unknown value but 312 for all cities
-                                                // 5-9 unused
-            int32_t area_level;                 // 10
-            char* area_name;                    // 11
-            uint32_t team;                      // 12
-            uint32_t liquid_type_override[4];   // 13-16 liquid override by type
-            //uint32_t unk17;                   // 17
-            //uint32_t unk18;                   // 18
-            //uint32_t unk19;                   // 19
-            //uint32_t unk20;                   // 20
-            //uint32_t unk21;                   // 21
-            //uint32_t unk22;                   // 22
-            //uint32_t unk23;                   // 23
-            //uint32_t unk24;                   // 24
-        };
+    struct AreaTableEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t map_id;                    // 1
+        uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;              // 3, main index
+        uint32_t flags;                     // 4, unknown value but 312 for all cities
+                                            // 5-9 unused
+        int32_t area_level;                 // 10
+        char* area_name;                    // 11
+        uint32_t team;                      // 12
+        uint32_t liquid_type_override[4];   // 13-16 liquid override by type
+        //uint32_t unk17;                   // 17
+        //uint32_t unk18;                   // 18
+        //uint32_t unk19;                   // 19
+        //uint32_t unk20;                   // 20
+        //uint32_t unk21;                   // 21
+        //uint32_t unk22;                   // 22
+        //uint32_t unk23;                   // 23
+        //uint32_t unk24;                   // 24
+    };
 
-        struct AreaTriggerEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t mapid;                     // 1
-            float x;                            // 2
-            float y;                            // 3
-            float z;                            // 4
-            //uint32_t                          // 5
-            //uint32_t                          // 6
-            //uint32_t                          // 7
-            float o;                            // 5 radius
-            float box_x;                        // 6 extent x edge
-            float box_y;                        // 7 extent y edge
-            float box_z;                        // 8 extent z edge
-            float box_o;                        // 9
-        };
+    struct AreaTriggerEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t mapid;                     // 1
+        float x;                            // 2
+        float y;                            // 3
+        float z;                            // 4
+        //uint32_t                          // 5
+        //uint32_t                          // 6
+        //uint32_t                          // 7
+        float o;                            // 5 radius
+        float box_x;                        // 6 extent x edge
+        float box_y;                        // 7 extent y edge
+        float box_z;                        // 8 extent z edge
+        float box_o;                        // 9
+    };
 
-        //\todo danko
-        //struct ArmorLocationEntry   
-        //{
-        //    uint32_t InventoryType;           // 0
-        //    float Value[5];                   // 1-5
-        //};
+    //\todo danko
+    //struct ArmorLocationEntry   
+    //{
+    //    uint32_t InventoryType;           // 0
+    //    float Value[5];                   // 1-5
+    //};
 
-        struct AuctionHouseEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t faction;                   // 1
-            uint32_t fee;                       // 2
-            uint32_t tax;                       // 3
-            //char* name;                       // 4
-        };
+    struct AuctionHouseEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t faction;                   // 1
+        uint32_t fee;                       // 2
+        uint32_t tax;                       // 3
+        //char* name;                       // 4
+    };
 
-        struct BankBagSlotPrices
-        {
-            uint32_t Id;                        // 0
-            uint32_t Price;                     // 1
-        };
+    struct BankBagSlotPrices
+    {
+        uint32_t Id;                        // 0
+        uint32_t Price;                     // 1
+    };
 
-        struct BarberShopStyleEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
-            //char* name;                       // 2
-            //uint32_t unk_name;                // 3
-            //float CostMultiplier;             // 4
-            uint32_t race;                      // 5
-            uint32_t gender;                    // 6 0 male, 1 female
-            uint32_t hair_id;                   // 7 Hair ID
-        };
+    struct BarberShopStyleEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;                       // 2
+        //uint32_t unk_name;                // 3
+        //float CostMultiplier;             // 4
+        uint32_t race;                      // 5
+        uint32_t gender;                    // 6 0 male, 1 female
+        uint32_t hair_id;                   // 7 Hair ID
+    };
 
-        struct BannedAddOnsEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t nameMD5[4];              // 1-4
-            //uint32_t versionMD5[4];           // 5-8
-            //uint32_t timestamp;               // 9
-            //uint32_t state;                   // 10
-        };
+    struct BannedAddOnsEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t nameMD5[4];              // 1-4
+        //uint32_t versionMD5[4];           // 5-8
+        //uint32_t timestamp;               // 9
+        //uint32_t state;                   // 10
+    };
 
-        #define OUTFIT_ITEMS 24
+    #define OUTFIT_ITEMS 24
 
-        struct CharStartOutfitEntry
-        {
-            //uint32_t Id;                                    // 0
-            uint8_t Race;                                     // 1
-            uint8_t Class;                                    // 2
-            uint8_t Gender;                                   // 3
-            //uint8_t Unused;                                 // 4
-            int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-            //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-            //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
-            uint32_t PetDisplayId;                            // 77
-            uint32_t PetFamilyEntry;                          // 78
-        };
+    struct CharStartOutfitEntry
+    {
+        //uint32_t Id;                                    // 0
+        uint8_t Race;                                     // 1
+        uint8_t Class;                                    // 2
+        uint8_t Gender;                                   // 3
+        //uint8_t Unused;                                 // 4
+        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
+        uint32_t PetDisplayId;                            // 77
+        uint32_t PetFamilyEntry;                          // 78
+    };
 
-        struct CharTitlesEntry
-        {
-            uint32_t ID;                        // 0
-            //uint32_t unk1;                    // 1
-            char* name;                         // 2
-            //char* name2;                      // 3
-            uint32_t bit_index;                 // 4
-            //uint32_t unk                      // 5
-        };
+    struct CharTitlesEntry
+    {
+        uint32_t ID;                        // 0
+        //uint32_t unk1;                    // 1
+        char* name;                         // 2
+        //char* name2;                      // 3
+        uint32_t bit_index;                 // 4
+        //uint32_t unk                      // 5
+    };
 
-        struct ChatChannelsEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t flags;                     // 1
-            //uint32_t faction                  // 2
-            char* name_pattern;                 // 3
-            //char* channel_name;               // 4
-        };
+    struct ChatChannelsEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t flags;                     // 1
+        //uint32_t faction                  // 2
+        char* name_pattern;                 // 3
+        //char* channel_name;               // 4
+    };
 
-        struct ChrClassesEntry
-        {
-            uint32_t class_id;                  // 0
-            uint32_t power_type;                // 1
-            //uint32_t unk2;                    // 2
-            char* name;                         // 3
-            //char* name_female;                // 4
-            //char* name_neutral;               // 5
-            //char* name_capitalized            // 6
-            uint32_t spellfamily;               // 7
-            //uint32_t unk4;                    // 8
-            uint32_t cinematic_id;              // 9 CinematicSequences.dbc
-            uint32_t expansion;                 // 10
-            uint32_t apPerStr;                  // 11
-            uint32_t apPerAgi;                  // 12
-            uint32_t rapPerAgi;                 // 13
-        };
+    struct ChrClassesEntry
+    {
+        uint32_t class_id;                  // 0
+        uint32_t power_type;                // 1
+        //uint32_t unk2;                    // 2
+        char* name;                         // 3
+        //char* name_female;                // 4
+        //char* name_neutral;               // 5
+        //char* name_capitalized            // 6
+        uint32_t spellfamily;               // 7
+        //uint32_t unk4;                    // 8
+        uint32_t cinematic_id;              // 9 CinematicSequences.dbc
+        uint32_t expansion;                 // 10
+        uint32_t apPerStr;                  // 11
+        uint32_t apPerAgi;                  // 12
+        uint32_t rapPerAgi;                 // 13
+    };
 
-        struct ChrRacesEntry
-        {
-            uint32_t race_id;                   // 0
-            //uint32_t flags;                   // 1
-            uint32_t faction_id;                // 2
-            //uint32_t unk1;                    // 3
-            uint32_t model_male;                // 4
-            uint32_t model_female;              // 5
-            // uint32_t unk2;                   // 6
-            uint32_t team_id;                   // 7
-            //uint32_t unk3[4];                 // 8-11
-            uint32_t cinematic_id;              // 12 CinematicSequences.dbc
-            //uint32_t unk4                     // 13
-            char* name;                         // 14
-            //char* name_female;                // 15
-            //char* name_neutral;               // 16
-            //uint32_t unk5[2]                  // 17-18
-            //uint32_t unk19                    // 19
-            uint32_t expansion;                 // 20
-            //uint32_t unk21                    // 21
-            //uint32_t unk22                    // 22
-            //uint32_t unk23                    // 23
-        };
+    struct ChrRacesEntry
+    {
+        uint32_t race_id;                   // 0
+        //uint32_t flags;                   // 1
+        uint32_t faction_id;                // 2
+        //uint32_t unk1;                    // 3
+        uint32_t model_male;                // 4
+        uint32_t model_female;              // 5
+        // uint32_t unk2;                   // 6
+        uint32_t team_id;                   // 7
+        //uint32_t unk3[4];                 // 8-11
+        uint32_t cinematic_id;              // 12 CinematicSequences.dbc
+        //uint32_t unk4                     // 13
+        char* name;                         // 14
+        //char* name_female;                // 15
+        //char* name_neutral;               // 16
+        //uint32_t unk5[2]                  // 17-18
+        //uint32_t unk19                    // 19
+        uint32_t expansion;                 // 20
+        //uint32_t unk21                    // 21
+        //uint32_t unk22                    // 22
+        //uint32_t unk23                    // 23
+    };
 
-        struct ChrPowerTypesEntry
-        {
-            uint32_t entry;                     // 0
-            uint32_t classId;                   // 1 class
-            uint32_t power;                     // 2 power type
-        };
+    struct ChrPowerTypesEntry
+    {
+        uint32_t entry;                     // 0
+        uint32_t classId;                   // 1 class
+        uint32_t power;                     // 2 power type
+    };
 
-        struct CreatureDisplayInfoEntry
-        {
-            uint32_t Displayid;                 // 0
-            uint32_t ModelId;                   // 1
-            //uint32_t sound_id;                // 2
-            uint32_t ExtendedDisplayInfoID;     // 3
-            float scale;                        // 4
-            //uint32_t unk01;                   // 5
-            //uint32_t unk02[2];                // 6-8
-            //uint32_t unk03;                   // 9
-            //uint32_t unk04;                   // 10
-            //uint32_t unk05;                   // 11
-            //uint32_t unk06;                   // 12
-            //uint32_t unk07;                   // 13
-            //uint32_t unk08;                   // 14
-            //uint32_t unk09;                   // 15
-            //uint32_t unk10;                   // 16
-        };
+    struct CreatureDisplayInfoEntry
+    {
+        uint32_t Displayid;                 // 0
+        uint32_t ModelId;                   // 1
+        //uint32_t sound_id;                // 2
+        uint32_t ExtendedDisplayInfoID;     // 3
+        float scale;                        // 4
+        //uint32_t unk01;                   // 5
+        //uint32_t unk02[2];                // 6-8
+        //uint32_t unk03;                   // 9
+        //uint32_t unk04;                   // 10
+        //uint32_t unk05;                   // 11
+        //uint32_t unk06;                   // 12
+        //uint32_t unk07;                   // 13
+        //uint32_t unk08;                   // 14
+        //uint32_t unk09;                   // 15
+        //uint32_t unk10;                   // 16
+    };
 
-        struct CreatureDisplayInfoExtraEntry
-        {
-            uint32_t DisplayExtraId;            // 0
-            uint32_t Race;                      // 1
-            //uint32_t Gender;                  // 2
-            //uint32_t SkinColor;               // 3
-            //uint32_t FaceType;                // 4
-            //uint32_t HairType;                // 5
-            //uint32_t HairStyle;               // 6
-            //uint32_t BeardStyle;              // 7
-            //uint32_t Equipment[11];           // 8-18
-            //uint32_t CanEquip;                // 19
-            //char* unk                         // 20
-        };
+    struct CreatureDisplayInfoExtraEntry
+    {
+        uint32_t DisplayExtraId;            // 0
+        uint32_t Race;                      // 1
+        //uint32_t Gender;                  // 2
+        //uint32_t SkinColor;               // 3
+        //uint32_t FaceType;                // 4
+        //uint32_t HairType;                // 5
+        //uint32_t HairStyle;               // 6
+        //uint32_t BeardStyle;              // 7
+        //uint32_t Equipment[11];           // 8-18
+        //uint32_t CanEquip;                // 19
+        //char* unk                         // 20
+    };
 
-        struct CreatureFamilyEntry
-        {
-            uint32_t ID;                        // 0
-            float minsize;                      // 1
-            uint32_t minlevel;                  // 2
-            float maxsize;                      // 3
-            uint32_t maxlevel;                  // 4
-            uint32_t skilline;                  // 5
-            uint32_t tameable;                  // 6 second skill line - 270 Generic
-            uint32_t petdietflags;              // 7
-            uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-            //uint32_t unk;                     // 9 some index 0 - 63
-            char* name;                         // 10
-            //uint32_t nameflags;               // 11
-        };
+    struct CreatureFamilyEntry
+    {
+        uint32_t ID;                        // 0
+        float minsize;                      // 1
+        uint32_t minlevel;                  // 2
+        float maxsize;                      // 3
+        uint32_t maxlevel;                  // 4
+        uint32_t skilline;                  // 5
+        uint32_t tameable;                  // 6 second skill line - 270 Generic
+        uint32_t petdietflags;              // 7
+        uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                     // 9 some index 0 - 63
+        char* name;                         // 10
+        //uint32_t nameflags;               // 11
+    };
 
-        struct CreatureSpellDataEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t Spells[3];
-            uint32_t PHSpell;
-            uint32_t Cooldowns[3];
-            uint32_t PH;
-        };
+    struct CreatureSpellDataEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t Spells[3];
+        uint32_t PHSpell;
+        uint32_t Cooldowns[3];
+        uint32_t PH;
+    };
 
-        //\todo danko
-        //struct CreatureTypeEntry
-        //{
-        //    uint32_t ID;                      // 0
-        //    //char* Name;                     // 1
-        //    //uint32_t no_expirience;         // 2
-        //};
+    //\todo danko
+    //struct CreatureTypeEntry
+    //{
+    //    uint32_t ID;                      // 0
+    //    //char* Name;                     // 1
+    //    //uint32_t no_expirience;         // 2
+    //};
 
-        struct CurrencyTypesEntry
-        {
-            uint32_t item_id;                   // 0
-            uint32_t Category;                  // 1
-            char* name;                         // 2
-            //char* unk                         // 3
-            //char* unk2                        // 4
-            //uint32_t unk5;                    // 5
-            //uint32_t unk6;                    // 6
-            uint32_t TotalCap;                  // 7
-            uint32_t WeekCap;                   // 8
-            uint32_t Flags;                     // 9
-            //char* description;                // 10
-        };
+    struct CurrencyTypesEntry
+    {
+        uint32_t item_id;                   // 0
+        uint32_t Category;                  // 1
+        char* name;                         // 2
+        //char* unk                         // 3
+        //char* unk2                        // 4
+        //uint32_t unk5;                    // 5
+        //uint32_t unk6;                    // 6
+        uint32_t TotalCap;                  // 7
+        uint32_t WeekCap;                   // 8
+        uint32_t Flags;                     // 9
+        //char* description;                // 10
+    };
 
-        struct DurabilityCostsEntry
-        {
-            uint32_t itemlevel;                 // 0
-            uint32_t modifier[29];              // 1-29
-        };
+    struct DurabilityCostsEntry
+    {
+        uint32_t itemlevel;                 // 0
+        uint32_t modifier[29];              // 1-29
+    };
 
-        struct DurabilityQualityEntry
-        {
-            uint32_t id;                        // 0
-            float quality_modifier;             // 1
-        };
+    struct DurabilityQualityEntry
+    {
+        uint32_t id;                        // 0
+        float quality_modifier;             // 1
+    };
 
-        struct EmotesEntry
-        {
-            uint32_t Id;                        // 0
-            //char* name;                       // 1
-            //uint32_t animationId;             // 2
-            uint32_t Flags;                     // 3
-            uint32_t EmoteType;                 // 4
-            uint32_t UnitStandState;            // 5
-            //uint32_t soundId;                 // 6
-            //uint32_t unk;                     // 7
-        };
+    struct EmotesEntry
+    {
+        uint32_t Id;                        // 0
+        //char* name;                       // 1
+        //uint32_t animationId;             // 2
+        uint32_t Flags;                     // 3
+        uint32_t EmoteType;                 // 4
+        uint32_t UnitStandState;            // 5
+        //uint32_t soundId;                 // 6
+        //uint32_t unk;                     // 7
+    };
 
-        struct EmotesTextEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t name;                    // 1
-            uint32_t textid;                    // 2
-            //uint32_t unk1;                    // 4
-        };
+    struct EmotesTextEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t name;                    // 1
+        uint32_t textid;                    // 2
+        //uint32_t unk1;                    // 4
+    };
 
-        struct FactionEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t RepListId;                  // 1
-            uint32_t RaceMask[4];               // 2-5
-            uint32_t ClassMask[4];              // 6-9
-            int32_t baseRepValue[4];            // 10-13
-            uint32_t repFlags[4];               // 14-17
-            uint32_t parentFaction;             // 18
-            float spillover_rate_in;            // 19
-            float spillover_rate_out;           // 20
-            uint32_t spillover_max_in;          // 21
-            //uint32_t unk1;                    // 22
-            char* Name;                         // 23
-            //uint32_t Description;             // 24
-            //uint32_t description_flags;       // 25
-        };
+    struct FactionEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t RepListId;                  // 1
+        uint32_t RaceMask[4];               // 2-5
+        uint32_t ClassMask[4];              // 6-9
+        int32_t baseRepValue[4];            // 10-13
+        uint32_t repFlags[4];               // 14-17
+        uint32_t parentFaction;             // 18
+        float spillover_rate_in;            // 19
+        float spillover_rate_out;           // 20
+        uint32_t spillover_max_in;          // 21
+        //uint32_t unk1;                    // 22
+        char* Name;                         // 23
+        //uint32_t Description;             // 24
+        //uint32_t description_flags;       // 25
+    };
 
-        struct FactionTemplateEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t Faction;                   // 1
-            uint32_t FactionGroup;              // 2
-            uint32_t Mask;                      // 3
-            uint32_t FriendlyMask;              // 4
-            uint32_t HostileMask;               // 5
-            uint32_t EnemyFactions[4];          // 6-9
-            uint32_t FriendlyFactions[4];       // 10-13
-        };
+    struct FactionTemplateEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t Faction;                   // 1
+        uint32_t FactionGroup;              // 2
+        uint32_t Mask;                      // 3
+        uint32_t FriendlyMask;              // 4
+        uint32_t HostileMask;               // 5
+        uint32_t EnemyFactions[4];          // 6-9
+        uint32_t FriendlyFactions[4];       // 10-13
+    };
 
-        struct GameObjectDisplayInfoEntry
-        {
-            uint32_t Displayid;                 // 0
-            char* filename;                     // 1
-            //uint32_t  unk1[10];               // 2-11
-            float minX;                         // 12
-            float minY;                         // 13
-            float minZ;                         // 14
-            float maxX;                         // 15
-            float maxY;                         // 16
-            float maxZ;                         // 17
-            //uint32_t transport;               // 18
-            //uint32_t unk;                     // 19
-            //uint32_t unk;                     // 20
-        };
+    struct GameObjectDisplayInfoEntry
+    {
+        uint32_t Displayid;                 // 0
+        char* filename;                     // 1
+        //uint32_t  unk1[10];               // 2-11
+        float minX;                         // 12
+        float minY;                         // 13
+        float minZ;                         // 14
+        float maxX;                         // 15
+        float maxY;                         // 16
+        float maxZ;                         // 17
+        //uint32_t transport;               // 18
+        //uint32_t unk;                     // 19
+        //uint32_t unk;                     // 20
+    };
 
-        struct GemPropertiesEntry
-        {
-            uint32_t Entry;                     // 0
-            uint32_t EnchantmentID;             // 1
-            //uint32_t unk1;                    // 2 bool
-            //uint32_t unk2;                    // 3 bool
-            uint32_t SocketMask;                // 4
-        };
+    struct GemPropertiesEntry
+    {
+        uint32_t Entry;                     // 0
+        uint32_t EnchantmentID;             // 1
+        //uint32_t unk1;                    // 2 bool
+        //uint32_t unk2;                    // 3 bool
+        uint32_t SocketMask;                // 4
+    };
 
-        struct GlyphPropertiesEntry
-        {
-            uint32_t Entry;                     // 0
-            uint32_t SpellID;                   // 1
-            uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
-            uint32_t unk;                       // 3 glyph_icon spell.dbc
-        };
+    struct GlyphPropertiesEntry
+    {
+        uint32_t Entry;                     // 0
+        uint32_t SpellID;                   // 1
+        uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                       // 3 glyph_icon spell.dbc
+    };
 
-        struct GlyphSlotEntry
-        {
-            uint32_t Id;                        // 0
-            uint32_t Type;                      // 1
-            uint32_t Slot;                      // 2
-        };
+    struct GlyphSlotEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t Type;                      // 1
+        uint32_t Slot;                      // 2
+    };
 
-        struct GtBarberShopCostBaseEntry
-        {
-            float cost;                         // 0
-        };
+    struct GtBarberShopCostBaseEntry
+    {
+        float cost;                         // 0
+    };
 
-        struct GtChanceToMeleeCritEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToMeleeCritEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToMeleeCritBaseEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToMeleeCritBaseEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToSpellCritEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToSpellCritEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToSpellCritBaseEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToSpellCritBaseEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtCombatRatingsEntry
-        {
-            float val;                          // 0
-        };
+    struct GtCombatRatingsEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtOCTClassCombatRatingScalarEntry
-        {
-            float val;                          // 0
-        };
+    struct GtOCTClassCombatRatingScalarEntry
+    {
+        float val;                          // 0
+    };
 
-        //\todo danko
-        //struct GtOCTRegenHPEntry
-        //{
-        //    float ratio;                      // 0
-        //};
+    //\todo danko
+    //struct GtOCTRegenHPEntry
+    //{
+    //    float ratio;                      // 0
+    //};
 
-        struct GtOCTRegenMPEntry
-        {
-            float ratio;                        // 0
-        };
+    struct GtOCTRegenMPEntry
+    {
+        float ratio;                        // 0
+    };
 
-        //\todo danko
-        //struct GtRegenHPPerSptEntry
-        //{
-        //    float ratio;                      // 0
-        //};
+    //\todo danko
+    //struct GtRegenHPPerSptEntry
+    //{
+    //    float ratio;                      // 0
+    //};
 
-        struct GtRegenMPPerSptEntry
-        {
-            float ratio;                        // 0
-        };
+    struct GtRegenMPPerSptEntry
+    {
+        float ratio;                        // 0
+    };
 
-        struct GuildPerkSpellsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Level;                     // 1
-            uint32_t SpellId;                   // 2
-        };
+    struct GuildPerkSpellsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Level;                     // 1
+        uint32_t SpellId;                   // 2
+    };
 
 #define MAX_HOLIDAY_DURATIONS 10
 #define MAX_HOLIDAY_DATES 26
 #define MAX_HOLIDAY_FLAGS 10
 
-        struct HolidaysEntry
-        {
-            uint32_t Id;                                    // 0
-            //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-            //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-            //uint32_t Region;                              // 37
-            //uint32_t Looping;                             // 38
-            //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-            //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
-            //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
-            //char* TextureFilename;                        // 51
-            //uint32_t Priority;                            // 52
-            //uint32_t CalendarFilterType;                  // 53
-            //uint32_t flags;                               // 54
-        };
+    struct HolidaysEntry
+    {
+        uint32_t Id;                                    // 0
+        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
+        //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
+        //uint32_t Region;                              // 37
+        //uint32_t Looping;                             // 38
+        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
+        //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
+        //char* TextureFilename;                        // 51
+        //uint32_t Priority;                            // 52
+        //uint32_t CalendarFilterType;                  // 53
+        //uint32_t flags;                               // 54
+    };
 
-        struct ItemLimitCategoryEntry
-        {
-            uint32_t Id;                        // 0
-            //char* name;                       // 1
-            uint32_t maxAmount;                 // 2
-            uint32_t equippedFlag;              // 3
-        };
+    struct ItemLimitCategoryEntry
+    {
+        uint32_t Id;                        // 0
+        //char* name;                       // 1
+        uint32_t maxAmount;                 // 2
+        uint32_t equippedFlag;              // 3
+    };
 
-        struct ItemRandomPropertiesEntry
-        {
-            uint32_t ID;                        // 0
-            //char* name1;                      // 1
-            uint32_t spells[5];                 // 2-6 enchant_id
-            char* name_suffix;                  // 7
-        };
+    struct ItemRandomPropertiesEntry
+    {
+        uint32_t ID;                        // 0
+        //char* name1;                      // 1
+        uint32_t spells[5];                 // 2-6 enchant_id
+        char* name_suffix;                  // 7
+    };
 
-        struct ItemRandomSuffixEntry
-        {
-            uint32_t id;                        // 0
-            char* name_suffix;                  // 1
-            //uint32_t name_suffix_flags;       // 2
-            uint32_t enchantments[5];           // 3-7
-            uint32_t prefixes[5];               // 8-12
-        };
+    struct ItemRandomSuffixEntry
+    {
+        uint32_t id;                        // 0
+        char* name_suffix;                  // 1
+        //uint32_t name_suffix_flags;       // 2
+        uint32_t enchantments[5];           // 3-7
+        uint32_t prefixes[5];               // 8-12
+    };
 
-        struct ItemSetEntry
-        {
-            //uint32_t id;                      // 0
-            char* name;                         // 1
-            //uint32_t itemid[17];              // 2-18
-            uint32_t SpellID[8];                // 19-26
-            uint32_t itemscount[8];             // 27-34
-            uint32_t RequiredSkillID;           // 35
-            uint32_t RequiredSkillAmt;          // 36
-        };
+    struct ItemSetEntry
+    {
+        //uint32_t id;                      // 0
+        char* name;                         // 1
+        //uint32_t itemid[17];              // 2-18
+        uint32_t SpellID[8];                // 19-26
+        uint32_t itemscount[8];             // 27-34
+        uint32_t RequiredSkillID;           // 35
+        uint32_t RequiredSkillAmt;          // 36
+    };
 
-        struct LFGDungeonEntry
-        {
-            uint32_t ID;                        // 0
-            char* name;                         // 1
-            uint32_t minlevel;                  // 2
-            uint32_t maxlevel;                  // 3
-            uint32_t reclevel;                  // 4
-            uint32_t recminlevel;               // 5
-            uint32_t recmaxlevel;               // 6
-            int32_t map;                        // 7
-            uint32_t difficulty;                // 8
-            uint32_t unk;                       // 9
-            uint32_t flags;                     // 10
-            int32_t type;                       // 11
-            char* iconname;                     // 12
-            uint32_t expansion;                 // 13
-            uint32_t unk4;                      // 14
-            uint32_t unk5;                      // 15
-            char* unk_text;                     // 16
-            uint32_t grouptype;                 // 17
-            uint32_t unkflags1;                 // 18
-            uint32_t unkflags2;                 // 19
-            uint32_t unk7;                      // 20
+    struct LFGDungeonEntry
+    {
+        uint32_t ID;                        // 0
+        char* name;                         // 1
+        uint32_t minlevel;                  // 2
+        uint32_t maxlevel;                  // 3
+        uint32_t reclevel;                  // 4
+        uint32_t recminlevel;               // 5
+        uint32_t recmaxlevel;               // 6
+        int32_t map;                        // 7
+        uint32_t difficulty;                // 8
+        uint32_t unk;                       // 9
+        uint32_t flags;                     // 10
+        int32_t type;                       // 11
+        char* iconname;                     // 12
+        uint32_t expansion;                 // 13
+        uint32_t unk4;                      // 14
+        uint32_t unk5;                      // 15
+        char* unk_text;                     // 16
+        uint32_t grouptype;                 // 17
+        uint32_t unkflags1;                 // 18
+        uint32_t unkflags2;                 // 19
+        uint32_t unk7;                      // 20
 
-            // Helpers
-            uint32_t Entry() const { return ID + (type << 24); }
-        };
+        // Helpers
+        uint32_t Entry() const { return ID + (type << 24); }
+    };
 
-        struct DungeonEncounterEntry
-        {
-            uint32 id;                                              // 0        unique id
-            uint32 mapId;                                           // 1        map id
-            uint32 difficulty;                                      // 2        instance mode
-            //uint32 unk0;                                          // 3
-            uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-            char* encounterName;                                    // 5        encounter name
-            //uint32 nameFlags;                                     // 21
-            //uint32 unk1;                                          // 22
-        };
+    struct DungeonEncounterEntry
+    {
+        uint32 id;                                              // 0        unique id
+        uint32 mapId;                                           // 1        map id
+        uint32 difficulty;                                      // 2        instance mode
+        //uint32 unk0;                                          // 3
+        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
+        char* encounterName;                                    // 5        encounter name
+        //uint32 nameFlags;                                     // 21
+        //uint32 unk1;                                          // 22
+    };
 
-        struct LiquidTypeEntry
-        {
-            uint32_t Id;                        // 0
-            //char* Name;                       // 1
-            //uint32_t Flags;                   // 2
-            uint32_t Type;                      // 3
-            //uint32_t SoundId;                 // 4
-            uint32_t SpellId;                   // 5
-            //float MaxDarkenDepth;             // 6
-            //float FogDarkenIntensity;         // 7
-            //float AmbDarkenIntensity;         // 8
-            //float DirDarkenIntensity;         // 9
-            //uint32_t LightID;                 // 10
-            //float ParticleScale;              // 11
-            //uint32_t ParticleMovement;        // 12
-            //uint32_t ParticleTexSlots;        // 13
-            //uint32_t LiquidMaterialID;        // 14
-            //char* Texture[6];                 // 15-20
-            //uint32_t Color[2];                // 21-22
-            //float Unk1[18];                   // 23-40
-            //uint32_t Unk2[4];                 // 41-44
-        };
+    struct LiquidTypeEntry
+    {
+        uint32_t Id;                        // 0
+        //char* Name;                       // 1
+        //uint32_t Flags;                   // 2
+        uint32_t Type;                      // 3
+        //uint32_t SoundId;                 // 4
+        uint32_t SpellId;                   // 5
+        //float MaxDarkenDepth;             // 6
+        //float FogDarkenIntensity;         // 7
+        //float AmbDarkenIntensity;         // 8
+        //float DirDarkenIntensity;         // 9
+        //uint32_t LightID;                 // 10
+        //float ParticleScale;              // 11
+        //uint32_t ParticleMovement;        // 12
+        //uint32_t ParticleTexSlots;        // 13
+        //uint32_t LiquidMaterialID;        // 14
+        //char* Texture[6];                 // 15-20
+        //uint32_t Color[2];                // 21-22
+        //float Unk1[18];                   // 23-40
+        //uint32_t Unk2[4];                 // 41-44
+    };
 
 #define LOCK_NUM_CASES 8
 
-        struct LockEntry
+    struct LockEntry
+    {
+        uint32_t Id;                              // 0
+        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+    };
+
+    struct MailTemplateEntry
+    {
+        uint32_t ID;                        // 0
+        char* subject;                      // 1
+        char* content;                      // 2
+    };
+
+    struct MapEntry
+    {
+        uint32_t id;                        // 0
+        char* name_internal;                // 1
+        uint32_t map_type;                  // 2
+        uint32_t map_flags;                 // 3
+        uint32_t unk4;                      // 4
+        uint32_t is_pvp_zone;               // 5
+        char* map_name;                     // 6
+        uint32_t linked_zone;               // 7 common zone for instance and continent map
+        char* horde_intro;                  // 8 horde text for PvP Zones
+        char* alliance_intro;               // 9 alliance text for PvP Zones
+        uint32_t multimap_id;               // 10
+        float battlefield_map_icon;         // 11
+        int32_t parent_map;                 // 12 ghost map_id of parent map
+        float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
+        float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
+        uint32_t dayTime_override;          // 15
+        uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                  // 17
+        uint32_t max_players;               // 18
+        uint32_t next_phase_map;            // 19
+
+        bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
+        bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
+        bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isRaid() const { return map_type == MAP_RAID; }
+        bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
+        bool isBattleArena() const { return map_type == MAP_ARENA; }
+        bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isWorldMap() const { return map_type == MAP_COMMON; }
+
+        bool isContinent() const
         {
-            uint32_t Id;                              // 0
-            uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-            uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-            uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-            //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
-        };
+            return id == 0 || id == 1 || id == 530 || id == 571;
+        }
+    };
 
-        struct MailTemplateEntry
+    struct NameGenEntry
+    {
+        uint32_t ID;                        // 0
+        char* Name;                         // 1
+        uint32_t unk1;                      // 2
+        uint32_t type;                      // 3
+    };
+
+    struct NumTalentsAtLevel
+    {
+        //uint32_t level;                   // 0
+        float talentPoints;                 // 1
+    };
+
+    struct PhaseEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t PhaseShift;                // 1
+        uint32_t Flags;                     // 2
+    };
+
+    struct QuestSortEntry
+    {
+        uint32_t id;                        // 0
+        //char* name;                       // 1
+    };
+
+    struct QuestXP
+    {
+        uint32_t questLevel;                // 0
+        uint32_t xpIndex[10];               // 1-10
+    };
+
+    struct ScalingStatDistributionEntry
+    {
+        uint32_t id;                        // 0
+        int32_t stat[10];                   // 1-10
+        uint32_t statmodifier[10];          // 11-20
+        //uint32_t unk;                     // 21
+        uint32_t maxlevel;                  // 22
+    };
+
+    struct ScalingStatValuesEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t level;                     // 1
+        uint32_t multiplier[20];            // 
+        //\todo danko Rewrite GetStatScalingStatValueColumn!
+        //uint32_t dpsMod[6];               // 2-7
+        //uint32_t spellBonus;              // 8
+        //uint32_t scalingstatmultipl[5];   // 9-13
+        //uint32_t amor_mod[4];             // 14-17
+        //uint32_t amor_mod2[4];            // 18-21
+        //uint32_t junk[24];                // 22-45
+        //uint32_t unk2;                    // 46
+    };
+
+    struct SkillLineEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t type;                      // 1
+        char* Name;                         // 2
+        //char* Description;                // 3
+        uint32_t spell_icon;                // 4
+        //char* add_name;                   // 5
+        uint32_t linkable;                  // 6
+    };
+
+    struct SkillLineAbilityEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t skilline;                  // 1 skill id
+        uint32_t spell;                     // 2
+        uint32_t race_mask;                 // 3
+        uint32_t class_mask;                // 4
+        //uint32_t excludeRace;             // 5
+        //uint32_t excludeClass;            // 6
+        uint32_t minSkillLineRank;          // 7 req skill value
+        uint32_t next;                      // 8
+        uint32_t acquireMethod;             // 9 auto learn
+        uint32_t grey;                      // 10 max
+        uint32_t green;                     // 11 min
+        uint32_t characterPoints;           // 12
+        //uint32_t unk;                     // 13
+    };
+
+    //\todo danko
+    //struct StableSlotPrices
+    //{
+    //    uint32_t Id;                      // 0
+    //    uint32_t Price;                   // 1
+    //};
+
+    //\ todo: confirm effect count
+    #define MAX_SPELL_EFFECTS 3
+    #define MAX_SPELL_REAGENTS 8
+    #define MAX_SPELL_TOTEMS 2
+    #define MAX_SPELL_TOTEM_CATEGORIES 2
+
+    // SpellAuraOptions.dbc
+    struct SpellAuraOptionsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t MaxStackAmount;            // 1
+        uint32_t procChance;                // 2
+        uint32_t procCharges;               // 3
+        uint32_t procFlags;                 // 4
+    };
+
+    // SpellAuraRestrictions.dbc
+    struct SpellAuraRestrictionsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t CasterAuraState;           // 1
+        uint32_t TargetAuraState;           // 2
+        uint32_t CasterAuraStateNot;        // 3
+        uint32_t TargetAuraStateNot;        // 4
+        uint32_t casterAuraSpell;           // 5
+        uint32_t targetAuraSpell;           // 6
+        uint32_t CasterAuraSpellNot;        // 7
+        uint32_t TargetAuraSpellNot;        // 8
+    };
+
+    // SpellCastingRequirements.dbc
+    struct SpellCastingRequirementsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t FacingCasterFlags;         // 1
+        //uint32_t MinFactionId;            // 2
+        //uint32_t MinReputation;           // 3
+        int32_t AreaGroupId;                // 4
+        //uint32_t RequiredAuraVision;      // 5
+        uint32_t RequiresSpellFocus;        // 6
+    };
+
+    // SpellCastTimes.dbc
+    struct SpellCastTimesEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t CastTime;                  // 1
+        float CastTimePerLevel;             // 2
+        int32_t MinCastTime;                // 3
+    };
+
+    // SpellCategories.dbc
+    struct SpellCategoriesEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Category;                  // 1
+        uint32_t DmgClass;                  // 2
+        uint32_t DispelType;                // 3
+        uint32_t MechanicsType;             // 4
+        uint32_t PreventionType;            // 5
+        uint32_t StartRecoveryCategory;     // 6
+    };
+
+    // SpellClassOptions.dbc
+    struct SpellClassOptionsEntry
+    {
+        //uint32_t Id;                                  // 0
+        //uint32_t modalNextSpell;                      // 1
+        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
+        uint32_t SpellFamilyName;                       // 5
+        //char* Description;                            // 6
+    };
+
+    // SpellCooldowns.dbc
+    struct SpellCooldownsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t CategoryRecoveryTime;      // 1
+        uint32_t RecoveryTime;              // 2
+        uint32_t StartRecoveryTime;         // 3
+    };
+
+    // SpellDifficulty.dbc
+    struct SpellDifficultyEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t SpellId[MAX_DIFFICULTY];    // 1-4
+    };
+
+    // SpellDuration.dbc
+    struct SpellDurationEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t Duration1;                 // 1
+        uint32_t Duration2;                 // 2
+        uint32_t Duration3;                 // 3
+    };
+
+    // SpellEffect.dbc
+    struct SpellEffectEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Effect;                    // 1
+        float EffectMultipleValue;          // 2
+        uint32_t EffectApplyAuraName;       // 3
+        uint32_t EffectAmplitude;           // 4
+        int32_t EffectBasePoints;           // 5
+        float EffectBonusMultiplier;        // 6
+        float EffectDamageMultiplier;       // 7
+        uint32_t EffectChainTarget;         // 8
+        int32_t EffectDieSides;             // 9
+        uint32_t EffectItemType;            // 10
+        uint32_t EffectMechanic;            // 11
+        int32_t EffectMiscValue;            // 12
+        int32_t EffectMiscValueB;           // 13
+        float EffectPointsPerComboPoint;    // 14
+        uint32_t EffectRadiusIndex;         // 15
+        uint32_t EffectRadiusMaxIndex;      // 16
+        float EffectRealPointsPerLevel;     // 17
+        uint32_t EffectSpellClassMask[3];   // 18-20
+        //ClassFamilyMask EffectSpellClassMask;
+        uint32_t EffectTriggerSpell;        // 21
+        uint32_t EffectImplicitTargetA;     // 22
+        uint32_t EffectImplicitTargetB;     // 23
+        uint32_t EffectSpellId;             // 24
+        uint32_t EffectIndex;               // 25
+        //uint32_t unk;                     // 26
+
+        uint32_t GetRadiusIndex() const
         {
-            uint32_t ID;                        // 0
-            char* subject;                      // 1
-            char* content;                      // 2
-        };
+            if (EffectRadiusIndex != 0)
+                return EffectRadiusIndex;
 
-        struct MapEntry
+            return EffectRadiusMaxIndex;
+        }
+    };
+
+    // SpellEquippedItems.dbc
+    struct SpellEquippedItemsEntry
+    {
+        //uint32_t Id;                          // 0
+        int32_t EquippedItemClass;              // 1
+        int32_t EquippedItemInventoryTypeMask;  // 2
+        int32_t EquippedItemSubClassMask;       // 3
+    };
+
+    // SpellFocusObject.dbc
+    struct SpellFocusObjectEntry
+    {
+        uint32_t ID;                        // 0
+        //char* Name;                       // 1
+    };
+
+    // SpellInterrupts.dbc
+    struct SpellInterruptsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t AuraInterruptFlags;        // 1
+        //uint32_t unk2                     // 2
+        uint32_t ChannelInterruptFlags;     // 3
+        //uint32_t unk4                     // 4
+        uint32_t InterruptFlags;            // 5
+    };
+
+    // SpellItemEnchantment.dbc
+    struct SpellItemEnchantmentEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t charges;                 // 1
+        uint32_t type[3];                   // 2-4
+        uint32_t min[3];                    // 5-7 for combat, in practice min==max
+        //uint32_t max[3];                  // 8-10
+        uint32_t spell[3];                  // 11-13
+        char* Name;                         // 14-29
+        //uint32_t NameFlags;               // 30
+        uint32_t visual;                    // 31 aura
+        uint32_t EnchantGroups;             // 32 slot
+        uint32_t GemEntry;                  // 33
+        uint32_t ench_condition;            // 34
+        uint32_t req_skill;                 // 35
+        uint32_t req_skill_value;           // 36
+        uint32_t req_level;                 // 37
+    };
+
+    // SpellItemEnchantmentCondition.dbc
+    struct SpellItemEnchantmentConditionEntry
+    {
+        uint32_t ID;                        // 0
+        uint8_t Color[5];                   // 1-5
+        //uint32_t LT_Operand[5];           // 6-10
+        uint8_t Comparator[5];              // 11-15
+        uint8_t CompareColor[5];            // 15-20
+        uint32_t Value[5];                  // 21-25
+        //uint8_t Logic[5]                  // 25-30
+    };
+
+    // SpellLevels.dbc
+    struct SpellLevelsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t baseLevel;                 // 1
+        uint32_t maxLevel;                  // 2
+        uint32_t spellLevel;                // 3
+    };
+
+    // SpellPower.dbc
+    struct SpellPowerEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t manaCost;                  // 1
+        uint32_t manaCostPerlevel;          // 2
+        uint32_t ManaCostPercentage;        // 3
+        uint32_t manaPerSecond;             // 4
+        uint32_t manaPerSecondPerLevel;     // 5
+        //uint32_t PowerDisplayId;          // 6 
+        float ManaCostPercentageFloat;      // 7
+    };
+
+    // SpellRadius.dbc
+    struct SpellRadiusEntry
+    {
+        uint32_t ID;                        // 0
+        float radius_min;                   // 1
+        float radius_per_level;             // 2
+        float radius_max;                   // 3
+    };
+
+    // SpellRange.dbc
+    struct SpellRangeEntry
+    {
+        uint32_t ID;                        // 0
+        float minRange;                     // 1
+        float minRangeFriendly;             // 2
+        float maxRange;                     // 3
+        float maxRangeFriendly;             // 4
+        uint32_t range_type;                // 5
+        //char* name1[16]                   // 6-21
+        //uint32_t name1_falgs;             // 22
+        //char* name2[16]                   // 23-38
+        //uint32_t name2_falgs;             // 39
+    };
+
+    // SpellReagents.dbc
+    struct SpellReagentsEntry
+    {
+        //uint32_t Id;                              // 0
+        int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
+    };
+
+    // SpellRuneCost.dbc
+    struct SpellRuneCostEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t bloodRuneCost;             // 1
+        uint32_t frostRuneCost;             // 2
+        uint32_t unholyRuneCost;            // 3
+        uint32_t runePowerGain;             // 4
+    };
+
+    // SpellScaling.dbc
+    struct SpellScalingEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t castTimeMin;               // 1
+        uint32_t castTimeMax;               // 2
+        uint32_t castScalingMaxLevel;       // 3
+        uint32_t playerClass;               // 4
+        float coeff1[3];                    // 5-7
+        float coeff2[3];                    // 8-10
+        float coeff3[3];                    // 11-13
+        float coefBase;                     // 14
+        uint32_t coefLevelBase;             // 15
+
+        bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
+    };
+
+    // SpellShapeshift.dbc
+    struct SpellShapeshiftEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t ShapeshiftsExcluded;       // 1
+        //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
+        uint32_t Shapeshifts;               // 3
+        //uint32_t Shapeshifts1;            // 4 unused, all zeros
+        //uint32_t StanceBarOrder;          // 5
+    };
+
+    // SpellTargetRestrictions.dbc
+    struct SpellTargetRestrictionsEntry
+    {
+        //uint32_t Id;                      // 0
+        float MaxTargetRadius;              // 1
+        uint32_t MaxAffectedTargets;        // 2
+        uint32_t MaxTargetLevel;            // 3
+        uint32_t TargetCreatureType;        // 4
+        uint32_t Targets;                   // 5
+    };
+
+    // SpellTotems.dbc
+    struct SpellTotemsEntry
+    {
+        //uint32_t Id;                                         // 0
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
+        uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
+    };
+
+    struct SERVER_DECL SpellEntry
+    {
+        uint32_t Id;                                          // 0
+        uint32_t Attributes;                                  // 1
+        uint32_t AttributesEx;                                // 2
+        uint32_t AttributesExB;                               // 3
+        uint32_t AttributesExC;                               // 4
+        uint32_t AttributesExD;                               // 5
+        uint32_t AttributesExE;                               // 6
+        uint32_t AttributesExF;                               // 7
+        uint32_t AttributesExG;                               // 8
+        uint32_t AttributesExH;                               // 9
+        uint32_t AttributesExI;                               // 10
+        uint32_t AttributesExJ;                               // 11
+        uint32_t CastingTimeIndex;                            // 12
+        uint32_t DurationIndex;                               // 13
+        int32_t powerType;                                    // 14
+        uint32_t rangeIndex;                                  // 15
+        float speed;                                          // 16
+        uint32_t SpellVisual;                                 // 17
+        uint32_t SpellVisual1;                                // 18
+        uint32_t spellIconID;                                 // 19
+        uint32_t activeIconID;                                // 20
+        const char* Name;                                     // 21
+        const char* Rank;                                     // 22
+        //char* Description;                                  // 23 not used
+        //char* BuffDescription;                              // 24 not used
+        uint32_t School;                                      // 25
+        uint32_t RuneCostID;                                  // 26
+        //uint32_t spellMissileID;                            // 27
+        //uint32_t spellDescriptionVariableID;                // 28
+        uint32_t SpellDifficultyId;                           // 29
+        //float unk_1;                                        // 30
+        uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
+        uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
+        uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
+        uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
+        uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
+        uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
+        uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
+        //uint32_t unk_2;                                     // 38 all zeros...
+        uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
+        uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
+        uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
+        uint32_t SpellPowerId;                                // 42 SpellPower.dbc
+        uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
+        uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
+        uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
+        uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
+        //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
+
+        // struct access functions
+        SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
+        SpellAuraRestrictionsEntry const* GetSpellAuraRestrictions() const;
+        SpellCastingRequirementsEntry const* GetSpellCastingRequirements() const;
+        SpellCategoriesEntry const* GetSpellCategories() const;
+        SpellClassOptionsEntry const* GetSpellClassOptions() const;
+        SpellCooldownsEntry const* GetSpellCooldowns() const;
+        SpellEffectEntry const* GetSpellEffect(uint8_t eff) const;
+        SpellEquippedItemsEntry const* GetSpellEquippedItems() const;
+        SpellInterruptsEntry const* GetSpellInterrupts() const;
+        SpellLevelsEntry const* GetSpellLevels() const;
+        SpellPowerEntry const* GetSpellPower() const;
+        SpellReagentsEntry const* GetSpellReagents() const;
+        SpellScalingEntry const* GetSpellScaling() const;
+        SpellShapeshiftEntry const* GetSpellShapeshift() const;
+        SpellTargetRestrictionsEntry const* GetSpellTargetRestrictions() const;
+        SpellTotemsEntry const* GetSpellTotems() const;
+
+        // single fields
+        uint32_t GetManaCost() const;
+        uint32_t GetPreventionType() const;
+        uint32_t GetCategory() const;
+        uint32_t GetStartRecoveryTime() const;
+        uint32_t GetMechanic() const;
+        uint32_t GetRecoveryTime() const;
+        uint32_t GetCategoryRecoveryTime() const;
+        uint32_t GetStartRecoveryCategory() const;
+        uint32_t GetSpellLevel() const;
+        int32_t GetEquippedItemClass() const;
+        uint32_t GetSpellFamilyName() const;
+        uint32_t GetDmgClass() const;
+        uint32_t GetDispel() const;
+        uint32_t GetMaxAffectedTargets() const;
+        uint32_t GetStackAmount() const;
+        uint32_t GetManaCostPercentage() const;
+        uint32_t GetProcCharges() const;
+        uint32_t GetProcChance() const;
+        uint32_t GetMaxLevel() const;
+        uint32_t GetTargetAuraState() const;
+        uint32_t GetManaPerSecond() const;
+        uint32_t GetRequiresSpellFocus() const;
+        uint32_t GetSpellEffectIdByIndex(uint8_t index) const;
+        uint32_t GetAuraInterruptFlags() const;
+        uint32_t GetEffectImplicitTargetAByIndex(uint8_t index) const;
+        int32_t GetAreaGroupId() const;
+        uint32_t GetFacingCasterFlags() const;
+        uint32_t GetBaseLevel() const;
+        uint32_t GetInterruptFlags() const;
+        uint32_t GetTargetCreatureType() const;
+        int32_t GetEffectMiscValue(uint8_t index) const;
+        uint32_t GetStances() const;
+        uint32_t GetStancesNot() const;
+        uint32_t GetProcFlags() const;
+        uint32_t GetChannelInterruptFlags() const;
+        uint32_t GetManaCostPerLevel() const;
+        uint32_t GetCasterAuraState() const;
+        uint32_t GetTargets() const;
+        uint32_t GetEffectApplyAuraNameByIndex(uint8_t index) const;
+
+    private:
+
+        SpellEntry(SpellEntry const&);
+    };
+
+    struct SpellShapeshiftFormEntry
+    {
+        uint32_t id;                  // 0
+        //uint32_t button_pos;        // 1
+        //char* name[16];             // 2-17
+        //uint32_t name_flags;        // 18
+        uint32_t Flags;               // 19
+        uint32_t unit_type;           // 20
+        //uint32_t unk1               // 21
+        uint32_t AttackSpeed;         // 22
+        uint32_t modelId;             // 23 alliance?
+        uint32_t modelId2;            // 24 horde?
+        //uint32_t unk2               // 25
+        //uint32_t unk3               // 26
+        uint32_t spells[8];           // 27-34
+    };
+
+    struct SummonPropertiesEntry
+    {
+        uint32_t ID;                  // 0
+        uint32_t ControlType;         // 1
+        uint32_t FactionID;           // 2
+        uint32_t Type;                // 3
+        uint32_t Slot;                // 4
+        uint32_t Flags;               // 5
+    };
+
+    struct TalentEntry
+    {
+        uint32_t TalentID;            // 0
+        uint32_t TalentTree;          // 1
+        uint32_t Row;                 // 2
+        uint32_t Col;                 // 3
+        uint32_t RankID[5];           // 4-8
+        //uint32_t unk[4];            // 9-12
+        uint32_t DependsOn;           // 13
+        //uint32_t unk1[2];           // 14-15
+        uint32_t DependsOnRank;       // 16
+        //uint32_t unk2[2];           // 17-18
+        //uint32_t unk3;              // 19
+        //uint32_t unk4;              // 20
+        //uint32_t unk5;              // 21
+    };
+
+    struct TalentTabEntry
+    {
+        uint32_t TalentTabID;         // 0
+        //char* Name;                 // 1
+        //uint32_t unk5;              // 2
+        uint32_t ClassMask;           // 3
+        uint32_t PetTalentMask;       // 4
+        uint32_t TabPage;             // 5
+        //char* InternalName;         // 6
+        //char* description;          // 7
+        uint32_t rolesMask;           // 8
+        uint32_t masterySpells[2];    // 9-10
+    };
+
+    struct TalentTreePrimarySpells
+    {
+        uint32_t ID;                  // 0
+        uint32_t tabID;               // 1
+        uint32_t SpellID;             // 2
+        //uint32_t unk                // 3
+    };
+
+    struct TaxiNodesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t mapid;               // 1
+        float x;                      // 2
+        float y;                      // 3
+        float z;                      // 4
+        char* name;                   // 5
+        uint32_t horde_mount;         // 6
+        uint32_t alliance_mount;      // 7
+    };
+
+    struct TaxiPathEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t from;                // 1
+        uint32_t to;                  // 2
+        uint32_t price;               // 3
+    };
+
+    struct TaxiPathNodeEntry
+    {
+        //uint32_t id;                // 0
+        uint32_t path;                // 1
+        uint32_t seq;                 // 2 nodeIndex
+        uint32_t mapid;               // 3
+        float x;                      // 4
+        float y;                      // 5
+        float z;                      // 6
+        uint32_t flags;               // 7
+        uint32_t waittime;            // 8
+        uint32_t arivalEventID;       // 9
+        uint32_t departureEventID;    // 10
+    };
+
+    struct TransportAnimationEntry
+    {
+        //uint32_t Id;          // 0
+        uint32_t TransportID;   // 1
+        uint32_t TimeIndex;     // 2
+        DBCPosition3D Pos;      // 3
+        //uint32_t SequenceID;  // 4
+    };
+
+    struct TransportRotationEntry
+    {
+        //uint32_t ID;          // 0
+        uint32_t GameObjectsID; // 1
+        uint32_t TimeIndex;     // 2
+        float X;                // 3
+        float Y;                // 4
+        float Z;                // 5
+        float W;                // 6
+    };
+
+    struct TotemCategoryEntry
+    {
+        uint32_t id;            // 0
+        //char* name;           // 1
+        uint32_t categoryType;  // 2
+        uint32_t categoryMask;  // 3
+    };
+
+    #define MAX_VEHICLE_SEATS 8
+
+    struct VehicleEntry
+    {
+        uint32_t ID;                                        // 0
+        uint32_t flags;                                     // 1
+        float turnSpeed;                                    // 2
+        float pitchSpeed;                                   // 3
+        float pitchMin;                                     // 4
+        float pitchMax;                                     // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
+        float mouseLookOffsetPitch;                         // 14
+        float cameraFadeDistScalarMin;                      // 15
+        float cameraFadeDistScalarMax;                      // 16
+        float cameraPitchOffset;                            // 17
+        float facingLimitRight;                             // 18
+        float facingLimitLeft;                              // 19
+        float msslTrgtTurnLingering;                        // 20
+        float msslTrgtPitchLingering;                       // 21
+        float msslTrgtMouseLingering;                       // 22
+        float msslTrgtEndOpacity;                           // 23
+        float msslTrgtArcSpeed;                             // 24
+        float msslTrgtArcRepeat;                            // 25
+        float msslTrgtArcWidth;                             // 26
+        float msslTrgtImpactRadius[2];                      // 27-28
+        char* msslTrgtArcTexture;                           // 29
+        char* msslTrgtImpactTexture;                        // 30
+        char* msslTrgtImpactModel[2];                       // 31-32
+        float cameraYawOffset;                              // 33
+        uint32_t uiLocomotionType;                          // 34
+        float msslTrgtImpactTexRadius;                      // 35
+        uint32_t uiSeatIndicatorType;                       // 36
+        uint32_t powerType;                                 // 37
+        //uint32_t unk1;                                    // 38
+        //uint32_t unk2;                                    // 39  
+    };
+
+    enum VehicleSeatFlags
+    {
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+    };
+
+    enum VehicleSeatFlagsB
+    {
+        VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
+    };
+
+    struct VehicleSeatEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        int32_t attachmentID;                                 // 2
+        float attachmentOffsetX;                              // 3
+        float attachmentOffsetY;                              // 4
+        float attachmentOffsetZ;                              // 5
+        float enterPreDelay;                                  // 6
+        float enterSpeed;                                     // 7
+        float enterGravity;                                   // 8
+        float enterMinDuration;                               // 9
+        float enterMaxDuration;                               // 10
+        float enterMinArcHeight;                              // 11
+        float enterMaxArcHeight;                              // 12
+        int32_t enterAnimStart;                               // 13
+        int32_t enterAnimLoop;                                // 14
+        int32_t rideAnimStart;                                // 15
+        int32_t rideAnimLoop;                                 // 16
+        int32_t rideUpperAnimStart;                           // 17
+        int32_t rideUpperAnimLoop;                            // 18
+        float exitPreDelay;                                   // 19
+        float exitSpeed;                                      // 20
+        float exitGravity;                                    // 21
+        float exitMinDuration;                                // 22
+        float exitMaxDuration;                                // 23
+        float exitMinArcHeight;                               // 24
+        float exitMaxArcHeight;                               // 25
+        int32_t exitAnimStart;                                // 26
+        int32_t exitAnimLoop;                                 // 27
+        int32_t exitAnimEnd;                                  // 28
+        float passengerYaw;                                   // 29
+        float passengerPitch;                                 // 30
+        float passengerRoll;                                  // 31
+        int32_t passengerAttachmentID;                        // 32
+        int32_t vehicleEnterAnim;                             // 33
+        int32_t vehicleExitAnim;                              // 34
+        int32_t vehicleRideAnimLoop;                          // 35
+        int32_t vehicleEnterAnimBone;                         // 36
+        int32_t vehicleExitAnimBone;                          // 37
+        int32_t vehicleRideAnimLoopBone;                      // 38
+        float vehicleEnterAnimDelay;                          // 39
+        float vehicleExitAnimDelay;                           // 40
+        uint32_t vehicleAbilityDisplay;                       // 41
+        uint32_t enterUISoundID;                              // 42
+        uint32_t exitUISoundID;                               // 43
+        int32_t uiSkin;                                       // 44
+        uint32_t flagsB;                                      // 45
+
+        bool IsUsable() const
         {
-            uint32_t id;                        // 0
-            char* name_internal;                // 1
-            uint32_t map_type;                  // 2
-            uint32_t map_flags;                 // 3
-            uint32_t unk4;                      // 4
-            uint32_t is_pvp_zone;               // 5
-            char* map_name;                     // 6
-            uint32_t linked_zone;               // 7 common zone for instance and continent map
-            char* horde_intro;                  // 8 horde text for PvP Zones
-            char* alliance_intro;               // 9 alliance text for PvP Zones
-            uint32_t multimap_id;               // 10
-            float battlefield_map_icon;         // 11
-            int32_t parent_map;                 // 12 ghost map_id of parent map
-            float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
-            float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
-            uint32_t dayTime_override;          // 15
-            uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
-            uint32_t unk_time;                  // 17
-            uint32_t max_players;               // 18
-            uint32_t next_phase_map;            // 19
+            if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
+                return true;
+            else
+                return false;
+        }
 
-            bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
-            bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
-            bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isRaid() const { return map_type == MAP_RAID; }
-            bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
-            bool isBattleArena() const { return map_type == MAP_ARENA; }
-            bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isWorldMap() const { return map_type == MAP_COMMON; }
-
-            bool isContinent() const
-            {
-                return id == 0 || id == 1 || id == 530 || id == 571;
-            }
-        };
-
-        struct NameGenEntry
+        bool IsController() const
         {
-            uint32_t ID;                        // 0
-            char* Name;                         // 1
-            uint32_t unk1;                      // 2
-            uint32_t type;                      // 3
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
+                return true;
+            else
+                return false;
+        }
 
-        struct NumTalentsAtLevel
+        bool HidesPassenger() const
         {
-            //uint32_t level;                   // 0
-            float talentPoints;                 // 1
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
+                return true;
+            else
+                return false;
+        }
+    };
 
-        struct PhaseEntry
+    struct WMOAreaTableEntry
+    {
+        uint32_t id;                // 0
+        int32_t rootId;             // 1
+        int32_t adtId;              // 2
+        int32_t groupId;            // 3
+        //uint32_t field4;          // 4
+        //uint32_t field5;          // 5
+        //uint32_t field6;          // 6
+        //uint32_t field7;          // 7
+        //uint32_t field8;          // 8
+        uint32_t flags;             // 9
+        uint32_t areaId;            // 10
+        //char Name[16];            // 11-26
+        //uint32_t nameflags;       // 27
+    };
+
+    struct WorldMapAreaEntry
+    {
+        //uint32_t id;              // 0
+        uint32_t mapId;             // 1
+        uint32_t zoneId;            // 2
+        //const char* name;         // 3
+        //float y1;                 // 4
+        //float y2;                 // 5
+        //float x1;                 // 6
+        //float x2;                 // 7
+        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1             // 9
+        //uint32_t parentId         // 10
+        //uint32_t unk2             // 11
+        //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
+        //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
+    };
+
+    struct WorldMapOverlayEntry
+    {
+        uint32_t ID;                // 0
+        //uint32_t worldMapID;      // 1
+        uint32_t areaID;            // 2
+        uint32_t areaID_2;          // 3
+        uint32_t areaID_3;          // 4
+        uint32_t areaID_4;          // 5
+        //uint32_t unk1[2];         // 6-7
+        //uint32_t unk2;            // 8
+        //uint32_t unk3[7];         // 9-16
+    };
+
+    #pragma pack(pop)
+
+    typedef std::set<uint32_t> SpellCategorySet;
+    typedef std::map<uint32_t, SpellCategorySet> SpellCategoryStore;
+    struct SpellEffect
+    {
+        SpellEffect()
         {
-            uint32_t Id;                        // 0
-            uint32_t PhaseShift;                // 1
-            uint32_t Flags;                     // 2
-        };
-
-        struct QuestSortEntry
-        {
-            uint32_t id;                        // 0
-            //char* name;                       // 1
-        };
-
-        struct QuestXP
-        {
-            uint32_t questLevel;                // 0
-            uint32_t xpIndex[10];               // 1-10
-        };
-
-        struct ScalingStatDistributionEntry
-        {
-            uint32_t id;                        // 0
-            int32_t stat[10];                   // 1-10
-            uint32_t statmodifier[10];          // 11-20
-            //uint32_t unk;                     // 21
-            uint32_t maxlevel;                  // 22
-        };
-
-        struct ScalingStatValuesEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t level;                     // 1
-            uint32_t multiplier[20];            // 
-            //\todo danko Rewrite GetStatScalingStatValueColumn!
-            //uint32_t dpsMod[6];               // 2-7
-            //uint32_t spellBonus;              // 8
-            //uint32_t scalingstatmultipl[5];   // 9-13
-            //uint32_t amor_mod[4];             // 14-17
-            //uint32_t amor_mod2[4];            // 18-21
-            //uint32_t junk[24];                // 22-45
-            //uint32_t unk2;                    // 46
-        };
-
-        struct SkillLineEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t type;                      // 1
-            char* Name;                         // 2
-            //char* Description;                // 3
-            uint32_t spell_icon;                // 4
-            //char* add_name;                   // 5
-            uint32_t linkable;                  // 6
-        };
-
-        struct SkillLineAbilityEntry
-        {
-            uint32_t Id;                        // 0
-            uint32_t skilline;                  // 1 skill id
-            uint32_t spell;                     // 2
-            uint32_t race_mask;                 // 3
-            uint32_t class_mask;                // 4
-            //uint32_t excludeRace;             // 5
-            //uint32_t excludeClass;            // 6
-            uint32_t minSkillLineRank;          // 7 req skill value
-            uint32_t next;                      // 8
-            uint32_t acquireMethod;             // 9 auto learn
-            uint32_t grey;                      // 10 max
-            uint32_t green;                     // 11 min
-            uint32_t characterPoints;           // 12
-            //uint32_t unk;                     // 13
-        };
-
-        //\todo danko
-        //struct StableSlotPrices
-        //{
-        //    uint32_t Id;                      // 0
-        //    uint32_t Price;                   // 1
-        //};
-
-        //\ todo: confirm effect count
-        #define MAX_SPELL_EFFECTS 3
-        #define MAX_SPELL_REAGENTS 8
-        #define MAX_SPELL_TOTEMS 2
-        #define MAX_SPELL_TOTEM_CATEGORIES 2
-
-        // SpellAuraOptions.dbc
-        struct SpellAuraOptionsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t MaxStackAmount;            // 1
-            uint32_t procChance;                // 2
-            uint32_t procCharges;               // 3
-            uint32_t procFlags;                 // 4
-        };
-
-        // SpellAuraRestrictions.dbc
-        struct SpellAuraRestrictionsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t CasterAuraState;           // 1
-            uint32_t TargetAuraState;           // 2
-            uint32_t CasterAuraStateNot;        // 3
-            uint32_t TargetAuraStateNot;        // 4
-            uint32_t casterAuraSpell;           // 5
-            uint32_t targetAuraSpell;           // 6
-            uint32_t CasterAuraSpellNot;        // 7
-            uint32_t TargetAuraSpellNot;        // 8
-        };
-
-        // SpellCastingRequirements.dbc
-        struct SpellCastingRequirementsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t FacingCasterFlags;         // 1
-            //uint32_t MinFactionId;            // 2
-            //uint32_t MinReputation;           // 3
-            int32_t AreaGroupId;                // 4
-            //uint32_t RequiredAuraVision;      // 5
-            uint32_t RequiresSpellFocus;        // 6
-        };
-
-        // SpellCastTimes.dbc
-        struct SpellCastTimesEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t CastTime;                  // 1
-            float CastTimePerLevel;             // 2
-            int32_t MinCastTime;                // 3
-        };
-
-        // SpellCategories.dbc
-        struct SpellCategoriesEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Category;                  // 1
-            uint32_t DmgClass;                  // 2
-            uint32_t DispelType;                // 3
-            uint32_t MechanicsType;             // 4
-            uint32_t PreventionType;            // 5
-            uint32_t StartRecoveryCategory;     // 6
-        };
-
-        // SpellClassOptions.dbc
-        struct SpellClassOptionsEntry
-        {
-            //uint32_t Id;                                  // 0
-            //uint32_t modalNextSpell;                      // 1
-            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
-            uint32_t SpellFamilyName;                       // 5
-            //char* Description;                            // 6
-        };
-
-        // SpellCooldowns.dbc
-        struct SpellCooldownsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t CategoryRecoveryTime;      // 1
-            uint32_t RecoveryTime;              // 2
-            uint32_t StartRecoveryTime;         // 3
-        };
-
-        // SpellDifficulty.dbc
-        struct SpellDifficultyEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t SpellId[MAX_DIFFICULTY];    // 1-4
-        };
-
-        // SpellDuration.dbc
-        struct SpellDurationEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t Duration1;                 // 1
-            uint32_t Duration2;                 // 2
-            uint32_t Duration3;                 // 3
-        };
-
-        // SpellEffect.dbc
-        struct SpellEffectEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Effect;                    // 1
-            float EffectMultipleValue;          // 2
-            uint32_t EffectApplyAuraName;       // 3
-            uint32_t EffectAmplitude;           // 4
-            int32_t EffectBasePoints;           // 5
-            float EffectBonusMultiplier;        // 6
-            float EffectDamageMultiplier;       // 7
-            uint32_t EffectChainTarget;         // 8
-            int32_t EffectDieSides;             // 9
-            uint32_t EffectItemType;            // 10
-            uint32_t EffectMechanic;            // 11
-            int32_t EffectMiscValue;            // 12
-            int32_t EffectMiscValueB;           // 13
-            float EffectPointsPerComboPoint;    // 14
-            uint32_t EffectRadiusIndex;         // 15
-            uint32_t EffectRadiusMaxIndex;      // 16
-            float EffectRealPointsPerLevel;     // 17
-            uint32_t EffectSpellClassMask[3];   // 18-20
-            //ClassFamilyMask EffectSpellClassMask;
-            uint32_t EffectTriggerSpell;        // 21
-            uint32_t EffectImplicitTargetA;     // 22
-            uint32_t EffectImplicitTargetB;     // 23
-            uint32_t EffectSpellId;             // 24
-            uint32_t EffectIndex;               // 25
-            //uint32_t unk;                     // 26
-
-            uint32_t GetRadiusIndex() const
-            {
-                if (EffectRadiusIndex != 0)
-                    return EffectRadiusIndex;
-
-                return EffectRadiusMaxIndex;
-            }
-        };
-
-        // SpellEquippedItems.dbc
-        struct SpellEquippedItemsEntry
-        {
-            //uint32_t Id;                          // 0
-            int32_t EquippedItemClass;              // 1
-            int32_t EquippedItemInventoryTypeMask;  // 2
-            int32_t EquippedItemSubClassMask;       // 3
-        };
-
-        // SpellFocusObject.dbc
-        struct SpellFocusObjectEntry
-        {
-            uint32_t ID;                        // 0
-            //char* Name;                       // 1
-        };
-
-        // SpellInterrupts.dbc
-        struct SpellInterruptsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t AuraInterruptFlags;        // 1
-            //uint32_t unk2                     // 2
-            uint32_t ChannelInterruptFlags;     // 3
-            //uint32_t unk4                     // 4
-            uint32_t InterruptFlags;            // 5
-        };
-
-        // SpellItemEnchantment.dbc
-        struct SpellItemEnchantmentEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t charges;                 // 1
-            uint32_t type[3];                   // 2-4
-            uint32_t min[3];                    // 5-7 for combat, in practice min==max
-            //uint32_t max[3];                  // 8-10
-            uint32_t spell[3];                  // 11-13
-            char* Name;                         // 14-29
-            //uint32_t NameFlags;               // 30
-            uint32_t visual;                    // 31 aura
-            uint32_t EnchantGroups;             // 32 slot
-            uint32_t GemEntry;                  // 33
-            uint32_t ench_condition;            // 34
-            uint32_t req_skill;                 // 35
-            uint32_t req_skill_value;           // 36
-            uint32_t req_level;                 // 37
-        };
-
-        // SpellItemEnchantmentCondition.dbc
-        struct SpellItemEnchantmentConditionEntry
-        {
-            uint32_t ID;                        // 0
-            uint8_t Color[5];                   // 1-5
-            //uint32_t LT_Operand[5];           // 6-10
-            uint8_t Comparator[5];              // 11-15
-            uint8_t CompareColor[5];            // 15-20
-            uint32_t Value[5];                  // 21-25
-            //uint8_t Logic[5]                  // 25-30
-        };
-
-        // SpellLevels.dbc
-        struct SpellLevelsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t baseLevel;                 // 1
-            uint32_t maxLevel;                  // 2
-            uint32_t spellLevel;                // 3
-        };
-
-        // SpellPower.dbc
-        struct SpellPowerEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t manaCost;                  // 1
-            uint32_t manaCostPerlevel;          // 2
-            uint32_t ManaCostPercentage;        // 3
-            uint32_t manaPerSecond;             // 4
-            uint32_t manaPerSecondPerLevel;     // 5
-            //uint32_t PowerDisplayId;          // 6 
-            float ManaCostPercentageFloat;      // 7
-        };
-
-        // SpellRadius.dbc
-        struct SpellRadiusEntry
-        {
-            uint32_t ID;                        // 0
-            float radius_min;                   // 1
-            float radius_per_level;             // 2
-            float radius_max;                   // 3
-        };
-
-        // SpellRange.dbc
-        struct SpellRangeEntry
-        {
-            uint32_t ID;                        // 0
-            float minRange;                     // 1
-            float minRangeFriendly;             // 2
-            float maxRange;                     // 3
-            float maxRangeFriendly;             // 4
-            uint32_t range_type;                // 5
-            //char* name1[16]                   // 6-21
-            //uint32_t name1_falgs;             // 22
-            //char* name2[16]                   // 23-38
-            //uint32_t name2_falgs;             // 39
-        };
-
-        // SpellReagents.dbc
-        struct SpellReagentsEntry
-        {
-            //uint32_t Id;                              // 0
-            int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
-            uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
-        };
-
-        // SpellRuneCost.dbc
-        struct SpellRuneCostEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t bloodRuneCost;             // 1
-            uint32_t frostRuneCost;             // 2
-            uint32_t unholyRuneCost;            // 3
-            uint32_t runePowerGain;             // 4
-        };
-
-        // SpellScaling.dbc
-        struct SpellScalingEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t castTimeMin;               // 1
-            uint32_t castTimeMax;               // 2
-            uint32_t castScalingMaxLevel;       // 3
-            uint32_t playerClass;               // 4
-            float coeff1[3];                    // 5-7
-            float coeff2[3];                    // 8-10
-            float coeff3[3];                    // 11-13
-            float coefBase;                     // 14
-            uint32_t coefLevelBase;             // 15
-
-            bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
-        };
-
-        // SpellShapeshift.dbc
-        struct SpellShapeshiftEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t ShapeshiftsExcluded;       // 1
-            //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
-            uint32_t Shapeshifts;               // 3
-            //uint32_t Shapeshifts1;            // 4 unused, all zeros
-            //uint32_t StanceBarOrder;          // 5
-        };
-
-        // SpellTargetRestrictions.dbc
-        struct SpellTargetRestrictionsEntry
-        {
-            //uint32_t Id;                      // 0
-            float MaxTargetRadius;              // 1
-            uint32_t MaxAffectedTargets;        // 2
-            uint32_t MaxTargetLevel;            // 3
-            uint32_t TargetCreatureType;        // 4
-            uint32_t Targets;                   // 5
-        };
-
-        // SpellTotems.dbc
-        struct SpellTotemsEntry
-        {
-            //uint32_t Id;                                         // 0
-            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
-            uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
-        };
-
-        struct SERVER_DECL SpellEntry
-        {
-            uint32_t Id;                                          // 0
-            uint32_t Attributes;                                  // 1
-            uint32_t AttributesEx;                                // 2
-            uint32_t AttributesExB;                               // 3
-            uint32_t AttributesExC;                               // 4
-            uint32_t AttributesExD;                               // 5
-            uint32_t AttributesExE;                               // 6
-            uint32_t AttributesExF;                               // 7
-            uint32_t AttributesExG;                               // 8
-            uint32_t AttributesExH;                               // 9
-            uint32_t AttributesExI;                               // 10
-            uint32_t AttributesExJ;                               // 11
-            uint32_t CastingTimeIndex;                            // 12
-            uint32_t DurationIndex;                               // 13
-            int32_t powerType;                                    // 14
-            uint32_t rangeIndex;                                  // 15
-            float speed;                                          // 16
-            uint32_t SpellVisual;                                 // 17
-            uint32_t SpellVisual1;                                // 18
-            uint32_t spellIconID;                                 // 19
-            uint32_t activeIconID;                                // 20
-            const char* Name;                                     // 21
-            const char* Rank;                                     // 22
-            //char* Description;                                  // 23 not used
-            //char* BuffDescription;                              // 24 not used
-            uint32_t School;                                      // 25
-            uint32_t RuneCostID;                                  // 26
-            //uint32_t spellMissileID;                            // 27
-            //uint32_t spellDescriptionVariableID;                // 28
-            uint32_t SpellDifficultyId;                           // 29
-            //float unk_1;                                        // 30
-            uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
-            uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
-            uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
-            uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
-            uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
-            uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
-            uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
-            //uint32_t unk_2;                                     // 38 all zeros...
-            uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
-            uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
-            uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
-            uint32_t SpellPowerId;                                // 42 SpellPower.dbc
-            uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
-            uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
-            uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
-            uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
-            //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
-
-            // struct access functions
-            SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
-            SpellAuraRestrictionsEntry const* GetSpellAuraRestrictions() const;
-            SpellCastingRequirementsEntry const* GetSpellCastingRequirements() const;
-            SpellCategoriesEntry const* GetSpellCategories() const;
-            SpellClassOptionsEntry const* GetSpellClassOptions() const;
-            SpellCooldownsEntry const* GetSpellCooldowns() const;
-            SpellEffectEntry const* GetSpellEffect(uint8_t eff) const;
-            SpellEquippedItemsEntry const* GetSpellEquippedItems() const;
-            SpellInterruptsEntry const* GetSpellInterrupts() const;
-            SpellLevelsEntry const* GetSpellLevels() const;
-            SpellPowerEntry const* GetSpellPower() const;
-            SpellReagentsEntry const* GetSpellReagents() const;
-            SpellScalingEntry const* GetSpellScaling() const;
-            SpellShapeshiftEntry const* GetSpellShapeshift() const;
-            SpellTargetRestrictionsEntry const* GetSpellTargetRestrictions() const;
-            SpellTotemsEntry const* GetSpellTotems() const;
-
-            // single fields
-            uint32_t GetManaCost() const;
-            uint32_t GetPreventionType() const;
-            uint32_t GetCategory() const;
-            uint32_t GetStartRecoveryTime() const;
-            uint32_t GetMechanic() const;
-            uint32_t GetRecoveryTime() const;
-            uint32_t GetCategoryRecoveryTime() const;
-            uint32_t GetStartRecoveryCategory() const;
-            uint32_t GetSpellLevel() const;
-            int32_t GetEquippedItemClass() const;
-            uint32_t GetSpellFamilyName() const;
-            uint32_t GetDmgClass() const;
-            uint32_t GetDispel() const;
-            uint32_t GetMaxAffectedTargets() const;
-            uint32_t GetStackAmount() const;
-            uint32_t GetManaCostPercentage() const;
-            uint32_t GetProcCharges() const;
-            uint32_t GetProcChance() const;
-            uint32_t GetMaxLevel() const;
-            uint32_t GetTargetAuraState() const;
-            uint32_t GetManaPerSecond() const;
-            uint32_t GetRequiresSpellFocus() const;
-            uint32_t GetSpellEffectIdByIndex(uint8_t index) const;
-            uint32_t GetAuraInterruptFlags() const;
-            uint32_t GetEffectImplicitTargetAByIndex(uint8_t index) const;
-            int32_t GetAreaGroupId() const;
-            uint32_t GetFacingCasterFlags() const;
-            uint32_t GetBaseLevel() const;
-            uint32_t GetInterruptFlags() const;
-            uint32_t GetTargetCreatureType() const;
-            int32_t GetEffectMiscValue(uint8_t index) const;
-            uint32_t GetStances() const;
-            uint32_t GetStancesNot() const;
-            uint32_t GetProcFlags() const;
-            uint32_t GetChannelInterruptFlags() const;
-            uint32_t GetManaCostPerLevel() const;
-            uint32_t GetCasterAuraState() const;
-            uint32_t GetTargets() const;
-            uint32_t GetEffectApplyAuraNameByIndex(uint8_t index) const;
-
-        private:
-
-            SpellEntry(SpellEntry const&);
-        };
-
-        struct SpellShapeshiftFormEntry
-        {
-            uint32_t id;                  // 0
-            //uint32_t button_pos;        // 1
-            //char* name[16];             // 2-17
-            //uint32_t name_flags;        // 18
-            uint32_t Flags;               // 19
-            uint32_t unit_type;           // 20
-            //uint32_t unk1               // 21
-            uint32_t AttackSpeed;         // 22
-            uint32_t modelId;             // 23 alliance?
-            uint32_t modelId2;            // 24 horde?
-            //uint32_t unk2               // 25
-            //uint32_t unk3               // 26
-            uint32_t spells[8];           // 27-34
-        };
-
-        struct SummonPropertiesEntry
-        {
-            uint32_t ID;                  // 0
-            uint32_t ControlType;         // 1
-            uint32_t FactionID;           // 2
-            uint32_t Type;                // 3
-            uint32_t Slot;                // 4
-            uint32_t Flags;               // 5
-        };
-
-        struct TalentEntry
-        {
-            uint32_t TalentID;            // 0
-            uint32_t TalentTree;          // 1
-            uint32_t Row;                 // 2
-            uint32_t Col;                 // 3
-            uint32_t RankID[5];           // 4-8
-            //uint32_t unk[4];            // 9-12
-            uint32_t DependsOn;           // 13
-            //uint32_t unk1[2];           // 14-15
-            uint32_t DependsOnRank;       // 16
-            //uint32_t unk2[2];           // 17-18
-            //uint32_t unk3;              // 19
-            //uint32_t unk4;              // 20
-            //uint32_t unk5;              // 21
-        };
-
-        struct TalentTabEntry
-        {
-            uint32_t TalentTabID;         // 0
-            //char* Name;                 // 1
-            //uint32_t unk5;              // 2
-            uint32_t ClassMask;           // 3
-            uint32_t PetTalentMask;       // 4
-            uint32_t TabPage;             // 5
-            //char* InternalName;         // 6
-            //char* description;          // 7
-            uint32_t rolesMask;           // 8
-            uint32_t masterySpells[2];    // 9-10
-        };
-
-        struct TalentTreePrimarySpells
-        {
-            uint32_t ID;                  // 0
-            uint32_t tabID;               // 1
-            uint32_t SpellID;             // 2
-            //uint32_t unk                // 3
-        };
-
-        struct TaxiNodesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t mapid;               // 1
-            float x;                      // 2
-            float y;                      // 3
-            float z;                      // 4
-            char* name;                   // 5
-            uint32_t horde_mount;         // 6
-            uint32_t alliance_mount;      // 7
-        };
-
-        struct TaxiPathEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t from;                // 1
-            uint32_t to;                  // 2
-            uint32_t price;               // 3
-        };
-
-        struct TaxiPathNodeEntry
-        {
-            //uint32_t id;                // 0
-            uint32_t path;                // 1
-            uint32_t seq;                 // 2 nodeIndex
-            uint32_t mapid;               // 3
-            float x;                      // 4
-            float y;                      // 5
-            float z;                      // 6
-            uint32_t flags;               // 7
-            uint32_t waittime;            // 8
-            uint32_t arivalEventID;       // 9
-            uint32_t departureEventID;    // 10
-        };
-
-        struct TransportAnimationEntry
-        {
-            //uint32_t Id;          // 0
-            uint32_t TransportID;   // 1
-            uint32_t TimeIndex;     // 2
-            DBCPosition3D Pos;      // 3
-            //uint32_t SequenceID;  // 4
-        };
-
-        struct TransportRotationEntry
-        {
-            //uint32_t ID;          // 0
-            uint32_t GameObjectsID; // 1
-            uint32_t TimeIndex;     // 2
-            float X;                // 3
-            float Y;                // 4
-            float Z;                // 5
-            float W;                // 6
-        };
-
-        struct TotemCategoryEntry
-        {
-            uint32_t id;            // 0
-            //char* name;           // 1
-            uint32_t categoryType;  // 2
-            uint32_t categoryMask;  // 3
-        };
-
-        #define MAX_VEHICLE_SEATS 8
-
-        struct VehicleEntry
-        {
-            uint32_t ID;                                        // 0
-            uint32_t flags;                                     // 1
-            float turnSpeed;                                    // 2
-            float pitchSpeed;                                   // 3
-            float pitchMin;                                     // 4
-            float pitchMax;                                     // 5
-            uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
-            float mouseLookOffsetPitch;                         // 14
-            float cameraFadeDistScalarMin;                      // 15
-            float cameraFadeDistScalarMax;                      // 16
-            float cameraPitchOffset;                            // 17
-            float facingLimitRight;                             // 18
-            float facingLimitLeft;                              // 19
-            float msslTrgtTurnLingering;                        // 20
-            float msslTrgtPitchLingering;                       // 21
-            float msslTrgtMouseLingering;                       // 22
-            float msslTrgtEndOpacity;                           // 23
-            float msslTrgtArcSpeed;                             // 24
-            float msslTrgtArcRepeat;                            // 25
-            float msslTrgtArcWidth;                             // 26
-            float msslTrgtImpactRadius[2];                      // 27-28
-            char* msslTrgtArcTexture;                           // 29
-            char* msslTrgtImpactTexture;                        // 30
-            char* msslTrgtImpactModel[2];                       // 31-32
-            float cameraYawOffset;                              // 33
-            uint32_t uiLocomotionType;                          // 34
-            float msslTrgtImpactTexRadius;                      // 35
-            uint32_t uiSeatIndicatorType;                       // 36
-            uint32_t powerType;                                 // 37
-            //uint32_t unk1;                                    // 38
-            //uint32_t unk2;                                    // 39  
-        };
-
-        enum VehicleSeatFlags
-        {
-            VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
-            VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-            VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-            VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-            VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-            VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-            VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
-        };
-
-        enum VehicleSeatFlagsB
-        {
-            VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
-        };
-
-        struct VehicleSeatEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            int32_t attachmentID;                                 // 2
-            float attachmentOffsetX;                              // 3
-            float attachmentOffsetY;                              // 4
-            float attachmentOffsetZ;                              // 5
-            float enterPreDelay;                                  // 6
-            float enterSpeed;                                     // 7
-            float enterGravity;                                   // 8
-            float enterMinDuration;                               // 9
-            float enterMaxDuration;                               // 10
-            float enterMinArcHeight;                              // 11
-            float enterMaxArcHeight;                              // 12
-            int32_t enterAnimStart;                               // 13
-            int32_t enterAnimLoop;                                // 14
-            int32_t rideAnimStart;                                // 15
-            int32_t rideAnimLoop;                                 // 16
-            int32_t rideUpperAnimStart;                           // 17
-            int32_t rideUpperAnimLoop;                            // 18
-            float exitPreDelay;                                   // 19
-            float exitSpeed;                                      // 20
-            float exitGravity;                                    // 21
-            float exitMinDuration;                                // 22
-            float exitMaxDuration;                                // 23
-            float exitMinArcHeight;                               // 24
-            float exitMaxArcHeight;                               // 25
-            int32_t exitAnimStart;                                // 26
-            int32_t exitAnimLoop;                                 // 27
-            int32_t exitAnimEnd;                                  // 28
-            float passengerYaw;                                   // 29
-            float passengerPitch;                                 // 30
-            float passengerRoll;                                  // 31
-            int32_t passengerAttachmentID;                        // 32
-            int32_t vehicleEnterAnim;                             // 33
-            int32_t vehicleExitAnim;                              // 34
-            int32_t vehicleRideAnimLoop;                          // 35
-            int32_t vehicleEnterAnimBone;                         // 36
-            int32_t vehicleExitAnimBone;                          // 37
-            int32_t vehicleRideAnimLoopBone;                      // 38
-            float vehicleEnterAnimDelay;                          // 39
-            float vehicleExitAnimDelay;                           // 40
-            uint32_t vehicleAbilityDisplay;                       // 41
-            uint32_t enterUISoundID;                              // 42
-            uint32_t exitUISoundID;                               // 43
-            int32_t uiSkin;                                       // 44
-            uint32_t flagsB;                                      // 45
-
-            bool IsUsable() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool IsController() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool HidesPassenger() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
-                    return true;
-                else
-                    return false;
-            }
-        };
-
-        struct WMOAreaTableEntry
-        {
-            uint32_t id;                // 0
-            int32_t rootId;             // 1
-            int32_t adtId;              // 2
-            int32_t groupId;            // 3
-            //uint32_t field4;          // 4
-            //uint32_t field5;          // 5
-            //uint32_t field6;          // 6
-            //uint32_t field7;          // 7
-            //uint32_t field8;          // 8
-            uint32_t flags;             // 9
-            uint32_t areaId;            // 10
-            //char Name[16];            // 11-26
-            //uint32_t nameflags;       // 27
-        };
-
-        struct WorldMapAreaEntry
-        {
-            //uint32_t id;              // 0
-            uint32_t mapId;             // 1
-            uint32_t zoneId;            // 2
-            //const char* name;         // 3
-            //float y1;                 // 4
-            //float y2;                 // 5
-            //float x1;                 // 6
-            //float x2;                 // 7
-            int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-            //uint32_t unk1             // 9
-            //uint32_t parentId         // 10
-            //uint32_t unk2             // 11
-            //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
-            //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
-        };
-
-        struct WorldMapOverlayEntry
-        {
-            uint32_t ID;                // 0
-            //uint32_t worldMapID;      // 1
-            uint32_t areaID;            // 2
-            uint32_t areaID_2;          // 3
-            uint32_t areaID_3;          // 4
-            uint32_t areaID_4;          // 5
-            //uint32_t unk1[2];         // 6-7
-            //uint32_t unk2;            // 8
-            //uint32_t unk3[7];         // 9-16
-        };
-
-        #pragma pack(pop)
-
-        typedef std::set<uint32_t> SpellCategorySet;
-        typedef std::map<uint32_t, SpellCategorySet> SpellCategoryStore;
-        struct SpellEffect
-        {
-            SpellEffect()
-            {
-                effects[0] = nullptr;
-                effects[1] = nullptr;
-                effects[2] = nullptr;
-            }
-            SpellEffectEntry const* effects[3];
-        };
-        typedef std::map<uint32_t, SpellEffect> SpellEffectMap;
-    }
+            effects[0] = nullptr;
+            effects[1] = nullptr;
+            effects[2] = nullptr;
+        }
+        SpellEffectEntry const* effects[3];
+    };
+    typedef std::map<uint32_t, SpellEffect> SpellEffectMap;
 }

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -26,125 +26,125 @@ struct WMOAreaTableTripple
 ///\ These will be verified and ported to Spell/Definitions/SpellEffectTarget.h when spell targeting is being rewritten -Appled
 enum Targets
 {
-    TARGET_NONE                        = 0,
-    TARGET_SELF_ONE                     = 1,
-    TARGET_RANDOM_ENEMY_CHAIN_IN_AREA  = 2,                 // only one spell has that, but regardless, it's a target type after all
-    TARGET_RANDOM_FRIEND_CHAIN_IN_AREA = 3,
-    TARGET_RANDOM_UNIT_CHAIN_IN_AREA   = 4,                 // some plague spells that are infectious - maybe targets not-infected friends inrange
-    TARGET_PET                         = 5,
-    TARGET_CHAIN_DAMAGE                = 6,
-    TARGET_AREAEFFECT_INSTANT          = 7,                 // targets around provided destination point
-    TARGET_AREAEFFECT_CUSTOM           = 8,
-    TARGET_INNKEEPER_COORDINATES       = 9,                 // uses in teleport to innkeeper spells
-    TARGET_11                          = 11,                // used by spell 4 'Word of Recall Other'
-    TARGET_ALL_ENEMY_IN_AREA           = 15,
-    TARGET_ALL_ENEMY_IN_AREA_INSTANT   = 16,
-    TARGET_TABLE_X_Y_Z_COORDINATES     = 17,                // uses in teleport spells and some other
-    TARGET_EFFECT_SELECT               = 18,                // highly depends on the spell effect
-    TARGET_ALL_PARTY_AROUND_CASTER     = 20,
-    TARGET_SINGLE_FRIEND               = 21,
-    TARGET_CASTER_COORDINATES          = 22,                // used only in TargetA, target selection dependent from TargetB
-    TARGET_GAMEOBJECT                  = 23,
-    TARGET_IN_FRONT_OF_CASTER          = 24,
-    TARGET_DUELVSPLAYER                = 25,
-    TARGET_GAMEOBJECT_ITEM             = 26,
-    TARGET_MASTER                      = 27,
-    TARGET_ALL_ENEMY_IN_AREA_CHANNELED = 28,
-    TARGET_29                          = 29,
-    TARGET_ALL_FRIENDLY_UNITS_AROUND_CASTER = 30,           // select friendly for caster object faction (in different original caster faction) in TargetB used only with TARGET_ALL_AROUND_CASTER and in self casting range in TargetA
-    TARGET_ALL_FRIENDLY_UNITS_IN_AREA  = 31,
-    TARGET_MINION                      = 32,
-    TARGET_ALL_PARTY                   = 33,
-    TARGET_ALL_PARTY_AROUND_CASTER_2   = 34,                // used in Tranquility
-    TARGET_SINGLE_PARTY                = 35,
-    TARGET_ALL_HOSTILE_UNITS_AROUND_CASTER = 36,
-    TARGET_AREAEFFECT_PARTY            = 37,
-    TARGET_SCRIPT                      = 38,
-    TARGET_SELF_FISHING                = 39,
-    TARGET_FOCUS_OR_SCRIPTED_GAMEOBJECT = 40,
-    TARGET_TOTEM_EARTH                 = 41,
-    TARGET_TOTEM_WATER                 = 42,
-    TARGET_TOTEM_AIR                   = 43,
-    TARGET_TOTEM_FIRE                  = 44,
-    TARGET_CHAIN_HEAL                  = 45,
-    TARGET_SCRIPT_COORDINATES          = 46,
-    TARGET_DYNAMIC_OBJECT_FRONT        = 47,
-    TARGET_DYNAMIC_OBJECT_BEHIND       = 48,
-    TARGET_DYNAMIC_OBJECT_LEFT_SIDE    = 49,
-    TARGET_DYNAMIC_OBJECT_RIGHT_SIDE   = 50,
-    TARGET_AREAEFFECT_GO_AROUND_SOURCE = 51,
-    TARGET_AREAEFFECT_GO_AROUND_DEST   = 52,                // gameobject around destination, select by spell_script_target
-    TARGET_CURRENT_ENEMY_COORDINATES   = 53,                // set unit coordinates as dest, only 16 target B imlemented
-    TARGET_LARGE_FRONTAL_CONE          = 54,
-    TARGET_ALL_RAID_AROUND_CASTER      = 56,
-    TARGET_SINGLE_FRIEND_2             = 57,
-    TARGET_58                          = 58,
-    TARGET_FRIENDLY_FRONTAL_CONE       = 59,
-    TARGET_NARROW_FRONTAL_CONE         = 60,
-    TARGET_AREAEFFECT_PARTY_AND_CLASS  = 61,
-    TARGET_DUELVSPLAYER_COORDINATES    = 63,
-    TARGET_INFRONT_OF_VICTIM           = 64,
-    TARGET_BEHIND_VICTIM               = 65,                // used in teleport behind spells, caster/target dependent from spell effect
-    TARGET_RIGHT_FROM_VICTIM           = 66,
-    TARGET_LEFT_FROM_VICTIM            = 67,
-    TARGET_68                          = 68,
-    TARGET_69                          = 69,
-    TARGET_70                          = 70,
-    TARGET_RANDOM_NEARBY_LOC           = 72,                // used in teleport onto nearby locations
-    TARGET_RANDOM_CIRCUMFERENCE_POINT  = 73,
-    TARGET_74                          = 74,
-    TARGET_75                          = 75,
-    TARGET_DYNAMIC_OBJECT_COORDINATES  = 76,
-    TARGET_SINGLE_ENEMY                = 77,
-    TARGET_POINT_AT_NORTH              = 78,                // 78-85 possible _COORDINATES at radius with pi/4 step around target in unknown order, N?
-    TARGET_POINT_AT_SOUTH              = 79,                // S?
-    TARGET_POINT_AT_EAST               = 80,                // 80/81 must be symmetric from line caster->target, E (base at 82/83, 84/85 order) ?
-    TARGET_POINT_AT_WEST               = 81,                // 80/81 must be symmetric from line caster->target, W (base at 82/83, 84/85 order) ?
-    TARGET_POINT_AT_NE                 = 82,                // from spell desc: "(NE)"
-    TARGET_POINT_AT_NW                 = 83,                // from spell desc: "(NW)"
-    TARGET_POINT_AT_SE                 = 84,                // from spell desc: "(SE)"
-    TARGET_POINT_AT_SW                 = 85,                // from spell desc: "(SW)"
-    TARGET_RANDOM_NEARBY_DEST          = 86,                // "Test Nearby Dest Random" - random around selected destination
-    TARGET_SELF2                       = 87,
-    TARGET_88                          = 88,                // Smoke Flare(s) and Hurricane
-    TARGET_DIRECTLY_FORWARD            = 89,
-    TARGET_NONCOMBAT_PET               = 90,
-    TARGET_91                          = 91,
-    TARGET_SUMMONER                    = 92,
-    TARGET_CONTROLLED_VEHICLE          = 94,
-    TARGET_VEHICLE_DRIVER              = 95,
-    TARGET_VEHICLE_PASSENGER_0         = 96,
-    TARGET_VEHICLE_PASSENGER_1         = 97,
-    TARGET_VEHICLE_PASSENGER_2         = 98,
-    TARGET_VEHICLE_PASSENGER_3         = 99,
-    TARGET_VEHICLE_PASSENGER_4         = 100,
-    TARGET_VEHICLE_PASSENGER_5         = 101,
-    TARGET_VEHICLE_PASSENGER_6         = 102,
-    TARGET_VEHICLE_PASSENGER_7         = 103,
-    TARGET_IN_FRONT_OF_CASTER_30       = 104,
-    TARGET_105                         = 105,
-    TARGET_106                         = 106,
-    TARGET_107                         = 107,               // possible TARGET_WMO(GO?)_IN_FRONT_OF_CASTER(_30 ?) TODO: Verify the angle!
-    TARGET_GO_IN_FRONT_OF_CASTER_90    = 108,
-    TARGET_109                         = 109,               // spell 89008
-    TARGET_NARROW_FRONTAL_CONE_2       = 110,
-    TARGET_111                         = 111,               // not used
-    TARGET_112                         = 112,               // spell 89549
-    TARGET_113                         = 113,               // not used
-    TARGET_114                         = 114,               // not used
-    TARGET_115                         = 115,               // not used
-    TARGET_116                         = 116,               // not used
-    TARGET_117                         = 117,               // test spell 83658
-    TARGET_118                         = 118,               // test spell 79579
-    TARGET_119                         = 119,               // mass ressurection 83968
-    TARGET_120                         = 120,
-    TARGET_121                         = 121,               // spell 95750
-    TARGET_122                         = 122,               // spell 100661
-    TARGET_123                         = 123,
-    TARGET_124                         = 124,
-    TARGET_125                         = 125,
-    TARGET_126                         = 126,
-    TARGET_127                         = 127,
+    TARGET_NONE                                 = 0,
+    TARGET_SELF_ONE                             = 1,
+    TARGET_RANDOM_ENEMY_CHAIN_IN_AREA           = 2,  // only one spell has that, but regardless, it's a target type after all
+    TARGET_RANDOM_FRIEND_CHAIN_IN_AREA          = 3,
+    TARGET_RANDOM_UNIT_CHAIN_IN_AREA            = 4,  // some plague spells that are infectious - maybe targets not-infected friends inrange
+    TARGET_PET                                  = 5,
+    TARGET_CHAIN_DAMAGE                         = 6,
+    TARGET_AREAEFFECT_INSTANT                   = 7,  // targets around provided destination point
+    TARGET_AREAEFFECT_CUSTOM                    = 8,
+    TARGET_INNKEEPER_COORDINATES                = 9,  // uses in teleport to innkeeper spells
+    TARGET_11                                   = 11, // used by spell 4 'Word of Recall Other'
+    TARGET_ALL_ENEMY_IN_AREA                    = 15,
+    TARGET_ALL_ENEMY_IN_AREA_INSTANT            = 16,
+    TARGET_TABLE_X_Y_Z_COORDINATES              = 17, // uses in teleport spells and some other
+    TARGET_EFFECT_SELECT                        = 18, // highly depends on the spell effect
+    TARGET_ALL_PARTY_AROUND_CASTER              = 20,
+    TARGET_SINGLE_FRIEND                        = 21,
+    TARGET_CASTER_COORDINATES                   = 22, // used only in TargetA, target selection dependent from TargetB
+    TARGET_GAMEOBJECT                           = 23,
+    TARGET_IN_FRONT_OF_CASTER                   = 24,
+    TARGET_DUELVSPLAYER                         = 25,
+    TARGET_GAMEOBJECT_ITEM                      = 26,
+    TARGET_MASTER                               = 27,
+    TARGET_ALL_ENEMY_IN_AREA_CHANNELED          = 28,
+    TARGET_29                                   = 29,
+    TARGET_ALL_FRIENDLY_UNITS_AROUND_CASTER     = 30, // select friendly for caster object faction (in different original caster faction) in TargetB used only with TARGET_ALL_AROUND_CASTER and in self casting range in TargetA
+    TARGET_ALL_FRIENDLY_UNITS_IN_AREA           = 31,
+    TARGET_MINION                               = 32,
+    TARGET_ALL_PARTY                            = 33,
+    TARGET_ALL_PARTY_AROUND_CASTER_2            = 34, // used in Tranquility
+    TARGET_SINGLE_PARTY                         = 35,
+    TARGET_ALL_HOSTILE_UNITS_AROUND_CASTER      = 36,
+    TARGET_AREAEFFECT_PARTY                     = 37,
+    TARGET_SCRIPT                               = 38,
+    TARGET_SELF_FISHING                         = 39,
+    TARGET_FOCUS_OR_SCRIPTED_GAMEOBJECT         = 40,
+    TARGET_TOTEM_EARTH                          = 41,
+    TARGET_TOTEM_WATER                          = 42,
+    TARGET_TOTEM_AIR                            = 43,
+    TARGET_TOTEM_FIRE                           = 44,
+    TARGET_CHAIN_HEAL                           = 45,
+    TARGET_SCRIPT_COORDINATES                   = 46,
+    TARGET_DYNAMIC_OBJECT_FRONT                 = 47,
+    TARGET_DYNAMIC_OBJECT_BEHIND                = 48,
+    TARGET_DYNAMIC_OBJECT_LEFT_SIDE             = 49,
+    TARGET_DYNAMIC_OBJECT_RIGHT_SIDE            = 50,
+    TARGET_AREAEFFECT_GO_AROUND_SOURCE          = 51,
+    TARGET_AREAEFFECT_GO_AROUND_DEST            = 52, // gameobject around destination, select by spell_script_target
+    TARGET_CURRENT_ENEMY_COORDINATES            = 53, // set unit coordinates as dest, only 16 target B imlemented
+    TARGET_LARGE_FRONTAL_CONE                   = 54,
+    TARGET_ALL_RAID_AROUND_CASTER               = 56,
+    TARGET_SINGLE_FRIEND_2                      = 57,
+    TARGET_58                                   = 58,
+    TARGET_FRIENDLY_FRONTAL_CONE                = 59,
+    TARGET_NARROW_FRONTAL_CONE                  = 60,
+    TARGET_AREAEFFECT_PARTY_AND_CLASS           = 61,
+    TARGET_DUELVSPLAYER_COORDINATES             = 63,
+    TARGET_INFRONT_OF_VICTIM                    = 64,
+    TARGET_BEHIND_VICTIM                        = 65, // used in teleport behind spells, caster/target dependent from spell effect
+    TARGET_RIGHT_FROM_VICTIM                    = 66,
+    TARGET_LEFT_FROM_VICTIM                     = 67,
+    TARGET_68                                   = 68,
+    TARGET_69                                   = 69,
+    TARGET_70                                   = 70,
+    TARGET_RANDOM_NEARBY_LOC                    = 72, // used in teleport onto nearby locations
+    TARGET_RANDOM_CIRCUMFERENCE_POINT           = 73,
+    TARGET_74                                   = 74,
+    TARGET_75                                   = 75,
+    TARGET_DYNAMIC_OBJECT_COORDINATES           = 76,
+    TARGET_SINGLE_ENEMY                         = 77,
+    TARGET_POINT_AT_NORTH                       = 78, // 78-85 possible _COORDINATES at radius with pi/4 step around target in unknown order, N?
+    TARGET_POINT_AT_SOUTH                       = 79, // S?
+    TARGET_POINT_AT_EAST                        = 80, // 80/81 must be symmetric from line caster->target, E (base at 82/83, 84/85 order) ?
+    TARGET_POINT_AT_WEST                        = 81, // 80/81 must be symmetric from line caster->target, W (base at 82/83, 84/85 order) ?
+    TARGET_POINT_AT_NE                          = 82, // from spell desc: "(NE)"
+    TARGET_POINT_AT_NW                          = 83, // from spell desc: "(NW)"
+    TARGET_POINT_AT_SE                          = 84, // from spell desc: "(SE)"
+    TARGET_POINT_AT_SW                          = 85, // from spell desc: "(SW)"
+    TARGET_RANDOM_NEARBY_DEST                   = 86, // "Test Nearby Dest Random" - random around selected destination
+    TARGET_SELF2                                = 87,
+    TARGET_88                                   = 88, // Smoke Flare(s) and Hurricane
+    TARGET_DIRECTLY_FORWARD                     = 89,
+    TARGET_NONCOMBAT_PET                        = 90,
+    TARGET_91                                   = 91,
+    TARGET_SUMMONER                             = 92,
+    TARGET_CONTROLLED_VEHICLE                   = 94,
+    TARGET_VEHICLE_DRIVER                       = 95,
+    TARGET_VEHICLE_PASSENGER_0                  = 96,
+    TARGET_VEHICLE_PASSENGER_1                  = 97,
+    TARGET_VEHICLE_PASSENGER_2                  = 98,
+    TARGET_VEHICLE_PASSENGER_3                  = 99,
+    TARGET_VEHICLE_PASSENGER_4                  = 100,
+    TARGET_VEHICLE_PASSENGER_5                  = 101,
+    TARGET_VEHICLE_PASSENGER_6                  = 102,
+    TARGET_VEHICLE_PASSENGER_7                  = 103,
+    TARGET_IN_FRONT_OF_CASTER_30                = 104,
+    TARGET_105                                  = 105,
+    TARGET_106                                  = 106,
+    TARGET_107                                  = 107, // possible TARGET_WMO(GO?)_IN_FRONT_OF_CASTER(_30 ?) TODO: Verify the angle!
+    TARGET_GO_IN_FRONT_OF_CASTER_90             = 108,
+    TARGET_109                                  = 109, // spell 89008
+    TARGET_NARROW_FRONTAL_CONE_2                = 110,
+    TARGET_111                                  = 111, // not used
+    TARGET_112                                  = 112, // spell 89549
+    TARGET_113                                  = 113, // not used
+    TARGET_114                                  = 114, // not used
+    TARGET_115                                  = 115, // not used
+    TARGET_116                                  = 116, // not used
+    TARGET_117                                  = 117, // test spell 83658
+    TARGET_118                                  = 118, // test spell 79579
+    TARGET_119                                  = 119, // mass ressurection 83968
+    TARGET_120                                  = 120,
+    TARGET_121                                  = 121, // spell 95750
+    TARGET_122                                  = 122, // spell 100661
+    TARGET_123                                  = 123,
+    TARGET_124                                  = 124,
+    TARGET_125                                  = 125,
+    TARGET_126                                  = 126,
+    TARGET_127                                  = 127,
 };
 
 struct DBCPosition3D
@@ -156,11 +156,11 @@ struct DBCPosition3D
 
 enum MapTypes
 {
-    MAP_COMMON                          = 0,                                // none
-    MAP_INSTANCE                        = 1,                                // party
-    MAP_RAID                            = 2,                                // raid
-    MAP_BATTLEGROUND                    = 3,                                // pvp
-    MAP_ARENA                           = 4                                 // arena
+    MAP_COMMON          = 0, // none
+    MAP_INSTANCE        = 1, // party
+    MAP_RAID            = 2, // raid
+    MAP_BATTLEGROUND    = 3, // pvp
+    MAP_ARENA           = 4  // arena
 };
 
 #define MAX_DUNGEON_DIFFICULTY     2
@@ -310,660 +310,660 @@ namespace DBC::Structures
     #pragma pack(push, 1)
     struct AchievementCategoryEntry
     {
-        uint32_t ID;                 // 0
-        uint32_t parentCategory;     // 1 -1 for main category
-        const char* name;          // 2-17
-        uint32_t name_flags;         // 18
-        uint32_t sortOrder;          // 19
+        uint32_t ID;                                                // 0
+        uint32_t parentCategory;                                    // 1 -1 for main category
+        const char* name;                                           // 2-17
+        uint32_t name_flags;                                        // 18
+        uint32_t sortOrder;                                         // 19
     };
 
     struct AchievementCriteriaEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t referredAchievement;     // 1
-        uint32_t requiredType;            // 2
+        uint32_t ID;                                                // 0
+        uint32_t referredAchievement;                               // 1
+        uint32_t requiredType;                                      // 2
         union
         {
             // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
             ///\todo also used for player deaths..
             struct
             {
-                uint32_t creatureID;                             // 3
-                uint32_t creatureCount;                          // 4
+                uint32_t creatureID;                                // 3
+                uint32_t creatureCount;                             // 4
             } kill_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
             ///\todo there are further criterias instead just winning
             struct
             {
-                uint32_t bgMapID;                                // 3
-                uint32_t winCount;                               // 4
+                uint32_t bgMapID;                                   // 3
+                uint32_t winCount;                                  // 4
             } win_bg;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t level;                                  // 4
+                uint32_t unused;                                    // 3
+                uint32_t level;                                     // 4
             } reach_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4
             } reach_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
             struct
             {
-                uint32_t linkedAchievement;                      // 3
+                uint32_t linkedAchievement;                         // 3
             } complete_achievement;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t totalQuestCount;                        // 4
+                uint32_t unused;                                    // 3
+                uint32_t totalQuestCount;                           // 4
             } complete_quest_count;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfDays;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfDays;                              // 4
             } complete_daily_quest_daily;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
             struct
             {
-                uint32_t zoneID;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t zoneID;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_quests_in_zone;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_daily_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } complete_battleground;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } death_at_map;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
             struct
             {
-                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+                uint32_t groupSize;                                 // 3 can be 5, 10 or 25
             } complete_raid;
 
             // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
             struct
             {
-                uint32_t creatureEntry;                          // 3
+                uint32_t creatureEntry;                             // 3
             } killed_by_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t fallHeight;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t fallHeight;                                // 4
             } fall_without_dying;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
             struct
             {
-                uint32_t questID;                                // 3
-                uint32_t questCount;                             // 4
+                uint32_t questID;                                   // 3
+                uint32_t questCount;                                // 4
             } complete_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t spellCount;                             // 4
+                uint32_t spellID;                                   // 3
+                uint32_t spellCount;                                // 4
             } be_spell_target;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t castCount;                              // 4
+                uint32_t spellID;                                   // 3
+                uint32_t castCount;                                 // 4
             } cast_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
             struct
             {
-                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                uint32_t killCount;                              // 4
+                uint32_t areaID;                                    // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                                 // 4
             } honorable_kill_at_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } win_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } play_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
             struct
             {
-                uint32_t spellID;                                // 3 Reference to Map.dbc
+                uint32_t spellID;                                   // 3 Reference to Map.dbc
             } learn_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } own_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 4=in a row
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 4=in a row
             } win_rated_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamtype;                                  // 3 {2,3,5}
             } highest_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
-                uint32_t teamrating;                             // 4
+                uint32_t teamtype;                                  // 3 {2,3,5}
+                uint32_t teamrating;                                // 4
             } reach_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
             } learn_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } use_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } loot_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
             struct
             {
-                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+                uint32_t areaReference;                             // 3 - this is an index to WorldMapOverlay
             } explore_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
             struct
             {
                 ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                uint32_t rank;                                   // 3
+                uint32_t rank;                                      // 3
             } own_rank;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfSlots;                          // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfSlots;                             // 4
             } buy_bank_slot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
             struct
             {
-                uint32_t factionID;                              // 3
-                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+                uint32_t factionID;                                 // 3
+                uint32_t reputationAmount;                          // 4 Total reputation amount, so 42000 = exalted
             } gain_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfExaltedFactions;                // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfExaltedFactions;                   // 4
             } gain_exalted_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
             ///\todo where is the required itemlevel stored?
             struct
             {
-                uint32_t itemSlot;                               // 3
+                uint32_t itemSlot;                                  // 3
             } equip_epic_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
             struct
             {
-                uint32_t rollValue;                              // 3
-                uint32_t count;                                  // 4
+                uint32_t rollValue;                                 // 3
+                uint32_t count;                                     // 4
             } roll_need_on_loot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
             struct
             {
-                uint32_t classID;                                // 3
-                uint32_t count;                                  // 4
+                uint32_t classID;                                   // 3
+                uint32_t count;                                     // 4
             } hk_class;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
             struct
             {
-                uint32_t raceID;                                 // 3
-                uint32_t count;                                  // 4
+                uint32_t raceID;                                    // 3
+                uint32_t count;                                     // 4
             } hk_race;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
             ///\todo where is the information about the target stored?
             struct
             {
-                uint32_t emoteID;                                // 3
+                uint32_t emoteID;                                   // 3
             } do_emote;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 =3 for battleground healing
-                uint32_t mapid;                                  // 6
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 =3 for battleground healing
+                uint32_t mapid;                                     // 6
             } healing_done;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
             struct
             {
-                uint32_t itemID;                                 // 3
+                uint32_t itemID;                                    // 3
             } equip_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
             struct
             {
-                uint32_t unknown;                                 // 3
-                uint32_t goldInCopper;                            // 4
+                uint32_t unknown;                                   // 3
+                uint32_t goldInCopper;                              // 4
             } quest_reward_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t goldInCopper;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t goldInCopper;                              // 4
             } loot_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t useCount;                               // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t useCount;                                  // 4
             } use_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
             ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } special_pvp_kill;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t lootCount;                              // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t lootCount;                                 // 4
             } fish_in_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
             struct
             {
-                uint32_t unknown;                                // 3 777=?
-                uint32_t mountCount;                             // 4
+                uint32_t unknown;                                   // 3 777=?
+                uint32_t mountCount;                                // 4
             } number_of_mounts;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t duelCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t duelCount;                                 // 4
             } win_duel;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
             struct
             {
-                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+                uint32_t powerType;                                 // 3 mana= 0, 1=rage, 3=energy, 6=runic power
             } highest_power;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
             struct
             {
-                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+                uint32_t statType;                                  // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
             } highest_stat;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
             struct
             {
-                uint32_t spellSchool;                            // 3
+                uint32_t spellSchool;                               // 3
             } highest_spellpower;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
             struct
             {
-                uint32_t ratingType;                             // 3
+                uint32_t ratingType;                                // 3
             } highest_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
             struct
             {
-                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                uint32_t lootTypeCount;                          // 4
+                uint32_t lootType;                                  // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                             // 4
             } loot_type;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } cast_spell2;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } learn_skill_line;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } honorable_kill;
 
             struct
             {
-                uint32_t field3;                                 // 3 main requirement
-                uint32_t field4;                                 // 4 main requirement count
-                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+                uint32_t field3;                                    // 3 main requirement
+                uint32_t field4;                                    // 4 main requirement count
+                uint32_t additionalRequirement1_type;               // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;              // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;               // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;              // 8 additional requirement 1 value
             } raw;
         };
-        //uint32_t unk                      // 9
-        char* name;                         // 10
-        uint32_t completionFlag;            // 11
-        uint32_t groupFlag;                 // 12 timed criteria
-        uint32_t unk1;                      // 13 timed criteria misc id
-        uint32_t timeLimit;                 // 14 time limit in seconds
-        uint32_t index;                     // 15 order
+        //uint32_t unk                                              // 9
+        char* name;                                                 // 10
+        uint32_t completionFlag;                                    // 11
+        uint32_t groupFlag;                                         // 12 timed criteria
+        uint32_t unk1;                                              // 13 timed criteria misc id
+        uint32_t timeLimit;                                         // 14 time limit in seconds
+        uint32_t index;                                             // 15 order
     };
 
     struct AchievementEntry
     {
-        uint32_t ID;                        // 0
-        int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
-        int32_t mapID;                      // 2 -1=none
-        uint32_t parentAchievement;         // 3
-        char* name;                         // 4
-        char* description;                  // 5
-        uint32_t categoryId;                // 6
-        uint32_t points;                    // 7 reward points
-        uint32_t orderInCategory;           // 8
-        uint32_t flags;                     // 9
-        uint32_t icon;                      // 10
-        char* rewardName;                   // 11 title/item reward name
-        uint32_t count;                     // 12
-        uint32_t refAchievement;            // 13
+        uint32_t ID;                                                // 0
+        int32_t factionFlag;                                        // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                                              // 2 -1=none
+        uint32_t parentAchievement;                                 // 3
+        char* name;                                                 // 4
+        char* description;                                          // 5
+        uint32_t categoryId;                                        // 6
+        uint32_t points;                                            // 7 reward points
+        uint32_t orderInCategory;                                   // 8
+        uint32_t flags;                                             // 9
+        uint32_t icon;                                              // 10
+        char* rewardName;                                           // 11 title/item reward name
+        uint32_t count;                                             // 12
+        uint32_t refAchievement;                                    // 13
     };
 
     struct AreaGroupEntry
     {
-        uint32_t AreaGroupId;               // 0
-        uint32_t AreaId[6];                 // 1-6
-        uint32_t next_group;                // 7
+        uint32_t AreaGroupId;                                       // 0
+        uint32_t AreaId[6];                                         // 1-6
+        uint32_t next_group;                                        // 7
     };
 
     struct AreaTableEntry
     {
-        uint32_t id;                        // 0
-        uint32_t map_id;                    // 1
-        uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;              // 3, main index
-        uint32_t flags;                     // 4, unknown value but 312 for all cities
-                                            // 5-9 unused
-        int32_t area_level;                 // 10
-        char* area_name;                    // 11
-        uint32_t team;                      // 12
-        uint32_t liquid_type_override[4];   // 13-16 liquid override by type
-        //uint32_t unk17;                   // 17
-        //uint32_t unk18;                   // 18
-        //uint32_t unk19;                   // 19
-        //uint32_t unk20;                   // 20
-        //uint32_t unk21;                   // 21
-        //uint32_t unk22;                   // 22
-        //uint32_t unk23;                   // 23
-        //uint32_t unk24;                   // 24
+        uint32_t id;                                                // 0
+        uint32_t map_id;                                            // 1
+        uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;                                      // 3, main index
+        uint32_t flags;                                             // 4, unknown value but 312 for all cities
+                                                                    // 5-9 unused
+        int32_t area_level;                                         // 10
+        char* area_name;                                            // 11
+        uint32_t team;                                              // 12
+        uint32_t liquid_type_override[4];                           // 13-16 liquid override by type
+        //uint32_t unk17;                                           // 17
+        //uint32_t unk18;                                           // 18
+        //uint32_t unk19;                                           // 19
+        //uint32_t unk20;                                           // 20
+        //uint32_t unk21;                                           // 21
+        //uint32_t unk22;                                           // 22
+        //uint32_t unk23;                                           // 23
+        //uint32_t unk24;                                           // 24
     };
 
     struct AreaTriggerEntry
     {
-        uint32_t id;                        // 0
-        uint32_t mapid;                     // 1
-        float x;                            // 2
-        float y;                            // 3
-        float z;                            // 4
-        //uint32_t                          // 5
-        //uint32_t                          // 6
-        //uint32_t                          // 7
-        float o;                            // 5 radius
-        float box_x;                        // 6 extent x edge
-        float box_y;                        // 7 extent y edge
-        float box_z;                        // 8 extent z edge
-        float box_o;                        // 9
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        //uint32_t                                                  // 5
+        //uint32_t                                                  // 6
+        //uint32_t                                                  // 7
+        float o;                                                    // 5 radius
+        float box_x;                                                // 6 extent x edge
+        float box_y;                                                // 7 extent y edge
+        float box_z;                                                // 8 extent z edge
+        float box_o;                                                // 9
     };
 
     //\todo danko
     //struct ArmorLocationEntry   
     //{
-    //    uint32_t InventoryType;           // 0
-    //    float Value[5];                   // 1-5
+    //    uint32_t InventoryType;                                   // 0
+    //    float Value[5];                                           // 1-5
     //};
 
     struct AuctionHouseEntry
     {
-        uint32_t id;                        // 0
-        uint32_t faction;                   // 1
-        uint32_t fee;                       // 2
-        uint32_t tax;                       // 3
-        //char* name;                       // 4
+        uint32_t id;                                                // 0
+        uint32_t faction;                                           // 1
+        uint32_t fee;                                               // 2
+        uint32_t tax;                                               // 3
+        //char* name;                                               // 4
     };
 
     struct BankBagSlotPrices
     {
-        uint32_t Id;                        // 0
-        uint32_t Price;                     // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct BarberShopStyleEntry
     {
-        uint32_t id;                        // 0
-        uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
-        //char* name;                       // 2
-        //uint32_t unk_name;                // 3
-        //float CostMultiplier;             // 4
-        uint32_t race;                      // 5
-        uint32_t gender;                    // 6 0 male, 1 female
-        uint32_t hair_id;                   // 7 Hair ID
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;                                               // 2
+        //uint32_t unk_name;                                        // 3
+        //float CostMultiplier;                                     // 4
+        uint32_t race;                                              // 5
+        uint32_t gender;                                            // 6 0 male, 1 female
+        uint32_t hair_id;                                           // 7 Hair ID
     };
 
     struct BannedAddOnsEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t nameMD5[4];              // 1-4
-        //uint32_t versionMD5[4];           // 5-8
-        //uint32_t timestamp;               // 9
-        //uint32_t state;                   // 10
+        uint32_t Id;                                                // 0
+        //uint32_t nameMD5[4];                                      // 1-4
+        //uint32_t versionMD5[4];                                   // 5-8
+        //uint32_t timestamp;                                       // 9
+        //uint32_t state;                                           // 10
     };
 
     #define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
-        //uint32_t Id;                                    // 0
-        uint8_t Race;                                     // 1
-        uint8_t Class;                                    // 2
-        uint8_t Gender;                                   // 3
-        //uint8_t Unused;                                 // 4
-        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
-        uint32_t PetDisplayId;                            // 77
-        uint32_t PetFamilyEntry;                          // 78
+        //uint32_t Id;                                              // 0
+        uint8_t Race;                                               // 1
+        uint8_t Class;                                              // 2
+        uint8_t Gender;                                             // 3
+        //uint8_t Unused;                                           // 4
+        int32_t ItemId[OUTFIT_ITEMS];                               // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];                      // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];                  // 53-76
+        uint32_t PetDisplayId;                                      // 77
+        uint32_t PetFamilyEntry;                                    // 78
     };
 
     struct CharTitlesEntry
     {
-        uint32_t ID;                        // 0
-        //uint32_t unk1;                    // 1
-        char* name;                         // 2
-        //char* name2;                      // 3
-        uint32_t bit_index;                 // 4
-        //uint32_t unk                      // 5
+        uint32_t ID;                                                // 0
+        //uint32_t unk1;                                            // 1
+        char* name;                                                 // 2
+        //char* name2;                                              // 3
+        uint32_t bit_index;                                         // 4
+        //uint32_t unk                                              // 5
     };
 
     struct ChatChannelsEntry
     {
-        uint32_t id;                        // 0
-        uint32_t flags;                     // 1
-        //uint32_t faction                  // 2
-        char* name_pattern;                 // 3
-        //char* channel_name;               // 4
+        uint32_t id;                                                // 0
+        uint32_t flags;                                             // 1
+        //uint32_t faction                                          // 2
+        char* name_pattern;                                         // 3
+        //char* channel_name;                                       // 4
     };
 
     struct ChrClassesEntry
     {
-        uint32_t class_id;                  // 0
-        uint32_t power_type;                // 1
-        //uint32_t unk2;                    // 2
-        char* name;                         // 3
-        //char* name_female;                // 4
-        //char* name_neutral;               // 5
-        //char* name_capitalized            // 6
-        uint32_t spellfamily;               // 7
-        //uint32_t unk4;                    // 8
-        uint32_t cinematic_id;              // 9 CinematicSequences.dbc
-        uint32_t expansion;                 // 10
-        uint32_t apPerStr;                  // 11
-        uint32_t apPerAgi;                  // 12
-        uint32_t rapPerAgi;                 // 13
+        uint32_t class_id;                                          // 0
+        uint32_t power_type;                                        // 1
+        //uint32_t unk2;                                            // 2
+        char* name;                                                 // 3
+        //char* name_female;                                        // 4
+        //char* name_neutral;                                       // 5
+        //char* name_capitalized                                    // 6
+        uint32_t spellfamily;                                       // 7
+        //uint32_t unk4;                                            // 8
+        uint32_t cinematic_id;                                      // 9 CinematicSequences.dbc
+        uint32_t expansion;                                         // 10
+        uint32_t apPerStr;                                          // 11
+        uint32_t apPerAgi;                                          // 12
+        uint32_t rapPerAgi;                                         // 13
     };
 
     struct ChrRacesEntry
     {
-        uint32_t race_id;                   // 0
-        //uint32_t flags;                   // 1
-        uint32_t faction_id;                // 2
-        //uint32_t unk1;                    // 3
-        uint32_t model_male;                // 4
-        uint32_t model_female;              // 5
-        // uint32_t unk2;                   // 6
-        uint32_t team_id;                   // 7
-        //uint32_t unk3[4];                 // 8-11
-        uint32_t cinematic_id;              // 12 CinematicSequences.dbc
-        //uint32_t unk4                     // 13
-        char* name;                         // 14
-        //char* name_female;                // 15
-        //char* name_neutral;               // 16
-        //uint32_t unk5[2]                  // 17-18
-        //uint32_t unk19                    // 19
-        uint32_t expansion;                 // 20
-        //uint32_t unk21                    // 21
-        //uint32_t unk22                    // 22
-        //uint32_t unk23                    // 23
+        uint32_t race_id;                                           // 0
+        //uint32_t flags;                                           // 1
+        uint32_t faction_id;                                        // 2
+        //uint32_t unk1;                                            // 3
+        uint32_t model_male;                                        // 4
+        uint32_t model_female;                                      // 5
+        // uint32_t unk2;                                           // 6
+        uint32_t team_id;                                           // 7
+        //uint32_t unk3[4];                                         // 8-11
+        uint32_t cinematic_id;                                      // 12 CinematicSequences.dbc
+        //uint32_t unk4                                             // 13
+        char* name;                                                 // 14
+        //char* name_female;                                        // 15
+        //char* name_neutral;                                       // 16
+        //uint32_t unk5[2]                                          // 17-18
+        //uint32_t unk19                                            // 19
+        uint32_t expansion;                                         // 20
+        //uint32_t unk21                                            // 21
+        //uint32_t unk22                                            // 22
+        //uint32_t unk23                                            // 23
     };
 
     struct ChrPowerTypesEntry
     {
-        uint32_t entry;                     // 0
-        uint32_t classId;                   // 1 class
-        uint32_t power;                     // 2 power type
+        uint32_t entry;                                             // 0
+        uint32_t classId;                                           // 1 class
+        uint32_t power;                                             // 2 power type
     };
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t Displayid;                 // 0
-        uint32_t ModelId;                   // 1
-        //uint32_t sound_id;                // 2
-        uint32_t ExtendedDisplayInfoID;     // 3
-        float scale;                        // 4
-        //uint32_t unk01;                   // 5
-        //uint32_t unk02[2];                // 6-8
-        //uint32_t unk03;                   // 9
-        //uint32_t unk04;                   // 10
-        //uint32_t unk05;                   // 11
-        //uint32_t unk06;                   // 12
-        //uint32_t unk07;                   // 13
-        //uint32_t unk08;                   // 14
-        //uint32_t unk09;                   // 15
-        //uint32_t unk10;                   // 16
+        uint32_t Displayid;                                         // 0
+        uint32_t ModelId;                                           // 1
+        //uint32_t sound_id;                                        // 2
+        uint32_t ExtendedDisplayInfoID;                             // 3
+        float scale;                                                // 4
+        //uint32_t unk01;                                           // 5
+        //uint32_t unk02[2];                                        // 6-8
+        //uint32_t unk03;                                           // 9
+        //uint32_t unk04;                                           // 10
+        //uint32_t unk05;                                           // 11
+        //uint32_t unk06;                                           // 12
+        //uint32_t unk07;                                           // 13
+        //uint32_t unk08;                                           // 14
+        //uint32_t unk09;                                           // 15
+        //uint32_t unk10;                                           // 16
     };
 
     struct CreatureDisplayInfoExtraEntry
     {
-        uint32_t DisplayExtraId;            // 0
-        uint32_t Race;                      // 1
-        //uint32_t Gender;                  // 2
-        //uint32_t SkinColor;               // 3
-        //uint32_t FaceType;                // 4
-        //uint32_t HairType;                // 5
-        //uint32_t HairStyle;               // 6
-        //uint32_t BeardStyle;              // 7
-        //uint32_t Equipment[11];           // 8-18
-        //uint32_t CanEquip;                // 19
-        //char* unk                         // 20
+        uint32_t DisplayExtraId;                                    // 0
+        uint32_t Race;                                              // 1
+        //uint32_t Gender;                                          // 2
+        //uint32_t SkinColor;                                       // 3
+        //uint32_t FaceType;                                        // 4
+        //uint32_t HairType;                                        // 5
+        //uint32_t HairStyle;                                       // 6
+        //uint32_t BeardStyle;                                      // 7
+        //uint32_t Equipment[11];                                   // 8-18
+        //uint32_t CanEquip;                                        // 19
+        //char* unk                                                 // 20
     };
 
     struct CreatureFamilyEntry
     {
-        uint32_t ID;                        // 0
-        float minsize;                      // 1
-        uint32_t minlevel;                  // 2
-        float maxsize;                      // 3
-        uint32_t maxlevel;                  // 4
-        uint32_t skilline;                  // 5
-        uint32_t tameable;                  // 6 second skill line - 270 Generic
-        uint32_t petdietflags;              // 7
-        uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-        //uint32_t unk;                     // 9 some index 0 - 63
-        char* name;                         // 10
-        //uint32_t nameflags;               // 11
+        uint32_t ID;                                                // 0
+        float minsize;                                              // 1
+        uint32_t minlevel;                                          // 2
+        float maxsize;                                              // 3
+        uint32_t maxlevel;                                          // 4
+        uint32_t skilline;                                          // 5
+        uint32_t tameable;                                          // 6 second skill line - 270 Generic
+        uint32_t petdietflags;                                      // 7
+        uint32_t talenttree;                                        // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                                             // 9 some index 0 - 63
+        char* name;                                                 // 10
+        //uint32_t nameflags;                                       // 11
     };
 
     struct CreatureSpellDataEntry
     {
-        uint32_t id;                        // 0
+        uint32_t id;                                                // 0
         uint32_t Spells[3];
         uint32_t PHSpell;
         uint32_t Cooldowns[3];
@@ -973,190 +973,190 @@ namespace DBC::Structures
     //\todo danko
     //struct CreatureTypeEntry
     //{
-    //    uint32_t ID;                      // 0
-    //    //char* Name;                     // 1
-    //    //uint32_t no_expirience;         // 2
+    //    uint32_t ID;                                              // 0
+    //    //char* Name;                                             // 1
+    //    //uint32_t no_expirience;                                 // 2
     //};
 
     struct CurrencyTypesEntry
     {
-        uint32_t item_id;                   // 0
-        uint32_t Category;                  // 1
-        char* name;                         // 2
-        //char* unk                         // 3
-        //char* unk2                        // 4
-        //uint32_t unk5;                    // 5
-        //uint32_t unk6;                    // 6
-        uint32_t TotalCap;                  // 7
-        uint32_t WeekCap;                   // 8
-        uint32_t Flags;                     // 9
-        //char* description;                // 10
+        uint32_t item_id;                                           // 0
+        uint32_t Category;                                          // 1
+        char* name;                                                 // 2
+        //char* unk                                                 // 3
+        //char* unk2                                                // 4
+        //uint32_t unk5;                                            // 5
+        //uint32_t unk6;                                            // 6
+        uint32_t TotalCap;                                          // 7
+        uint32_t WeekCap;                                           // 8
+        uint32_t Flags;                                             // 9
+        //char* description;                                        // 10
     };
 
     struct DurabilityCostsEntry
     {
-        uint32_t itemlevel;                 // 0
-        uint32_t modifier[29];              // 1-29
+        uint32_t itemlevel;                                         // 0
+        uint32_t modifier[29];                                      // 1-29
     };
 
     struct DurabilityQualityEntry
     {
-        uint32_t id;                        // 0
-        float quality_modifier;             // 1
+        uint32_t id;                                                // 0
+        float quality_modifier;                                     // 1
     };
 
     struct EmotesEntry
     {
-        uint32_t Id;                        // 0
-        //char* name;                       // 1
-        //uint32_t animationId;             // 2
-        uint32_t Flags;                     // 3
-        uint32_t EmoteType;                 // 4
-        uint32_t UnitStandState;            // 5
-        //uint32_t soundId;                 // 6
-        //uint32_t unk;                     // 7
+        uint32_t Id;                                                // 0
+        //char* name;                                               // 1
+        //uint32_t animationId;                                     // 2
+        uint32_t Flags;                                             // 3
+        uint32_t EmoteType;                                         // 4
+        uint32_t UnitStandState;                                    // 5
+        //uint32_t soundId;                                         // 6
+        //uint32_t unk;                                             // 7
     };
 
     struct EmotesTextEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t name;                    // 1
-        uint32_t textid;                    // 2
-        //uint32_t unk1;                    // 4
+        uint32_t Id;                                                // 0
+        //uint32_t name;                                            // 1
+        uint32_t textid;                                            // 2
+        //uint32_t unk1;                                            // 4
     };
 
     struct FactionEntry
     {
-        uint32_t ID;                        // 0
-        int32_t RepListId;                  // 1
-        uint32_t RaceMask[4];               // 2-5
-        uint32_t ClassMask[4];              // 6-9
-        int32_t baseRepValue[4];            // 10-13
-        uint32_t repFlags[4];               // 14-17
-        uint32_t parentFaction;             // 18
-        float spillover_rate_in;            // 19
-        float spillover_rate_out;           // 20
-        uint32_t spillover_max_in;          // 21
-        //uint32_t unk1;                    // 22
-        char* Name;                         // 23
-        //uint32_t Description;             // 24
-        //uint32_t description_flags;       // 25
+        uint32_t ID;                                                // 0
+        int32_t RepListId;                                          // 1
+        uint32_t RaceMask[4];                                       // 2-5
+        uint32_t ClassMask[4];                                      // 6-9
+        int32_t baseRepValue[4];                                    // 10-13
+        uint32_t repFlags[4];                                       // 14-17
+        uint32_t parentFaction;                                     // 18
+        float spillover_rate_in;                                    // 19
+        float spillover_rate_out;                                   // 20
+        uint32_t spillover_max_in;                                  // 21
+        //uint32_t unk1;                                            // 22
+        char* Name;                                                 // 23
+        //uint32_t Description;                                     // 24
+        //uint32_t description_flags;                               // 25
     };
 
     struct FactionTemplateEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t Faction;                   // 1
-        uint32_t FactionGroup;              // 2
-        uint32_t Mask;                      // 3
-        uint32_t FriendlyMask;              // 4
-        uint32_t HostileMask;               // 5
-        uint32_t EnemyFactions[4];          // 6-9
-        uint32_t FriendlyFactions[4];       // 10-13
+        uint32_t ID;                                                // 0
+        uint32_t Faction;                                           // 1
+        uint32_t FactionGroup;                                      // 2
+        uint32_t Mask;                                              // 3
+        uint32_t FriendlyMask;                                      // 4
+        uint32_t HostileMask;                                       // 5
+        uint32_t EnemyFactions[4];                                  // 6-9
+        uint32_t FriendlyFactions[4];                               // 10-13
     };
 
     struct GameObjectDisplayInfoEntry
     {
-        uint32_t Displayid;                 // 0
-        char* filename;                     // 1
-        //uint32_t  unk1[10];               // 2-11
-        float minX;                         // 12
-        float minY;                         // 13
-        float minZ;                         // 14
-        float maxX;                         // 15
-        float maxY;                         // 16
-        float maxZ;                         // 17
-        //uint32_t transport;               // 18
-        //uint32_t unk;                     // 19
-        //uint32_t unk;                     // 20
+        uint32_t Displayid;                                         // 0
+        char* filename;                                             // 1
+        //uint32_t unk1[10];                                        // 2-11
+        float minX;                                                 // 12
+        float minY;                                                 // 13
+        float minZ;                                                 // 14
+        float maxX;                                                 // 15
+        float maxY;                                                 // 16
+        float maxZ;                                                 // 17
+        //uint32_t transport;                                       // 18
+        //uint32_t unk;                                             // 19
+        //uint32_t unk;                                             // 20
     };
 
     struct GemPropertiesEntry
     {
-        uint32_t Entry;                     // 0
-        uint32_t EnchantmentID;             // 1
-        //uint32_t unk1;                    // 2 bool
-        //uint32_t unk2;                    // 3 bool
-        uint32_t SocketMask;                // 4
+        uint32_t Entry;                                             // 0
+        uint32_t EnchantmentID;                                     // 1
+        //uint32_t unk1;                                            // 2 bool
+        //uint32_t unk2;                                            // 3 bool
+        uint32_t SocketMask;                                        // 4
     };
 
     struct GlyphPropertiesEntry
     {
-        uint32_t Entry;                     // 0
-        uint32_t SpellID;                   // 1
-        uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
-        uint32_t unk;                       // 3 glyph_icon spell.dbc
+        uint32_t Entry;                                             // 0
+        uint32_t SpellID;                                           // 1
+        uint32_t Type;                                              // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                                               // 3 glyph_icon spell.dbc
     };
 
     struct GlyphSlotEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t Type;                      // 1
-        uint32_t Slot;                      // 2
+        uint32_t Id;                                                // 0
+        uint32_t Type;                                              // 1
+        uint32_t Slot;                                              // 2
     };
 
     struct GtBarberShopCostBaseEntry
     {
-        float cost;                         // 0
+        float cost;                                                 // 0
     };
 
     struct GtChanceToMeleeCritEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToMeleeCritBaseEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritBaseEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtCombatRatingsEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtOCTClassCombatRatingScalarEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     //\todo danko
     //struct GtOCTRegenHPEntry
     //{
-    //    float ratio;                      // 0
+    //    float ratio;                                              // 0
     //};
 
     struct GtOCTRegenMPEntry
     {
-        float ratio;                        // 0
+        float ratio;                                                // 0
     };
 
     //\todo danko
     //struct GtRegenHPPerSptEntry
     //{
-    //    float ratio;                      // 0
+    //    float ratio;                                              // 0
     //};
 
     struct GtRegenMPPerSptEntry
     {
-        float ratio;                        // 0
+        float ratio;                                                // 0
     };
 
     struct GuildPerkSpellsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Level;                     // 1
-        uint32_t SpellId;                   // 2
+        //uint32_t Id;                                              // 0
+        uint32_t Level;                                             // 1
+        uint32_t SpellId;                                           // 2
     };
 
 #define MAX_HOLIDAY_DURATIONS 10
@@ -1165,79 +1165,79 @@ namespace DBC::Structures
 
     struct HolidaysEntry
     {
-        uint32_t Id;                                    // 0
-        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-        //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-        //uint32_t Region;                              // 37
-        //uint32_t Looping;                             // 38
-        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-        //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
-        //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
-        //char* TextureFilename;                        // 51
-        //uint32_t Priority;                            // 52
-        //uint32_t CalendarFilterType;                  // 53
-        //uint32_t flags;                               // 54
+        uint32_t Id;                                                // 0
+        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];                 // 1-10
+        //uint32_t Date[MAX_HOLIDAY_DATES];                         // 11-36
+        //uint32_t Region;                                          // 37
+        //uint32_t Looping;                                         // 38
+        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];                // 39-48
+        //uint32_t holidayNameId;                                   // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;                            // 50 HolidayDescriptions.dbc
+        //char* TextureFilename;                                    // 51
+        //uint32_t Priority;                                        // 52
+        //uint32_t CalendarFilterType;                              // 53
+        //uint32_t flags;                                           // 54
     };
 
     struct ItemLimitCategoryEntry
     {
-        uint32_t Id;                        // 0
-        //char* name;                       // 1
-        uint32_t maxAmount;                 // 2
-        uint32_t equippedFlag;              // 3
+        uint32_t Id;                                                // 0
+        //char* name;                                               // 1
+        uint32_t maxAmount;                                         // 2
+        uint32_t equippedFlag;                                      // 3
     };
 
     struct ItemRandomPropertiesEntry
     {
-        uint32_t ID;                        // 0
-        //char* name1;                      // 1
-        uint32_t spells[5];                 // 2-6 enchant_id
-        char* name_suffix;                  // 7
+        uint32_t ID;                                                // 0
+        //char* name1;                                              // 1
+        uint32_t spells[5];                                         // 2-6 enchant_id
+        char* name_suffix;                                          // 7
     };
 
     struct ItemRandomSuffixEntry
     {
-        uint32_t id;                        // 0
-        char* name_suffix;                  // 1
-        //uint32_t name_suffix_flags;       // 2
-        uint32_t enchantments[5];           // 3-7
-        uint32_t prefixes[5];               // 8-12
+        uint32_t id;                                                // 0
+        char* name_suffix;                                          // 1
+        //uint32_t name_suffix_flags;                               // 2
+        uint32_t enchantments[5];                                   // 3-7
+        uint32_t prefixes[5];                                       // 8-12
     };
 
     struct ItemSetEntry
     {
-        //uint32_t id;                      // 0
-        char* name;                         // 1
-        //uint32_t itemid[17];              // 2-18
-        uint32_t SpellID[8];                // 19-26
-        uint32_t itemscount[8];             // 27-34
-        uint32_t RequiredSkillID;           // 35
-        uint32_t RequiredSkillAmt;          // 36
+        //uint32_t id;                                              // 0
+        char* name;                                                 // 1
+        //uint32_t itemid[17];                                      // 2-18
+        uint32_t SpellID[8];                                        // 19-26
+        uint32_t itemscount[8];                                     // 27-34
+        uint32_t RequiredSkillID;                                   // 35
+        uint32_t RequiredSkillAmt;                                  // 36
     };
 
     struct LFGDungeonEntry
     {
-        uint32_t ID;                        // 0
-        char* name;                         // 1
-        uint32_t minlevel;                  // 2
-        uint32_t maxlevel;                  // 3
-        uint32_t reclevel;                  // 4
-        uint32_t recminlevel;               // 5
-        uint32_t recmaxlevel;               // 6
-        int32_t map;                        // 7
-        uint32_t difficulty;                // 8
-        uint32_t unk;                       // 9
-        uint32_t flags;                     // 10
-        int32_t type;                       // 11
-        char* iconname;                     // 12
-        uint32_t expansion;                 // 13
-        uint32_t unk4;                      // 14
-        uint32_t unk5;                      // 15
-        char* unk_text;                     // 16
-        uint32_t grouptype;                 // 17
-        uint32_t unkflags1;                 // 18
-        uint32_t unkflags2;                 // 19
-        uint32_t unk7;                      // 20
+        uint32_t ID;                                                // 0
+        char* name;                                                 // 1
+        uint32_t minlevel;                                          // 2
+        uint32_t maxlevel;                                          // 3
+        uint32_t reclevel;                                          // 4
+        uint32_t recminlevel;                                       // 5
+        uint32_t recmaxlevel;                                       // 6
+        int32_t map;                                                // 7
+        uint32_t difficulty;                                        // 8
+        uint32_t unk;                                               // 9
+        uint32_t flags;                                             // 10
+        int32_t type;                                               // 11
+        char* iconname;                                             // 12
+        uint32_t expansion;                                         // 13
+        uint32_t unk4;                                              // 14
+        uint32_t unk5;                                              // 15
+        char* unk_text;                                             // 16
+        uint32_t grouptype;                                         // 17
+        uint32_t unkflags1;                                         // 18
+        uint32_t unkflags2;                                         // 19
+        uint32_t unk7;                                              // 20
 
         // Helpers
         uint32_t Entry() const { return ID + (type << 24); }
@@ -1245,79 +1245,79 @@ namespace DBC::Structures
 
     struct DungeonEncounterEntry
     {
-        uint32 id;                                              // 0        unique id
-        uint32 mapId;                                           // 1        map id
-        uint32 difficulty;                                      // 2        instance mode
-        //uint32 unk0;                                          // 3
-        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-        char* encounterName;                                    // 5        encounter name
-        //uint32 nameFlags;                                     // 21
-        //uint32 unk1;                                          // 22
+        uint32_t id;                                                // 0 unique id
+        uint32_t mapId;                                             // 1 map id
+        uint32_t difficulty;                                        // 2 instance mode
+        //uint32_t unk0;                                            // 3
+        uint32_t encounterIndex;                                    // 4 encounter index for creating completed mask
+        char* encounterName;                                        // 5 encounter name
+        //uint32_t nameFlags;                                       // 21
+        //uint32_t unk1;                                            // 22
     };
 
     struct LiquidTypeEntry
     {
-        uint32_t Id;                        // 0
-        //char* Name;                       // 1
-        //uint32_t Flags;                   // 2
-        uint32_t Type;                      // 3
-        //uint32_t SoundId;                 // 4
-        uint32_t SpellId;                   // 5
-        //float MaxDarkenDepth;             // 6
-        //float FogDarkenIntensity;         // 7
-        //float AmbDarkenIntensity;         // 8
-        //float DirDarkenIntensity;         // 9
-        //uint32_t LightID;                 // 10
-        //float ParticleScale;              // 11
-        //uint32_t ParticleMovement;        // 12
-        //uint32_t ParticleTexSlots;        // 13
-        //uint32_t LiquidMaterialID;        // 14
-        //char* Texture[6];                 // 15-20
-        //uint32_t Color[2];                // 21-22
-        //float Unk1[18];                   // 23-40
-        //uint32_t Unk2[4];                 // 41-44
+        uint32_t Id;                                                // 0
+        //char* Name;                                               // 1
+        //uint32_t Flags;                                           // 2
+        uint32_t Type;                                              // 3
+        //uint32_t SoundId;                                         // 4
+        uint32_t SpellId;                                           // 5
+        //float MaxDarkenDepth;                                     // 6
+        //float FogDarkenIntensity;                                 // 7
+        //float AmbDarkenIntensity;                                 // 8
+        //float DirDarkenIntensity;                                 // 9
+        //uint32_t LightID;                                         // 10
+        //float ParticleScale;                                      // 11
+        //uint32_t ParticleMovement;                                // 12
+        //uint32_t ParticleTexSlots;                                // 13
+        //uint32_t LiquidMaterialID;                                // 14
+        //char* Texture[6];                                         // 15-20
+        //uint32_t Color[2];                                        // 21-22
+        //float Unk1[18];                                           // 23-40
+        //uint32_t Unk2[4];                                         // 41-44
     };
 
 #define LOCK_NUM_CASES 8
 
     struct LockEntry
     {
-        uint32_t Id;                              // 0
-        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+        uint32_t Id;                                                // 0
+        uint32_t locktype[LOCK_NUM_CASES];                          // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];                          // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];                      // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];                          // 25-32 Something to do with direction / opening / closing.
     };
 
     struct MailTemplateEntry
     {
-        uint32_t ID;                        // 0
-        char* subject;                      // 1
-        char* content;                      // 2
+        uint32_t ID;                                                // 0
+        char* subject;                                              // 1
+        char* content;                                              // 2
     };
 
     struct MapEntry
     {
-        uint32_t id;                        // 0
-        char* name_internal;                // 1
-        uint32_t map_type;                  // 2
-        uint32_t map_flags;                 // 3
-        uint32_t unk4;                      // 4
-        uint32_t is_pvp_zone;               // 5
-        char* map_name;                     // 6
-        uint32_t linked_zone;               // 7 common zone for instance and continent map
-        char* horde_intro;                  // 8 horde text for PvP Zones
-        char* alliance_intro;               // 9 alliance text for PvP Zones
-        uint32_t multimap_id;               // 10
-        float battlefield_map_icon;         // 11
-        int32_t parent_map;                 // 12 ghost map_id of parent map
-        float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
-        float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
-        uint32_t dayTime_override;          // 15
-        uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
-        uint32_t unk_time;                  // 17
-        uint32_t max_players;               // 18
-        uint32_t next_phase_map;            // 19
+        uint32_t id;                                                // 0
+        char* name_internal;                                        // 1
+        uint32_t map_type;                                          // 2
+        uint32_t map_flags;                                         // 3
+        uint32_t unk4;                                              // 4
+        uint32_t is_pvp_zone;                                       // 5
+        char* map_name;                                             // 6
+        uint32_t linked_zone;                                       // 7 common zone for instance and continent map
+        char* horde_intro;                                          // 8 horde text for PvP Zones
+        char* alliance_intro;                                       // 9 alliance text for PvP Zones
+        uint32_t multimap_id;                                       // 10
+        float battlefield_map_icon;                                 // 11
+        int32_t parent_map;                                         // 12 ghost map_id of parent map
+        float start_x;                                              // 13 ghost enter x coordinate (if exist single entry)
+        float start_y;                                              // 14 ghost enter y coordinate (if exist single entry)
+        uint32_t dayTime_override;                                  // 15
+        uint32_t addon;                                             // 16 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                                          // 17
+        uint32_t max_players;                                       // 18
+        uint32_t next_phase_map;                                    // 19
 
         bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
         bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
@@ -1336,95 +1336,95 @@ namespace DBC::Structures
 
     struct NameGenEntry
     {
-        uint32_t ID;                        // 0
-        char* Name;                         // 1
-        uint32_t unk1;                      // 2
-        uint32_t type;                      // 3
+        uint32_t ID;                                                // 0
+        char* Name;                                                 // 1
+        uint32_t unk1;                                              // 2
+        uint32_t type;                                              // 3
     };
 
     struct NumTalentsAtLevel
     {
-        //uint32_t level;                   // 0
-        float talentPoints;                 // 1
+        //uint32_t level;                                           // 0
+        float talentPoints;                                         // 1
     };
 
     struct PhaseEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t PhaseShift;                // 1
-        uint32_t Flags;                     // 2
+        uint32_t Id;                                                // 0
+        uint32_t PhaseShift;                                        // 1
+        uint32_t Flags;                                             // 2
     };
 
     struct QuestSortEntry
     {
-        uint32_t id;                        // 0
-        //char* name;                       // 1
+        uint32_t id;                                                // 0
+        //char* name;                                               // 1
     };
 
     struct QuestXP
     {
-        uint32_t questLevel;                // 0
-        uint32_t xpIndex[10];               // 1-10
+        uint32_t questLevel;                                        // 0
+        uint32_t xpIndex[10];                                       // 1-10
     };
 
     struct ScalingStatDistributionEntry
     {
-        uint32_t id;                        // 0
-        int32_t stat[10];                   // 1-10
-        uint32_t statmodifier[10];          // 11-20
-        //uint32_t unk;                     // 21
-        uint32_t maxlevel;                  // 22
+        uint32_t id;                                                // 0
+        int32_t stat[10];                                           // 1-10
+        uint32_t statmodifier[10];                                  // 11-20
+        //uint32_t unk;                                             // 21
+        uint32_t maxlevel;                                          // 22
     };
 
     struct ScalingStatValuesEntry
     {
-        uint32_t id;                        // 0
-        uint32_t level;                     // 1
-        uint32_t multiplier[20];            // 
+        uint32_t id;                                                // 0
+        uint32_t level;                                             // 1
+        uint32_t multiplier[20];                                    // 
         //\todo danko Rewrite GetStatScalingStatValueColumn!
-        //uint32_t dpsMod[6];               // 2-7
-        //uint32_t spellBonus;              // 8
-        //uint32_t scalingstatmultipl[5];   // 9-13
-        //uint32_t amor_mod[4];             // 14-17
-        //uint32_t amor_mod2[4];            // 18-21
-        //uint32_t junk[24];                // 22-45
-        //uint32_t unk2;                    // 46
+        //uint32_t dpsMod[6];                                       // 2-7
+        //uint32_t spellBonus;                                      // 8
+        //uint32_t scalingstatmultipl[5];                           // 9-13
+        //uint32_t amor_mod[4];                                     // 14-17
+        //uint32_t amor_mod2[4];                                    // 18-21
+        //uint32_t junk[24];                                        // 22-45
+        //uint32_t unk2;                                            // 46
     };
 
     struct SkillLineEntry
     {
-        uint32_t id;                        // 0
-        uint32_t type;                      // 1
-        char* Name;                         // 2
-        //char* Description;                // 3
-        uint32_t spell_icon;                // 4
-        //char* add_name;                   // 5
-        uint32_t linkable;                  // 6
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1
+        char* Name;                                                 // 2
+        //char* Description;                                        // 3
+        uint32_t spell_icon;                                        // 4
+        //char* add_name;                                           // 5
+        uint32_t linkable;                                          // 6
     };
 
     struct SkillLineAbilityEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t skilline;                  // 1 skill id
-        uint32_t spell;                     // 2
-        uint32_t race_mask;                 // 3
-        uint32_t class_mask;                // 4
-        //uint32_t excludeRace;             // 5
-        //uint32_t excludeClass;            // 6
-        uint32_t minSkillLineRank;          // 7 req skill value
-        uint32_t next;                      // 8
-        uint32_t acquireMethod;             // 9 auto learn
-        uint32_t grey;                      // 10 max
-        uint32_t green;                     // 11 min
-        uint32_t characterPoints;           // 12
-        //uint32_t unk;                     // 13
+        uint32_t Id;                                                // 0
+        uint32_t skilline;                                          // 1 skill id
+        uint32_t spell;                                             // 2
+        uint32_t race_mask;                                         // 3
+        uint32_t class_mask;                                        // 4
+        //uint32_t excludeRace;                                     // 5
+        //uint32_t excludeClass;                                    // 6
+        uint32_t minSkillLineRank;                                  // 7 req skill value
+        uint32_t next;                                              // 8
+        uint32_t acquireMethod;                                     // 9 auto learn
+        uint32_t grey;                                              // 10 max
+        uint32_t green;                                             // 11 min
+        uint32_t characterPoints;                                   // 12
+        //uint32_t unk;                                             // 13
     };
 
     //\todo danko
     //struct StableSlotPrices
     //{
-    //    uint32_t Id;                      // 0
-    //    uint32_t Price;                   // 1
+    //    uint32_t Id;                                              // 0
+    //    uint32_t Price;                                           // 1
     //};
 
     //\ todo: confirm effect count
@@ -1436,124 +1436,124 @@ namespace DBC::Structures
     // SpellAuraOptions.dbc
     struct SpellAuraOptionsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t MaxStackAmount;            // 1
-        uint32_t procChance;                // 2
-        uint32_t procCharges;               // 3
-        uint32_t procFlags;                 // 4
+        //uint32_t Id;                                              // 0
+        uint32_t MaxStackAmount;                                    // 1
+        uint32_t procChance;                                        // 2
+        uint32_t procCharges;                                       // 3
+        uint32_t procFlags;                                         // 4
     };
 
     // SpellAuraRestrictions.dbc
     struct SpellAuraRestrictionsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t CasterAuraState;           // 1
-        uint32_t TargetAuraState;           // 2
-        uint32_t CasterAuraStateNot;        // 3
-        uint32_t TargetAuraStateNot;        // 4
-        uint32_t casterAuraSpell;           // 5
-        uint32_t targetAuraSpell;           // 6
-        uint32_t CasterAuraSpellNot;        // 7
-        uint32_t TargetAuraSpellNot;        // 8
+        //uint32_t Id;                                              // 0
+        uint32_t CasterAuraState;                                   // 1
+        uint32_t TargetAuraState;                                   // 2
+        uint32_t CasterAuraStateNot;                                // 3
+        uint32_t TargetAuraStateNot;                                // 4
+        uint32_t casterAuraSpell;                                   // 5
+        uint32_t targetAuraSpell;                                   // 6
+        uint32_t CasterAuraSpellNot;                                // 7
+        uint32_t TargetAuraSpellNot;                                // 8
     };
 
     // SpellCastingRequirements.dbc
     struct SpellCastingRequirementsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t FacingCasterFlags;         // 1
-        //uint32_t MinFactionId;            // 2
-        //uint32_t MinReputation;           // 3
-        int32_t AreaGroupId;                // 4
-        //uint32_t RequiredAuraVision;      // 5
-        uint32_t RequiresSpellFocus;        // 6
+        //uint32_t Id;                                              // 0
+        uint32_t FacingCasterFlags;                                 // 1
+        //uint32_t MinFactionId;                                    // 2
+        //uint32_t MinReputation;                                   // 3
+        int32_t AreaGroupId;                                        // 4
+        //uint32_t RequiredAuraVision;                              // 5
+        uint32_t RequiresSpellFocus;                                // 6
     };
 
     // SpellCastTimes.dbc
     struct SpellCastTimesEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t CastTime;                  // 1
-        float CastTimePerLevel;             // 2
-        int32_t MinCastTime;                // 3
+        uint32_t ID;                                                // 0
+        uint32_t CastTime;                                          // 1
+        float CastTimePerLevel;                                     // 2
+        int32_t MinCastTime;                                        // 3
     };
 
     // SpellCategories.dbc
     struct SpellCategoriesEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Category;                  // 1
-        uint32_t DmgClass;                  // 2
-        uint32_t DispelType;                // 3
-        uint32_t MechanicsType;             // 4
-        uint32_t PreventionType;            // 5
-        uint32_t StartRecoveryCategory;     // 6
+        //uint32_t Id;                                              // 0
+        uint32_t Category;                                          // 1
+        uint32_t DmgClass;                                          // 2
+        uint32_t DispelType;                                        // 3
+        uint32_t MechanicsType;                                     // 4
+        uint32_t PreventionType;                                    // 5
+        uint32_t StartRecoveryCategory;                             // 6
     };
 
     // SpellClassOptions.dbc
     struct SpellClassOptionsEntry
     {
-        //uint32_t Id;                                  // 0
-        //uint32_t modalNextSpell;                      // 1
-        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
-        uint32_t SpellFamilyName;                       // 5
-        //char* Description;                            // 6
+        //uint32_t Id;                                              // 0
+        //uint32_t modalNextSpell;                                  // 1
+        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 2 - 4
+        uint32_t SpellFamilyName;                                   // 5
+        //char* Description;                                        // 6
     };
 
     // SpellCooldowns.dbc
     struct SpellCooldownsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t CategoryRecoveryTime;      // 1
-        uint32_t RecoveryTime;              // 2
-        uint32_t StartRecoveryTime;         // 3
+        //uint32_t Id;                                              // 0
+        uint32_t CategoryRecoveryTime;                              // 1
+        uint32_t RecoveryTime;                                      // 2
+        uint32_t StartRecoveryTime;                                 // 3
     };
 
     // SpellDifficulty.dbc
     struct SpellDifficultyEntry
     {
-        uint32_t ID;                        // 0
-        int32_t SpellId[MAX_DIFFICULTY];    // 1-4
+        uint32_t ID;                                                // 0
+        int32_t SpellId[MAX_DIFFICULTY];                            // 1-4
     };
 
     // SpellDuration.dbc
     struct SpellDurationEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t Duration1;                 // 1
-        uint32_t Duration2;                 // 2
-        uint32_t Duration3;                 // 3
+        uint32_t ID;                                                // 0
+        uint32_t Duration1;                                         // 1
+        uint32_t Duration2;                                         // 2
+        uint32_t Duration3;                                         // 3
     };
 
     // SpellEffect.dbc
     struct SpellEffectEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Effect;                    // 1
-        float EffectMultipleValue;          // 2
-        uint32_t EffectApplyAuraName;       // 3
-        uint32_t EffectAmplitude;           // 4
-        int32_t EffectBasePoints;           // 5
-        float EffectBonusMultiplier;        // 6
-        float EffectDamageMultiplier;       // 7
-        uint32_t EffectChainTarget;         // 8
-        int32_t EffectDieSides;             // 9
-        uint32_t EffectItemType;            // 10
-        uint32_t EffectMechanic;            // 11
-        int32_t EffectMiscValue;            // 12
-        int32_t EffectMiscValueB;           // 13
-        float EffectPointsPerComboPoint;    // 14
-        uint32_t EffectRadiusIndex;         // 15
-        uint32_t EffectRadiusMaxIndex;      // 16
-        float EffectRealPointsPerLevel;     // 17
-        uint32_t EffectSpellClassMask[3];   // 18-20
+        //uint32_t Id;                                              // 0
+        uint32_t Effect;                                            // 1
+        float EffectMultipleValue;                                  // 2
+        uint32_t EffectApplyAuraName;                               // 3
+        uint32_t EffectAmplitude;                                   // 4
+        int32_t EffectBasePoints;                                   // 5
+        float EffectBonusMultiplier;                                // 6
+        float EffectDamageMultiplier;                               // 7
+        uint32_t EffectChainTarget;                                 // 8
+        int32_t EffectDieSides;                                     // 9
+        uint32_t EffectItemType;                                    // 10
+        uint32_t EffectMechanic;                                    // 11
+        int32_t EffectMiscValue;                                    // 12
+        int32_t EffectMiscValueB;                                   // 13
+        float EffectPointsPerComboPoint;                            // 14
+        uint32_t EffectRadiusIndex;                                 // 15
+        uint32_t EffectRadiusMaxIndex;                              // 16
+        float EffectRealPointsPerLevel;                             // 17
+        uint32_t EffectSpellClassMask[3];                           // 18-20
         //ClassFamilyMask EffectSpellClassMask;
-        uint32_t EffectTriggerSpell;        // 21
-        uint32_t EffectImplicitTargetA;     // 22
-        uint32_t EffectImplicitTargetB;     // 23
-        uint32_t EffectSpellId;             // 24
-        uint32_t EffectIndex;               // 25
-        //uint32_t unk;                     // 26
+        uint32_t EffectTriggerSpell;                                // 21
+        uint32_t EffectImplicitTargetA;                             // 22
+        uint32_t EffectImplicitTargetB;                             // 23
+        uint32_t EffectSpellId;                                     // 24
+        uint32_t EffectIndex;                                       // 25
+        //uint32_t unk;                                             // 26
 
         uint32_t GetRadiusIndex() const
         {
@@ -1567,139 +1567,139 @@ namespace DBC::Structures
     // SpellEquippedItems.dbc
     struct SpellEquippedItemsEntry
     {
-        //uint32_t Id;                          // 0
-        int32_t EquippedItemClass;              // 1
-        int32_t EquippedItemInventoryTypeMask;  // 2
-        int32_t EquippedItemSubClassMask;       // 3
+        //uint32_t Id;                                              // 0
+        int32_t EquippedItemClass;                                  // 1
+        int32_t EquippedItemInventoryTypeMask;                      // 2
+        int32_t EquippedItemSubClassMask;                           // 3
     };
 
     // SpellFocusObject.dbc
     struct SpellFocusObjectEntry
     {
-        uint32_t ID;                        // 0
-        //char* Name;                       // 1
+        uint32_t ID;                                                // 0
+        //char* Name;                                               // 1
     };
 
     // SpellInterrupts.dbc
     struct SpellInterruptsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t AuraInterruptFlags;        // 1
-        //uint32_t unk2                     // 2
-        uint32_t ChannelInterruptFlags;     // 3
-        //uint32_t unk4                     // 4
-        uint32_t InterruptFlags;            // 5
+        //uint32_t Id;                                              // 0
+        uint32_t AuraInterruptFlags;                                // 1
+        //uint32_t unk2                                             // 2
+        uint32_t ChannelInterruptFlags;                             // 3
+        //uint32_t unk4                                             // 4
+        uint32_t InterruptFlags;                                    // 5
     };
 
     // SpellItemEnchantment.dbc
     struct SpellItemEnchantmentEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t charges;                 // 1
-        uint32_t type[3];                   // 2-4
-        uint32_t min[3];                    // 5-7 for combat, in practice min==max
-        //uint32_t max[3];                  // 8-10
-        uint32_t spell[3];                  // 11-13
-        char* Name;                         // 14-29
-        //uint32_t NameFlags;               // 30
-        uint32_t visual;                    // 31 aura
-        uint32_t EnchantGroups;             // 32 slot
-        uint32_t GemEntry;                  // 33
-        uint32_t ench_condition;            // 34
-        uint32_t req_skill;                 // 35
-        uint32_t req_skill_value;           // 36
-        uint32_t req_level;                 // 37
+        uint32_t Id;                                                // 0
+        //uint32_t charges;                                         // 1
+        uint32_t type[3];                                           // 2-4
+        uint32_t min[3];                                            // 5-7 for combat, in practice min==max
+        //uint32_t max[3];                                          // 8-10
+        uint32_t spell[3];                                          // 11-13
+        char* Name;                                                 // 14-29
+        //uint32_t NameFlags;                                       // 30
+        uint32_t visual;                                            // 31 aura
+        uint32_t EnchantGroups;                                     // 32 slot
+        uint32_t GemEntry;                                          // 33
+        uint32_t ench_condition;                                    // 34
+        uint32_t req_skill;                                         // 35
+        uint32_t req_skill_value;                                   // 36
+        uint32_t req_level;                                         // 37
     };
 
     // SpellItemEnchantmentCondition.dbc
     struct SpellItemEnchantmentConditionEntry
     {
-        uint32_t ID;                        // 0
-        uint8_t Color[5];                   // 1-5
-        //uint32_t LT_Operand[5];           // 6-10
-        uint8_t Comparator[5];              // 11-15
-        uint8_t CompareColor[5];            // 15-20
-        uint32_t Value[5];                  // 21-25
-        //uint8_t Logic[5]                  // 25-30
+        uint32_t ID;                                                // 0
+        uint8_t Color[5];                                           // 1-5
+        //uint32_t LT_Operand[5];                                   // 6-10
+        uint8_t Comparator[5];                                      // 11-15
+        uint8_t CompareColor[5];                                    // 15-20
+        uint32_t Value[5];                                          // 21-25
+        //uint8_t Logic[5]                                          // 25-30
     };
 
     // SpellLevels.dbc
     struct SpellLevelsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t baseLevel;                 // 1
-        uint32_t maxLevel;                  // 2
-        uint32_t spellLevel;                // 3
+        //uint32_t Id;                                              // 0
+        uint32_t baseLevel;                                         // 1
+        uint32_t maxLevel;                                          // 2
+        uint32_t spellLevel;                                        // 3
     };
 
     // SpellPower.dbc
     struct SpellPowerEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t manaCost;                  // 1
-        uint32_t manaCostPerlevel;          // 2
-        uint32_t ManaCostPercentage;        // 3
-        uint32_t manaPerSecond;             // 4
-        uint32_t manaPerSecondPerLevel;     // 5
-        //uint32_t PowerDisplayId;          // 6 
-        float ManaCostPercentageFloat;      // 7
+        //uint32_t Id;                                              // 0
+        uint32_t manaCost;                                          // 1
+        uint32_t manaCostPerlevel;                                  // 2
+        uint32_t ManaCostPercentage;                                // 3
+        uint32_t manaPerSecond;                                     // 4
+        uint32_t manaPerSecondPerLevel;                             // 5
+        //uint32_t PowerDisplayId;                                  // 6 
+        float ManaCostPercentageFloat;                              // 7
     };
 
     // SpellRadius.dbc
     struct SpellRadiusEntry
     {
-        uint32_t ID;                        // 0
-        float radius_min;                   // 1
-        float radius_per_level;             // 2
-        float radius_max;                   // 3
+        uint32_t ID;                                                // 0
+        float radius_min;                                           // 1
+        float radius_per_level;                                     // 2
+        float radius_max;                                           // 3
     };
 
     // SpellRange.dbc
     struct SpellRangeEntry
     {
-        uint32_t ID;                        // 0
-        float minRange;                     // 1
-        float minRangeFriendly;             // 2
-        float maxRange;                     // 3
-        float maxRangeFriendly;             // 4
-        uint32_t range_type;                // 5
-        //char* name1[16]                   // 6-21
-        //uint32_t name1_falgs;             // 22
-        //char* name2[16]                   // 23-38
-        //uint32_t name2_falgs;             // 39
+        uint32_t ID;                                                // 0
+        float minRange;                                             // 1
+        float minRangeFriendly;                                     // 2
+        float maxRange;                                             // 3
+        float maxRangeFriendly;                                     // 4
+        uint32_t range_type;                                        // 5
+        //char* name1[16]                                           // 6-21
+        //uint32_t name1_falgs;                                     // 22
+        //char* name2[16]                                           // 23-38
+        //uint32_t name2_falgs;                                     // 39
     };
 
     // SpellReagents.dbc
     struct SpellReagentsEntry
     {
-        //uint32_t Id;                              // 0
-        int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
-        uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
+        //uint32_t Id;                                              // 0
+        int32_t Reagent[MAX_SPELL_REAGENTS];                        // 54-61
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 62-69
     };
 
     // SpellRuneCost.dbc
     struct SpellRuneCostEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t bloodRuneCost;             // 1
-        uint32_t frostRuneCost;             // 2
-        uint32_t unholyRuneCost;            // 3
-        uint32_t runePowerGain;             // 4
+        uint32_t ID;                                                // 0
+        uint32_t bloodRuneCost;                                     // 1
+        uint32_t frostRuneCost;                                     // 2
+        uint32_t unholyRuneCost;                                    // 3
+        uint32_t runePowerGain;                                     // 4
     };
 
     // SpellScaling.dbc
     struct SpellScalingEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t castTimeMin;               // 1
-        uint32_t castTimeMax;               // 2
-        uint32_t castScalingMaxLevel;       // 3
-        uint32_t playerClass;               // 4
-        float coeff1[3];                    // 5-7
-        float coeff2[3];                    // 8-10
-        float coeff3[3];                    // 11-13
-        float coefBase;                     // 14
-        uint32_t coefLevelBase;             // 15
+        //uint32_t Id;                                              // 0
+        uint32_t castTimeMin;                                       // 1
+        uint32_t castTimeMax;                                       // 2
+        uint32_t castScalingMaxLevel;                               // 3
+        uint32_t playerClass;                                       // 4
+        float coeff1[3];                                            // 5-7
+        float coeff2[3];                                            // 8-10
+        float coeff3[3];                                            // 11-13
+        float coefBase;                                             // 14
+        uint32_t coefLevelBase;                                     // 15
 
         bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
     };
@@ -1707,83 +1707,83 @@ namespace DBC::Structures
     // SpellShapeshift.dbc
     struct SpellShapeshiftEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t ShapeshiftsExcluded;       // 1
-        //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
-        uint32_t Shapeshifts;               // 3
-        //uint32_t Shapeshifts1;            // 4 unused, all zeros
-        //uint32_t StanceBarOrder;          // 5
+        //uint32_t Id;                                              // 0
+        uint32_t ShapeshiftsExcluded;                               // 1
+        //uint32_t ShapeshiftsExcluded1;                            // 2 unused, all zeros
+        uint32_t Shapeshifts;                                       // 3
+        //uint32_t Shapeshifts1;                                    // 4 unused, all zeros
+        //uint32_t StanceBarOrder;                                  // 5
     };
 
     // SpellTargetRestrictions.dbc
     struct SpellTargetRestrictionsEntry
     {
-        //uint32_t Id;                      // 0
-        float MaxTargetRadius;              // 1
-        uint32_t MaxAffectedTargets;        // 2
-        uint32_t MaxTargetLevel;            // 3
-        uint32_t TargetCreatureType;        // 4
-        uint32_t Targets;                   // 5
+        //uint32_t Id;                                              // 0
+        float MaxTargetRadius;                                      // 1
+        uint32_t MaxAffectedTargets;                                // 2
+        uint32_t MaxTargetLevel;                                    // 3
+        uint32_t TargetCreatureType;                                // 4
+        uint32_t Targets;                                           // 5
     };
 
     // SpellTotems.dbc
     struct SpellTotemsEntry
     {
-        //uint32_t Id;                                         // 0
-        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
-        uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
+        //uint32_t Id;                                              // 0
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 1 2
+        uint32_t Totem[MAX_SPELL_TOTEMS];                           // 3 4
     };
 
     struct SERVER_DECL SpellEntry
     {
-        uint32_t Id;                                          // 0
-        uint32_t Attributes;                                  // 1
-        uint32_t AttributesEx;                                // 2
-        uint32_t AttributesExB;                               // 3
-        uint32_t AttributesExC;                               // 4
-        uint32_t AttributesExD;                               // 5
-        uint32_t AttributesExE;                               // 6
-        uint32_t AttributesExF;                               // 7
-        uint32_t AttributesExG;                               // 8
-        uint32_t AttributesExH;                               // 9
-        uint32_t AttributesExI;                               // 10
-        uint32_t AttributesExJ;                               // 11
-        uint32_t CastingTimeIndex;                            // 12
-        uint32_t DurationIndex;                               // 13
-        int32_t powerType;                                    // 14
-        uint32_t rangeIndex;                                  // 15
-        float speed;                                          // 16
-        uint32_t SpellVisual;                                 // 17
-        uint32_t SpellVisual1;                                // 18
-        uint32_t spellIconID;                                 // 19
-        uint32_t activeIconID;                                // 20
-        const char* Name;                                     // 21
-        const char* Rank;                                     // 22
-        //char* Description;                                  // 23 not used
-        //char* BuffDescription;                              // 24 not used
-        uint32_t School;                                      // 25
-        uint32_t RuneCostID;                                  // 26
-        //uint32_t spellMissileID;                            // 27
-        //uint32_t spellDescriptionVariableID;                // 28
-        uint32_t SpellDifficultyId;                           // 29
-        //float unk_1;                                        // 30
-        uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
-        uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
-        uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
-        uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
-        uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
-        uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
-        uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
-        //uint32_t unk_2;                                     // 38 all zeros...
-        uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
-        uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
-        uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
-        uint32_t SpellPowerId;                                // 42 SpellPower.dbc
-        uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
-        uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
-        uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
-        uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
-        //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
+        uint32_t Id;                                                // 0
+        uint32_t Attributes;                                        // 1
+        uint32_t AttributesEx;                                      // 2
+        uint32_t AttributesExB;                                     // 3
+        uint32_t AttributesExC;                                     // 4
+        uint32_t AttributesExD;                                     // 5
+        uint32_t AttributesExE;                                     // 6
+        uint32_t AttributesExF;                                     // 7
+        uint32_t AttributesExG;                                     // 8
+        uint32_t AttributesExH;                                     // 9
+        uint32_t AttributesExI;                                     // 10
+        uint32_t AttributesExJ;                                     // 11
+        uint32_t CastingTimeIndex;                                  // 12
+        uint32_t DurationIndex;                                     // 13
+        int32_t powerType;                                          // 14
+        uint32_t rangeIndex;                                        // 15
+        float speed;                                                // 16
+        uint32_t SpellVisual;                                       // 17
+        uint32_t SpellVisual1;                                      // 18
+        uint32_t spellIconID;                                       // 19
+        uint32_t activeIconID;                                      // 20
+        const char* Name;                                           // 21
+        const char* Rank;                                           // 22
+        //char* Description;                                        // 23 not used
+        //char* BuffDescription;                                    // 24 not used
+        uint32_t School;                                            // 25
+        uint32_t RuneCostID;                                        // 26
+        //uint32_t spellMissileID;                                  // 27
+        //uint32_t spellDescriptionVariableID;                      // 28
+        uint32_t SpellDifficultyId;                                 // 29
+        //float unk_1;                                              // 30
+        uint32_t SpellScalingId;                                    // 31 SpellScaling.dbc
+        uint32_t SpellAuraOptionsId;                                // 32 SpellAuraOptions.dbc
+        uint32_t SpellAuraRestrictionsId;                           // 33 SpellAuraRestrictions.dbc
+        uint32_t SpellCastingRequirementsId;                        // 34 SpellCastingRequirements.dbc
+        uint32_t SpellCategoriesId;                                 // 35 SpellCategories.dbc
+        uint32_t SpellClassOptionsId;                               // 36 SpellClassOptions.dbc
+        uint32_t SpellCooldownsId;                                  // 37 SpellCooldowns.dbc
+        //uint32_t unk_2;                                           // 38 all zeros...
+        uint32_t SpellEquippedItemsId;                              // 39 SpellEquippedItems.dbc
+        uint32_t SpellInterruptsId;                                 // 40 SpellInterrupts.dbc
+        uint32_t SpellLevelsId;                                     // 41 SpellLevels.dbc
+        uint32_t SpellPowerId;                                      // 42 SpellPower.dbc
+        uint32_t SpellReagentsId;                                   // 43 SpellReagents.dbc
+        uint32_t SpellShapeshiftId;                                 // 44 SpellShapeshift.dbc
+        uint32_t SpellTargetRestrictionsId;                         // 45 SpellTargetRestrictions.dbc
+        uint32_t SpellTotemsId;                                     // 46 SpellTotems.dbc
+        //uint32_t ResearchProject;                                 // 47 ResearchProject.dbc
 
         // struct access functions
         SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
@@ -1851,179 +1851,179 @@ namespace DBC::Structures
 
     struct SpellShapeshiftFormEntry
     {
-        uint32_t id;                  // 0
-        //uint32_t button_pos;        // 1
-        //char* name[16];             // 2-17
-        //uint32_t name_flags;        // 18
-        uint32_t Flags;               // 19
-        uint32_t unit_type;           // 20
-        //uint32_t unk1               // 21
-        uint32_t AttackSpeed;         // 22
-        uint32_t modelId;             // 23 alliance?
-        uint32_t modelId2;            // 24 horde?
-        //uint32_t unk2               // 25
-        //uint32_t unk3               // 26
-        uint32_t spells[8];           // 27-34
+        uint32_t id;                                                // 0
+        //uint32_t button_pos;                                      // 1
+        //char* name[16];                                           // 2-17
+        //uint32_t name_flags;                                      // 18
+        uint32_t Flags;                                             // 19
+        uint32_t unit_type;                                         // 20
+        //uint32_t unk1                                             // 21
+        uint32_t AttackSpeed;                                       // 22
+        uint32_t modelId;                                           // 23 alliance?
+        uint32_t modelId2;                                          // 24 horde?
+        //uint32_t unk2                                             // 25
+        //uint32_t unk3                                             // 26
+        uint32_t spells[8];                                         // 27-34
     };
 
     struct SummonPropertiesEntry
     {
-        uint32_t ID;                  // 0
-        uint32_t ControlType;         // 1
-        uint32_t FactionID;           // 2
-        uint32_t Type;                // 3
-        uint32_t Slot;                // 4
-        uint32_t Flags;               // 5
+        uint32_t ID;                                                // 0
+        uint32_t ControlType;                                       // 1
+        uint32_t FactionID;                                         // 2
+        uint32_t Type;                                              // 3
+        uint32_t Slot;                                              // 4
+        uint32_t Flags;                                             // 5
     };
 
     struct TalentEntry
     {
-        uint32_t TalentID;            // 0
-        uint32_t TalentTree;          // 1
-        uint32_t Row;                 // 2
-        uint32_t Col;                 // 3
-        uint32_t RankID[5];           // 4-8
-        //uint32_t unk[4];            // 9-12
-        uint32_t DependsOn;           // 13
-        //uint32_t unk1[2];           // 14-15
-        uint32_t DependsOnRank;       // 16
-        //uint32_t unk2[2];           // 17-18
-        //uint32_t unk3;              // 19
-        //uint32_t unk4;              // 20
-        //uint32_t unk5;              // 21
+        uint32_t TalentID;                                          // 0
+        uint32_t TalentTree;                                        // 1
+        uint32_t Row;                                               // 2
+        uint32_t Col;                                               // 3
+        uint32_t RankID[5];                                         // 4-8
+        //uint32_t unk[4];                                          // 9-12
+        uint32_t DependsOn;                                         // 13
+        //uint32_t unk1[2];                                         // 14-15
+        uint32_t DependsOnRank;                                     // 16
+        //uint32_t unk2[2];                                         // 17-18
+        //uint32_t unk3;                                            // 19
+        //uint32_t unk4;                                            // 20
+        //uint32_t unk5;                                            // 21
     };
 
     struct TalentTabEntry
     {
-        uint32_t TalentTabID;         // 0
-        //char* Name;                 // 1
-        //uint32_t unk5;              // 2
-        uint32_t ClassMask;           // 3
-        uint32_t PetTalentMask;       // 4
-        uint32_t TabPage;             // 5
-        //char* InternalName;         // 6
-        //char* description;          // 7
-        uint32_t rolesMask;           // 8
-        uint32_t masterySpells[2];    // 9-10
+        uint32_t TalentTabID;                                       // 0
+        //char* Name;                                               // 1
+        //uint32_t unk5;                                            // 2
+        uint32_t ClassMask;                                         // 3
+        uint32_t PetTalentMask;                                     // 4
+        uint32_t TabPage;                                           // 5
+        //char* InternalName;                                       // 6
+        //char* description;                                        // 7
+        uint32_t rolesMask;                                         // 8
+        uint32_t masterySpells[2];                                  // 9-10
     };
 
     struct TalentTreePrimarySpells
     {
-        uint32_t ID;                  // 0
-        uint32_t tabID;               // 1
-        uint32_t SpellID;             // 2
-        //uint32_t unk                // 3
+        uint32_t ID;                                                // 0
+        uint32_t tabID;                                             // 1
+        uint32_t SpellID;                                           // 2
+        //uint32_t unk                                              // 3
     };
 
     struct TaxiNodesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t mapid;               // 1
-        float x;                      // 2
-        float y;                      // 3
-        float z;                      // 4
-        char* name;                   // 5
-        uint32_t horde_mount;         // 6
-        uint32_t alliance_mount;      // 7
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        char* name;                                                 // 5
+        uint32_t horde_mount;                                       // 6
+        uint32_t alliance_mount;                                    // 7
     };
 
     struct TaxiPathEntry
     {
-        uint32_t id;                  // 0
-        uint32_t from;                // 1
-        uint32_t to;                  // 2
-        uint32_t price;               // 3
+        uint32_t id;                                                // 0
+        uint32_t from;                                              // 1
+        uint32_t to;                                                // 2
+        uint32_t price;                                             // 3
     };
 
     struct TaxiPathNodeEntry
     {
-        //uint32_t id;                // 0
-        uint32_t path;                // 1
-        uint32_t seq;                 // 2 nodeIndex
-        uint32_t mapid;               // 3
-        float x;                      // 4
-        float y;                      // 5
-        float z;                      // 6
-        uint32_t flags;               // 7
-        uint32_t waittime;            // 8
-        uint32_t arivalEventID;       // 9
-        uint32_t departureEventID;    // 10
+        //uint32_t id;                                              // 0
+        uint32_t path;                                              // 1
+        uint32_t seq;                                               // 2 nodeIndex
+        uint32_t mapid;                                             // 3
+        float x;                                                    // 4
+        float y;                                                    // 5
+        float z;                                                    // 6
+        uint32_t flags;                                             // 7
+        uint32_t waittime;                                          // 8
+        uint32_t arivalEventID;                                     // 9
+        uint32_t departureEventID;                                  // 10
     };
 
     struct TransportAnimationEntry
     {
-        //uint32_t Id;          // 0
-        uint32_t TransportID;   // 1
-        uint32_t TimeIndex;     // 2
-        DBCPosition3D Pos;      // 3
-        //uint32_t SequenceID;  // 4
+        //uint32_t Id;                                              // 0
+        uint32_t TransportID;                                       // 1
+        uint32_t TimeIndex;                                         // 2
+        DBCPosition3D Pos;                                          // 3
+        //uint32_t SequenceID;                                      // 4
     };
 
     struct TransportRotationEntry
     {
-        //uint32_t ID;          // 0
-        uint32_t GameObjectsID; // 1
-        uint32_t TimeIndex;     // 2
-        float X;                // 3
-        float Y;                // 4
-        float Z;                // 5
-        float W;                // 6
+        //uint32_t ID;                                              // 0
+        uint32_t GameObjectsID;                                     // 1
+        uint32_t TimeIndex;                                         // 2
+        float X;                                                    // 3
+        float Y;                                                    // 4
+        float Z;                                                    // 5
+        float W;                                                    // 6
     };
 
     struct TotemCategoryEntry
     {
-        uint32_t id;            // 0
-        //char* name;           // 1
-        uint32_t categoryType;  // 2
-        uint32_t categoryMask;  // 3
+        uint32_t id;                                                // 0
+        //char* name;                                               // 1
+        uint32_t categoryType;                                      // 2
+        uint32_t categoryMask;                                      // 3
     };
 
     #define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {
-        uint32_t ID;                                        // 0
-        uint32_t flags;                                     // 1
-        float turnSpeed;                                    // 2
-        float pitchSpeed;                                   // 3
-        float pitchMin;                                     // 4
-        float pitchMax;                                     // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
-        float mouseLookOffsetPitch;                         // 14
-        float cameraFadeDistScalarMin;                      // 15
-        float cameraFadeDistScalarMax;                      // 16
-        float cameraPitchOffset;                            // 17
-        float facingLimitRight;                             // 18
-        float facingLimitLeft;                              // 19
-        float msslTrgtTurnLingering;                        // 20
-        float msslTrgtPitchLingering;                       // 21
-        float msslTrgtMouseLingering;                       // 22
-        float msslTrgtEndOpacity;                           // 23
-        float msslTrgtArcSpeed;                             // 24
-        float msslTrgtArcRepeat;                            // 25
-        float msslTrgtArcWidth;                             // 26
-        float msslTrgtImpactRadius[2];                      // 27-28
-        char* msslTrgtArcTexture;                           // 29
-        char* msslTrgtImpactTexture;                        // 30
-        char* msslTrgtImpactModel[2];                       // 31-32
-        float cameraYawOffset;                              // 33
-        uint32_t uiLocomotionType;                          // 34
-        float msslTrgtImpactTexRadius;                      // 35
-        uint32_t uiSeatIndicatorType;                       // 36
-        uint32_t powerType;                                 // 37
-        //uint32_t unk1;                                    // 38
-        //uint32_t unk2;                                    // 39  
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        float turnSpeed;                                            // 2
+        float pitchSpeed;                                           // 3
+        float pitchMin;                                             // 4
+        float pitchMax;                                             // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
+        float mouseLookOffsetPitch;                                 // 14
+        float cameraFadeDistScalarMin;                              // 15
+        float cameraFadeDistScalarMax;                              // 16
+        float cameraPitchOffset;                                    // 17
+        float facingLimitRight;                                     // 18
+        float facingLimitLeft;                                      // 19
+        float msslTrgtTurnLingering;                                // 20
+        float msslTrgtPitchLingering;                               // 21
+        float msslTrgtMouseLingering;                               // 22
+        float msslTrgtEndOpacity;                                   // 23
+        float msslTrgtArcSpeed;                                     // 24
+        float msslTrgtArcRepeat;                                    // 25
+        float msslTrgtArcWidth;                                     // 26
+        float msslTrgtImpactRadius[2];                              // 27-28
+        char* msslTrgtArcTexture;                                   // 29
+        char* msslTrgtImpactTexture;                                // 30
+        char* msslTrgtImpactModel[2];                               // 31-32
+        float cameraYawOffset;                                      // 33
+        uint32_t uiLocomotionType;                                  // 34
+        float msslTrgtImpactTexRadius;                              // 35
+        uint32_t uiSeatIndicatorType;                               // 36
+        uint32_t powerType;                                         // 37
+        //uint32_t unk1;                                            // 38
+        //uint32_t unk2;                                            // 39  
     };
 
     enum VehicleSeatFlags
     {
-        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,  // Passenger is hidden
         VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,  // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,  // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,  // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,  // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,  // Lua_UnitHasVehicleUI
     };
 
     enum VehicleSeatFlagsB
@@ -2036,52 +2036,52 @@ namespace DBC::Structures
 
     struct VehicleSeatEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        int32_t attachmentID;                                 // 2
-        float attachmentOffsetX;                              // 3
-        float attachmentOffsetY;                              // 4
-        float attachmentOffsetZ;                              // 5
-        float enterPreDelay;                                  // 6
-        float enterSpeed;                                     // 7
-        float enterGravity;                                   // 8
-        float enterMinDuration;                               // 9
-        float enterMaxDuration;                               // 10
-        float enterMinArcHeight;                              // 11
-        float enterMaxArcHeight;                              // 12
-        int32_t enterAnimStart;                               // 13
-        int32_t enterAnimLoop;                                // 14
-        int32_t rideAnimStart;                                // 15
-        int32_t rideAnimLoop;                                 // 16
-        int32_t rideUpperAnimStart;                           // 17
-        int32_t rideUpperAnimLoop;                            // 18
-        float exitPreDelay;                                   // 19
-        float exitSpeed;                                      // 20
-        float exitGravity;                                    // 21
-        float exitMinDuration;                                // 22
-        float exitMaxDuration;                                // 23
-        float exitMinArcHeight;                               // 24
-        float exitMaxArcHeight;                               // 25
-        int32_t exitAnimStart;                                // 26
-        int32_t exitAnimLoop;                                 // 27
-        int32_t exitAnimEnd;                                  // 28
-        float passengerYaw;                                   // 29
-        float passengerPitch;                                 // 30
-        float passengerRoll;                                  // 31
-        int32_t passengerAttachmentID;                        // 32
-        int32_t vehicleEnterAnim;                             // 33
-        int32_t vehicleExitAnim;                              // 34
-        int32_t vehicleRideAnimLoop;                          // 35
-        int32_t vehicleEnterAnimBone;                         // 36
-        int32_t vehicleExitAnimBone;                          // 37
-        int32_t vehicleRideAnimLoopBone;                      // 38
-        float vehicleEnterAnimDelay;                          // 39
-        float vehicleExitAnimDelay;                           // 40
-        uint32_t vehicleAbilityDisplay;                       // 41
-        uint32_t enterUISoundID;                              // 42
-        uint32_t exitUISoundID;                               // 43
-        int32_t uiSkin;                                       // 44
-        uint32_t flagsB;                                      // 45
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        int32_t attachmentID;                                       // 2
+        float attachmentOffsetX;                                    // 3
+        float attachmentOffsetY;                                    // 4
+        float attachmentOffsetZ;                                    // 5
+        float enterPreDelay;                                        // 6
+        float enterSpeed;                                           // 7
+        float enterGravity;                                         // 8
+        float enterMinDuration;                                     // 9
+        float enterMaxDuration;                                     // 10
+        float enterMinArcHeight;                                    // 11
+        float enterMaxArcHeight;                                    // 12
+        int32_t enterAnimStart;                                     // 13
+        int32_t enterAnimLoop;                                      // 14
+        int32_t rideAnimStart;                                      // 15
+        int32_t rideAnimLoop;                                       // 16
+        int32_t rideUpperAnimStart;                                 // 17
+        int32_t rideUpperAnimLoop;                                  // 18
+        float exitPreDelay;                                         // 19
+        float exitSpeed;                                            // 20
+        float exitGravity;                                          // 21
+        float exitMinDuration;                                      // 22
+        float exitMaxDuration;                                      // 23
+        float exitMinArcHeight;                                     // 24
+        float exitMaxArcHeight;                                     // 25
+        int32_t exitAnimStart;                                      // 26
+        int32_t exitAnimLoop;                                       // 27
+        int32_t exitAnimEnd;                                        // 28
+        float passengerYaw;                                         // 29
+        float passengerPitch;                                       // 30
+        float passengerRoll;                                        // 31
+        int32_t passengerAttachmentID;                              // 32
+        int32_t vehicleEnterAnim;                                   // 33
+        int32_t vehicleExitAnim;                                    // 34
+        int32_t vehicleRideAnimLoop;                                // 35
+        int32_t vehicleEnterAnimBone;                               // 36
+        int32_t vehicleExitAnimBone;                                // 37
+        int32_t vehicleRideAnimLoopBone;                            // 38
+        float vehicleEnterAnimDelay;                                // 39
+        float vehicleExitAnimDelay;                                 // 40
+        uint32_t vehicleAbilityDisplay;                             // 41
+        uint32_t enterUISoundID;                                    // 42
+        uint32_t exitUISoundID;                                     // 43
+        int32_t uiSkin;                                             // 44
+        uint32_t flagsB;                                            // 45
 
         bool IsUsable() const
         {
@@ -2110,50 +2110,50 @@ namespace DBC::Structures
 
     struct WMOAreaTableEntry
     {
-        uint32_t id;                // 0
-        int32_t rootId;             // 1
-        int32_t adtId;              // 2
-        int32_t groupId;            // 3
-        //uint32_t field4;          // 4
-        //uint32_t field5;          // 5
-        //uint32_t field6;          // 6
-        //uint32_t field7;          // 7
-        //uint32_t field8;          // 8
-        uint32_t flags;             // 9
-        uint32_t areaId;            // 10
-        //char Name[16];            // 11-26
-        //uint32_t nameflags;       // 27
+        uint32_t id;                                                // 0
+        int32_t rootId;                                             // 1
+        int32_t adtId;                                              // 2
+        int32_t groupId;                                            // 3
+        //uint32_t field4;                                          // 4
+        //uint32_t field5;                                          // 5
+        //uint32_t field6;                                          // 6
+        //uint32_t field7;                                          // 7
+        //uint32_t field8;                                          // 8
+        uint32_t flags;                                             // 9
+        uint32_t areaId;                                            // 10
+        //char Name[16];                                            // 11-26
+        //uint32_t nameflags;                                       // 27
     };
 
     struct WorldMapAreaEntry
     {
-        //uint32_t id;              // 0
-        uint32_t mapId;             // 1
-        uint32_t zoneId;            // 2
-        //const char* name;         // 3
-        //float y1;                 // 4
-        //float y2;                 // 5
-        //float x1;                 // 6
-        //float x2;                 // 7
-        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-        //uint32_t unk1             // 9
-        //uint32_t parentId         // 10
-        //uint32_t unk2             // 11
-        //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
-        //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
+        //uint32_t id;                                              // 0
+        uint32_t mapId;                                             // 1
+        uint32_t zoneId;                                            // 2
+        //const char* name;                                         // 3
+        //float y1;                                                 // 4
+        //float y2;                                                 // 5
+        //float x1;                                                 // 6
+        //float x2;                                                 // 7
+        int32_t continentMapId;                                     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1                                             // 9
+        //uint32_t parentId                                         // 10
+        //uint32_t unk2                                             // 11
+        //uint32_t minLevel                                         // 12 looks like this is the recommended minimum level for the zone
+        //uint32_t maxLevel                                         // 13 looks like this is the recommended maximum level for the zone
     };
 
     struct WorldMapOverlayEntry
     {
-        uint32_t ID;                // 0
-        //uint32_t worldMapID;      // 1
-        uint32_t areaID;            // 2
-        uint32_t areaID_2;          // 3
-        uint32_t areaID_3;          // 4
-        uint32_t areaID_4;          // 5
-        //uint32_t unk1[2];         // 6-7
-        //uint32_t unk2;            // 8
-        //uint32_t unk3[7];         // 9-16
+        uint32_t ID;                                                // 0
+        //uint32_t worldMapID;                                      // 1 WorldMapArea.dbc
+        uint32_t areaID;                                            // 2
+        uint32_t areaID_2;                                          // 3
+        uint32_t areaID_3;                                          // 4
+        uint32_t areaID_4;                                          // 5
+        //uint32_t unk1[2];                                         // 6-7
+        //uint32_t unk2;                                            // 8
+        //uint32_t unk3[7];                                         // 9-16
     };
 
     #pragma pack(pop)

--- a/src/world/GameCata/Storage/DBCStructures.h
+++ b/src/world/GameCata/Storage/DBCStructures.h
@@ -777,7 +777,7 @@ namespace DBC::Structures
         //uint32_t                                                  // 5
         //uint32_t                                                  // 6
         //uint32_t                                                  // 7
-        float o;                                                    // 5 radius
+        float box_radius;                                           // 5 radius
         float box_x;                                                // 6 extent x edge
         float box_y;                                                // 7 extent y edge
         float box_z;                                                // 8 extent z edge

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -37,964 +37,961 @@ enum MapTypes
     MAP_BATTLEGROUND    = 3  // pvp
 };
 
-namespace DBC
+namespace DBC::Structures
 {
-    namespace Structures
+    namespace
     {
-        namespace
-        {
-            char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixx";
-            char const area_trigger_entry_format[] = "niffffffff";
-            char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
-            char const bank_bag_slot_prices_format[] = "ni";
-            char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxx"; //1.12.1
-            char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
-            char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const chr_classes_format[] = "nxxixssssssssxxix"; // 1.12.1
-            char const chr_races_format[] = "nxixiixxixxxxxixissssssssxxxx"; //1.12.1
-            char const creature_display_info_format[] = "nxxxxxxxxxxxxx";
-            char const creature_family_format[] = "nfifiiiissssssssssssssssxx";
-            char const creature_spell_data_format[] = "niiiiiiii";
-            char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-            char const durability_quality_format[] = "nf";
-            char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
-            char const faction_format[] = "niiiiiiiiiiiiiiiiiissssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const faction_template_format[] = "niiiiiiiiiiiii";
-            char const game_object_display_info_format[] = "nsxxxxxxxxxxffffff";
-            char const gem_properties_format[] = "nixxi";
-            char const gt_chance_to_melee_crit_format[] = "f";
-            char const gt_chance_to_melee_crit_base_format[] = "f";
-            char const gt_chance_to_spell_crit_format[] = "f";
-            char const gt_chance_to_spell_crit_base_format[] = "f";
-            char const gt_combat_ratings_format[] = "f";
-            char const gt_oct_regen_hp_format[] = "f";
-            char const gt_oct_regen_mp_format[] = "f";
-            char const gt_regen_hp_per_spt_format[] = "f";
-            char const gt_regen_mp_per_spt_format[] = "f";
-            char const item_entry_format[] = "niii";
-            char const item_extended_cost_format[] = "niiiiiiiiiiiii";
-            char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
-            char const item_random_suffix_format[] = "nssssssssssssssssxxiiiiii";
-            char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
-            char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
-            char const liquid_type_entry_format[] = "niii";
-            char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
-            char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
-            char const map_format[] = "nxixssssssssssssssssxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiffiixxi";
-            char const name_gen_format[] = "nsii";
-            char const skill_line_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxxi";
-            char const skill_line_ability_format[] = "niiiixxiiiiixxi";
-            char const stable_slot_prices_format[] = "ni";
-            char const spell_cast_times_format[] = "nixx";
-            char const spell_duration_format[] = "niii";
-            char const spell_entry_format[] = "niixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiifffiiiiissssssssxssssssssxxxxxxxxxxxxxxxxxxxiiiiiiiiiixfffxxx";
-            char const spell_item_enchantment_format[] = "nxiiiiiiiiiiiissssssssssssssssxiiii";
-            char const spell_radius_format[] = "nfff";
-            char const spell_range_format[] = "nffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
-            char const summon_properties_format[] = "niiiii";
-            char const talent_format[] = "niiiiiiiixxxxixxixxxi";
-            char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiix";
-            char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
-            char const taxi_path_format[] = "niii";
-            char const taxi_path_node_format[] = "niiifffiiii";
-            char const transport_animation_format[] = "diifffx";
-            char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
-            char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
-            char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
-            char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
-        }
+        char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixx";
+        char const area_trigger_entry_format[] = "niffffffff";
+        char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
+        char const bank_bag_slot_prices_format[] = "ni";
+        char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxx"; //1.12.1
+        char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
+        char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const chr_classes_format[] = "nxxixssssssssxxix"; // 1.12.1
+        char const chr_races_format[] = "nxixiixxixxxxxixissssssssxxxx"; //1.12.1
+        char const creature_display_info_format[] = "nxxxxxxxxxxxxx";
+        char const creature_family_format[] = "nfifiiiissssssssssssssssxx";
+        char const creature_spell_data_format[] = "niiiiiiii";
+        char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+        char const durability_quality_format[] = "nf";
+        char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiissssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const faction_template_format[] = "niiiiiiiiiiiii";
+        char const game_object_display_info_format[] = "nsxxxxxxxxxxffffff";
+        char const gem_properties_format[] = "nixxi";
+        char const gt_chance_to_melee_crit_format[] = "f";
+        char const gt_chance_to_melee_crit_base_format[] = "f";
+        char const gt_chance_to_spell_crit_format[] = "f";
+        char const gt_chance_to_spell_crit_base_format[] = "f";
+        char const gt_combat_ratings_format[] = "f";
+        char const gt_oct_regen_hp_format[] = "f";
+        char const gt_oct_regen_mp_format[] = "f";
+        char const gt_regen_hp_per_spt_format[] = "f";
+        char const gt_regen_mp_per_spt_format[] = "f";
+        char const item_entry_format[] = "niii";
+        char const item_extended_cost_format[] = "niiiiiiiiiiiii";
+        char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
+        char const item_random_suffix_format[] = "nssssssssssssssssxxiiiiii";
+        char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
+        char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
+        char const liquid_type_entry_format[] = "niii";
+        char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
+        char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
+        char const map_format[] = "nxixssssssssssssssssxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiffiixxi";
+        char const name_gen_format[] = "nsii";
+        char const skill_line_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxxi";
+        char const skill_line_ability_format[] = "niiiixxiiiiixxi";
+        char const stable_slot_prices_format[] = "ni";
+        char const spell_cast_times_format[] = "nixx";
+        char const spell_duration_format[] = "niii";
+        char const spell_entry_format[] = "niixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiifffiiiiissssssssxssssssssxxxxxxxxxxxxxxxxxxxiiiiiiiiiixfffxxx";
+        char const spell_item_enchantment_format[] = "nxiiiiiiiiiiiissssssssssssssssxiiii";
+        char const spell_radius_format[] = "nfff";
+        char const spell_range_format[] = "nffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
+        char const summon_properties_format[] = "niiiii";
+        char const talent_format[] = "niiiiiiiixxxxixxixxxi";
+        char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiix";
+        char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
+        char const taxi_path_format[] = "niii";
+        char const taxi_path_node_format[] = "niiifffiiii";
+        char const transport_animation_format[] = "diifffx";
+        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
+        char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
+        char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
+    }
 
-        #pragma pack(push, 1)
-        struct AchievementCategoryEntry
-        {
-            uint32_t ID;                 // 0
-            uint32_t parentCategory;     // 1 -1 for main category
-            const char* name;          // 2-17
-            uint32_t name_flags;         // 18
-            uint32_t sortOrder;          // 19
-        };
+    #pragma pack(push, 1)
+    struct AchievementCategoryEntry
+    {
+        uint32_t ID;                 // 0
+        uint32_t parentCategory;     // 1 -1 for main category
+        const char* name;          // 2-17
+        uint32_t name_flags;         // 18
+        uint32_t sortOrder;          // 19
+    };
 
-        struct AreaTableEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t map_id;                  // 1
-            uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-            uint32_t explore_flag;            // 3, main index
-            uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                            // 5-9 unused
-            int32_t area_level;               // 10
-            char* area_name[16];            // 11-26
-                                            // 27, string flags, unused
-            uint32_t team;                    // 28
-            uint32_t liquid_type_override[4]; // 29-32 liquid override by type
-        };
+    struct AreaTableEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t map_id;                  // 1
+        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;            // 3, main index
+        uint32_t flags;                   // 4, unknown value but 312 for all cities
+                                        // 5-9 unused
+        int32_t area_level;               // 10
+        char* area_name[16];            // 11-26
+                                        // 27, string flags, unused
+        uint32_t team;                    // 28
+        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+    };
 
-        struct AreaTriggerEntry
-        {
-            uint32_t id;              // 0
-            uint32_t mapid;           // 1
-            float x;                // 2
-            float y;                // 3
-            float z;                // 4
-            float o;                // 5 radius?
-            float box_x;            // 6 extent x edge
-            float box_y;            // 7 extent y edge
-            float box_z;            // 8 extent z edge
-            float box_o;            // 9 extent rotation by about z axis
-        };
+    struct AreaTriggerEntry
+    {
+        uint32_t id;              // 0
+        uint32_t mapid;           // 1
+        float x;                // 2
+        float y;                // 3
+        float z;                // 4
+        float o;                // 5 radius?
+        float box_x;            // 6 extent x edge
+        float box_y;            // 7 extent y edge
+        float box_z;            // 8 extent z edge
+        float box_o;            // 9 extent rotation by about z axis
+    };
 
-        struct AuctionHouseEntry
-        {
-            uint32_t id;              // 0
-            uint32_t faction;         // 1
-            uint32_t fee;             // 2
-            uint32_t tax;             // 3
-            //char* name[16];       // 4-19
-            //uint32_t name_flags;    // 20
-        };
+    struct AuctionHouseEntry
+    {
+        uint32_t id;              // 0
+        uint32_t faction;         // 1
+        uint32_t fee;             // 2
+        uint32_t tax;             // 3
+        //char* name[16];       // 4-19
+        //uint32_t name_flags;    // 20
+    };
 
-        struct BankBagSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
+    struct BankBagSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
 
-        struct CharTitlesEntry
-        {
-            uint32_t ID;                      // 0, title ids
-            //uint32_t unk1;                  // 1 flags?
-            char* name_male[16];            // 2-17
-            //uint32_t name_flag;             // 18 string flag, unused
-            char* name_female[16];          // 19-34
-            //const char* name2_flag;       // 35 string flag, unused
-            uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
-        };
+    struct CharTitlesEntry
+    {
+        uint32_t ID;                      // 0, title ids
+        //uint32_t unk1;                  // 1 flags?
+        char* name_male[16];            // 2-17
+        //uint32_t name_flag;             // 18 string flag, unused
+        char* name_female[16];          // 19-34
+        //const char* name2_flag;       // 35 string flag, unused
+        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+    };
 
-        #define OUTFIT_ITEMS 12
+    #define OUTFIT_ITEMS 12
 
-        struct CharStartOutfitEntry
-        {
-            //uint32_t Id;                                    // 0
-            uint8_t Race;                                     // 1
-            uint8_t Class;                                    // 2
-            uint8_t Gender;                                   // 3
-            //uint8_t Unused;                                 // 4
-            int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
-            //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
-            //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
-        };
+    struct CharStartOutfitEntry
+    {
+        //uint32_t Id;                                    // 0
+        uint8_t Race;                                     // 1
+        uint8_t Class;                                    // 2
+        uint8_t Gender;                                   // 3
+        //uint8_t Unused;                                 // 4
+        int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
+    };
 
 
-        struct ChatChannelsEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t flags;                   // 1
-            char* name_pattern[16];         // 3-18
-            //uint32_t name_pattern_flags;    // 19
-            //char* channel_name[16];       // 20-35
-            //uint32_t channel_name_flags;    // 36
-        };
+    struct ChatChannelsEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t flags;                   // 1
+        char* name_pattern[16];         // 3-18
+        //uint32_t name_pattern_flags;    // 19
+        //char* channel_name[16];       // 20-35
+        //uint32_t channel_name_flags;    // 36
+    };
 
-        struct ChrClassesEntry
-        {
-            uint32_t class_id;                // 0
-            //uint32_t unk1;                  // 1
-            //uint32_t unk2;                  // 2
-            uint32_t power_type;              // 3
-            //uint32_t unk3;                  // 4
-            char* name[8];                    // 5-12
-            //uint32_t nameflags;             // 13
-            //uint32_t unk4;                  // 14
-            uint32_t spellfamily;             // 15
-            //uint32_t unk4;                  // 16
-        };
+    struct ChrClassesEntry
+    {
+        uint32_t class_id;                // 0
+        //uint32_t unk1;                  // 1
+        //uint32_t unk2;                  // 2
+        uint32_t power_type;              // 3
+        //uint32_t unk3;                  // 4
+        char* name[8];                    // 5-12
+        //uint32_t nameflags;             // 13
+        //uint32_t unk4;                  // 14
+        uint32_t spellfamily;             // 15
+        //uint32_t unk4;                  // 16
+    };
 
-        struct ChrRacesEntry
-        {
-            uint32_t race_id;                 // 0
-            //uint32_t flags;                 // 1
-            uint32_t faction_id;              // 2
-            //uint32_t unk1;                  // 3
-            uint32_t model_male;              // 4
-            uint32_t model_female;            // 5
-            // uint32_t unk2;                 // 6
-            // uint32_t unk3;                 // 7
-            uint32_t team_id;                 // 8
-            //uint32_t unk4[4];               // 9-12
-            // uint32_t unk5;                 // 13
-            uint32_t start_taxi_mask;         // 14
-            // uint32_t unk6;                 // 15
-            uint32_t cinematic_id;            // 16 CinematicSequences.dbc
-            char* name[8];                    // 17-24
-            //uint32_t name_flags             // 25
-            //uint32_t unk7[2]                // 26-27
-            //uint32_t unk8;                  // 28
-        };
+    struct ChrRacesEntry
+    {
+        uint32_t race_id;                 // 0
+        //uint32_t flags;                 // 1
+        uint32_t faction_id;              // 2
+        //uint32_t unk1;                  // 3
+        uint32_t model_male;              // 4
+        uint32_t model_female;            // 5
+        // uint32_t unk2;                 // 6
+        // uint32_t unk3;                 // 7
+        uint32_t team_id;                 // 8
+        //uint32_t unk4[4];               // 9-12
+        // uint32_t unk5;                 // 13
+        uint32_t start_taxi_mask;         // 14
+        // uint32_t unk6;                 // 15
+        uint32_t cinematic_id;            // 16 CinematicSequences.dbc
+        char* name[8];                    // 17-24
+        //uint32_t name_flags             // 25
+        //uint32_t unk7[2]                // 26-27
+        //uint32_t unk8;                  // 28
+    };
 
-        struct CreatureDisplayInfoEntry
-        {
-            uint32_t display_id;            // 0
-            //uint32_t model;               // 1
-            //uint32_t unk0                 // 2
-            //uint32_t InfoExtra;           // 3
-            //float size;                   // 4
-                                            // 5 - 15 unk
-        };
+    struct CreatureDisplayInfoEntry
+    {
+        uint32_t display_id;            // 0
+        //uint32_t model;               // 1
+        //uint32_t unk0                 // 2
+        //uint32_t InfoExtra;           // 3
+        //float size;                   // 4
+                                        // 5 - 15 unk
+    };
 
-        struct CreatureFamilyEntry
-        {
-            uint32_t ID;                      // 0
-            float minsize;                  // 1
-            uint32_t minlevel;                // 2
-            float maxsize;                  // 3
-            uint32_t maxlevel;                // 4
-            uint32_t skilline;                // 5
-            uint32_t tameable;                // 6 second skill line - 270 Generic
-            uint32_t petdietflags;            // 7
-            char* name[16];                 // 8-23
-            //uint32_t nameflags;             // 24
-            //uint32_t iconFile;              // 25
-        };
+    struct CreatureFamilyEntry
+    {
+        uint32_t ID;                      // 0
+        float minsize;                  // 1
+        uint32_t minlevel;                // 2
+        float maxsize;                  // 3
+        uint32_t maxlevel;                // 4
+        uint32_t skilline;                // 5
+        uint32_t tameable;                // 6 second skill line - 270 Generic
+        uint32_t petdietflags;            // 7
+        char* name[16];                 // 8-23
+        //uint32_t nameflags;             // 24
+        //uint32_t iconFile;              // 25
+    };
 
-        struct CreatureSpellDataEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t Spells[3];               // 1-3
-            uint32_t PHSpell;                 // 4
-            uint32_t Cooldowns[3];            // 5-7
-            uint32_t PH;                      // 8
-        };
+    struct CreatureSpellDataEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t Spells[3];               // 1-3
+        uint32_t PHSpell;                 // 4
+        uint32_t Cooldowns[3];            // 5-7
+        uint32_t PH;                      // 8
+    };
 
-        struct DurabilityCostsEntry
-        {
-            uint32_t itemlevel;       // 0
-            uint32_t modifier[29];    // 1-29
-        };
+    struct DurabilityCostsEntry
+    {
+        uint32_t itemlevel;       // 0
+        uint32_t modifier[29];    // 1-29
+    };
 
-        struct DurabilityQualityEntry
-        {
-            uint32_t id;              // 0
-            float quality_modifier; // 1
-        };
+    struct DurabilityQualityEntry
+    {
+        uint32_t id;              // 0
+        float quality_modifier; // 1
+    };
 
-        struct EmotesTextEntry
-        {
-            uint32_t Id;              // 0
-            //uint32_t name;          // 1
-            uint32_t textid;          // 2
-            uint32_t textid2;         // 3
-            uint32_t textid3;         // 4
-            uint32_t textid4;         // 5
-            //uint32_t unk1;          // 6
-            uint32_t textid5;         // 7
-            //uint32_t unk2;          // 8
-            uint32_t textid6;         // 9
-            //uint32_t unk3;          // 10
-            //uint32_t unk4;          // 11
-            //uint32_t unk5;          // 12
-            //uint32_t unk6;          // 13
-            //uint32_t unk7;          // 14
-            //uint32_t unk8;          // 15
-            //uint32_t unk9;          // 16
-            //uint32_t unk10;         // 17
-            //uint32_t unk11;         // 18
-        };
+    struct EmotesTextEntry
+    {
+        uint32_t Id;              // 0
+        //uint32_t name;          // 1
+        uint32_t textid;          // 2
+        uint32_t textid2;         // 3
+        uint32_t textid3;         // 4
+        uint32_t textid4;         // 5
+        //uint32_t unk1;          // 6
+        uint32_t textid5;         // 7
+        //uint32_t unk2;          // 8
+        uint32_t textid6;         // 9
+        //uint32_t unk3;          // 10
+        //uint32_t unk4;          // 11
+        //uint32_t unk5;          // 12
+        //uint32_t unk6;          // 13
+        //uint32_t unk7;          // 14
+        //uint32_t unk8;          // 15
+        //uint32_t unk9;          // 16
+        //uint32_t unk10;         // 17
+        //uint32_t unk11;         // 18
+    };
 
-        struct FactionEntry
-        {
-            uint32_t ID;                      // 0
-            int32_t RepListId;                // 1
-            uint32_t RaceMask[4];             // 2-5
-            uint32_t ClassMask[4];            // 6-9
-            int32_t baseRepValue[4];          // 10-13
-            uint32_t repFlags[4];             // 14-17
-            uint32_t parentFaction;           // 18
-            char* Name[16];                 // 19-34
-            //uint32_t name_flags;            // 35
-            //uint32_t Description[16];       // 36-51
-            //uint32_t description_flags;     // 52
-        };
+    struct FactionEntry
+    {
+        uint32_t ID;                      // 0
+        int32_t RepListId;                // 1
+        uint32_t RaceMask[4];             // 2-5
+        uint32_t ClassMask[4];            // 6-9
+        int32_t baseRepValue[4];          // 10-13
+        uint32_t repFlags[4];             // 14-17
+        uint32_t parentFaction;           // 18
+        char* Name[16];                 // 19-34
+        //uint32_t name_flags;            // 35
+        //uint32_t Description[16];       // 36-51
+        //uint32_t description_flags;     // 52
+    };
 
-        struct FactionTemplateEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t Faction;                 // 1
-            uint32_t FactionGroup;            // 2
-            uint32_t Mask;                    // 3
-            uint32_t FriendlyMask;            // 4
-            uint32_t HostileMask;             // 5
-            uint32_t EnemyFactions[4];        // 6-9
-            uint32_t FriendlyFactions[4];     // 10-13
-        };
+    struct FactionTemplateEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t Faction;                 // 1
+        uint32_t FactionGroup;            // 2
+        uint32_t Mask;                    // 3
+        uint32_t FriendlyMask;            // 4
+        uint32_t HostileMask;             // 5
+        uint32_t EnemyFactions[4];        // 6-9
+        uint32_t FriendlyFactions[4];     // 10-13
+    };
 
-        struct GameObjectDisplayInfoEntry
-        {
-            uint32_t Displayid;               // 0
-            char* filename;                 // 1
-            //uint32_t  unk1[10];             // 2-11
-            float minX;                     // 12
-            float minY;                     // 13
-            float minZ;                     // 14
-            float maxX;                     // 15
-            float maxY;                     // 16
-            float maxZ;                     // 17
-        };
+    struct GameObjectDisplayInfoEntry
+    {
+        uint32_t Displayid;               // 0
+        char* filename;                 // 1
+        //uint32_t  unk1[10];             // 2-11
+        float minX;                     // 12
+        float minY;                     // 13
+        float minZ;                     // 14
+        float maxX;                     // 15
+        float maxY;                     // 16
+        float maxZ;                     // 17
+    };
 
-        struct GemPropertiesEntry
-        {
-            uint32_t Entry;                   // 0
-            uint32_t EnchantmentID;           // 1
-            //uint32_t unk1;                  // 2 bool
-            //uint32_t unk2;                  // 3 bool
-            uint32_t SocketMask;              // 4
-        };
+    struct GemPropertiesEntry
+    {
+        uint32_t Entry;                   // 0
+        uint32_t EnchantmentID;           // 1
+        //uint32_t unk1;                  // 2 bool
+        //uint32_t unk2;                  // 3 bool
+        uint32_t SocketMask;              // 4
+    };
 
-        struct GtChanceToMeleeCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToMeleeCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtCombatRatingsEntry
-        {
-            float val;              // 0
-        };
+    struct GtCombatRatingsEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtOCTRegenHPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenHPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtOCTRegenMPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenMPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtRegenHPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenHPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
-        struct GtRegenMPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenMPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
-        struct ItemEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t DisplayId;               // 1
-            uint32_t InventoryType;           // 2
-            uint32_t Sheath;                  // 3
-        };
+    struct ItemEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t DisplayId;               // 1
+        uint32_t InventoryType;           // 2
+        uint32_t Sheath;                  // 3
+    };
 
-        struct ItemExtendedCostEntry
-        {
-            uint32_t costid;                  // 0
-            uint32_t honor_points;            // 1
-            uint32_t arena_points;            // 2
-            uint32_t item[5];                 // 4-8
-            uint32_t count[5];                // 9-13
-            uint32_t personalrating;          // 14
-        };
+    struct ItemExtendedCostEntry
+    {
+        uint32_t costid;                  // 0
+        uint32_t honor_points;            // 1
+        uint32_t arena_points;            // 2
+        uint32_t item[5];                 // 4-8
+        uint32_t count[5];                // 9-13
+        uint32_t personalrating;          // 14
+    };
 
-        struct ItemRandomPropertiesEntry
-        {
-            uint32_t ID;                      // 0
-            //uint32_t name1;                 // 1
-            uint32_t spells[3];               // 2-4
-            //uint32_t unk1;                  // 5
-            //uint32_t unk2;                  // 6
-            char* name_suffix[16];          // 7-22
-            //uint32_t name_suffix_flags;     // 23
-        };
+    struct ItemRandomPropertiesEntry
+    {
+        uint32_t ID;                      // 0
+        //uint32_t name1;                 // 1
+        uint32_t spells[3];               // 2-4
+        //uint32_t unk1;                  // 5
+        //uint32_t unk2;                  // 6
+        char* name_suffix[16];          // 7-22
+        //uint32_t name_suffix_flags;     // 23
+    };
 
-        struct ItemRandomSuffixEntry
-        {
-            uint32_t id;                      // 0
-            char* name_suffix[16];          // 1-16
-            //uint32_t name_suffix_flags;     // 17
-            //uint32_t unk1;                  // 18
-            uint32_t enchantments[3];         // 19-21
-            //uint32_t unk2[2];               // 22-23
-            uint32_t prefixes[3];             // 24-26
-            //uint32_t[2];                    // 27-28
-        };
+    struct ItemRandomSuffixEntry
+    {
+        uint32_t id;                      // 0
+        char* name_suffix[16];          // 1-16
+        //uint32_t name_suffix_flags;     // 17
+        //uint32_t unk1;                  // 18
+        uint32_t enchantments[3];         // 19-21
+        //uint32_t unk2[2];               // 22-23
+        uint32_t prefixes[3];             // 24-26
+        //uint32_t[2];                    // 27-28
+    };
 
-        struct ItemSetEntry
-        {
-            uint32_t id;                      // 1
-            char* name[16];                 // 1-16 name (lang)
-            //uint32_t localeflag;            // 17 constant
-            uint32_t itemid[10];              // 18-27 item set items
-            //uint32_t unk[7];                // 28-34 all 0
-            uint32_t SpellID[8];              // 35-42
-            uint32_t itemscount[8];           // 43-50
-            uint32_t RequiredSkillID;         // 51
-            uint32_t RequiredSkillAmt;        // 52
-        };
+    struct ItemSetEntry
+    {
+        uint32_t id;                      // 1
+        char* name[16];                 // 1-16 name (lang)
+        //uint32_t localeflag;            // 17 constant
+        uint32_t itemid[10];              // 18-27 item set items
+        //uint32_t unk[7];                // 28-34 all 0
+        uint32_t SpellID[8];              // 35-42
+        uint32_t itemscount[8];           // 43-50
+        uint32_t RequiredSkillID;         // 51
+        uint32_t RequiredSkillAmt;        // 52
+    };
 
-        struct LFGDungeonEntry
-        {
-            uint32_t ID;              // 0
-            char* name[16];         // 1-17 Name lang
-            uint32_t minlevel;        // 18
-            uint32_t maxlevel;        // 19
-            uint32_t reclevel;        // 20
-            uint32_t recminlevel;     // 21
-            uint32_t recmaxlevel;     // 22
-            int32_t map;              // 23
-            uint32_t difficulty;      // 24
-            uint32_t flags;           // 25
-            uint32_t type;            // 26
-            //uint32_t  unk;          // 27
-            //char* iconname;       // 28
-            uint32_t expansion;       // 29
-            //uint32_t unk4;          // 30
-            uint32_t grouptype;       // 31
-            //char* desc[16];       // 32-47 Description
+    struct LFGDungeonEntry
+    {
+        uint32_t ID;              // 0
+        char* name[16];         // 1-17 Name lang
+        uint32_t minlevel;        // 18
+        uint32_t maxlevel;        // 19
+        uint32_t reclevel;        // 20
+        uint32_t recminlevel;     // 21
+        uint32_t recmaxlevel;     // 22
+        int32_t map;              // 23
+        uint32_t difficulty;      // 24
+        uint32_t flags;           // 25
+        uint32_t type;            // 26
+        //uint32_t  unk;          // 27
+        //char* iconname;       // 28
+        uint32_t expansion;       // 29
+        //uint32_t unk4;          // 30
+        uint32_t grouptype;       // 31
+        //char* desc[16];       // 32-47 Description
 
-            // Helpers
-            uint32_t Entry() const { return ID + (type << 24); }
-        };
+        // Helpers
+        uint32_t Entry() const { return ID + (type << 24); }
+    };
 
-        struct LiquidTypeEntry
-        {
-            uint32_t Id;                  // 0
-            uint32_t liquid_id;           // 1
-            uint32_t Type;                // 2
-            uint32_t SpellId;             // 3
-        };
+    struct LiquidTypeEntry
+    {
+        uint32_t Id;                  // 0
+        uint32_t liquid_id;           // 1
+        uint32_t Type;                // 2
+        uint32_t SpellId;             // 3
+    };
 
 #define LOCK_NUM_CASES 8
 
-        struct LockEntry
+    struct LockEntry
+    {
+        uint32_t Id;                              // 0
+        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+    };
+
+    struct MailTemplateEntry
+    {
+        uint32_t ID;              // 0
+        char* subject;          // 1
+        //float unused1[15]     // 2-16
+        //uint32_t flags1         // 17 name flags, unused
+        char* content;          // 18
+        //float unused2[15]     // 19-34
+        //uint32_t flags2         // 35 name flags, unused
+    };
+
+    struct MapEntry
+    {
+        uint32_t id;                      // 0
+        //char* name_internal;          // 1
+        uint32_t map_type;                // 2
+        //uint32_t is_pvp_zone;           // 3 -0 false -1 true
+        char* map_name[16];             // 4-19
+        //uint32_t name_flags;            // 20
+        uint32_t linked_zone;             // 22 common zone for instance and continent map
+        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;      // 39
+        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;   // 56
+        uint32_t multimap_id;             // 57
+        //uint32_t battlefield_map_icon;  // 58
+        int32_t parent_map;               // 59 map_id of parent map
+        float start_x;                  // 60 enter x coordinate (if exist single entry)
+        float start_y;                  // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;               // 62 
+        uint32_t reset_raid_time;
+        uint32_t reset_heroic_tim;
+        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+
+        bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
+        bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
+        bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND; }
+        bool isRaid() const { return map_type == MAP_RAID; }
+        bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
+        bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND; }
+        bool isWorldMap() const { return map_type == MAP_COMMON; }
+
+        bool isContinent() const
         {
-            uint32_t Id;                              // 0
-            uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-            uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-            uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-            //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
-        };
+            return id == 0 || id == 1 || id == 530 || id == 571;
+        }
+    };
 
-        struct MailTemplateEntry
+    struct NameGenEntry
+    {
+        uint32_t ID;              // 0
+        char* Name;             // 1
+        uint32_t unk1;            // 2
+        uint32_t type;            // 3
+    };
+
+    struct SkillLineEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t type;                // 1
+        //uint32_t skillCostsID;      // 2
+        char* Name[16];             // 3-18
+        //uint32_t NameFlags;         // 19
+        //char* Description[16];    // 20-35
+        //uint32_t DescriptionFlags;  // 36
+        uint32_t spell_icon;          // 37
+    };
+
+    struct SkillLineAbilityEntry
+    {
+        uint32_t Id;                      // 0
+        uint32_t skilline;                // 1 skill id
+        uint32_t spell;                   // 2
+        uint32_t race_mask;               // 3
+        uint32_t class_mask;              // 4
+        //uint32_t excludeRace;           // 5
+        //uint32_t excludeClass;          // 6
+        uint32_t minSkillLineRank;        // 7 req skill value
+        uint32_t next;                    // 8
+        uint32_t acquireMethod;           // 9 auto learn
+        uint32_t grey;                    // 10 max
+        uint32_t green;                   // 11 min
+        //uint32_t abandonable;           // 12
+        //uint32_t reqTP;                 // 13
+        uint32_t reqtrainpoints;          // 14
+    };
+
+    struct StableSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
+
+    struct SpellCastTimesEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t CastTime;        // 1
+        //uint32_t unk1;          // 2
+        //uint32_t unk2;          // 3
+    };
+
+    struct SpellDurationEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t Duration1;       // 1
+        uint32_t Duration2;       // 2
+        uint32_t Duration3;       // 3
+    };
+
+    #define MAX_SPELL_EFFECTS 3
+    #define MAX_SPELL_REAGENTS 8
+    #define MAX_SPELL_TOTEMS 2
+
+    struct SpellEntry
+    {
+        uint32_t Id;                                                // 0
+        uint32_t School;                                            // 1 NOT in bitmask!
+        uint32_t Category;                                          // 2
+        //uint32_t castUI;                                          // 3 not used
+        uint32_t DispelType;                                        // 4
+        uint32_t MechanicsType;                                     // 5
+        uint32_t Attributes;                                        // 6
+        uint32_t AttributesEx;                                      // 7
+        uint32_t AttributesExB;                                     // 8
+        uint32_t AttributesExC;                                     // 9
+        uint32_t AttributesExD;                                     // 10
+        uint32_t Shapeshifts;                                       // 11
+        uint32_t ShapeshiftsExcluded;                               // 12
+        uint32_t Targets;                                           // 13
+        uint32_t TargetCreatureType;                                // 14
+        uint32_t RequiresSpellFocus;                                // 15
+        uint32_t CasterAuraState;                                   // 16
+        uint32_t TargetAuraState;                                   // 17
+        uint32_t CastingTimeIndex;                                  // 18
+        uint32_t RecoveryTime;                                      // 19
+        uint32_t CategoryRecoveryTime;                              // 20
+        uint32_t InterruptFlags;                                    // 21
+        uint32_t AuraInterruptFlags;                                // 22
+        uint32_t ChannelInterruptFlags;                             // 23
+        uint32_t procFlags;                                         // 24
+        uint32_t procChance;                                        // 25
+        uint32_t procCharges;                                       // 26
+        uint32_t maxLevel;                                          // 27
+        uint32_t baseLevel;                                         // 28
+        uint32_t spellLevel;                                        // 29
+        uint32_t DurationIndex;                                     // 30
+        int32_t powerType;                                          // 31
+        uint32_t manaCost;                                          // 32
+        uint32_t manaCostPerlevel;                                  // 33
+        uint32_t manaPerSecond;                                     // 34
+        uint32_t manaPerSecondPerLevel;                             // 35
+        uint32_t rangeIndex;                                        // 36
+        float speed;                                                // 37
+        //uint32_t modalNextSpell;                                  // 38 not used
+        uint32_t MaxStackAmount;                                    // 39
+        uint32_t Totem[MAX_SPELL_TOTEMS];                           // 40 - 41
+        int32_t Reagent[MAX_SPELL_REAGENTS];                        // 42 - 49
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 50 - 57
+        int32_t EquippedItemClass;                                  // 58
+        int32_t EquippedItemSubClass;                               // 59
+        int32_t EquippedItemInventoryTypeMask;                      // 60
+        uint32_t Effect[MAX_SPELL_EFFECTS];                         // 61 - 63
+        int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 64 - 66
+        uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 67 - 69
+        float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 70 - 72
+        float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 73 - 75
+        int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 76 - 78
+        uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 79 - 81
+        uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 82 - 84
+        uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 85 - 87
+        uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 88 - 90
+        uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 91 - 93
+        uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 94 - 96
+        float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 97 - 99
+        uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 100 - 102
+        uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 105
+        int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 106 - 108
+        uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 109 - 111
+        float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 112 - 114
+        uint32_t SpellVisual;                                       // 115
+        uint32_t SpellVisual1;                                      // 116
+        uint32_t spellIconID;                                       // 117
+        uint32_t activeIconID;                                      // 118 activeIconID;
+        uint32_t spellPriority;                                     // 119
+        const char* Name[8];                                        // 120 - 127
+        //uint32_t NameFlags;                                       // 128 not used
+        const char* Rank[8];                                        // 129 - 136
+        //uint32_t RankFlags;                                       // 137 not used
+        //const char* Description[8];                               // 138 - 145 not used
+        //uint32_t DescriptionFlags;                                // 146 not used
+        //const char* BuffDescription[8];                           // 147 - 154 not used
+        //uint32_t buffdescflags;                                   // 155 not used
+        uint32_t ManaCostPercentage;                                // 156
+        uint32_t StartRecoveryCategory;                             // 157
+        uint32_t StartRecoveryTime;                                 // 158
+        uint32_t MaxTargetLevel;                                    // 159
+        uint32_t SpellFamilyName;                                   // 160
+        uint32_t SpellFamilyFlags[2];                               // 161 - 162
+        uint32_t MaxTargets;                                        // 163
+        uint32_t DmgClass;                                          // 164
+        uint32_t PreventionType;                                    // 165
+        //int32_t StanceBarOrder;                                   // 166 not used
+        float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 167 - 169
+        //uint32_t MinFactionID;                                    // 170 not used
+        //uint32_t MinReputation;                                   // 171 not used
+        //uint32_t RequiredAuraVision;                              // 172 not used
+    };
+
+    struct SpellItemEnchantmentEntry
+    {
+        uint32_t Id;                  // 0
+        uint32_t type[3];             // 1-3
+        uint32_t min[3];              // 4-6 for combat, in practice min==max
+        uint32_t max[3];              // 7-9
+        uint32_t spell[3];            // 10-12
+        char* Name[16];               // 13-28
+        //uint32_t NameFlags;         // 29
+        uint32_t visual;              // 30 aura
+        uint32_t EnchantGroups;       // 31 slot
+        uint32_t GemEntry;            // 32
+        uint32_t ench_condition;      // 33
+    };
+
+    struct SpellRadiusEntry
+    {
+        uint32_t ID;                  // 0
+        float radius_min;           // 1 Radius
+        float radius_per_level;     // 2
+        float radius_max;           // 3 Radius2
+    };
+
+    struct SpellRangeEntry
+    {
+        uint32_t ID;                  // 0
+        float minRange;             // 1
+        float maxRange;             // 3
+        uint32_t range_type;          // 4
+        //char* name1[16]           // 6-21
+        //uint32_t name1_falgs;       // 22
+        //char* name2[16]           // 23-38
+        //uint32_t name2_falgs;       // 39
+    };
+
+    struct SpellShapeshiftFormEntry
+    {
+        uint32_t id;                  // 0
+        //uint32_t button_pos;        // 1
+        //char* name[16];           // 2-17
+        //uint32_t name_flags;        // 18
+        uint32_t Flags;               // 19
+        uint32_t unit_type;           // 20
+        //uint32_t unk1               // 21
+        uint32_t AttackSpeed;         // 22
+        uint32_t modelId;             // 23 alliance?
+        uint32_t modelId2;            // 24 horde?
+        //uint32_t unk2               // 25
+        //uint32_t unk3               // 26
+        uint32_t spells[8];           // 27-34
+    };
+
+    struct SummonPropertiesEntry
+    {
+        uint32_t ID;                  // 0
+        uint32_t ControlType;         // 1
+        uint32_t FactionID;           // 2
+        uint32_t Type;                // 3
+        uint32_t Slot;                // 4
+        uint32_t Flags;               // 5
+    };
+
+    struct TalentEntry
+    {
+        uint32_t TalentID;            // 0
+        uint32_t TalentTree;          // 1
+        uint32_t Row;                 // 2
+        uint32_t Col;                 // 3
+        uint32_t RankID[5];           // 4-8
+        //uint32_t unk[4];            // 9-12
+        uint32_t DependsOn;           // 13
+        //uint32_t unk1[2];           // 14-15
+        uint32_t DependsOnRank;       // 16
+        //uint32_t unk2[2];           // 17-18
+        //uint32_t unk3;              // 19
+        uint32_t DependsOnSpell;      // 20
+    };
+
+    struct TalentTabEntry
+    {
+        uint32_t TalentTabID;         // 0
+        //char* Name[16];           // 1-16
+        //uint32_t name_flags;        // 17
+        //uint32_t unk4;              // 18
+        //uint32_t unk5;              // 19
+        uint32_t ClassMask;           // 20
+        uint32_t TabPage;             // 21
+        //char* InternalName;       // 22
+    };
+
+    struct TaxiNodesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t mapid;               // 1
+        float x;                    // 2
+        float y;                    // 3
+        float z;                    // 4
+        char* name[16];             // 5-21
+        //uint32_t nameflags;         // 22
+        uint32_t horde_mount;         // 23
+        uint32_t alliance_mount;      // 24
+    };
+
+    struct TaxiPathEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t from;                // 1
+        uint32_t to;                  // 2
+        uint32_t price;               // 3
+    };
+
+    struct TaxiPathNodeEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t path;                // 1
+        uint32_t seq;                 // 2 nodeIndex
+        uint32_t mapid;               // 3
+        float x;                      // 4
+        float y;                      // 5
+        float z;                      // 6
+        uint32_t flags;               // 7
+        uint32_t waittime;            // 8
+        uint32_t arivalEventID;       // 9
+        uint32_t departureEventID;    // 10
+    };
+
+    struct TransportAnimationEntry
+    {
+        //uint32_t Id;          // 0
+        uint32_t TransportID;   // 1
+        uint32_t TimeIndex;     // 2
+        DBCPosition3D Pos;      // 3
+        //uint32_t SequenceID;  // 4
+    };
+
+    #define MAX_VEHICLE_SEATS 8
+
+    struct VehicleEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        float turnSpeed;                                    // 2
+        float pitchSpeed;                                   // 3
+        float pitchMin;                                     // 4
+        float pitchMax;                                     // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
+        float mouseLookOffsetPitch;                         // 14
+        float cameraFadeDistScalarMin;                      // 15
+        float cameraFadeDistScalarMax;                      // 16
+        float cameraPitchOffset;                            // 17
+        float facingLimitRight;                             // 18
+        float facingLimitLeft;                              // 19
+        float msslTrgtTurnLingering;                        // 20
+        float msslTrgtPitchLingering;                       // 21
+        float msslTrgtMouseLingering;                       // 22
+        float msslTrgtEndOpacity;                           // 23
+        float msslTrgtArcSpeed;                             // 24
+        float msslTrgtArcRepeat;                            // 25
+        float msslTrgtArcWidth;                             // 26
+        float msslTrgtImpactRadius[2];                      // 27-28
+        char* msslTrgtArcTexture;                           // 29
+        char* msslTrgtImpactTexture;                        // 30
+        char* msslTrgtImpactModel[2];                       // 31-32
+        float cameraYawOffset;                              // 33
+        uint32_t uiLocomotionType;                            // 34
+        float msslTrgtImpactTexRadius;                      // 35
+        uint32_t uiSeatIndicatorType;                         // 36
+        uint32_t powerType;                                   // 37, new in 3.1
+        //uint32_t unk1;                                      // 38
+        //uint32_t unk2;                                      // 39  
+    };
+
+    enum VehicleSeatFlags
+    {
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+    };
+
+    enum VehicleSeatFlagsB
+    {
+        VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
+    };
+
+    struct VehicleSeatEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        int32_t attachmentID;                                 // 2
+        float attachmentOffsetX;                            // 3
+        float attachmentOffsetY;                            // 4
+        float attachmentOffsetZ;                            // 5
+        float enterPreDelay;                                // 6
+        float enterSpeed;                                   // 7
+        float enterGravity;                                 // 8
+        float enterMinDuration;                             // 9
+        float enterMaxDuration;                             // 10
+        float enterMinArcHeight;                            // 11
+        float enterMaxArcHeight;                            // 12
+        int32_t enterAnimStart;                               // 13
+        int32_t enterAnimLoop;                                // 14
+        int32_t rideAnimStart;                                // 15
+        int32_t rideAnimLoop;                                 // 16
+        int32_t rideUpperAnimStart;                           // 17
+        int32_t rideUpperAnimLoop;                            // 18
+        float exitPreDelay;                                 // 19
+        float exitSpeed;                                    // 20
+        float exitGravity;                                  // 21
+        float exitMinDuration;                              // 22
+        float exitMaxDuration;                              // 23
+        float exitMinArcHeight;                             // 24
+        float exitMaxArcHeight;                             // 25
+        int32_t exitAnimStart;                                // 26
+        int32_t exitAnimLoop;                                 // 27
+        int32_t exitAnimEnd;                                  // 28
+        float passengerYaw;                                 // 29
+        float passengerPitch;                               // 30
+        float passengerRoll;                                // 31
+        int32_t passengerAttachmentID;                        // 32
+        int32_t vehicleEnterAnim;                             // 33
+        int32_t vehicleExitAnim;                              // 34
+        int32_t vehicleRideAnimLoop;                          // 35
+        int32_t vehicleEnterAnimBone;                         // 36
+        int32_t vehicleExitAnimBone;                          // 37
+        int32_t vehicleRideAnimLoopBone;                      // 38
+        float vehicleEnterAnimDelay;                        // 39
+        float vehicleExitAnimDelay;                         // 40
+        uint32_t vehicleAbilityDisplay;                       // 41
+        uint32_t enterUISoundID;                              // 42
+        uint32_t exitUISoundID;                               // 43
+        int32_t uiSkin;                                       // 44
+        uint32_t flagsB;                                      // 45
+
+        bool IsUsable() const
         {
-            uint32_t ID;              // 0
-            char* subject;          // 1
-            //float unused1[15]     // 2-16
-            //uint32_t flags1         // 17 name flags, unused
-            char* content;          // 18
-            //float unused2[15]     // 19-34
-            //uint32_t flags2         // 35 name flags, unused
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
+                return true;
+            else
+                return false;
+        }
 
-        struct MapEntry
+        bool IsController() const
         {
-            uint32_t id;                      // 0
-            //char* name_internal;          // 1
-            uint32_t map_type;                // 2
-            //uint32_t is_pvp_zone;           // 3 -0 false -1 true
-            char* map_name[16];             // 4-19
-            //uint32_t name_flags;            // 20
-            uint32_t linked_zone;             // 22 common zone for instance and continent map
-            //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-            //uint32_t hordeIntro_flags;      // 39
-            //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-            //uint32_t allianceIntro_flags;   // 56
-            uint32_t multimap_id;             // 57
-            //uint32_t battlefield_map_icon;  // 58
-            int32_t parent_map;               // 59 map_id of parent map
-            float start_x;                  // 60 enter x coordinate (if exist single entry)
-            float start_y;                  // 61 enter y coordinate (if exist single entry)
-            //uint32_t dayTime;               // 62 
-            uint32_t reset_raid_time;
-            uint32_t reset_heroic_tim;
-            uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+            if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
+                return true;
+            else
+                return false;
+        }
 
-            bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
-            bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
-            bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND; }
-            bool isRaid() const { return map_type == MAP_RAID; }
-            bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
-            bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND; }
-            bool isWorldMap() const { return map_type == MAP_COMMON; }
-
-            bool isContinent() const
-            {
-                return id == 0 || id == 1 || id == 530 || id == 571;
-            }
-        };
-
-        struct NameGenEntry
+        bool HidesPassenger() const
         {
-            uint32_t ID;              // 0
-            char* Name;             // 1
-            uint32_t unk1;            // 2
-            uint32_t type;            // 3
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
+                return true;
+            else
+                return false;
+        }
+    };
 
-        struct SkillLineEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t type;                // 1
-            //uint32_t skillCostsID;      // 2
-            char* Name[16];             // 3-18
-            //uint32_t NameFlags;         // 19
-            //char* Description[16];    // 20-35
-            //uint32_t DescriptionFlags;  // 36
-            uint32_t spell_icon;          // 37
-        };
+    struct WMOAreaTableEntry
+    {
+        uint32_t id;              // 0
+        int32_t rootId;           // 1
+        int32_t adtId;            // 2
+        int32_t groupId;          // 3
+        //uint32_t field4;        // 4
+        //uint32_t field5;        // 5
+        //uint32_t field6;        // 6
+        //uint32_t field7;        // 7
+        //uint32_t field8;        // 8
+        uint32_t flags;           // 9
+        uint32_t areaId;          // 10  ref -> AreaTableEntry
+        //char Name[16];        // 11-26
+        //uint32_t nameflags;     // 27
+    };
 
-        struct SkillLineAbilityEntry
-        {
-            uint32_t Id;                      // 0
-            uint32_t skilline;                // 1 skill id
-            uint32_t spell;                   // 2
-            uint32_t race_mask;               // 3
-            uint32_t class_mask;              // 4
-            //uint32_t excludeRace;           // 5
-            //uint32_t excludeClass;          // 6
-            uint32_t minSkillLineRank;        // 7 req skill value
-            uint32_t next;                    // 8
-            uint32_t acquireMethod;           // 9 auto learn
-            uint32_t grey;                    // 10 max
-            uint32_t green;                   // 11 min
-            //uint32_t abandonable;           // 12
-            //uint32_t reqTP;                 // 13
-            uint32_t reqtrainpoints;          // 14
-        };
+    struct WorldMapOverlayEntry
+    {
+        uint32_t ID;              // 0
+        //uint32_t worldMapID;    // 1
+        uint32_t areaID;          // 2 - index to AreaTable
+        uint32_t areaID_2;        // 3 - index to AreaTable
+        uint32_t areaID_3;        // 4 - index to AreaTable
+        uint32_t areaID_4;        // 5 - index to AreaTable
+        //uint32_t unk1[2];       // 6-7
+        //uint32_t unk2;          // 8
+        //uint32_t unk3[7];       // 9-16
+    };
 
-        struct StableSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
-
-        struct SpellCastTimesEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t CastTime;        // 1
-            //uint32_t unk1;          // 2
-            //uint32_t unk2;          // 3
-        };
-
-        struct SpellDurationEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t Duration1;       // 1
-            uint32_t Duration2;       // 2
-            uint32_t Duration3;       // 3
-        };
-
-        #define MAX_SPELL_EFFECTS 3
-        #define MAX_SPELL_REAGENTS 8
-        #define MAX_SPELL_TOTEMS 2
-
-        struct SpellEntry
-        {
-            uint32_t Id;                                                // 0
-            uint32_t School;                                            // 1 NOT in bitmask!
-            uint32_t Category;                                          // 2
-            //uint32_t castUI;                                          // 3 not used
-            uint32_t DispelType;                                        // 4
-            uint32_t MechanicsType;                                     // 5
-            uint32_t Attributes;                                        // 6
-            uint32_t AttributesEx;                                      // 7
-            uint32_t AttributesExB;                                     // 8
-            uint32_t AttributesExC;                                     // 9
-            uint32_t AttributesExD;                                     // 10
-            uint32_t Shapeshifts;                                       // 11
-            uint32_t ShapeshiftsExcluded;                               // 12
-            uint32_t Targets;                                           // 13
-            uint32_t TargetCreatureType;                                // 14
-            uint32_t RequiresSpellFocus;                                // 15
-            uint32_t CasterAuraState;                                   // 16
-            uint32_t TargetAuraState;                                   // 17
-            uint32_t CastingTimeIndex;                                  // 18
-            uint32_t RecoveryTime;                                      // 19
-            uint32_t CategoryRecoveryTime;                              // 20
-            uint32_t InterruptFlags;                                    // 21
-            uint32_t AuraInterruptFlags;                                // 22
-            uint32_t ChannelInterruptFlags;                             // 23
-            uint32_t procFlags;                                         // 24
-            uint32_t procChance;                                        // 25
-            uint32_t procCharges;                                       // 26
-            uint32_t maxLevel;                                          // 27
-            uint32_t baseLevel;                                         // 28
-            uint32_t spellLevel;                                        // 29
-            uint32_t DurationIndex;                                     // 30
-            int32_t powerType;                                          // 31
-            uint32_t manaCost;                                          // 32
-            uint32_t manaCostPerlevel;                                  // 33
-            uint32_t manaPerSecond;                                     // 34
-            uint32_t manaPerSecondPerLevel;                             // 35
-            uint32_t rangeIndex;                                        // 36
-            float speed;                                                // 37
-            //uint32_t modalNextSpell;                                  // 38 not used
-            uint32_t MaxStackAmount;                                    // 39
-            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 40 - 41
-            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 42 - 49
-            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 50 - 57
-            int32_t EquippedItemClass;                                  // 58
-            int32_t EquippedItemSubClass;                               // 59
-            int32_t EquippedItemInventoryTypeMask;                      // 60
-            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 61 - 63
-            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 64 - 66
-            uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 67 - 69
-            float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 70 - 72
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 73 - 75
-            int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 76 - 78
-            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 79 - 81
-            uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 82 - 84
-            uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 85 - 87
-            uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 88 - 90
-            uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 91 - 93
-            uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 94 - 96
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 97 - 99
-            uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 100 - 102
-            uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 105
-            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 106 - 108
-            uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 109 - 111
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 112 - 114
-            uint32_t SpellVisual;                                       // 115
-            uint32_t SpellVisual1;                                      // 116
-            uint32_t spellIconID;                                       // 117
-            uint32_t activeIconID;                                      // 118 activeIconID;
-            uint32_t spellPriority;                                     // 119
-            const char* Name[8];                                        // 120 - 127
-            //uint32_t NameFlags;                                       // 128 not used
-            const char* Rank[8];                                        // 129 - 136
-            //uint32_t RankFlags;                                       // 137 not used
-            //const char* Description[8];                               // 138 - 145 not used
-            //uint32_t DescriptionFlags;                                // 146 not used
-            //const char* BuffDescription[8];                           // 147 - 154 not used
-            //uint32_t buffdescflags;                                   // 155 not used
-            uint32_t ManaCostPercentage;                                // 156
-            uint32_t StartRecoveryCategory;                             // 157
-            uint32_t StartRecoveryTime;                                 // 158
-            uint32_t MaxTargetLevel;                                    // 159
-            uint32_t SpellFamilyName;                                   // 160
-            uint32_t SpellFamilyFlags[2];                               // 161 - 162
-            uint32_t MaxTargets;                                        // 163
-            uint32_t DmgClass;                                          // 164
-            uint32_t PreventionType;                                    // 165
-            //int32_t StanceBarOrder;                                   // 166 not used
-            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 167 - 169
-            //uint32_t MinFactionID;                                    // 170 not used
-            //uint32_t MinReputation;                                   // 171 not used
-            //uint32_t RequiredAuraVision;                              // 172 not used
-        };
-
-        struct SpellItemEnchantmentEntry
-        {
-            uint32_t Id;                  // 0
-            uint32_t type[3];             // 1-3
-            uint32_t min[3];              // 4-6 for combat, in practice min==max
-            uint32_t max[3];              // 7-9
-            uint32_t spell[3];            // 10-12
-            char* Name[16];               // 13-28
-            //uint32_t NameFlags;         // 29
-            uint32_t visual;              // 30 aura
-            uint32_t EnchantGroups;       // 31 slot
-            uint32_t GemEntry;            // 32
-            uint32_t ench_condition;      // 33
-        };
-
-        struct SpellRadiusEntry
-        {
-            uint32_t ID;                  // 0
-            float radius_min;           // 1 Radius
-            float radius_per_level;     // 2
-            float radius_max;           // 3 Radius2
-        };
-
-        struct SpellRangeEntry
-        {
-            uint32_t ID;                  // 0
-            float minRange;             // 1
-            float maxRange;             // 3
-            uint32_t range_type;          // 4
-            //char* name1[16]           // 6-21
-            //uint32_t name1_falgs;       // 22
-            //char* name2[16]           // 23-38
-            //uint32_t name2_falgs;       // 39
-        };
-
-        struct SpellShapeshiftFormEntry
-        {
-            uint32_t id;                  // 0
-            //uint32_t button_pos;        // 1
-            //char* name[16];           // 2-17
-            //uint32_t name_flags;        // 18
-            uint32_t Flags;               // 19
-            uint32_t unit_type;           // 20
-            //uint32_t unk1               // 21
-            uint32_t AttackSpeed;         // 22
-            uint32_t modelId;             // 23 alliance?
-            uint32_t modelId2;            // 24 horde?
-            //uint32_t unk2               // 25
-            //uint32_t unk3               // 26
-            uint32_t spells[8];           // 27-34
-        };
-
-        struct SummonPropertiesEntry
-        {
-            uint32_t ID;                  // 0
-            uint32_t ControlType;         // 1
-            uint32_t FactionID;           // 2
-            uint32_t Type;                // 3
-            uint32_t Slot;                // 4
-            uint32_t Flags;               // 5
-        };
-
-        struct TalentEntry
-        {
-            uint32_t TalentID;            // 0
-            uint32_t TalentTree;          // 1
-            uint32_t Row;                 // 2
-            uint32_t Col;                 // 3
-            uint32_t RankID[5];           // 4-8
-            //uint32_t unk[4];            // 9-12
-            uint32_t DependsOn;           // 13
-            //uint32_t unk1[2];           // 14-15
-            uint32_t DependsOnRank;       // 16
-            //uint32_t unk2[2];           // 17-18
-            //uint32_t unk3;              // 19
-            uint32_t DependsOnSpell;      // 20
-        };
-
-        struct TalentTabEntry
-        {
-            uint32_t TalentTabID;         // 0
-            //char* Name[16];           // 1-16
-            //uint32_t name_flags;        // 17
-            //uint32_t unk4;              // 18
-            //uint32_t unk5;              // 19
-            uint32_t ClassMask;           // 20
-            uint32_t TabPage;             // 21
-            //char* InternalName;       // 22
-        };
-
-        struct TaxiNodesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t mapid;               // 1
-            float x;                    // 2
-            float y;                    // 3
-            float z;                    // 4
-            char* name[16];             // 5-21
-            //uint32_t nameflags;         // 22
-            uint32_t horde_mount;         // 23
-            uint32_t alliance_mount;      // 24
-        };
-
-        struct TaxiPathEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t from;                // 1
-            uint32_t to;                  // 2
-            uint32_t price;               // 3
-        };
-
-        struct TaxiPathNodeEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t path;                // 1
-            uint32_t seq;                 // 2 nodeIndex
-            uint32_t mapid;               // 3
-            float x;                      // 4
-            float y;                      // 5
-            float z;                      // 6
-            uint32_t flags;               // 7
-            uint32_t waittime;            // 8
-            uint32_t arivalEventID;       // 9
-            uint32_t departureEventID;    // 10
-        };
-
-        struct TransportAnimationEntry
-        {
-            //uint32_t Id;          // 0
-            uint32_t TransportID;   // 1
-            uint32_t TimeIndex;     // 2
-            DBCPosition3D Pos;      // 3
-            //uint32_t SequenceID;  // 4
-        };
-
-        #define MAX_VEHICLE_SEATS 8
-
-        struct VehicleEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            float turnSpeed;                                    // 2
-            float pitchSpeed;                                   // 3
-            float pitchMin;                                     // 4
-            float pitchMax;                                     // 5
-            uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-            float mouseLookOffsetPitch;                         // 14
-            float cameraFadeDistScalarMin;                      // 15
-            float cameraFadeDistScalarMax;                      // 16
-            float cameraPitchOffset;                            // 17
-            float facingLimitRight;                             // 18
-            float facingLimitLeft;                              // 19
-            float msslTrgtTurnLingering;                        // 20
-            float msslTrgtPitchLingering;                       // 21
-            float msslTrgtMouseLingering;                       // 22
-            float msslTrgtEndOpacity;                           // 23
-            float msslTrgtArcSpeed;                             // 24
-            float msslTrgtArcRepeat;                            // 25
-            float msslTrgtArcWidth;                             // 26
-            float msslTrgtImpactRadius[2];                      // 27-28
-            char* msslTrgtArcTexture;                           // 29
-            char* msslTrgtImpactTexture;                        // 30
-            char* msslTrgtImpactModel[2];                       // 31-32
-            float cameraYawOffset;                              // 33
-            uint32_t uiLocomotionType;                            // 34
-            float msslTrgtImpactTexRadius;                      // 35
-            uint32_t uiSeatIndicatorType;                         // 36
-            uint32_t powerType;                                   // 37, new in 3.1
-            //uint32_t unk1;                                      // 38
-            //uint32_t unk2;                                      // 39  
-        };
-
-        enum VehicleSeatFlags
-        {
-            VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
-            VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-            VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-            VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-            VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-            VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-            VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
-        };
-
-        enum VehicleSeatFlagsB
-        {
-            VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
-        };
-
-        struct VehicleSeatEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            int32_t attachmentID;                                 // 2
-            float attachmentOffsetX;                            // 3
-            float attachmentOffsetY;                            // 4
-            float attachmentOffsetZ;                            // 5
-            float enterPreDelay;                                // 6
-            float enterSpeed;                                   // 7
-            float enterGravity;                                 // 8
-            float enterMinDuration;                             // 9
-            float enterMaxDuration;                             // 10
-            float enterMinArcHeight;                            // 11
-            float enterMaxArcHeight;                            // 12
-            int32_t enterAnimStart;                               // 13
-            int32_t enterAnimLoop;                                // 14
-            int32_t rideAnimStart;                                // 15
-            int32_t rideAnimLoop;                                 // 16
-            int32_t rideUpperAnimStart;                           // 17
-            int32_t rideUpperAnimLoop;                            // 18
-            float exitPreDelay;                                 // 19
-            float exitSpeed;                                    // 20
-            float exitGravity;                                  // 21
-            float exitMinDuration;                              // 22
-            float exitMaxDuration;                              // 23
-            float exitMinArcHeight;                             // 24
-            float exitMaxArcHeight;                             // 25
-            int32_t exitAnimStart;                                // 26
-            int32_t exitAnimLoop;                                 // 27
-            int32_t exitAnimEnd;                                  // 28
-            float passengerYaw;                                 // 29
-            float passengerPitch;                               // 30
-            float passengerRoll;                                // 31
-            int32_t passengerAttachmentID;                        // 32
-            int32_t vehicleEnterAnim;                             // 33
-            int32_t vehicleExitAnim;                              // 34
-            int32_t vehicleRideAnimLoop;                          // 35
-            int32_t vehicleEnterAnimBone;                         // 36
-            int32_t vehicleExitAnimBone;                          // 37
-            int32_t vehicleRideAnimLoopBone;                      // 38
-            float vehicleEnterAnimDelay;                        // 39
-            float vehicleExitAnimDelay;                         // 40
-            uint32_t vehicleAbilityDisplay;                       // 41
-            uint32_t enterUISoundID;                              // 42
-            uint32_t exitUISoundID;                               // 43
-            int32_t uiSkin;                                       // 44
-            uint32_t flagsB;                                      // 45
-
-            bool IsUsable() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool IsController() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool HidesPassenger() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
-                    return true;
-                else
-                    return false;
-            }
-        };
-
-        struct WMOAreaTableEntry
-        {
-            uint32_t id;              // 0
-            int32_t rootId;           // 1
-            int32_t adtId;            // 2
-            int32_t groupId;          // 3
-            //uint32_t field4;        // 4
-            //uint32_t field5;        // 5
-            //uint32_t field6;        // 6
-            //uint32_t field7;        // 7
-            //uint32_t field8;        // 8
-            uint32_t flags;           // 9
-            uint32_t areaId;          // 10  ref -> AreaTableEntry
-            //char Name[16];        // 11-26
-            //uint32_t nameflags;     // 27
-        };
-
-        struct WorldMapOverlayEntry
-        {
-            uint32_t ID;              // 0
-            //uint32_t worldMapID;    // 1
-            uint32_t areaID;          // 2 - index to AreaTable
-            uint32_t areaID_2;        // 3 - index to AreaTable
-            uint32_t areaID_3;        // 4 - index to AreaTable
-            uint32_t areaID_4;        // 5 - index to AreaTable
-            //uint32_t unk1[2];       // 6-7
-            //uint32_t unk2;          // 8
-            //uint32_t unk3[7];       // 9-16
-        };
-
-        #pragma pack(pop)
-    }
+    #pragma pack(pop)
 }

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -169,7 +169,7 @@ namespace DBC::Structures
         uint32_t bit_index;                                         // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
     };
 
-    #define OUTFIT_ITEMS 12
+#define OUTFIT_ITEMS 12
 
     struct CharStartOutfitEntry
     {
@@ -599,9 +599,9 @@ namespace DBC::Structures
         uint32_t Duration3;                                         // 3
     };
 
-    #define MAX_SPELL_EFFECTS 3
-    #define MAX_SPELL_REAGENTS 8
-    #define MAX_SPELL_TOTEMS 2
+#define MAX_SPELL_EFFECTS 3
+#define MAX_SPELL_REAGENTS 8
+#define MAX_SPELL_TOTEMS 2
 
     struct SpellEntry
     {
@@ -833,7 +833,7 @@ namespace DBC::Structures
         //uint32_t SequenceID;                                      // 4
     };
 
-    #define MAX_VEHICLE_SEATS 8
+#define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -135,7 +135,7 @@ namespace DBC::Structures
         float x;                                                    // 2
         float y;                                                    // 3
         float z;                                                    // 4
-        float o;                                                    // 5 radius?
+        float box_radius;                                           // 5 radius
         float box_x;                                                // 6 extent x edge
         float box_y;                                                // 7 extent y edge
         float box_z;                                                // 8 extent z edge

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -106,366 +106,366 @@ namespace DBC::Structures
     #pragma pack(push, 1)
     struct AchievementCategoryEntry
     {
-        uint32_t ID;                 // 0
-        uint32_t parentCategory;     // 1 -1 for main category
-        const char* name;          // 2-17
-        uint32_t name_flags;         // 18
-        uint32_t sortOrder;          // 19
+        uint32_t ID;                                                // 0
+        uint32_t parentCategory;                                    // 1 -1 for main category
+        const char* name;                                           // 2-17
+        uint32_t name_flags;                                        // 18
+        uint32_t sortOrder;                                         // 19
     };
 
     struct AreaTableEntry
     {
-        uint32_t id;                      // 0
-        uint32_t map_id;                  // 1
-        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;            // 3, main index
-        uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                        // 5-9 unused
-        int32_t area_level;               // 10
-        char* area_name[16];            // 11-26
-                                        // 27, string flags, unused
-        uint32_t team;                    // 28
-        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+        uint32_t id;                                                // 0
+        uint32_t map_id;                                            // 1
+        uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;                                      // 3, main index
+        uint32_t flags;                                             // 4, unknown value but 312 for all cities
+                                                                    // 5-9 unused
+        int32_t area_level;                                         // 10
+        char* area_name[16];                                        // 11-26
+                                                                    // 27, string flags, unused
+        uint32_t team;                                              // 28
+        uint32_t liquid_type_override[4];                           // 29-32 liquid override by type
     };
 
     struct AreaTriggerEntry
     {
-        uint32_t id;              // 0
-        uint32_t mapid;           // 1
-        float x;                // 2
-        float y;                // 3
-        float z;                // 4
-        float o;                // 5 radius?
-        float box_x;            // 6 extent x edge
-        float box_y;            // 7 extent y edge
-        float box_z;            // 8 extent z edge
-        float box_o;            // 9 extent rotation by about z axis
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        float o;                                                    // 5 radius?
+        float box_x;                                                // 6 extent x edge
+        float box_y;                                                // 7 extent y edge
+        float box_z;                                                // 8 extent z edge
+        float box_o;                                                // 9 extent rotation by about z axis
     };
 
     struct AuctionHouseEntry
     {
-        uint32_t id;              // 0
-        uint32_t faction;         // 1
-        uint32_t fee;             // 2
-        uint32_t tax;             // 3
-        //char* name[16];       // 4-19
-        //uint32_t name_flags;    // 20
+        uint32_t id;                                                // 0
+        uint32_t faction;                                           // 1
+        uint32_t fee;                                               // 2
+        uint32_t tax;                                               // 3
+        //char* name[16];                                           // 4-19
+        //uint32_t name_flags;                                      // 20
     };
 
     struct BankBagSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct CharTitlesEntry
     {
-        uint32_t ID;                      // 0, title ids
-        //uint32_t unk1;                  // 1 flags?
-        char* name_male[16];            // 2-17
-        //uint32_t name_flag;             // 18 string flag, unused
-        char* name_female[16];          // 19-34
-        //const char* name2_flag;       // 35 string flag, unused
-        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+        uint32_t ID;                                                // 0, title ids
+        //uint32_t unk1;                                            // 1 flags?
+        char* name_male[16];                                        // 2-17
+        //uint32_t name_flag;                                       // 18 string flag, unused
+        char* name_female[16];                                      // 19-34
+        //const char* name2_flag;                                   // 35 string flag, unused
+        uint32_t bit_index;                                         // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
     };
 
     #define OUTFIT_ITEMS 12
 
     struct CharStartOutfitEntry
     {
-        //uint32_t Id;                                    // 0
-        uint8_t Race;                                     // 1
-        uint8_t Class;                                    // 2
-        uint8_t Gender;                                   // 3
-        //uint8_t Unused;                                 // 4
-        int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
-        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
-        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
+        //uint32_t Id;                                              // 0
+        uint8_t Race;                                               // 1
+        uint8_t Class;                                              // 2
+        uint8_t Gender;                                             // 3
+        //uint8_t Unused;                                           // 4
+        int32_t ItemId[OUTFIT_ITEMS];                               // 5-16
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];                      // 17-28
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];                  // 29-40
     };
 
 
     struct ChatChannelsEntry
     {
-        uint32_t id;                      // 0
-        uint32_t flags;                   // 1
-        char* name_pattern[16];         // 3-18
-        //uint32_t name_pattern_flags;    // 19
-        //char* channel_name[16];       // 20-35
-        //uint32_t channel_name_flags;    // 36
+        uint32_t id;                                                // 0
+        uint32_t flags;                                             // 1
+        char* name_pattern[16];                                     // 3-18
+        //uint32_t name_pattern_flags;                              // 19
+        //char* channel_name[16];                                   // 20-35
+        //uint32_t channel_name_flags;                              // 36
     };
 
     struct ChrClassesEntry
     {
-        uint32_t class_id;                // 0
-        //uint32_t unk1;                  // 1
-        //uint32_t unk2;                  // 2
-        uint32_t power_type;              // 3
-        //uint32_t unk3;                  // 4
-        char* name[8];                    // 5-12
-        //uint32_t nameflags;             // 13
-        //uint32_t unk4;                  // 14
-        uint32_t spellfamily;             // 15
-        //uint32_t unk4;                  // 16
+        uint32_t class_id;                                          // 0
+        //uint32_t unk1;                                            // 1
+        //uint32_t unk2;                                            // 2
+        uint32_t power_type;                                        // 3
+        //uint32_t unk3;                                            // 4
+        char* name[8];                                              // 5-12
+        //uint32_t nameflags;                                       // 13
+        //uint32_t unk4;                                            // 14
+        uint32_t spellfamily;                                       // 15
+        //uint32_t unk4;                                            // 16
     };
 
     struct ChrRacesEntry
     {
-        uint32_t race_id;                 // 0
-        //uint32_t flags;                 // 1
-        uint32_t faction_id;              // 2
-        //uint32_t unk1;                  // 3
-        uint32_t model_male;              // 4
-        uint32_t model_female;            // 5
-        // uint32_t unk2;                 // 6
-        // uint32_t unk3;                 // 7
-        uint32_t team_id;                 // 8
-        //uint32_t unk4[4];               // 9-12
-        // uint32_t unk5;                 // 13
-        uint32_t start_taxi_mask;         // 14
-        // uint32_t unk6;                 // 15
-        uint32_t cinematic_id;            // 16 CinematicSequences.dbc
-        char* name[8];                    // 17-24
-        //uint32_t name_flags             // 25
-        //uint32_t unk7[2]                // 26-27
-        //uint32_t unk8;                  // 28
+        uint32_t race_id;                                           // 0
+        //uint32_t flags;                                           // 1
+        uint32_t faction_id;                                        // 2
+        //uint32_t unk1;                                            // 3
+        uint32_t model_male;                                        // 4
+        uint32_t model_female;                                      // 5
+        //uint32_t unk2;                                            // 6
+        //uint32_t unk3;                                            // 7
+        uint32_t team_id;                                           // 8
+        //uint32_t unk4[4];                                         // 9-12
+        //uint32_t unk5;                                            // 13
+        uint32_t start_taxi_mask;                                   // 14
+        //uint32_t unk6;                                            // 15
+        uint32_t cinematic_id;                                      // 16 CinematicSequences.dbc
+        char* name[8];                                              // 17-24
+        //uint32_t name_flags                                       // 25
+        //uint32_t unk7[2]                                          // 26-27
+        //uint32_t unk8;                                            // 28
     };
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t display_id;            // 0
-        //uint32_t model;               // 1
-        //uint32_t unk0                 // 2
-        //uint32_t InfoExtra;           // 3
-        //float size;                   // 4
-                                        // 5 - 15 unk
+        uint32_t display_id;                                        // 0
+        //uint32_t model;                                           // 1
+        //uint32_t unk0                                             // 2
+        //uint32_t InfoExtra;                                       // 3
+        //float size;                                               // 4
+                                                                    // 5 - 15 unk
     };
 
     struct CreatureFamilyEntry
     {
-        uint32_t ID;                      // 0
-        float minsize;                  // 1
-        uint32_t minlevel;                // 2
-        float maxsize;                  // 3
-        uint32_t maxlevel;                // 4
-        uint32_t skilline;                // 5
-        uint32_t tameable;                // 6 second skill line - 270 Generic
-        uint32_t petdietflags;            // 7
-        char* name[16];                 // 8-23
-        //uint32_t nameflags;             // 24
-        //uint32_t iconFile;              // 25
+        uint32_t ID;                                                // 0
+        float minsize;                                              // 1
+        uint32_t minlevel;                                          // 2
+        float maxsize;                                              // 3
+        uint32_t maxlevel;                                          // 4
+        uint32_t skilline;                                          // 5
+        uint32_t tameable;                                          // 6 second skill line - 270 Generic
+        uint32_t petdietflags;                                      // 7
+        char* name[16];                                             // 8-23
+        //uint32_t nameflags;                                       // 24
+        //uint32_t iconFile;                                        // 25
     };
 
     struct CreatureSpellDataEntry
     {
-        uint32_t id;                      // 0
-        uint32_t Spells[3];               // 1-3
-        uint32_t PHSpell;                 // 4
-        uint32_t Cooldowns[3];            // 5-7
-        uint32_t PH;                      // 8
+        uint32_t id;                                                // 0
+        uint32_t Spells[3];                                         // 1-3
+        uint32_t PHSpell;                                           // 4
+        uint32_t Cooldowns[3];                                      // 5-7
+        uint32_t PH;                                                // 8
     };
 
     struct DurabilityCostsEntry
     {
-        uint32_t itemlevel;       // 0
-        uint32_t modifier[29];    // 1-29
+        uint32_t itemlevel;                                         // 0
+        uint32_t modifier[29];                                      // 1-29
     };
 
     struct DurabilityQualityEntry
     {
-        uint32_t id;              // 0
-        float quality_modifier; // 1
+        uint32_t id;                                                // 0
+        float quality_modifier;                                     // 1
     };
 
     struct EmotesTextEntry
     {
-        uint32_t Id;              // 0
-        //uint32_t name;          // 1
-        uint32_t textid;          // 2
-        uint32_t textid2;         // 3
-        uint32_t textid3;         // 4
-        uint32_t textid4;         // 5
-        //uint32_t unk1;          // 6
-        uint32_t textid5;         // 7
-        //uint32_t unk2;          // 8
-        uint32_t textid6;         // 9
-        //uint32_t unk3;          // 10
-        //uint32_t unk4;          // 11
-        //uint32_t unk5;          // 12
-        //uint32_t unk6;          // 13
-        //uint32_t unk7;          // 14
-        //uint32_t unk8;          // 15
-        //uint32_t unk9;          // 16
-        //uint32_t unk10;         // 17
-        //uint32_t unk11;         // 18
+        uint32_t Id;                                                // 0
+        //uint32_t name;                                            // 1
+        uint32_t textid;                                            // 2
+        uint32_t textid2;                                           // 3
+        uint32_t textid3;                                           // 4
+        uint32_t textid4;                                           // 5
+        //uint32_t unk1;                                            // 6
+        uint32_t textid5;                                           // 7
+        //uint32_t unk2;                                            // 8
+        uint32_t textid6;                                           // 9
+        //uint32_t unk3;                                            // 10
+        //uint32_t unk4;                                            // 11
+        //uint32_t unk5;                                            // 12
+        //uint32_t unk6;                                            // 13
+        //uint32_t unk7;                                            // 14
+        //uint32_t unk8;                                            // 15
+        //uint32_t unk9;                                            // 16
+        //uint32_t unk10;                                           // 17
+        //uint32_t unk11;                                           // 18
     };
 
     struct FactionEntry
     {
-        uint32_t ID;                      // 0
-        int32_t RepListId;                // 1
-        uint32_t RaceMask[4];             // 2-5
-        uint32_t ClassMask[4];            // 6-9
-        int32_t baseRepValue[4];          // 10-13
-        uint32_t repFlags[4];             // 14-17
-        uint32_t parentFaction;           // 18
-        char* Name[16];                 // 19-34
-        //uint32_t name_flags;            // 35
-        //uint32_t Description[16];       // 36-51
-        //uint32_t description_flags;     // 52
+        uint32_t ID;                                                // 0
+        int32_t RepListId;                                          // 1
+        uint32_t RaceMask[4];                                       // 2-5
+        uint32_t ClassMask[4];                                      // 6-9
+        int32_t baseRepValue[4];                                    // 10-13
+        uint32_t repFlags[4];                                       // 14-17
+        uint32_t parentFaction;                                     // 18
+        char* Name[16];                                             // 19-34
+        //uint32_t name_flags;                                      // 35
+        //uint32_t Description[16];                                 // 36-51
+        //uint32_t description_flags;                               // 52
     };
 
     struct FactionTemplateEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t Faction;                 // 1
-        uint32_t FactionGroup;            // 2
-        uint32_t Mask;                    // 3
-        uint32_t FriendlyMask;            // 4
-        uint32_t HostileMask;             // 5
-        uint32_t EnemyFactions[4];        // 6-9
-        uint32_t FriendlyFactions[4];     // 10-13
+        uint32_t ID;                                                // 0
+        uint32_t Faction;                                           // 1
+        uint32_t FactionGroup;                                      // 2
+        uint32_t Mask;                                              // 3
+        uint32_t FriendlyMask;                                      // 4
+        uint32_t HostileMask;                                       // 5
+        uint32_t EnemyFactions[4];                                  // 6-9
+        uint32_t FriendlyFactions[4];                               // 10-13
     };
 
     struct GameObjectDisplayInfoEntry
     {
-        uint32_t Displayid;               // 0
-        char* filename;                 // 1
-        //uint32_t  unk1[10];             // 2-11
-        float minX;                     // 12
-        float minY;                     // 13
-        float minZ;                     // 14
-        float maxX;                     // 15
-        float maxY;                     // 16
-        float maxZ;                     // 17
+        uint32_t Displayid;                                         // 0
+        char* filename;                                             // 1
+        //uint32_t unk1[10];                                        // 2-11
+        float minX;                                                 // 12
+        float minY;                                                 // 13
+        float minZ;                                                 // 14
+        float maxX;                                                 // 15
+        float maxY;                                                 // 16
+        float maxZ;                                                 // 17
     };
 
     struct GemPropertiesEntry
     {
-        uint32_t Entry;                   // 0
-        uint32_t EnchantmentID;           // 1
-        //uint32_t unk1;                  // 2 bool
-        //uint32_t unk2;                  // 3 bool
-        uint32_t SocketMask;              // 4
+        uint32_t Entry;                                             // 0
+        uint32_t EnchantmentID;                                     // 1
+        //uint32_t unk1;                                            // 2 bool
+        //uint32_t unk2;                                            // 3 bool
+        uint32_t SocketMask;                                        // 4
     };
 
     struct GtChanceToMeleeCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToMeleeCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtCombatRatingsEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtOCTRegenHPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtOCTRegenMPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtRegenHPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
     struct GtRegenMPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
     struct ItemEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t DisplayId;               // 1
-        uint32_t InventoryType;           // 2
-        uint32_t Sheath;                  // 3
+        uint32_t ID;                                                // 0
+        uint32_t DisplayId;                                         // 1
+        uint32_t InventoryType;                                     // 2
+        uint32_t Sheath;                                            // 3
     };
 
     struct ItemExtendedCostEntry
     {
-        uint32_t costid;                  // 0
-        uint32_t honor_points;            // 1
-        uint32_t arena_points;            // 2
-        uint32_t item[5];                 // 4-8
-        uint32_t count[5];                // 9-13
-        uint32_t personalrating;          // 14
+        uint32_t costid;                                            // 0
+        uint32_t honor_points;                                      // 1
+        uint32_t arena_points;                                      // 2
+        uint32_t item[5];                                           // 4-8
+        uint32_t count[5];                                          // 9-13
+        uint32_t personalrating;                                    // 14
     };
 
     struct ItemRandomPropertiesEntry
     {
-        uint32_t ID;                      // 0
-        //uint32_t name1;                 // 1
-        uint32_t spells[3];               // 2-4
-        //uint32_t unk1;                  // 5
-        //uint32_t unk2;                  // 6
-        char* name_suffix[16];          // 7-22
-        //uint32_t name_suffix_flags;     // 23
+        uint32_t ID;                                                // 0
+        //uint32_t name1;                                           // 1
+        uint32_t spells[3];                                         // 2-4
+        //uint32_t unk1;                                            // 5
+        //uint32_t unk2;                                            // 6
+        char* name_suffix[16];                                      // 7-22
+        //uint32_t name_suffix_flags;                               // 23
     };
 
     struct ItemRandomSuffixEntry
     {
-        uint32_t id;                      // 0
-        char* name_suffix[16];          // 1-16
-        //uint32_t name_suffix_flags;     // 17
-        //uint32_t unk1;                  // 18
-        uint32_t enchantments[3];         // 19-21
-        //uint32_t unk2[2];               // 22-23
-        uint32_t prefixes[3];             // 24-26
-        //uint32_t[2];                    // 27-28
+        uint32_t id;                                                // 0
+        char* name_suffix[16];                                      // 1-16
+        //uint32_t name_suffix_flags;                               // 17
+        //uint32_t unk1;                                            // 18
+        uint32_t enchantments[3];                                   // 19-21
+        //uint32_t unk2[2];                                         // 22-23
+        uint32_t prefixes[3];                                       // 24-26
+        //uint32_t[2];                                              // 27-28
     };
 
     struct ItemSetEntry
     {
-        uint32_t id;                      // 1
-        char* name[16];                 // 1-16 name (lang)
-        //uint32_t localeflag;            // 17 constant
-        uint32_t itemid[10];              // 18-27 item set items
-        //uint32_t unk[7];                // 28-34 all 0
-        uint32_t SpellID[8];              // 35-42
-        uint32_t itemscount[8];           // 43-50
-        uint32_t RequiredSkillID;         // 51
-        uint32_t RequiredSkillAmt;        // 52
+        uint32_t id;                                                // 1
+        char* name[16];                                             // 1-16 name (lang)
+        //uint32_t localeflag;                                      // 17 constant
+        uint32_t itemid[10];                                        // 18-27 item set items
+        //uint32_t unk[7];                                          // 28-34 all 0
+        uint32_t SpellID[8];                                        // 35-42
+        uint32_t itemscount[8];                                     // 43-50
+        uint32_t RequiredSkillID;                                   // 51
+        uint32_t RequiredSkillAmt;                                  // 52
     };
 
     struct LFGDungeonEntry
     {
-        uint32_t ID;              // 0
-        char* name[16];         // 1-17 Name lang
-        uint32_t minlevel;        // 18
-        uint32_t maxlevel;        // 19
-        uint32_t reclevel;        // 20
-        uint32_t recminlevel;     // 21
-        uint32_t recmaxlevel;     // 22
-        int32_t map;              // 23
-        uint32_t difficulty;      // 24
-        uint32_t flags;           // 25
-        uint32_t type;            // 26
-        //uint32_t  unk;          // 27
-        //char* iconname;       // 28
-        uint32_t expansion;       // 29
-        //uint32_t unk4;          // 30
-        uint32_t grouptype;       // 31
-        //char* desc[16];       // 32-47 Description
+        uint32_t ID;                                                // 0
+        char* name[16];                                             // 1-17 Name lang
+        uint32_t minlevel;                                          // 18
+        uint32_t maxlevel;                                          // 19
+        uint32_t reclevel;                                          // 20
+        uint32_t recminlevel;                                       // 21
+        uint32_t recmaxlevel;                                       // 22
+        int32_t map;                                                // 23
+        uint32_t difficulty;                                        // 24
+        uint32_t flags;                                             // 25
+        uint32_t type;                                              // 26
+        //uint32_t  unk;                                            // 27
+        //char* iconname;                                           // 28
+        uint32_t expansion;                                         // 29
+        //uint32_t unk4;                                            // 30
+        uint32_t grouptype;                                         // 31
+        //char* desc[16];                                           // 32-47 Description
 
         // Helpers
         uint32_t Entry() const { return ID + (type << 24); }
@@ -473,56 +473,56 @@ namespace DBC::Structures
 
     struct LiquidTypeEntry
     {
-        uint32_t Id;                  // 0
-        uint32_t liquid_id;           // 1
-        uint32_t Type;                // 2
-        uint32_t SpellId;             // 3
+        uint32_t Id;                                                // 0
+        uint32_t liquid_id;                                         // 1
+        uint32_t Type;                                              // 2
+        uint32_t SpellId;                                           // 3
     };
 
 #define LOCK_NUM_CASES 8
 
     struct LockEntry
     {
-        uint32_t Id;                              // 0
-        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+        uint32_t Id;                                                // 0
+        uint32_t locktype[LOCK_NUM_CASES];                          // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];                          // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];                      // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];                          // 25-32 Something to do with direction / opening / closing.
     };
 
     struct MailTemplateEntry
     {
-        uint32_t ID;              // 0
-        char* subject;          // 1
-        //float unused1[15]     // 2-16
-        //uint32_t flags1         // 17 name flags, unused
-        char* content;          // 18
-        //float unused2[15]     // 19-34
-        //uint32_t flags2         // 35 name flags, unused
+        uint32_t ID;                                                // 0
+        char* subject;                                              // 1
+        //float unused1[15]                                         // 2-16
+        //uint32_t flags1                                           // 17 name flags, unused
+        char* content;                                              // 18
+        //float unused2[15]                                         // 19-34
+        //uint32_t flags2                                           // 35 name flags, unused
     };
 
     struct MapEntry
     {
-        uint32_t id;                      // 0
-        //char* name_internal;          // 1
-        uint32_t map_type;                // 2
-        //uint32_t is_pvp_zone;           // 3 -0 false -1 true
-        char* map_name[16];             // 4-19
-        //uint32_t name_flags;            // 20
-        uint32_t linked_zone;             // 22 common zone for instance and continent map
-        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-        //uint32_t hordeIntro_flags;      // 39
-        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-        //uint32_t allianceIntro_flags;   // 56
-        uint32_t multimap_id;             // 57
-        //uint32_t battlefield_map_icon;  // 58
-        int32_t parent_map;               // 59 map_id of parent map
-        float start_x;                  // 60 enter x coordinate (if exist single entry)
-        float start_y;                  // 61 enter y coordinate (if exist single entry)
-        //uint32_t dayTime;               // 62 
+        uint32_t id;                                                // 0
+        //char* name_internal;                                      // 1
+        uint32_t map_type;                                          // 2
+        //uint32_t is_pvp_zone;                                     // 3 -0 false -1 true
+        char* map_name[16];                                         // 4-19
+        //uint32_t name_flags;                                      // 20
+        uint32_t linked_zone;                                       // 22 common zone for instance and continent map
+        //char* horde_intro[16];                                    // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;                                // 39
+        //char* alliance_intro[16];                                 // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;                             // 56
+        uint32_t multimap_id;                                       // 57
+        //uint32_t battlefield_map_icon;                            // 58
+        int32_t parent_map;                                         // 59 map_id of parent map
+        float start_x;                                              // 60 enter x coordinate (if exist single entry)
+        float start_y;                                              // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;                                         // 62 
         uint32_t reset_raid_time;
         uint32_t reset_heroic_tim;
-        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t addon;                                             // 63 0-original maps, 1-tbc addon, 2-wotlk addon
 
         bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
         bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
@@ -540,63 +540,63 @@ namespace DBC::Structures
 
     struct NameGenEntry
     {
-        uint32_t ID;              // 0
-        char* Name;             // 1
-        uint32_t unk1;            // 2
-        uint32_t type;            // 3
+        uint32_t ID;                                                // 0
+        char* Name;                                                 // 1
+        uint32_t unk1;                                              // 2
+        uint32_t type;                                              // 3
     };
 
     struct SkillLineEntry
     {
-        uint32_t id;                  // 0
-        uint32_t type;                // 1
-        //uint32_t skillCostsID;      // 2
-        char* Name[16];             // 3-18
-        //uint32_t NameFlags;         // 19
-        //char* Description[16];    // 20-35
-        //uint32_t DescriptionFlags;  // 36
-        uint32_t spell_icon;          // 37
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1
+        //uint32_t skillCostsID;                                    // 2
+        char* Name[16];                                             // 3-18
+        //uint32_t NameFlags;                                       // 19
+        //char* Description[16];                                    // 20-35
+        //uint32_t DescriptionFlags;                                // 36
+        uint32_t spell_icon;                                        // 37
     };
 
     struct SkillLineAbilityEntry
     {
-        uint32_t Id;                      // 0
-        uint32_t skilline;                // 1 skill id
-        uint32_t spell;                   // 2
-        uint32_t race_mask;               // 3
-        uint32_t class_mask;              // 4
-        //uint32_t excludeRace;           // 5
-        //uint32_t excludeClass;          // 6
-        uint32_t minSkillLineRank;        // 7 req skill value
-        uint32_t next;                    // 8
-        uint32_t acquireMethod;           // 9 auto learn
-        uint32_t grey;                    // 10 max
-        uint32_t green;                   // 11 min
-        //uint32_t abandonable;           // 12
-        //uint32_t reqTP;                 // 13
-        uint32_t reqtrainpoints;          // 14
+        uint32_t Id;                                                // 0
+        uint32_t skilline;                                          // 1 skill id
+        uint32_t spell;                                             // 2
+        uint32_t race_mask;                                         // 3
+        uint32_t class_mask;                                        // 4
+        //uint32_t excludeRace;                                     // 5
+        //uint32_t excludeClass;                                    // 6
+        uint32_t minSkillLineRank;                                  // 7 req skill value
+        uint32_t next;                                              // 8
+        uint32_t acquireMethod;                                     // 9 auto learn
+        uint32_t grey;                                              // 10 max
+        uint32_t green;                                             // 11 min
+        //uint32_t abandonable;                                     // 12
+        //uint32_t reqTP;                                           // 13
+        uint32_t reqtrainpoints;                                    // 14
     };
 
     struct StableSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct SpellCastTimesEntry
     {
-        uint32_t ID;              // 0
-        uint32_t CastTime;        // 1
-        //uint32_t unk1;          // 2
-        //uint32_t unk2;          // 3
+        uint32_t ID;                                                // 0
+        uint32_t CastTime;                                          // 1
+        //uint32_t unk1;                                            // 2
+        //uint32_t unk2;                                            // 3
     };
 
     struct SpellDurationEntry
     {
-        uint32_t ID;              // 0
-        uint32_t Duration1;       // 1
-        uint32_t Duration2;       // 2
-        uint32_t Duration3;       // 3
+        uint32_t ID;                                                // 0
+        uint32_t Duration1;                                         // 1
+        uint32_t Duration2;                                         // 2
+        uint32_t Duration3;                                         // 3
     };
 
     #define MAX_SPELL_EFFECTS 3
@@ -700,243 +700,243 @@ namespace DBC::Structures
 
     struct SpellItemEnchantmentEntry
     {
-        uint32_t Id;                  // 0
-        uint32_t type[3];             // 1-3
-        uint32_t min[3];              // 4-6 for combat, in practice min==max
-        uint32_t max[3];              // 7-9
-        uint32_t spell[3];            // 10-12
-        char* Name[16];               // 13-28
-        //uint32_t NameFlags;         // 29
-        uint32_t visual;              // 30 aura
-        uint32_t EnchantGroups;       // 31 slot
-        uint32_t GemEntry;            // 32
-        uint32_t ench_condition;      // 33
+        uint32_t Id;                                                // 0
+        uint32_t type[3];                                           // 1-3
+        uint32_t min[3];                                            // 4-6 for combat, in practice min==max
+        uint32_t max[3];                                            // 7-9
+        uint32_t spell[3];                                          // 10-12
+        char* Name[16];                                             // 13-28
+        //uint32_t NameFlags;                                       // 29
+        uint32_t visual;                                            // 30 aura
+        uint32_t EnchantGroups;                                     // 31 slot
+        uint32_t GemEntry;                                          // 32
+        uint32_t ench_condition;                                    // 33
     };
 
     struct SpellRadiusEntry
     {
-        uint32_t ID;                  // 0
-        float radius_min;           // 1 Radius
-        float radius_per_level;     // 2
-        float radius_max;           // 3 Radius2
+        uint32_t ID;                                                // 0
+        float radius_min;                                           // 1 Radius
+        float radius_per_level;                                     // 2
+        float radius_max;                                           // 3 Radius2
     };
 
     struct SpellRangeEntry
     {
-        uint32_t ID;                  // 0
-        float minRange;             // 1
-        float maxRange;             // 3
-        uint32_t range_type;          // 4
-        //char* name1[16]           // 6-21
-        //uint32_t name1_falgs;       // 22
-        //char* name2[16]           // 23-38
-        //uint32_t name2_falgs;       // 39
+        uint32_t ID;                                                // 0
+        float minRange;                                             // 1
+        float maxRange;                                             // 3
+        uint32_t range_type;                                        // 4
+        //char* name1[16]                                           // 6-21
+        //uint32_t name1_falgs;                                     // 22
+        //char* name2[16]                                           // 23-38
+        //uint32_t name2_falgs;                                     // 39
     };
 
     struct SpellShapeshiftFormEntry
     {
-        uint32_t id;                  // 0
-        //uint32_t button_pos;        // 1
-        //char* name[16];           // 2-17
-        //uint32_t name_flags;        // 18
-        uint32_t Flags;               // 19
-        uint32_t unit_type;           // 20
-        //uint32_t unk1               // 21
-        uint32_t AttackSpeed;         // 22
-        uint32_t modelId;             // 23 alliance?
-        uint32_t modelId2;            // 24 horde?
-        //uint32_t unk2               // 25
-        //uint32_t unk3               // 26
-        uint32_t spells[8];           // 27-34
+        uint32_t id;                                                // 0
+        //uint32_t button_pos;                                      // 1
+        //char* name[16];                                           // 2-17
+        //uint32_t name_flags;                                      // 18
+        uint32_t Flags;                                             // 19
+        uint32_t unit_type;                                         // 20
+        //uint32_t unk1                                             // 21
+        uint32_t AttackSpeed;                                       // 22
+        uint32_t modelId;                                           // 23 alliance?
+        uint32_t modelId2;                                          // 24 horde?
+        //uint32_t unk2                                             // 25
+        //uint32_t unk3                                             // 26
+        uint32_t spells[8];                                         // 27-34
     };
 
     struct SummonPropertiesEntry
     {
-        uint32_t ID;                  // 0
-        uint32_t ControlType;         // 1
-        uint32_t FactionID;           // 2
-        uint32_t Type;                // 3
-        uint32_t Slot;                // 4
-        uint32_t Flags;               // 5
+        uint32_t ID;                                                // 0
+        uint32_t ControlType;                                       // 1
+        uint32_t FactionID;                                         // 2
+        uint32_t Type;                                              // 3
+        uint32_t Slot;                                              // 4
+        uint32_t Flags;                                             // 5
     };
 
     struct TalentEntry
     {
-        uint32_t TalentID;            // 0
-        uint32_t TalentTree;          // 1
-        uint32_t Row;                 // 2
-        uint32_t Col;                 // 3
-        uint32_t RankID[5];           // 4-8
-        //uint32_t unk[4];            // 9-12
-        uint32_t DependsOn;           // 13
-        //uint32_t unk1[2];           // 14-15
-        uint32_t DependsOnRank;       // 16
-        //uint32_t unk2[2];           // 17-18
-        //uint32_t unk3;              // 19
-        uint32_t DependsOnSpell;      // 20
+        uint32_t TalentID;                                          // 0
+        uint32_t TalentTree;                                        // 1
+        uint32_t Row;                                               // 2
+        uint32_t Col;                                               // 3
+        uint32_t RankID[5];                                         // 4-8
+        //uint32_t unk[4];                                          // 9-12
+        uint32_t DependsOn;                                         // 13
+        //uint32_t unk1[2];                                         // 14-15
+        uint32_t DependsOnRank;                                     // 16
+        //uint32_t unk2[2];                                         // 17-18
+        //uint32_t unk3;                                            // 19
+        uint32_t DependsOnSpell;                                    // 20
     };
 
     struct TalentTabEntry
     {
-        uint32_t TalentTabID;         // 0
-        //char* Name[16];           // 1-16
-        //uint32_t name_flags;        // 17
-        //uint32_t unk4;              // 18
-        //uint32_t unk5;              // 19
-        uint32_t ClassMask;           // 20
-        uint32_t TabPage;             // 21
-        //char* InternalName;       // 22
+        uint32_t TalentTabID;                                       // 0
+        //char* Name[16];                                           // 1-16
+        //uint32_t name_flags;                                      // 17
+        //uint32_t unk4;                                            // 18
+        //uint32_t unk5;                                            // 19
+        uint32_t ClassMask;                                         // 20
+        uint32_t TabPage;                                           // 21
+        //char* InternalName;                                       // 22
     };
 
     struct TaxiNodesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t mapid;               // 1
-        float x;                    // 2
-        float y;                    // 3
-        float z;                    // 4
-        char* name[16];             // 5-21
-        //uint32_t nameflags;         // 22
-        uint32_t horde_mount;         // 23
-        uint32_t alliance_mount;      // 24
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        char* name[16];                                             // 5-21
+        //uint32_t nameflags;                                       // 22
+        uint32_t horde_mount;                                       // 23
+        uint32_t alliance_mount;                                    // 24
     };
 
     struct TaxiPathEntry
     {
-        uint32_t id;                  // 0
-        uint32_t from;                // 1
-        uint32_t to;                  // 2
-        uint32_t price;               // 3
+        uint32_t id;                                                // 0
+        uint32_t from;                                              // 1
+        uint32_t to;                                                // 2
+        uint32_t price;                                             // 3
     };
 
     struct TaxiPathNodeEntry
     {
-        uint32_t id;                  // 0
-        uint32_t path;                // 1
-        uint32_t seq;                 // 2 nodeIndex
-        uint32_t mapid;               // 3
-        float x;                      // 4
-        float y;                      // 5
-        float z;                      // 6
-        uint32_t flags;               // 7
-        uint32_t waittime;            // 8
-        uint32_t arivalEventID;       // 9
-        uint32_t departureEventID;    // 10
+        uint32_t id;                                                // 0
+        uint32_t path;                                              // 1
+        uint32_t seq;                                               // 2 nodeIndex
+        uint32_t mapid;                                             // 3
+        float x;                                                    // 4
+        float y;                                                    // 5
+        float z;                                                    // 6
+        uint32_t flags;                                             // 7
+        uint32_t waittime;                                          // 8
+        uint32_t arivalEventID;                                     // 9
+        uint32_t departureEventID;                                  // 10
     };
 
     struct TransportAnimationEntry
     {
-        //uint32_t Id;          // 0
-        uint32_t TransportID;   // 1
-        uint32_t TimeIndex;     // 2
-        DBCPosition3D Pos;      // 3
-        //uint32_t SequenceID;  // 4
+        //uint32_t Id;                                              // 0
+        uint32_t TransportID;                                       // 1
+        uint32_t TimeIndex;                                         // 2
+        DBCPosition3D Pos;                                          // 3
+        //uint32_t SequenceID;                                      // 4
     };
 
     #define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        float turnSpeed;                                    // 2
-        float pitchSpeed;                                   // 3
-        float pitchMin;                                     // 4
-        float pitchMax;                                     // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-        float mouseLookOffsetPitch;                         // 14
-        float cameraFadeDistScalarMin;                      // 15
-        float cameraFadeDistScalarMax;                      // 16
-        float cameraPitchOffset;                            // 17
-        float facingLimitRight;                             // 18
-        float facingLimitLeft;                              // 19
-        float msslTrgtTurnLingering;                        // 20
-        float msslTrgtPitchLingering;                       // 21
-        float msslTrgtMouseLingering;                       // 22
-        float msslTrgtEndOpacity;                           // 23
-        float msslTrgtArcSpeed;                             // 24
-        float msslTrgtArcRepeat;                            // 25
-        float msslTrgtArcWidth;                             // 26
-        float msslTrgtImpactRadius[2];                      // 27-28
-        char* msslTrgtArcTexture;                           // 29
-        char* msslTrgtImpactTexture;                        // 30
-        char* msslTrgtImpactModel[2];                       // 31-32
-        float cameraYawOffset;                              // 33
-        uint32_t uiLocomotionType;                            // 34
-        float msslTrgtImpactTexRadius;                      // 35
-        uint32_t uiSeatIndicatorType;                         // 36
-        uint32_t powerType;                                   // 37, new in 3.1
-        //uint32_t unk1;                                      // 38
-        //uint32_t unk2;                                      // 39  
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        float turnSpeed;                                            // 2
+        float pitchSpeed;                                           // 3
+        float pitchMin;                                             // 4
+        float pitchMax;                                             // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
+        float mouseLookOffsetPitch;                                 // 14
+        float cameraFadeDistScalarMin;                              // 15
+        float cameraFadeDistScalarMax;                              // 16
+        float cameraPitchOffset;                                    // 17
+        float facingLimitRight;                                     // 18
+        float facingLimitLeft;                                      // 19
+        float msslTrgtTurnLingering;                                // 20
+        float msslTrgtPitchLingering;                               // 21
+        float msslTrgtMouseLingering;                               // 22
+        float msslTrgtEndOpacity;                                   // 23
+        float msslTrgtArcSpeed;                                     // 24
+        float msslTrgtArcRepeat;                                    // 25
+        float msslTrgtArcWidth;                                     // 26
+        float msslTrgtImpactRadius[2];                              // 27-28
+        char* msslTrgtArcTexture;                                   // 29
+        char* msslTrgtImpactTexture;                                // 30
+        char* msslTrgtImpactModel[2];                               // 31-32
+        float cameraYawOffset;                                      // 33
+        uint32_t uiLocomotionType;                                  // 34
+        float msslTrgtImpactTexRadius;                              // 35
+        uint32_t uiSeatIndicatorType;                               // 36
+        uint32_t powerType;                                         // 37, new in 3.1
+        //uint32_t unk1;                                            // 38
+        //uint32_t unk2;                                            // 39
     };
 
     enum VehicleSeatFlags
     {
-        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,  // Passenger is hidden
         VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,  // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,  // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,  // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,  // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,  // Lua_UnitHasVehicleUI
     };
 
     enum VehicleSeatFlagsB
     {
         VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002,
         VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
         VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
     };
 
     struct VehicleSeatEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        int32_t attachmentID;                                 // 2
-        float attachmentOffsetX;                            // 3
-        float attachmentOffsetY;                            // 4
-        float attachmentOffsetZ;                            // 5
-        float enterPreDelay;                                // 6
-        float enterSpeed;                                   // 7
-        float enterGravity;                                 // 8
-        float enterMinDuration;                             // 9
-        float enterMaxDuration;                             // 10
-        float enterMinArcHeight;                            // 11
-        float enterMaxArcHeight;                            // 12
-        int32_t enterAnimStart;                               // 13
-        int32_t enterAnimLoop;                                // 14
-        int32_t rideAnimStart;                                // 15
-        int32_t rideAnimLoop;                                 // 16
-        int32_t rideUpperAnimStart;                           // 17
-        int32_t rideUpperAnimLoop;                            // 18
-        float exitPreDelay;                                 // 19
-        float exitSpeed;                                    // 20
-        float exitGravity;                                  // 21
-        float exitMinDuration;                              // 22
-        float exitMaxDuration;                              // 23
-        float exitMinArcHeight;                             // 24
-        float exitMaxArcHeight;                             // 25
-        int32_t exitAnimStart;                                // 26
-        int32_t exitAnimLoop;                                 // 27
-        int32_t exitAnimEnd;                                  // 28
-        float passengerYaw;                                 // 29
-        float passengerPitch;                               // 30
-        float passengerRoll;                                // 31
-        int32_t passengerAttachmentID;                        // 32
-        int32_t vehicleEnterAnim;                             // 33
-        int32_t vehicleExitAnim;                              // 34
-        int32_t vehicleRideAnimLoop;                          // 35
-        int32_t vehicleEnterAnimBone;                         // 36
-        int32_t vehicleExitAnimBone;                          // 37
-        int32_t vehicleRideAnimLoopBone;                      // 38
-        float vehicleEnterAnimDelay;                        // 39
-        float vehicleExitAnimDelay;                         // 40
-        uint32_t vehicleAbilityDisplay;                       // 41
-        uint32_t enterUISoundID;                              // 42
-        uint32_t exitUISoundID;                               // 43
-        int32_t uiSkin;                                       // 44
-        uint32_t flagsB;                                      // 45
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        int32_t attachmentID;                                       // 2
+        float attachmentOffsetX;                                    // 3
+        float attachmentOffsetY;                                    // 4
+        float attachmentOffsetZ;                                    // 5
+        float enterPreDelay;                                        // 6
+        float enterSpeed;                                           // 7
+        float enterGravity;                                         // 8
+        float enterMinDuration;                                     // 9
+        float enterMaxDuration;                                     // 10
+        float enterMinArcHeight;                                    // 11
+        float enterMaxArcHeight;                                    // 12
+        int32_t enterAnimStart;                                     // 13
+        int32_t enterAnimLoop;                                      // 14
+        int32_t rideAnimStart;                                      // 15
+        int32_t rideAnimLoop;                                       // 16
+        int32_t rideUpperAnimStart;                                 // 17
+        int32_t rideUpperAnimLoop;                                  // 18
+        float exitPreDelay;                                         // 19
+        float exitSpeed;                                            // 20
+        float exitGravity;                                          // 21
+        float exitMinDuration;                                      // 22
+        float exitMaxDuration;                                      // 23
+        float exitMinArcHeight;                                     // 24
+        float exitMaxArcHeight;                                     // 25
+        int32_t exitAnimStart;                                      // 26
+        int32_t exitAnimLoop;                                       // 27
+        int32_t exitAnimEnd;                                        // 28
+        float passengerYaw;                                         // 29
+        float passengerPitch;                                       // 30
+        float passengerRoll;                                        // 31
+        int32_t passengerAttachmentID;                              // 32
+        int32_t vehicleEnterAnim;                                   // 33
+        int32_t vehicleExitAnim;                                    // 34
+        int32_t vehicleRideAnimLoop;                                // 35
+        int32_t vehicleEnterAnimBone;                               // 36
+        int32_t vehicleExitAnimBone;                                // 37
+        int32_t vehicleRideAnimLoopBone;                            // 38
+        float vehicleEnterAnimDelay;                                // 39
+        float vehicleExitAnimDelay;                                 // 40
+        uint32_t vehicleAbilityDisplay;                             // 41
+        uint32_t enterUISoundID;                                    // 42
+        uint32_t exitUISoundID;                                     // 43
+        int32_t uiSkin;                                             // 44
+        uint32_t flagsB;                                            // 45
 
         bool IsUsable() const
         {
@@ -965,33 +965,32 @@ namespace DBC::Structures
 
     struct WMOAreaTableEntry
     {
-        uint32_t id;              // 0
-        int32_t rootId;           // 1
-        int32_t adtId;            // 2
-        int32_t groupId;          // 3
-        //uint32_t field4;        // 4
-        //uint32_t field5;        // 5
-        //uint32_t field6;        // 6
-        //uint32_t field7;        // 7
-        //uint32_t field8;        // 8
-        uint32_t flags;           // 9
-        uint32_t areaId;          // 10  ref -> AreaTableEntry
-        //char Name[16];        // 11-26
-        //uint32_t nameflags;     // 27
+        uint32_t id;                                                // 0
+        int32_t rootId;                                             // 1
+        int32_t adtId;                                              // 2
+        int32_t groupId;                                            // 3
+        //uint32_t field4;                                          // 4
+        //uint32_t field5;                                          // 5
+        //uint32_t field6;                                          // 6
+        //uint32_t field7;                                          // 7
+        //uint32_t field8;                                          // 8
+        uint32_t flags;                                             // 9
+        uint32_t areaId;                                            // 10 ref -> AreaTableEntry
+        //char Name[16];                                            // 11-26
+        //uint32_t nameflags;                                       // 27
     };
 
     struct WorldMapOverlayEntry
     {
-        uint32_t ID;              // 0
-        //uint32_t worldMapID;    // 1
-        uint32_t areaID;          // 2 - index to AreaTable
-        uint32_t areaID_2;        // 3 - index to AreaTable
-        uint32_t areaID_3;        // 4 - index to AreaTable
-        uint32_t areaID_4;        // 5 - index to AreaTable
-        //uint32_t unk1[2];       // 6-7
-        //uint32_t unk2;          // 8
-        //uint32_t unk3[7];       // 9-16
+        uint32_t ID;                                                // 0
+        //uint32_t worldMapID;                                      // 1
+        uint32_t areaID;                                            // 2 - index to AreaTable
+        uint32_t areaID_2;                                          // 3 - index to AreaTable
+        uint32_t areaID_3;                                          // 4 - index to AreaTable
+        uint32_t areaID_4;                                          // 5 - index to AreaTable
+        //uint32_t unk1[2];                                         // 6-7
+        //uint32_t unk2;                                            // 8
+        //uint32_t unk3[7];                                         // 9-16
     };
-
     #pragma pack(pop)
 }

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -175,7 +175,7 @@ namespace DBC::Structures
         char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
         char const area_group_format[] = "niiiiiii";
         char const area_table_entry_format[] = "iiinixxxxxxxisiiiiiffixxxxxxxx";
-        char const area_trigger_entry_format[] = "nifffxxxfffff";
+        char const area_trigger_entry_format[] = "nifffxxxfffffxxx";
         //char const armor_location_format[] = "nfffff"; new
         char const auction_house_format[] = "niiix";
         char const bank_bag_slot_prices_format[] = "ni";
@@ -255,7 +255,7 @@ namespace DBC::Structures
         char const quest_xp_format[] = "niiiiiiiiii";
         //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
         char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
-        char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxx";
         char const skill_line_format[] = "nisxixixx";
         char const skill_line_ability_format[] = "niiiixxiiiiiix";
         //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
@@ -785,11 +785,14 @@ namespace DBC::Structures
         //uint32_t                                                  // 5
         //uint32_t                                                  // 6
         //uint32_t                                                  // 7
-        float o;                                                    // 5 radius
-        float box_x;                                                // 6 extent x edge
-        float box_y;                                                // 7 extent y edge
-        float box_z;                                                // 8 extent z edge
-        float box_o;                                                // 9
+        float box_radius;                                           // 8 radius
+        float box_x;                                                // 9 extent x edge
+        float box_y;                                                // 10 extent y edge
+        float box_z;                                                // 11 extent z edge
+        float box_o;                                                // 12 extent o edge
+        //uint32_t unk13;                                           // 13 Pandaria
+        //uint32_t unk14;                                           // 14 Pandaria
+        //uint32_t unk15;                                           // 15 Pandaria
     };
 
     //\todo danko
@@ -1272,14 +1275,14 @@ namespace DBC::Structures
 
     struct DungeonEncounterEntry
     {
-        uint32 id;                                                  // 0 unique id
-        uint32 mapId;                                               // 1 map id
-        uint32 difficulty;                                          // 2 instance mode
-        //uint32 unk0;                                              // 3
-        uint32 encounterIndex;                                      // 4 encounter index for creating completed mask
+        uint32_t id;                                                // 0 unique id
+        uint32_t mapId;                                             // 1 map id
+        uint32_t difficulty;                                        // 2 instance mode
+        //uint32_t unk0;                                            // 3
+        uint32_t encounterIndex;                                    // 4 encounter index for creating completed mask
         char* encounterName;                                        // 5 encounter name
-        //uint32 nameFlags;                                         // 21
-        //uint32 u
+        //uint32_t nameFlags;                                       // 21
+        //uint32_t u
     };
 
     struct LiquidTypeEntry
@@ -1416,20 +1419,21 @@ namespace DBC::Structures
         //uint32_t amor_mod2[4];                                    // 18-21
         //uint32_t junk[24];                                        // 22-45
         //uint32_t unk2;                                            // 46
+        //uint32_t unk;                                             // 47 Pandaria
     };
 
     struct SkillLineEntry
     {
         uint32_t id;                                                // 0
         uint32_t type;                                              // 1
-        //uint32 unk2                                               // 2
+        //uint32_t unk2                                             // 2
         char* Name;                                                 // 3
         //char* Description;                                        // 4
         uint32_t spell_icon;                                        // 5
         //char* add_name;                                           // 6
         uint32_t linkable;                                          // 7
-        //uint32 unk8                                               // 8 Pandaria
-        //uint32 unk9                                               // 9 Pandaria
+        //uint32_t unk8                                             // 8 Pandaria
+        //uint32_t unk9                                             // 9 Pandaria
     };
 
     struct SkillLineAbilityEntry
@@ -1957,10 +1961,10 @@ namespace DBC::Structures
         char* name;                                                 // 5
         uint32_t horde_mount;                                       // [6-7]
         uint32_t alliance_mount;                                    //
-        //uint32 unk1                                               // 8 Pandaria
+        //uint32_t unk1                                             // 8 Pandaria
         uint32_t nameflags;                                         // 9
-        //uint32 unk1                                               // 10 4.0.0
-        //uint32 unk1                                               // 11 4.0.0
+        //uint32_t unk1                                             // 10 4.0.0
+        //uint32_t unk1                                             // 11 4.0.0
     };
 
     struct TaxiPathEntry

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -197,7 +197,7 @@ namespace DBC::Structures
         //char const creature_type_format[]="nxx"; new
         char const currency_types_format[] = "nixxxiiiiixx";
         //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
-        char const dungeon_encounter_format[] = "niixisxx";
+        char const dungeon_encounter_format[] = "niixisxxx";
         char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
         char const durability_quality_format[] = "nf";
         char const emotes_entry_format[] = "nxxiiixx";
@@ -1281,8 +1281,9 @@ namespace DBC::Structures
         //uint32_t unk0;                                            // 3
         uint32_t encounterIndex;                                    // 4 encounter index for creating completed mask
         char* encounterName;                                        // 5 encounter name
-        //uint32_t nameFlags;                                       // 21
-        //uint32_t u
+        //uint32_t nameFlags;                                       // 6
+        //uint32_t unk7;                                            // 7
+        //uint32_t unk8;                                            // 8 Pandaria
     };
 
     struct LiquidTypeEntry

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -256,7 +256,7 @@ namespace DBC::Structures
         //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
         char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
         char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
-        char const skill_line_format[] = "nisxixi";
+        char const skill_line_format[] = "nisxixixx";
         char const skill_line_ability_format[] = "niiiixxiiiiiix";
         //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
         char const spell_aura_options_format[] = "diiii";
@@ -1412,11 +1412,14 @@ namespace DBC::Structures
     {
         uint32_t id;                                                // 0
         uint32_t type;                                              // 1
-        char* Name;                                                 // 2
-        //char* Description;                                        // 3
-        uint32_t spell_icon;                                        // 4
-        //char* add_name;                                           // 5
-        uint32_t linkable;                                          // 6
+        //uint32 unk2                                               // 2 skillCostID
+        char* Name;                                                 // 3
+        //char* Description;                                        // 4
+        uint32_t spell_icon;                                        // 5
+        //char* add_name;                                           // 6
+        uint32_t linkable;                                          // 7
+        //uint32 unk8                                               // 8 Pandaria
+        //uint32 unk9                                               // 9 Pandaria
     };
 
     struct SkillLineAbilityEntry

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -298,7 +298,7 @@ namespace DBC::Structures
         char const totem_category_entry_format[] = "nxii";
         char const transport_animation_format[] = "diifffx";
         char const transport_rotation_format[] = "diiffff";
-        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_format[] = "nixffffiiiiiiiifffffffffffffffssssfifiixx";
         char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxxxxxxxxxx";
         char const wmo_area_table_format[] = "niiixxxxxiixxxx";
         char const world_map_area_entry_format[] = "xinxxxxxixxxxx";
@@ -2026,34 +2026,35 @@ namespace DBC::Structures
         uint32_t ID;                                                // 0
         uint32_t flags;                                             // 1
         float turnSpeed;                                            // 2
-        float pitchSpeed;                                           // 3
-        float pitchMin;                                             // 4
-        float pitchMax;                                             // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
-        float mouseLookOffsetPitch;                                 // 14
-        float cameraFadeDistScalarMin;                              // 15
-        float cameraFadeDistScalarMax;                              // 16
-        float cameraPitchOffset;                                    // 17
-        float facingLimitRight;                                     // 18
-        float facingLimitLeft;                                      // 19
-        float msslTrgtTurnLingering;                                // 20
-        float msslTrgtPitchLingering;                               // 21
-        float msslTrgtMouseLingering;                               // 22
-        float msslTrgtEndOpacity;                                   // 23
-        float msslTrgtArcSpeed;                                     // 24
-        float msslTrgtArcRepeat;                                    // 25
-        float msslTrgtArcWidth;                                     // 26
-        float msslTrgtImpactRadius[2];                              // 27-28
-        char* msslTrgtArcTexture;                                   // 29
-        char* msslTrgtImpactTexture;                                // 30
-        char* msslTrgtImpactModel[2];                               // 31-32
-        float cameraYawOffset;                                      // 33
-        uint32_t uiLocomotionType;                                  // 34
-        float msslTrgtImpactTexRadius;                              // 35
-        uint32_t uiSeatIndicatorType;                               // 36
-        uint32_t powerType;                                         // 37
-        //uint32_t unk1;                                            // 38
-        //uint32_t unk2;                                            // 39
+        //char* unkName                                             // 3 Panradia
+        float pitchSpeed;                                           // 4
+        float pitchMin;                                             // 5
+        float pitchMax;                                             // 6
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 7-15
+        float mouseLookOffsetPitch;                                 // 16
+        float cameraFadeDistScalarMin;                              // 17
+        float cameraFadeDistScalarMax;                              // 18
+        float cameraPitchOffset;                                    // 19
+        float facingLimitRight;                                     // 20
+        float facingLimitLeft;                                      // 21
+        float msslTrgtTurnLingering;                                // 21
+        float msslTrgtPitchLingering;                               // 22
+        float msslTrgtMouseLingering;                               // 23
+        float msslTrgtEndOpacity;                                   // 24
+        float msslTrgtArcSpeed;                                     // 25
+        float msslTrgtArcRepeat;                                    // 26
+        float msslTrgtArcWidth;                                     // 27
+        float msslTrgtImpactRadius[2];                              // 28-30
+        char* msslTrgtArcTexture;                                   // 31
+        char* msslTrgtImpactTexture;                                // 32
+        char* msslTrgtImpactModel[2];                               // 33-35
+        float cameraYawOffset;                                      // 36
+        uint32_t uiLocomotionType;                                  // 37
+        float msslTrgtImpactTexRadius;                              // 38
+        uint32_t uiSeatIndicatorType;                               // 39
+        uint32_t powerType;                                         // 40 new in 3.1
+        //uint32_t unk1;                                            // 41 new in 3.1
+        //uint32_t unk2;                                            // 42 new in 3.1
     };
 
     enum VehicleSeatFlags

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -167,2027 +167,2024 @@ enum Targets
 #define MAX_RAID_DIFFICULTY        4
 #define MAX_DIFFICULTY             4
 
-namespace DBC
+namespace DBC::Structures
 {
-    namespace Structures
+    namespace
     {
-        namespace
-        {
-            char const achievement_format[] = "niiissiiiiisii";
-            char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
-            char const area_group_format[] = "niiiiiii";
-            char const area_table_entry_format[] = "iiinixxxxxisiiiiixxxxxxxxx";
-            char const area_trigger_entry_format[] = "nifffxxxfffff";
-            //char const armor_location_format[] = "nfffff"; new
-            char const auction_house_format[] = "niiix";
-            char const bank_bag_slot_prices_format[] = "ni";
-            char const barber_shop_style_entry_format[] = "nixxxiii";
-            char const banned_addons_entry_format[] = "nxxxxxxxxxx";
-            //char const battlemaster_list_format[]="niiiiiiiiixsiiiiiiii"; new
-            char const char_start_outfit_format[]="dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxii"; 
-            char const char_titles_format[] = "nxsxix";
-            char const chat_channels_format[] = "iixsx";
-            char const chr_classes_format[] = "nixsxxxixiiiixxxxx";
-            char const chr_races_format[] = "nxixiixixxxxixsxxxxxxxxxxxxxxxxxxxxx";
-            char const chr_classes_xpower_types_format[]="nii";
-            //char const cinematic_sequences_format[]="nxxxxxxxxx"; new
-            char const creature_display_info_format[]="nixifxxxxxxxxxxxx";
-            char const creature_display_info_extra_format[]="nixxxxxxxxxxxxxxxxxxx";
-            char const creature_family_format[] = "nfifiiiiixsx";
-            //char const creature_model_data_format[] = "nxxxxxxxxxxxxxxffxxxxxxxxxxxxxx"; new
-            char const creature_spell_data_format[] = "niiiiiiii";  //niiiixxxx
-            //char const creature_type_format[]="nxx"; new
-            char const currency_types_format[] = "nisxxxxiiix";
-            //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
-            char const dungeon_encounter_format[] = "niixisxx";
-            char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-            char const durability_quality_format[] = "nf";
-            char const emotes_entry_format[] = "nxxiiixx";
-            char const emotes_text_format[] = "nxixxxxxxxxxxxxxxxx";
-            char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxx";
-            char const faction_template_format[] = "niiiiiiiiiiiii";
-            char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffxxx";
-            char const gem_properties_format[] = "nixxix";
-            char const glyph_properties_format[] = "niii";
-            char const glyph_slot_format[] = "nii";
-            char const gt_barber_shop_cost_format[] = "xf";
-            char const gt_chance_to_melee_crit_format[] = "xf";
-            char const gt_chance_to_melee_crit_base_format[] = "xf";
-            char const gt_chance_to_spell_crit_format[] = "xf";
-            char const gt_chance_to_spell_crit_base_format[] = "xf";
-            char const gt_combat_ratings_format[] = "xf";
-            //char const gt_oct_base_hp_by_class_format[] = "df"; new
-            //char const gt_oct_base_mp_by_class_format[] = "df"; new
-            char const gt_oct_class_combat_rating_scalar_format[] = "df";
-            //char const gt_oct_hp_per_stamina_format[] = "df"; new
-            //char const gt_oct_regen_hp_format[] = "xf";
-            char const gt_oct_regen_mp_format[] = "df";
-            char const gt_regen_hp_per_spt_format[] = "xf";
-            char const gt_regen_mp_per_spt_format[] = "xf";
-            //char const gt_spell_scaling_format[] = "df"; new
-            char const guild_perk_spells_format[] = "xii";
-            char const holidays_format[] = "nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            //char const item_armor_quality_format[] = "nfffffffi"; new
-            //char const item_armor_shield_format[] = "nifffffff"; new
-            //char const item_armor_total_format[] = "niffff"; new
-            //char const item_bag_family_format[] = "nx"; new
-            //char const item_class_format[] = "nixxxs"; new
-            //char const item_damage_format[] = "nfffffffi"; new
-            char const item_random_properties_format[] = "nxiiiiis";
-            char const item_random_suffix_format[] = "nsxiiiiiiiiii";
-            char const item_set_format[] = "dsxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii";
-            char const item_limit_category_format[] = "nxii";
-            char const lfg_dungeon_entry_format[] = "nsiiiiiiiiiisiiisiiii";
-            char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
-            char const mail_template_format[] = "nss";  //nxs
-            char const map_format[] = "nsiiiisissififfiiiii";
-            //char const map_difficulty_entry_format[] = "niisiis"; new
-            //char const mount_capability_format[] = "niiiiiii"; new
-            //char const mount_type_format[] = "niiiiiiiiiiiiiiiiiiiiiiii"; new
-            //char const movie_entry_format[] = "nxxx"; new
-            char const name_gen_format[] = "nsii";
-            char const num_talents_at_level_format[] = "df";
-            //char const override_spell_data_format[] = "niiiiiiiiiixx"; new
-            char const phase_entry_format[] = "nii";
-            //char const power_display_format[] = "nixxxx"; new
-            //char const pvp_difficulty_format[] = "diiiii"; new
-            //char const quest_faction_reward_format[] = "niiiiiiiiii"; new
-            char const quest_sort_entry_format[] = "nx";
-            char const quest_xp_format[] = "niiiiiiiiii";
-            //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
-            char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
-            char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const skill_line_format[] = "nisxixi";
-            char const skill_line_ability_format[] = "niiiixxiiiiiix";
-            //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
-            char const spell_aura_options_format[] = "diiii";
-            char const spell_aura_restrictions_format[] = "diiiiiiii";
-            char const spell_cast_times_format[] = "niii";
-            char const spell_casting_requirements_format[] = "dixxixi";
-            char const spell_categories_format[] = "diiiiii";
-            char const spell_class_options_format[] = "dxiiiix";
-            char const spell_cooldowns_format[] = "diii";
-            char const spell_difficulty_format[] = "niiii";
-            char const spell_duration_format[] = "niii";
-            char const spell_entry_format[] = "niiiiiiiiiiiiiiifiiiissxxiixxixiiiiiiixiiiiiiiix";
-            char const spell_item_enchantment_format[] = "nxiiiiiixxxiiisiiiiiiix";
-            //char const skill_race_class_info_format[] = "diiiiixxx"; new
-            char const spell_radius_format[] = "nfff";
-            char const spell_range_format[] = "nffffixx";
-            char const spell_rune_cost_format[] = "niiii";
-            char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
-            char const spell_effect_format[] = "difiiiffiiiiiifiifiiiiiiiix";
-            char const spell_equipped_items_format[] = "diii";
-            //char const spell_focus_object_format[] = "nx"; new
-            char const spell_interrupts_format[] = "dixixi";
-            //char const spell_item_enchantment_condition_format[] = "nbbbbbxxxxxbbbbbbbbbbiiiiixxxxx"; new
-            char const spell_levels_format[] = "diii";
-            char const spell_power_format[] = "diiiiixf";
-            char const spell_reagents_format[] = "diiiiiiiiiiiiiiii";
-            char const spell_scaling_format[] = "diiiiffffffffffi";
-            char const spell_shapeshift_format[] = "dixixx";
-            char const spell_target_restrictions_format[] = "dfiiii";
-            char const spell_totems_format[] = "diiii";
-            //char const stable_slot_prices_format[] = "ni"; NA
-            char const summon_properties_format[] = "niiiii";
-            char const talent_format[] = "niiiiiiiiixxixxxxxx";
-            char const talent_tab_format[] = "nxxiiixxiii";
-            char const talent_tree_primary_spells_format[] = "iiix";
-            char const taxi_nodes_format[] = "nifffsiixxx";
-            char const taxi_path_format[] = "niii";
-            char const taxi_path_node_format[] = "diiifffiiii";
-            char const totem_category_entry_format[] = "nxii";
-            char const transport_animation_format[] = "diifffx";
-            char const transport_rotation_format[] = "diiffff";
-            char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
-            char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxxxxxxxxxx";
-            char const wmo_area_table_format[] = "niiixxxxxiixxxx";
-            char const world_map_area_entry_format[] = "xinxxxxxixxxxx";
-            char const world_map_overlay_format[] = "nxiiiixxxxxxxxx";
-            //char const world_pvp_area_enrty_format[] = "niiiiii"; new
-            //char const world_safe_locs_entry_format[] = "nifffx"; new
-        }
+        char const achievement_format[] = "niiissiiiiisii";
+        char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
+        char const area_group_format[] = "niiiiiii";
+        char const area_table_entry_format[] = "iiinixxxxxisiiiiixxxxxxxxx";
+        char const area_trigger_entry_format[] = "nifffxxxfffff";
+        //char const armor_location_format[] = "nfffff"; new
+        char const auction_house_format[] = "niiix";
+        char const bank_bag_slot_prices_format[] = "ni";
+        char const barber_shop_style_entry_format[] = "nixxxiii";
+        char const banned_addons_entry_format[] = "nxxxxxxxxxx";
+        //char const battlemaster_list_format[]="niiiiiiiiixsiiiiiiii"; new
+        char const char_start_outfit_format[]="dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxii"; 
+        char const char_titles_format[] = "nxsxix";
+        char const chat_channels_format[] = "iixsx";
+        char const chr_classes_format[] = "nixsxxxixiiiixxxxx";
+        char const chr_races_format[] = "nxixiixixxxxixsxxxxxxxxxxxxxxxxxxxxx";
+        char const chr_classes_xpower_types_format[]="nii";
+        //char const cinematic_sequences_format[]="nxxxxxxxxx"; new
+        char const creature_display_info_format[]="nixifxxxxxxxxxxxx";
+        char const creature_display_info_extra_format[]="nixxxxxxxxxxxxxxxxxxx";
+        char const creature_family_format[] = "nfifiiiiixsx";
+        //char const creature_model_data_format[] = "nxxxxxxxxxxxxxxffxxxxxxxxxxxxxx"; new
+        char const creature_spell_data_format[] = "niiiiiiii";  //niiiixxxx
+        //char const creature_type_format[]="nxx"; new
+        char const currency_types_format[] = "nisxxxxiiix";
+        //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
+        char const dungeon_encounter_format[] = "niixisxx";
+        char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+        char const durability_quality_format[] = "nf";
+        char const emotes_entry_format[] = "nxxiiixx";
+        char const emotes_text_format[] = "nxixxxxxxxxxxxxxxxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxx";
+        char const faction_template_format[] = "niiiiiiiiiiiii";
+        char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffxxx";
+        char const gem_properties_format[] = "nixxix";
+        char const glyph_properties_format[] = "niii";
+        char const glyph_slot_format[] = "nii";
+        char const gt_barber_shop_cost_format[] = "xf";
+        char const gt_chance_to_melee_crit_format[] = "xf";
+        char const gt_chance_to_melee_crit_base_format[] = "xf";
+        char const gt_chance_to_spell_crit_format[] = "xf";
+        char const gt_chance_to_spell_crit_base_format[] = "xf";
+        char const gt_combat_ratings_format[] = "xf";
+        //char const gt_oct_base_hp_by_class_format[] = "df"; new
+        //char const gt_oct_base_mp_by_class_format[] = "df"; new
+        char const gt_oct_class_combat_rating_scalar_format[] = "df";
+        //char const gt_oct_hp_per_stamina_format[] = "df"; new
+        //char const gt_oct_regen_hp_format[] = "xf";
+        char const gt_oct_regen_mp_format[] = "df";
+        char const gt_regen_hp_per_spt_format[] = "xf";
+        char const gt_regen_mp_per_spt_format[] = "xf";
+        //char const gt_spell_scaling_format[] = "df"; new
+        char const guild_perk_spells_format[] = "xii";
+        char const holidays_format[] = "nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        //char const item_armor_quality_format[] = "nfffffffi"; new
+        //char const item_armor_shield_format[] = "nifffffff"; new
+        //char const item_armor_total_format[] = "niffff"; new
+        //char const item_bag_family_format[] = "nx"; new
+        //char const item_class_format[] = "nixxxs"; new
+        //char const item_damage_format[] = "nfffffffi"; new
+        char const item_random_properties_format[] = "nxiiiiis";
+        char const item_random_suffix_format[] = "nsxiiiiiiiiii";
+        char const item_set_format[] = "dsxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii";
+        char const item_limit_category_format[] = "nxii";
+        char const lfg_dungeon_entry_format[] = "nsiiiiiiiiiisiiisiiii";
+        char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
+        char const mail_template_format[] = "nss";  //nxs
+        char const map_format[] = "nsiiiisissififfiiiii";
+        //char const map_difficulty_entry_format[] = "niisiis"; new
+        //char const mount_capability_format[] = "niiiiiii"; new
+        //char const mount_type_format[] = "niiiiiiiiiiiiiiiiiiiiiiii"; new
+        //char const movie_entry_format[] = "nxxx"; new
+        char const name_gen_format[] = "nsii";
+        char const num_talents_at_level_format[] = "df";
+        //char const override_spell_data_format[] = "niiiiiiiiiixx"; new
+        char const phase_entry_format[] = "nii";
+        //char const power_display_format[] = "nixxxx"; new
+        //char const pvp_difficulty_format[] = "diiiii"; new
+        //char const quest_faction_reward_format[] = "niiiiiiiiii"; new
+        char const quest_sort_entry_format[] = "nx";
+        char const quest_xp_format[] = "niiiiiiiiii";
+        //char const random_properties_points_format[] = "niiiiiiiiiiiiiii"; new
+        char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiixi";
+        char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const skill_line_format[] = "nisxixi";
+        char const skill_line_ability_format[] = "niiiixxiiiiiix";
+        //char const sound_entries_format[] = "nissssssssssssssssssssssxxxxxxxxxxx"; new
+        char const spell_aura_options_format[] = "diiii";
+        char const spell_aura_restrictions_format[] = "diiiiiiii";
+        char const spell_cast_times_format[] = "niii";
+        char const spell_casting_requirements_format[] = "dixxixi";
+        char const spell_categories_format[] = "diiiiii";
+        char const spell_class_options_format[] = "dxiiiix";
+        char const spell_cooldowns_format[] = "diii";
+        char const spell_difficulty_format[] = "niiii";
+        char const spell_duration_format[] = "niii";
+        char const spell_entry_format[] = "niiiiiiiiiiiiiiifiiiissxxiixxixiiiiiiixiiiiiiiix";
+        char const spell_item_enchantment_format[] = "nxiiiiiixxxiiisiiiiiiix";
+        //char const skill_race_class_info_format[] = "diiiiixxx"; new
+        char const spell_radius_format[] = "nfff";
+        char const spell_range_format[] = "nffffixx";
+        char const spell_rune_cost_format[] = "niiii";
+        char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
+        char const spell_effect_format[] = "difiiiffiiiiiifiifiiiiiiiix";
+        char const spell_equipped_items_format[] = "diii";
+        //char const spell_focus_object_format[] = "nx"; new
+        char const spell_interrupts_format[] = "dixixi";
+        //char const spell_item_enchantment_condition_format[] = "nbbbbbxxxxxbbbbbbbbbbiiiiixxxxx"; new
+        char const spell_levels_format[] = "diii";
+        char const spell_power_format[] = "diiiiixf";
+        char const spell_reagents_format[] = "diiiiiiiiiiiiiiii";
+        char const spell_scaling_format[] = "diiiiffffffffffi";
+        char const spell_shapeshift_format[] = "dixixx";
+        char const spell_target_restrictions_format[] = "dfiiii";
+        char const spell_totems_format[] = "diiii";
+        //char const stable_slot_prices_format[] = "ni"; NA
+        char const summon_properties_format[] = "niiiii";
+        char const talent_format[] = "niiiiiiiiixxixxxxxx";
+        char const talent_tab_format[] = "nxxiiixxiii";
+        char const talent_tree_primary_spells_format[] = "iiix";
+        char const taxi_nodes_format[] = "nifffsiixxx";
+        char const taxi_path_format[] = "niii";
+        char const taxi_path_node_format[] = "diiifffiiii";
+        char const totem_category_entry_format[] = "nxii";
+        char const transport_animation_format[] = "diifffx";
+        char const transport_rotation_format[] = "diiffff";
+        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxxxxxxxxxx";
+        char const wmo_area_table_format[] = "niiixxxxxiixxxx";
+        char const world_map_area_entry_format[] = "xinxxxxxixxxxx";
+        char const world_map_overlay_format[] = "nxiiiixxxxxxxxx";
+        //char const world_pvp_area_enrty_format[] = "niiiiii"; new
+        //char const world_safe_locs_entry_format[] = "nifffx"; new
+    }
 
-        #pragma pack(push, 1)
-        struct AchievementCategoryEntry
-        {
-            uint32_t ID;                 // 0
-            uint32_t parentCategory;     // 1 -1 for main category
-            const char* name;          // 2-17
-            uint32_t name_flags;         // 18
-            uint32_t sortOrder;          // 19
-        };
+    #pragma pack(push, 1)
+    struct AchievementCategoryEntry
+    {
+        uint32_t ID;                 // 0
+        uint32_t parentCategory;     // 1 -1 for main category
+        const char* name;          // 2-17
+        uint32_t name_flags;         // 18
+        uint32_t sortOrder;          // 19
+    };
 
-        struct AchievementCriteriaEntry
+    struct AchievementCriteriaEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t referredAchievement;     // 1
+        uint32_t requiredType;            // 2
+        union
         {
-            uint32_t ID;                      // 0
-            uint32_t referredAchievement;     // 1
-            uint32_t requiredType;            // 2
-            union
+            // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
+            ///\todo also used for player deaths..
+            struct
             {
-                // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
-                ///\todo also used for player deaths..
-                struct
-                {
-                    uint32_t creatureID;                             // 3
-                    uint32_t creatureCount;                          // 4
-                } kill_creature;
+                uint32_t creatureID;                             // 3
+                uint32_t creatureCount;                          // 4
+            } kill_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
-                ///\todo there are further criterias instead just winning
-                struct
-                {
-                    uint32_t bgMapID;                                // 3
-                    uint32_t winCount;                               // 4
-                } win_bg;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
+            ///\todo there are further criterias instead just winning
+            struct
+            {
+                uint32_t bgMapID;                                // 3
+                uint32_t winCount;                               // 4
+            } win_bg;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t level;                                  // 4
-                } reach_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t level;                                  // 4
+            } reach_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4
-                } reach_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4
+            } reach_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
-                struct
-                {
-                    uint32_t linkedAchievement;                      // 3
-                } complete_achievement;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
+            struct
+            {
+                uint32_t linkedAchievement;                      // 3
+            } complete_achievement;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t totalQuestCount;                        // 4
-                } complete_quest_count;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t totalQuestCount;                        // 4
+            } complete_quest_count;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfDays;                           // 4
-                } complete_daily_quest_daily;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfDays;                           // 4
+            } complete_daily_quest_daily;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
-                struct
-                {
-                    uint32_t zoneID;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_quests_in_zone;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
+            struct
+            {
+                uint32_t zoneID;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_quests_in_zone;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_daily_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_daily_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } complete_battleground;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } complete_battleground;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } death_at_map;
+            // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } death_at_map;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
-                struct
-                {
-                    uint32_t groupSize;                              // 3 can be 5, 10 or 25
-                } complete_raid;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
+            struct
+            {
+                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+            } complete_raid;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
-                struct
-                {
-                    uint32_t creatureEntry;                          // 3
-                } killed_by_creature;
+            // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
+            struct
+            {
+                uint32_t creatureEntry;                          // 3
+            } killed_by_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t fallHeight;                             // 4
-                } fall_without_dying;
+            // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t fallHeight;                             // 4
+            } fall_without_dying;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
-                struct
-                {
-                    uint32_t questID;                                // 3
-                    uint32_t questCount;                             // 4
-                } complete_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
+            struct
+            {
+                uint32_t questID;                                // 3
+                uint32_t questCount;                             // 4
+            } complete_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t spellCount;                             // 4
-                } be_spell_target;
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t spellCount;                             // 4
+            } be_spell_target;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t castCount;                              // 4
-                } cast_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t castCount;                              // 4
+            } cast_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
-                struct
-                {
-                    uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                    uint32_t killCount;                              // 4
-                } honorable_kill_at_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
+            struct
+            {
+                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                              // 4
+            } honorable_kill_at_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } win_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } win_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } play_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } play_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
-                struct
-                {
-                    uint32_t spellID;                                // 3 Reference to Map.dbc
-                } learn_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
+            struct
+            {
+                uint32_t spellID;                                // 3 Reference to Map.dbc
+            } learn_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } own_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } own_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 4=in a row
-                } win_rated_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 4=in a row
+            } win_rated_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                } highest_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+            } highest_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                    uint32_t teamrating;                             // 4
-                } reach_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamrating;                             // 4
+            } reach_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
-                } learn_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+            } learn_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } use_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } use_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } loot_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } loot_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
-                struct
-                {
-                    uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
-                } explore_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
+            struct
+            {
+                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+            } explore_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
-                struct
-                {
-                    ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                    uint32_t rank;                                   // 3
-                } own_rank;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
+            struct
+            {
+                ///\todo This rank is _NOT_ the index from CharTitles.dbc
+                uint32_t rank;                                   // 3
+            } own_rank;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfSlots;                          // 4
-                } buy_bank_slot;
+            // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfSlots;                          // 4
+            } buy_bank_slot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
-                struct
-                {
-                    uint32_t factionID;                              // 3
-                    uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
-                } gain_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
+            struct
+            {
+                uint32_t factionID;                              // 3
+                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+            } gain_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfExaltedFactions;                // 4
-                } gain_exalted_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfExaltedFactions;                // 4
+            } gain_exalted_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
-                ///\todo where is the required itemlevel stored?
-                struct
-                {
-                    uint32_t itemSlot;                               // 3
-                } equip_epic_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
+            ///\todo where is the required itemlevel stored?
+            struct
+            {
+                uint32_t itemSlot;                               // 3
+            } equip_epic_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
-                struct
-                {
-                    uint32_t rollValue;                              // 3
-                    uint32_t count;                                  // 4
-                } roll_need_on_loot;
+            // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
+            struct
+            {
+                uint32_t rollValue;                              // 3
+                uint32_t count;                                  // 4
+            } roll_need_on_loot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
-                struct
-                {
-                    uint32_t classID;                                // 3
-                    uint32_t count;                                  // 4
-                } hk_class;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
+            struct
+            {
+                uint32_t classID;                                // 3
+                uint32_t count;                                  // 4
+            } hk_class;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
-                struct
-                {
-                    uint32_t raceID;                                 // 3
-                    uint32_t count;                                  // 4
-                } hk_race;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
+            struct
+            {
+                uint32_t raceID;                                 // 3
+                uint32_t count;                                  // 4
+            } hk_race;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
-                ///\todo where is the information about the target stored?
-                struct
-                {
-                    uint32_t emoteID;                                // 3
-                } do_emote;
+            // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
+            ///\todo where is the information about the target stored?
+            struct
+            {
+                uint32_t emoteID;                                // 3
+            } do_emote;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 =3 for battleground healing
-                    uint32_t mapid;                                  // 6
-                } healing_done;
+            // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 =3 for battleground healing
+                uint32_t mapid;                                  // 6
+            } healing_done;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                } equip_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
+            struct
+            {
+                uint32_t itemID;                                 // 3
+            } equip_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
-                struct
-                {
-                    uint32_t unknown;                                 // 3
-                    uint32_t goldInCopper;                            // 4
-                } quest_reward_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
+            struct
+            {
+                uint32_t unknown;                                 // 3
+                uint32_t goldInCopper;                            // 4
+            } quest_reward_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t goldInCopper;                           // 4
-                } loot_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t goldInCopper;                           // 4
+            } loot_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t useCount;                               // 4
-                } use_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t useCount;                               // 4
+            } use_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
-                ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } special_pvp_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
+            ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } special_pvp_kill;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t lootCount;                              // 4
-                } fish_in_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t lootCount;                              // 4
+            } fish_in_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
-                struct
-                {
-                    uint32_t unknown;                                // 3 777=?
-                    uint32_t mountCount;                             // 4
-                } number_of_mounts;
+            // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
+            struct
+            {
+                uint32_t unknown;                                // 3 777=?
+                uint32_t mountCount;                             // 4
+            } number_of_mounts;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t duelCount;                              // 4
-                } win_duel;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t duelCount;                              // 4
+            } win_duel;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
-                struct
-                {
-                    uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
-                } highest_power;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
+            struct
+            {
+                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+            } highest_power;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
-                struct
-                {
-                    uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
-                } highest_stat;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
+            struct
+            {
+                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+            } highest_stat;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
-                struct
-                {
-                    uint32_t spellSchool;                            // 3
-                } highest_spellpower;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
+            struct
+            {
+                uint32_t spellSchool;                            // 3
+            } highest_spellpower;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
-                struct
-                {
-                    uint32_t ratingType;                             // 3
-                } highest_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
+            struct
+            {
+                uint32_t ratingType;                             // 3
+            } highest_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
-                struct
-                {
-                    uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                    uint32_t lootTypeCount;                          // 4
-                } loot_type;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
+            struct
+            {
+                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                          // 4
+            } loot_type;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } cast_spell2;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } cast_spell2;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } learn_skill_line;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } learn_skill_line;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } honorable_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } honorable_kill;
 
-                struct
-                {
-                    uint32_t field3;                                 // 3 main requirement
-                    uint32_t field4;                                 // 4 main requirement count
-                    uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                    uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                    uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                    uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
-                } raw;
-            };
-            //uint32_t unk                      // 9
-            char* name;                         // 10
-            uint32_t completionFlag;            // 11
-            uint32_t groupFlag;                 // 12 timed criteria
-            uint32_t unk1;                      // 13 timed criteria misc id
-            uint32_t timeLimit;                 // 14 time limit in seconds
-            uint32_t index;                     // 15 order
+            struct
+            {
+                uint32_t field3;                                 // 3 main requirement
+                uint32_t field4;                                 // 4 main requirement count
+                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+            } raw;
         };
+        //uint32_t unk                      // 9
+        char* name;                         // 10
+        uint32_t completionFlag;            // 11
+        uint32_t groupFlag;                 // 12 timed criteria
+        uint32_t unk1;                      // 13 timed criteria misc id
+        uint32_t timeLimit;                 // 14 time limit in seconds
+        uint32_t index;                     // 15 order
+    };
 
-        struct AchievementEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
-            int32_t mapID;                      // 2 -1=none
-            uint32_t parentAchievement;         // 3
-            char* name;                         // 4
-            char* description;                  // 5
-            uint32_t categoryId;                // 6
-            uint32_t points;                    // 7 reward points
-            uint32_t orderInCategory;           // 8
-            uint32_t flags;                     // 9
-            uint32_t icon;                      // 10
-            char* rewardName;                   // 11 title/item reward name
-            uint32_t count;                     // 12
-            uint32_t refAchievement;            // 13
-        };
+    struct AchievementEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                      // 2 -1=none
+        uint32_t parentAchievement;         // 3
+        char* name;                         // 4
+        char* description;                  // 5
+        uint32_t categoryId;                // 6
+        uint32_t points;                    // 7 reward points
+        uint32_t orderInCategory;           // 8
+        uint32_t flags;                     // 9
+        uint32_t icon;                      // 10
+        char* rewardName;                   // 11 title/item reward name
+        uint32_t count;                     // 12
+        uint32_t refAchievement;            // 13
+    };
 
-        struct AreaGroupEntry
-        {
-            uint32_t AreaGroupId;               // 0
-            uint32_t AreaId[6];                 // 1-6
-            uint32_t next_group;                // 7
-        };
+    struct AreaGroupEntry
+    {
+        uint32_t AreaGroupId;               // 0
+        uint32_t AreaId[6];                 // 1-6
+        uint32_t next_group;                // 7
+    };
 
-        struct AreaTableEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t map_id;                    // 1
-            uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
-            uint32_t explore_flag;              // 3, main index
-            uint32_t flags;                     // 4, unknown value but 312 for all cities
-                                                // 5-9 unused
-            int32_t area_level;                 // 10
-            char* area_name;                    // 11
-            uint32_t team;                      // 12
-            uint32_t liquid_type_override[4];   // 13-16 liquid override by type
-            //uint32_t unk17;                   // 17
-            //uint32_t unk18;                   // 18
-            //uint32_t unk19;                   // 19
-            //uint32_t unk20;                   // 20
-            //uint32_t unk21;                   // 21
-            //uint32_t unk22;                   // 22
-            //uint32_t unk23;                   // 23
-            //uint32_t unk24;                   // 24
-        };
+    struct AreaTableEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t map_id;                    // 1
+        uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;              // 3, main index
+        uint32_t flags;                     // 4, unknown value but 312 for all cities
+                                            // 5-9 unused
+        int32_t area_level;                 // 10
+        char* area_name;                    // 11
+        uint32_t team;                      // 12
+        uint32_t liquid_type_override[4];   // 13-16 liquid override by type
+        //uint32_t unk17;                   // 17
+        //uint32_t unk18;                   // 18
+        //uint32_t unk19;                   // 19
+        //uint32_t unk20;                   // 20
+        //uint32_t unk21;                   // 21
+        //uint32_t unk22;                   // 22
+        //uint32_t unk23;                   // 23
+        //uint32_t unk24;                   // 24
+    };
 
-        struct AreaTriggerEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t mapid;                     // 1
-            float x;                            // 2
-            float y;                            // 3
-            float z;                            // 4
-            //uint32_t                          // 5
-            //uint32_t                          // 6
-            //uint32_t                          // 7
-            float o;                            // 5 radius
-            float box_x;                        // 6 extent x edge
-            float box_y;                        // 7 extent y edge
-            float box_z;                        // 8 extent z edge
-            float box_o;                        // 9
-        };
+    struct AreaTriggerEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t mapid;                     // 1
+        float x;                            // 2
+        float y;                            // 3
+        float z;                            // 4
+        //uint32_t                          // 5
+        //uint32_t                          // 6
+        //uint32_t                          // 7
+        float o;                            // 5 radius
+        float box_x;                        // 6 extent x edge
+        float box_y;                        // 7 extent y edge
+        float box_z;                        // 8 extent z edge
+        float box_o;                        // 9
+    };
 
-        //\todo danko
-        //struct ArmorLocationEntry   
-        //{
-        //    uint32_t InventoryType;           // 0
-        //    float Value[5];                   // 1-5
-        //};
+    //\todo danko
+    //struct ArmorLocationEntry   
+    //{
+    //    uint32_t InventoryType;           // 0
+    //    float Value[5];                   // 1-5
+    //};
 
-        struct AuctionHouseEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t faction;                   // 1
-            uint32_t fee;                       // 2
-            uint32_t tax;                       // 3
-            //char* name;                       // 4
-        };
+    struct AuctionHouseEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t faction;                   // 1
+        uint32_t fee;                       // 2
+        uint32_t tax;                       // 3
+        //char* name;                       // 4
+    };
 
-        struct BankBagSlotPrices
-        {
-            uint32_t Id;                        // 0
-            uint32_t Price;                     // 1
-        };
+    struct BankBagSlotPrices
+    {
+        uint32_t Id;                        // 0
+        uint32_t Price;                     // 1
+    };
 
-        struct BarberShopStyleEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
-            //char* name;                       // 2
-            //uint32_t unk_name;                // 3
-            //float CostMultiplier;             // 4
-            uint32_t race;                      // 5
-            uint32_t gender;                    // 6 0 male, 1 female
-            uint32_t hair_id;                   // 7 Hair ID
-        };
+    struct BarberShopStyleEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;                       // 2
+        //uint32_t unk_name;                // 3
+        //float CostMultiplier;             // 4
+        uint32_t race;                      // 5
+        uint32_t gender;                    // 6 0 male, 1 female
+        uint32_t hair_id;                   // 7 Hair ID
+    };
 
-        struct BannedAddOnsEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t nameMD5[4];              // 1-4
-            //uint32_t versionMD5[4];           // 5-8
-            //uint32_t timestamp;               // 9
-            //uint32_t state;                   // 10
-        };
+    struct BannedAddOnsEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t nameMD5[4];              // 1-4
+        //uint32_t versionMD5[4];           // 5-8
+        //uint32_t timestamp;               // 9
+        //uint32_t state;                   // 10
+    };
 
-        #define OUTFIT_ITEMS 24
+    #define OUTFIT_ITEMS 24
 
-        struct CharStartOutfitEntry
-        {
-            //uint32_t Id;                                    // 0
-            uint8_t Race;                                     // 1
-            uint8_t Class;                                    // 2
-            uint8_t Gender;                                   // 3
-            //uint8_t Unused;                                 // 4
-            int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-            //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-            //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
-            uint32_t PetDisplayId;                            // 77
-            uint32_t PetFamilyEntry;                          // 78
-        };
+    struct CharStartOutfitEntry
+    {
+        //uint32_t Id;                                    // 0
+        uint8_t Race;                                     // 1
+        uint8_t Class;                                    // 2
+        uint8_t Gender;                                   // 3
+        //uint8_t Unused;                                 // 4
+        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
+        uint32_t PetDisplayId;                            // 77
+        uint32_t PetFamilyEntry;                          // 78
+    };
 
-        struct CharTitlesEntry
-        {
-            uint32_t ID;                        // 0
-            //uint32_t unk1;                    // 1
-            char* name;                         // 2
-            //char* name2;                      // 3
-            uint32_t bit_index;                 // 4
-            //uint32_t unk                      // 5
-        };
+    struct CharTitlesEntry
+    {
+        uint32_t ID;                        // 0
+        //uint32_t unk1;                    // 1
+        char* name;                         // 2
+        //char* name2;                      // 3
+        uint32_t bit_index;                 // 4
+        //uint32_t unk                      // 5
+    };
 
-        struct ChatChannelsEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t flags;                     // 1
-            //uint32_t faction                  // 2
-            char* name_pattern;                 // 3
-            //char* channel_name;               // 4
-        };
+    struct ChatChannelsEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t flags;                     // 1
+        //uint32_t faction                  // 2
+        char* name_pattern;                 // 3
+        //char* channel_name;               // 4
+    };
 
-        struct ChrClassesEntry
-        {
-            uint32_t class_id;                  // 0
-            uint32_t power_type;                // 1
-            //uint32_t unk2;                    // 2
-            char* name;                         // 3
-            //char* name_female;                // 4
-            //char* name_neutral;               // 5
-            //char* name_capitalized            // 6
-            uint32_t spellfamily;               // 7
-            //uint32_t unk4;                    // 8
-            uint32_t cinematic_id;              // 9 CinematicSequences.dbc
-            uint32_t apPerStr;                  // 10
-            uint32_t apPerAgi;                  // 11
-            uint32_t rapPerAgi;                 // 12
-            //uint32_t unk1                     // 13 Pandaria
-            //uint32_t unk2                     // 14 Pandaria
-            //uint32_t unk3                     // 15 Pandaria
-            //uint32_t unk4                     // 16 Pandaria
-            //uint32_t unk5                     // 17 Pandaria
-        };
+    struct ChrClassesEntry
+    {
+        uint32_t class_id;                  // 0
+        uint32_t power_type;                // 1
+        //uint32_t unk2;                    // 2
+        char* name;                         // 3
+        //char* name_female;                // 4
+        //char* name_neutral;               // 5
+        //char* name_capitalized            // 6
+        uint32_t spellfamily;               // 7
+        //uint32_t unk4;                    // 8
+        uint32_t cinematic_id;              // 9 CinematicSequences.dbc
+        uint32_t apPerStr;                  // 10
+        uint32_t apPerAgi;                  // 11
+        uint32_t rapPerAgi;                 // 12
+        //uint32_t unk1                     // 13 Pandaria
+        //uint32_t unk2                     // 14 Pandaria
+        //uint32_t unk3                     // 15 Pandaria
+        //uint32_t unk4                     // 16 Pandaria
+        //uint32_t unk5                     // 17 Pandaria
+    };
 
-        struct ChrRacesEntry
-        {
-            uint32_t race_id;                   // 0
-            //uint32_t flags;                   // 1
-            uint32_t faction_id;                // 2
-            //uint32_t unk1;                    // 3
-            uint32_t model_male;                // 4
-            uint32_t model_female;              // 5
-            // uint32_t unk2;                   // 6
-            uint32_t team_id;                   // 7
-            //uint32_t unk3[4];                 // 8-11
-            uint32_t cinematic_id;              // 12 CinematicSequences.dbc
-            //uint32_t unk4                     // 13
-            char* name;                         // 14
-            //char* name_female;                // 15
-            //char* name_neutral;               // 16
-            //uint32_t unk5[2]                  // 17-18
-            //uint32_t unk19                    // 19
-            //uint32_t m_enemyRace;             // 20
-            //uint32_t unk21                    // 21
-            //uint32_t unk22                    // 22
-            //uint32_t unk23                    // 23
-            //uint32_t unk24;                   // 24
-            //uint32_t defaultClassForRace      // 25
-            //uint32_t unk26;                   // 26
-            //uint32_t unk27;                   // 27
-            //float unk28;                      // 28
-            //uint32_t unk29;                   // 29
-            //float unk30;                      // 30
-            //float unk31;                      // 31
-            //uint32_t unk32;                   // 32
-            //float unk33;                      // 33
-            //uint32_t unk34;                   // 34
-            //uint32_t unk35;                   // 35
-        };
+    struct ChrRacesEntry
+    {
+        uint32_t race_id;                   // 0
+        //uint32_t flags;                   // 1
+        uint32_t faction_id;                // 2
+        //uint32_t unk1;                    // 3
+        uint32_t model_male;                // 4
+        uint32_t model_female;              // 5
+        // uint32_t unk2;                   // 6
+        uint32_t team_id;                   // 7
+        //uint32_t unk3[4];                 // 8-11
+        uint32_t cinematic_id;              // 12 CinematicSequences.dbc
+        //uint32_t unk4                     // 13
+        char* name;                         // 14
+        //char* name_female;                // 15
+        //char* name_neutral;               // 16
+        //uint32_t unk5[2]                  // 17-18
+        //uint32_t unk19                    // 19
+        //uint32_t m_enemyRace;             // 20
+        //uint32_t unk21                    // 21
+        //uint32_t unk22                    // 22
+        //uint32_t unk23                    // 23
+        //uint32_t unk24;                   // 24
+        //uint32_t defaultClassForRace      // 25
+        //uint32_t unk26;                   // 26
+        //uint32_t unk27;                   // 27
+        //float unk28;                      // 28
+        //uint32_t unk29;                   // 29
+        //float unk30;                      // 30
+        //float unk31;                      // 31
+        //uint32_t unk32;                   // 32
+        //float unk33;                      // 33
+        //uint32_t unk34;                   // 34
+        //uint32_t unk35;                   // 35
+    };
 
-        struct ChrPowerTypesEntry
-        {
-            uint32_t entry;                     // 0
-            uint32_t classId;                   // 1 class
-            uint32_t power;                     // 2 power type
-        };
+    struct ChrPowerTypesEntry
+    {
+        uint32_t entry;                     // 0
+        uint32_t classId;                   // 1 class
+        uint32_t power;                     // 2 power type
+    };
 
-        struct CreatureDisplayInfoEntry
-        {
-            uint32_t Displayid;                 // 0
-            uint32_t ModelId;                   // 1
-            //uint32_t sound_id;                // 2
-            uint32_t ExtendedDisplayInfoID;     // 3
-            float scale;                        // 4
-            //uint32_t unk01;                   // 5
-            //uint32_t unk02[2];                // 6-8
-            //uint32_t unk03;                   // 9
-            //uint32_t unk04;                   // 10
-            //uint32_t unk05;                   // 11
-            //uint32_t unk06;                   // 12
-            //uint32_t unk07;                   // 13
-            //uint32_t unk08;                   // 14
-            //uint32_t unk09;                   // 15
-            //uint32_t unk10;                   // 16
-        };
+    struct CreatureDisplayInfoEntry
+    {
+        uint32_t Displayid;                 // 0
+        uint32_t ModelId;                   // 1
+        //uint32_t sound_id;                // 2
+        uint32_t ExtendedDisplayInfoID;     // 3
+        float scale;                        // 4
+        //uint32_t unk01;                   // 5
+        //uint32_t unk02[2];                // 6-8
+        //uint32_t unk03;                   // 9
+        //uint32_t unk04;                   // 10
+        //uint32_t unk05;                   // 11
+        //uint32_t unk06;                   // 12
+        //uint32_t unk07;                   // 13
+        //uint32_t unk08;                   // 14
+        //uint32_t unk09;                   // 15
+        //uint32_t unk10;                   // 16
+    };
 
-        struct CreatureDisplayInfoExtraEntry
-        {
-            uint32_t DisplayExtraId;            // 0
-            uint32_t Race;                      // 1
-            //uint32_t Gender;                  // 2
-            //uint32_t SkinColor;               // 3
-            //uint32_t FaceType;                // 4
-            //uint32_t HairType;                // 5
-            //uint32_t HairStyle;               // 6
-            //uint32_t BeardStyle;              // 7
-            //uint32_t Equipment[11];           // 8-18
-            //uint32_t CanEquip;                // 19
-            //char* unk                         // 20
-        };
+    struct CreatureDisplayInfoExtraEntry
+    {
+        uint32_t DisplayExtraId;            // 0
+        uint32_t Race;                      // 1
+        //uint32_t Gender;                  // 2
+        //uint32_t SkinColor;               // 3
+        //uint32_t FaceType;                // 4
+        //uint32_t HairType;                // 5
+        //uint32_t HairStyle;               // 6
+        //uint32_t BeardStyle;              // 7
+        //uint32_t Equipment[11];           // 8-18
+        //uint32_t CanEquip;                // 19
+        //char* unk                         // 20
+    };
 
-        struct CreatureFamilyEntry
-        {
-            uint32_t ID;                        // 0
-            float minsize;                      // 1
-            uint32_t minlevel;                  // 2
-            float maxsize;                      // 3
-            uint32_t maxlevel;                  // 4
-            uint32_t skilline;                  // 5
-            uint32_t tameable;                  // 6 second skill line - 270 Generic
-            uint32_t petdietflags;              // 7
-            uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-            //uint32_t unk;                     // 9 some index 0 - 63
-            char* name;                         // 10
-            //uint32_t nameflags;               // 11
-        };
+    struct CreatureFamilyEntry
+    {
+        uint32_t ID;                        // 0
+        float minsize;                      // 1
+        uint32_t minlevel;                  // 2
+        float maxsize;                      // 3
+        uint32_t maxlevel;                  // 4
+        uint32_t skilline;                  // 5
+        uint32_t tameable;                  // 6 second skill line - 270 Generic
+        uint32_t petdietflags;              // 7
+        uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                     // 9 some index 0 - 63
+        char* name;                         // 10
+        //uint32_t nameflags;               // 11
+    };
 
-        struct CreatureSpellDataEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t Spells[3];
-            uint32_t PHSpell;
-            uint32_t Cooldowns[3];
-            uint32_t PH;
-        };
+    struct CreatureSpellDataEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t Spells[3];
+        uint32_t PHSpell;
+        uint32_t Cooldowns[3];
+        uint32_t PH;
+    };
 
-        //\todo danko
-        //struct CreatureTypeEntry
-        //{
-        //    uint32_t ID;                      // 0
-        //    //char* Name;                     // 1
-        //    //uint32_t no_expirience;         // 2
-        //};
+    //\todo danko
+    //struct CreatureTypeEntry
+    //{
+    //    uint32_t ID;                      // 0
+    //    //char* Name;                     // 1
+    //    //uint32_t no_expirience;         // 2
+    //};
 
-        struct CurrencyTypesEntry
-        {
-            uint32_t item_id;                   // 0
-            uint32_t Category;                  // 1
-            char* name;                         // 2
-            //char* unk                         // 3
-            //char* unk2                        // 4
-            //uint32_t unk5;                    // 5
-            //uint32_t unk6;                    // 6
-            uint32_t TotalCap;                  // 7
-            uint32_t WeekCap;                   // 8
-            uint32_t Flags;                     // 9
-            //char* description;                // 10
-        };
+    struct CurrencyTypesEntry
+    {
+        uint32_t item_id;                   // 0
+        uint32_t Category;                  // 1
+        char* name;                         // 2
+        //char* unk                         // 3
+        //char* unk2                        // 4
+        //uint32_t unk5;                    // 5
+        //uint32_t unk6;                    // 6
+        uint32_t TotalCap;                  // 7
+        uint32_t WeekCap;                   // 8
+        uint32_t Flags;                     // 9
+        //char* description;                // 10
+    };
 
-        struct DurabilityCostsEntry
-        {
-            uint32_t itemlevel;                 // 0
-            uint32_t modifier[29];              // 1-29
-        };
+    struct DurabilityCostsEntry
+    {
+        uint32_t itemlevel;                 // 0
+        uint32_t modifier[29];              // 1-29
+    };
 
-        struct DurabilityQualityEntry
-        {
-            uint32_t id;                        // 0
-            float quality_modifier;             // 1
-        };
+    struct DurabilityQualityEntry
+    {
+        uint32_t id;                        // 0
+        float quality_modifier;             // 1
+    };
 
-        struct EmotesEntry
-        {
-            uint32_t Id;                        // 0
-            //char* name;                       // 1
-            //uint32_t animationId;             // 2
-            uint32_t Flags;                     // 3
-            uint32_t EmoteType;                 // 4
-            uint32_t UnitStandState;            // 5
-            //uint32_t soundId;                 // 6
-            //uint32_t unk;                     // 7
-        };
+    struct EmotesEntry
+    {
+        uint32_t Id;                        // 0
+        //char* name;                       // 1
+        //uint32_t animationId;             // 2
+        uint32_t Flags;                     // 3
+        uint32_t EmoteType;                 // 4
+        uint32_t UnitStandState;            // 5
+        //uint32_t soundId;                 // 6
+        //uint32_t unk;                     // 7
+    };
 
-        struct EmotesTextEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t name;                    // 1
-            uint32_t textid;                    // 2
-            //uint32_t unk1;                    // 4
-        };
+    struct EmotesTextEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t name;                    // 1
+        uint32_t textid;                    // 2
+        //uint32_t unk1;                    // 4
+    };
 
-        struct FactionEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t RepListId;                  // 1
-            uint32_t RaceMask[4];               // 2-5
-            uint32_t ClassMask[4];              // 6-9
-            int32_t baseRepValue[4];            // 10-13
-            uint32_t repFlags[4];               // 14-17
-            uint32_t parentFaction;             // 18
-            float spillover_rate_in;            // 19
-            float spillover_rate_out;           // 20
-            uint32_t spillover_max_in;          // 21
-            //uint32_t unk1;                    // 22
-            char* Name;                         // 23
-            //uint32_t Description;             // 24
-            //uint32_t description_flags;       // 25
-        };
+    struct FactionEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t RepListId;                  // 1
+        uint32_t RaceMask[4];               // 2-5
+        uint32_t ClassMask[4];              // 6-9
+        int32_t baseRepValue[4];            // 10-13
+        uint32_t repFlags[4];               // 14-17
+        uint32_t parentFaction;             // 18
+        float spillover_rate_in;            // 19
+        float spillover_rate_out;           // 20
+        uint32_t spillover_max_in;          // 21
+        //uint32_t unk1;                    // 22
+        char* Name;                         // 23
+        //uint32_t Description;             // 24
+        //uint32_t description_flags;       // 25
+    };
 
-        struct FactionTemplateEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t Faction;                   // 1
-            uint32_t FactionGroup;              // 2
-            uint32_t Mask;                      // 3
-            uint32_t FriendlyMask;              // 4
-            uint32_t HostileMask;               // 5
-            uint32_t EnemyFactions[4];          // 6-9
-            uint32_t FriendlyFactions[4];       // 10-13
-        };
+    struct FactionTemplateEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t Faction;                   // 1
+        uint32_t FactionGroup;              // 2
+        uint32_t Mask;                      // 3
+        uint32_t FriendlyMask;              // 4
+        uint32_t HostileMask;               // 5
+        uint32_t EnemyFactions[4];          // 6-9
+        uint32_t FriendlyFactions[4];       // 10-13
+    };
 
-        struct GameObjectDisplayInfoEntry
-        {
-            uint32_t Displayid;                 // 0
-            char* filename;                     // 1
-            //uint32_t  unk1[10];               // 2-11
-            float minX;                         // 12
-            float minY;                         // 13
-            float minZ;                         // 14
-            float maxX;                         // 15
-            float maxY;                         // 16
-            float maxZ;                         // 17
-            //uint32_t transport;               // 18
-            //uint32_t unk;                     // 19
-            //uint32_t unk;                     // 20
-        };
+    struct GameObjectDisplayInfoEntry
+    {
+        uint32_t Displayid;                 // 0
+        char* filename;                     // 1
+        //uint32_t  unk1[10];               // 2-11
+        float minX;                         // 12
+        float minY;                         // 13
+        float minZ;                         // 14
+        float maxX;                         // 15
+        float maxY;                         // 16
+        float maxZ;                         // 17
+        //uint32_t transport;               // 18
+        //uint32_t unk;                     // 19
+        //uint32_t unk;                     // 20
+    };
 
-        struct GemPropertiesEntry
-        {
-            uint32_t Entry;                     // 0
-            uint32_t EnchantmentID;             // 1
-            //uint32_t unk1;                    // 2 bool
-            //uint32_t unk2;                    // 3 bool
-            uint32_t SocketMask;                // 4
-        };
+    struct GemPropertiesEntry
+    {
+        uint32_t Entry;                     // 0
+        uint32_t EnchantmentID;             // 1
+        //uint32_t unk1;                    // 2 bool
+        //uint32_t unk2;                    // 3 bool
+        uint32_t SocketMask;                // 4
+    };
 
-        struct GlyphPropertiesEntry
-        {
-            uint32_t Entry;                     // 0
-            uint32_t SpellID;                   // 1
-            uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
-            uint32_t unk;                       // 3 glyph_icon spell.dbc
-        };
+    struct GlyphPropertiesEntry
+    {
+        uint32_t Entry;                     // 0
+        uint32_t SpellID;                   // 1
+        uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                       // 3 glyph_icon spell.dbc
+    };
 
-        struct GlyphSlotEntry
-        {
-            uint32_t Id;                        // 0
-            uint32_t Type;                      // 1
-            uint32_t Slot;                      // 2
-        };
+    struct GlyphSlotEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t Type;                      // 1
+        uint32_t Slot;                      // 2
+    };
 
-        struct GtBarberShopCostBaseEntry
-        {
-            float cost;                         // 0
-        };
+    struct GtBarberShopCostBaseEntry
+    {
+        float cost;                         // 0
+    };
 
-        struct GtChanceToMeleeCritEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToMeleeCritEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToMeleeCritBaseEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToMeleeCritBaseEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToSpellCritEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToSpellCritEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtChanceToSpellCritBaseEntry
-        {
-            float val;                          // 0
-        };
+    struct GtChanceToSpellCritBaseEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtCombatRatingsEntry
-        {
-            float val;                          // 0
-        };
+    struct GtCombatRatingsEntry
+    {
+        float val;                          // 0
+    };
 
-        struct GtOCTClassCombatRatingScalarEntry
-        {
-            float val;                          // 0
-        };
+    struct GtOCTClassCombatRatingScalarEntry
+    {
+        float val;                          // 0
+    };
 
-        //\todo danko
-        //struct GtOCTRegenHPEntry
-        //{
-        //    float ratio;                      // 0
-        //};
+    //\todo danko
+    //struct GtOCTRegenHPEntry
+    //{
+    //    float ratio;                      // 0
+    //};
 
-        struct GtOCTRegenMPEntry
-        {
-            float ratio;                        // 0
-        };
+    struct GtOCTRegenMPEntry
+    {
+        float ratio;                        // 0
+    };
 
-        //\todo danko
-        //struct GtRegenHPPerSptEntry
-        //{
-        //    float ratio;                      // 0
-        //};
+    //\todo danko
+    //struct GtRegenHPPerSptEntry
+    //{
+    //    float ratio;                      // 0
+    //};
 
-        struct GtRegenMPPerSptEntry
-        {
-            float ratio;                        // 0
-        };
+    struct GtRegenMPPerSptEntry
+    {
+        float ratio;                        // 0
+    };
 
-        struct GuildPerkSpellsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Level;                     // 1
-            uint32_t SpellId;                   // 2
-        };
+    struct GuildPerkSpellsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Level;                     // 1
+        uint32_t SpellId;                   // 2
+    };
 
 #define MAX_HOLIDAY_DURATIONS 10
 #define MAX_HOLIDAY_DATES 26
 #define MAX_HOLIDAY_FLAGS 10
 
-        struct HolidaysEntry
-        {
-            uint32_t Id;                                    // 0
-            //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-            //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-            //uint32_t Region;                              // 37
-            //uint32_t Looping;                             // 38
-            //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-            //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
-            //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
-            //char* TextureFilename;                        // 51
-            //uint32_t Priority;                            // 52
-            //uint32_t CalendarFilterType;                  // 53
-            //uint32_t flags;                               // 54
-        };
+    struct HolidaysEntry
+    {
+        uint32_t Id;                                    // 0
+        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
+        //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
+        //uint32_t Region;                              // 37
+        //uint32_t Looping;                             // 38
+        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
+        //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
+        //char* TextureFilename;                        // 51
+        //uint32_t Priority;                            // 52
+        //uint32_t CalendarFilterType;                  // 53
+        //uint32_t flags;                               // 54
+    };
 
-        struct ItemLimitCategoryEntry
-        {
-            uint32_t Id;                        // 0
-            //char* name;                       // 1
-            uint32_t maxAmount;                 // 2
-            uint32_t equippedFlag;              // 3
-        };
+    struct ItemLimitCategoryEntry
+    {
+        uint32_t Id;                        // 0
+        //char* name;                       // 1
+        uint32_t maxAmount;                 // 2
+        uint32_t equippedFlag;              // 3
+    };
 
-        struct ItemRandomPropertiesEntry
-        {
-            uint32_t ID;                        // 0
-            //char* name1;                      // 1
-            uint32_t spells[5];                 // 2-6 enchant_id
-            char* name_suffix;                  // 7
-        };
+    struct ItemRandomPropertiesEntry
+    {
+        uint32_t ID;                        // 0
+        //char* name1;                      // 1
+        uint32_t spells[5];                 // 2-6 enchant_id
+        char* name_suffix;                  // 7
+    };
 
-        struct ItemRandomSuffixEntry
-        {
-            uint32_t id;                        // 0
-            char* name_suffix;                  // 1
-            //uint32_t name_suffix_flags;       // 2
-            uint32_t enchantments[5];           // 3-7
-            uint32_t prefixes[5];               // 8-12
-        };
+    struct ItemRandomSuffixEntry
+    {
+        uint32_t id;                        // 0
+        char* name_suffix;                  // 1
+        //uint32_t name_suffix_flags;       // 2
+        uint32_t enchantments[5];           // 3-7
+        uint32_t prefixes[5];               // 8-12
+    };
 
-        struct ItemSetEntry
-        {
-            //uint32_t id;                      // 0
-            char* name;                         // 1
-            //uint32_t itemid[17];              // 2-18
-            uint32_t SpellID[8];                // 19-26
-            uint32_t itemscount[8];             // 27-34
-            uint32_t RequiredSkillID;           // 35
-            uint32_t RequiredSkillAmt;          // 36
-        };
+    struct ItemSetEntry
+    {
+        //uint32_t id;                      // 0
+        char* name;                         // 1
+        //uint32_t itemid[17];              // 2-18
+        uint32_t SpellID[8];                // 19-26
+        uint32_t itemscount[8];             // 27-34
+        uint32_t RequiredSkillID;           // 35
+        uint32_t RequiredSkillAmt;          // 36
+    };
 
-        struct LFGDungeonEntry
-        {
-            uint32_t ID;                        // 0
-            char* name;                         // 1
-            uint32_t minlevel;                  // 2
-            uint32_t maxlevel;                  // 3
-            uint32_t reclevel;                  // 4
-            uint32_t recminlevel;               // 5
-            uint32_t recmaxlevel;               // 6
-            int32_t map;                        // 7
-            uint32_t difficulty;                // 8
-            uint32_t unk;                       // 9
-            uint32_t flags;                     // 10
-            int32_t type;                       // 11
-            char* iconname;                     // 12
-            uint32_t expansion;                 // 13
-            uint32_t unk4;                      // 14
-            uint32_t unk5;                      // 15
-            char* unk_text;                     // 16
-            uint32_t grouptype;                 // 17
-            uint32_t unkflags1;                 // 18
-            uint32_t unkflags2;                 // 19
-            uint32_t unk7;                      // 20
+    struct LFGDungeonEntry
+    {
+        uint32_t ID;                        // 0
+        char* name;                         // 1
+        uint32_t minlevel;                  // 2
+        uint32_t maxlevel;                  // 3
+        uint32_t reclevel;                  // 4
+        uint32_t recminlevel;               // 5
+        uint32_t recmaxlevel;               // 6
+        int32_t map;                        // 7
+        uint32_t difficulty;                // 8
+        uint32_t unk;                       // 9
+        uint32_t flags;                     // 10
+        int32_t type;                       // 11
+        char* iconname;                     // 12
+        uint32_t expansion;                 // 13
+        uint32_t unk4;                      // 14
+        uint32_t unk5;                      // 15
+        char* unk_text;                     // 16
+        uint32_t grouptype;                 // 17
+        uint32_t unkflags1;                 // 18
+        uint32_t unkflags2;                 // 19
+        uint32_t unk7;                      // 20
 
-            // Helpers
-            uint32_t Entry() const { return ID + (type << 24); }
-        };
+        // Helpers
+        uint32_t Entry() const { return ID + (type << 24); }
+    };
 
-        struct DungeonEncounterEntry
-        {
-            uint32 id;                                              // 0        unique id
-            uint32 mapId;                                           // 1        map id
-            uint32 difficulty;                                      // 2        instance mode
-            //uint32 unk0;                                          // 3
-            uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-            char* encounterName;                                    // 5        encounter name
-            //uint32 nameFlags;                                     // 21
-            //uint32 u
-        };
+    struct DungeonEncounterEntry
+    {
+        uint32 id;                                              // 0        unique id
+        uint32 mapId;                                           // 1        map id
+        uint32 difficulty;                                      // 2        instance mode
+        //uint32 unk0;                                          // 3
+        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
+        char* encounterName;                                    // 5        encounter name
+        //uint32 nameFlags;                                     // 21
+        //uint32 u
+    };
 
-        struct LiquidTypeEntry
-        {
-            uint32_t Id;                        // 0
-            //char* Name;                       // 1
-            //uint32_t Flags;                   // 2
-            uint32_t Type;                      // 3
-            //uint32_t SoundId;                 // 4
-            uint32_t SpellId;                   // 5
-            //float MaxDarkenDepth;             // 6
-            //float FogDarkenIntensity;         // 7
-            //float AmbDarkenIntensity;         // 8
-            //float DirDarkenIntensity;         // 9
-            //uint32_t LightID;                 // 10
-            //float ParticleScale;              // 11
-            //uint32_t ParticleMovement;        // 12
-            //uint32_t ParticleTexSlots;        // 13
-            //uint32_t LiquidMaterialID;        // 14
-            //char* Texture[6];                 // 15-20
-            //uint32_t Color[2];                // 21-22
-            //float Unk1[18];                   // 23-40
-            //uint32_t Unk2[4];                 // 41-44
-        };
+    struct LiquidTypeEntry
+    {
+        uint32_t Id;                        // 0
+        //char* Name;                       // 1
+        //uint32_t Flags;                   // 2
+        uint32_t Type;                      // 3
+        //uint32_t SoundId;                 // 4
+        uint32_t SpellId;                   // 5
+        //float MaxDarkenDepth;             // 6
+        //float FogDarkenIntensity;         // 7
+        //float AmbDarkenIntensity;         // 8
+        //float DirDarkenIntensity;         // 9
+        //uint32_t LightID;                 // 10
+        //float ParticleScale;              // 11
+        //uint32_t ParticleMovement;        // 12
+        //uint32_t ParticleTexSlots;        // 13
+        //uint32_t LiquidMaterialID;        // 14
+        //char* Texture[6];                 // 15-20
+        //uint32_t Color[2];                // 21-22
+        //float Unk1[18];                   // 23-40
+        //uint32_t Unk2[4];                 // 41-44
+    };
 
 #define LOCK_NUM_CASES 8
 
-        struct LockEntry
+    struct LockEntry
+    {
+        uint32_t Id;                              // 0
+        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+    };
+
+    struct MailTemplateEntry
+    {
+        uint32_t ID;                        // 0
+        char* subject;                      // 1
+        char* content;                      // 2
+    };
+
+    struct MapEntry
+    {
+        uint32_t id;                        // 0
+        char* name_internal;                // 1
+        uint32_t map_type;                  // 2
+        uint32_t map_flags;                 // 3
+        uint32_t unk4;                      // 4
+        uint32_t is_pvp_zone;               // 5
+        char* map_name;                     // 6
+        uint32_t linked_zone;               // 7 common zone for instance and continent map
+        char* horde_intro;                  // 8 horde text for PvP Zones
+        char* alliance_intro;               // 9 alliance text for PvP Zones
+        uint32_t multimap_id;               // 10
+        float battlefield_map_icon;         // 11
+        int32_t parent_map;                 // 12 ghost map_id of parent map
+        float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
+        float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
+        uint32_t dayTime_override;          // 15
+        uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                  // 17
+        uint32_t max_players;               // 18
+        uint32_t next_phase_map;            // 19
+
+        bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
+        bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
+        bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isRaid() const { return map_type == MAP_RAID; }
+        bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
+        bool isBattleArena() const { return map_type == MAP_ARENA; }
+        bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isWorldMap() const { return map_type == MAP_COMMON; }
+
+        bool isContinent() const
         {
-            uint32_t Id;                              // 0
-            uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-            uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-            uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-            //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
-        };
+            return id == 0 || id == 1 || id == 530 || id == 571;
+        }
+    };
 
-        struct MailTemplateEntry
+    struct NameGenEntry
+    {
+        uint32_t ID;                        // 0
+        char* Name;                         // 1
+        uint32_t unk1;                      // 2
+        uint32_t type;                      // 3
+    };
+
+    struct NumTalentsAtLevel
+    {
+        //uint32_t level;                   // 0
+        float talentPoints;                 // 1
+    };
+
+    struct PhaseEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t PhaseShift;                // 1
+        uint32_t Flags;                     // 2
+    };
+
+    struct QuestSortEntry
+    {
+        uint32_t id;                        // 0
+        //char* name;                       // 1
+    };
+
+    struct QuestXP
+    {
+        uint32_t questLevel;                // 0
+        uint32_t xpIndex[10];               // 1-10
+    };
+
+    struct ScalingStatDistributionEntry
+    {
+        uint32_t id;                        // 0
+        int32_t stat[10];                   // 1-10
+        uint32_t statmodifier[10];          // 11-20
+        //uint32_t unk;                     // 21
+        uint32_t maxlevel;                  // 22
+    };
+
+    struct ScalingStatValuesEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t level;                     // 1
+        uint32_t multiplier[20];            // 
+        //\todo danko Rewrite GetStatScalingStatValueColumn!
+        //uint32_t dpsMod[6];               // 2-7
+        //uint32_t spellBonus;              // 8
+        //uint32_t scalingstatmultipl[5];   // 9-13
+        //uint32_t amor_mod[4];             // 14-17
+        //uint32_t amor_mod2[4];            // 18-21
+        //uint32_t junk[24];                // 22-45
+        //uint32_t unk2;                    // 46
+    };
+
+    struct SkillLineEntry
+    {
+        uint32_t id;                        // 0
+        uint32_t type;                      // 1
+        char* Name;                         // 2
+        //char* Description;                // 3
+        uint32_t spell_icon;                // 4
+        //char* add_name;                   // 5
+        uint32_t linkable;                  // 6
+    };
+
+    struct SkillLineAbilityEntry
+    {
+        uint32_t Id;                        // 0
+        uint32_t skilline;                  // 1 skill id
+        uint32_t spell;                     // 2
+        uint32_t race_mask;                 // 3
+        uint32_t class_mask;                // 4
+        //uint32_t excludeRace;             // 5
+        //uint32_t excludeClass;            // 6
+        uint32_t minSkillLineRank;          // 7 req skill value
+        uint32_t next;                      // 8
+        uint32_t acquireMethod;             // 9 auto learn
+        uint32_t grey;                      // 10 max
+        uint32_t green;                     // 11 min
+        uint32_t characterPoints;           // 12
+        //uint32_t unk;                     // 13
+    };
+
+    //\todo danko
+    //struct StableSlotPrices
+    //{
+    //    uint32_t Id;                      // 0
+    //    uint32_t Price;                   // 1
+    //};
+
+    //\ todo: confirm effect count
+    #define MAX_SPELL_EFFECTS 3
+    #define MAX_SPELL_REAGENTS 8
+    #define MAX_SPELL_TOTEMS 2
+    #define MAX_SPELL_TOTEM_CATEGORIES 2
+
+    // SpellAuraOptions.dbc
+    struct SpellAuraOptionsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t MaxStackAmount;            // 1
+        uint32_t procChance;                // 2
+        uint32_t procCharges;               // 3
+        uint32_t procFlags;                 // 4
+    };
+
+    // SpellAuraRestrictions.dbc
+    struct SpellAuraRestrictionsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t CasterAuraState;           // 1
+        uint32_t TargetAuraState;           // 2
+        uint32_t CasterAuraStateNot;        // 3
+        uint32_t TargetAuraStateNot;        // 4
+        uint32_t casterAuraSpell;           // 5
+        uint32_t targetAuraSpell;           // 6
+        uint32_t CasterAuraSpellNot;        // 7
+        uint32_t TargetAuraSpellNot;        // 8
+    };
+
+    // SpellCastingRequirements.dbc
+    struct SpellCastingRequirementsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t FacingCasterFlags;         // 1
+        //uint32_t MinFactionId;            // 2
+        //uint32_t MinReputation;           // 3
+        int32_t AreaGroupId;                // 4
+        //uint32_t RequiredAuraVision;      // 5
+        uint32_t RequiresSpellFocus;        // 6
+    };
+
+    // SpellCastTimes.dbc
+    struct SpellCastTimesEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t CastTime;                  // 1
+        float CastTimePerLevel;             // 2
+        int32_t MinCastTime;                // 3
+    };
+
+    // SpellCategories.dbc
+    struct SpellCategoriesEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Category;                  // 1
+        uint32_t DmgClass;                  // 2
+        uint32_t DispelType;                // 3
+        uint32_t MechanicsType;             // 4
+        uint32_t PreventionType;            // 5
+        uint32_t StartRecoveryCategory;     // 6
+    };
+
+    // SpellClassOptions.dbc
+    struct SpellClassOptionsEntry
+    {
+        //uint32_t Id;                                  // 0
+        //uint32_t modalNextSpell;                      // 1
+        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
+        uint32_t SpellFamilyName;                       // 5
+        //char* Description;                            // 6
+    };
+
+    // SpellCooldowns.dbc
+    struct SpellCooldownsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t CategoryRecoveryTime;      // 1
+        uint32_t RecoveryTime;              // 2
+        uint32_t StartRecoveryTime;         // 3
+    };
+
+    // SpellDifficulty.dbc
+    struct SpellDifficultyEntry
+    {
+        uint32_t ID;                        // 0
+        int32_t SpellId[MAX_DIFFICULTY];    // 1-4
+    };
+
+    // SpellDuration.dbc
+    struct SpellDurationEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t Duration1;                 // 1
+        uint32_t Duration2;                 // 2
+        uint32_t Duration3;                 // 3
+    };
+
+    // SpellEffect.dbc
+    struct SpellEffectEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t Effect;                    // 1
+        float EffectMultipleValue;          // 2
+        uint32_t EffectApplyAuraName;       // 3
+        uint32_t EffectAmplitude;           // 4
+        int32_t EffectBasePoints;           // 5
+        float EffectBonusMultiplier;        // 6
+        float EffectDamageMultiplier;       // 7
+        uint32_t EffectChainTarget;         // 8
+        int32_t EffectDieSides;             // 9
+        uint32_t EffectItemType;            // 10
+        uint32_t EffectMechanic;            // 11
+        int32_t EffectMiscValue;            // 12
+        int32_t EffectMiscValueB;           // 13
+        float EffectPointsPerComboPoint;    // 14
+        uint32_t EffectRadiusIndex;         // 15
+        uint32_t EffectRadiusMaxIndex;      // 16
+        float EffectRealPointsPerLevel;     // 17
+        uint32_t EffectSpellClassMask[3];   // 18-20
+        //ClassFamilyMask EffectSpellClassMask;
+        uint32_t EffectTriggerSpell;        // 21
+        uint32_t EffectImplicitTargetA;     // 22
+        uint32_t EffectImplicitTargetB;     // 23
+        uint32_t EffectSpellId;             // 24
+        uint32_t EffectIndex;               // 25
+        //uint32_t unk;                     // 26
+
+        uint32_t GetRadiusIndex() const
         {
-            uint32_t ID;                        // 0
-            char* subject;                      // 1
-            char* content;                      // 2
-        };
+            if (EffectRadiusIndex != 0)
+                return EffectRadiusIndex;
 
-        struct MapEntry
+            return EffectRadiusMaxIndex;
+        }
+    };
+
+    // SpellEquippedItems.dbc
+    struct SpellEquippedItemsEntry
+    {
+        //uint32_t Id;                          // 0
+        int32_t EquippedItemClass;              // 1
+        int32_t EquippedItemInventoryTypeMask;  // 2
+        int32_t EquippedItemSubClassMask;       // 3
+    };
+
+    // SpellFocusObject.dbc
+    struct SpellFocusObjectEntry
+    {
+        uint32_t ID;                        // 0
+        //char* Name;                       // 1
+    };
+
+    // SpellInterrupts.dbc
+    struct SpellInterruptsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t AuraInterruptFlags;        // 1
+        //uint32_t unk2                     // 2
+        uint32_t ChannelInterruptFlags;     // 3
+        //uint32_t unk4                     // 4
+        uint32_t InterruptFlags;            // 5
+    };
+
+    // SpellItemEnchantment.dbc
+    struct SpellItemEnchantmentEntry
+    {
+        uint32_t Id;                        // 0
+        //uint32_t charges;                 // 1
+        uint32_t type[3];                   // 2-4
+        uint32_t min[3];                    // 5-7 for combat, in practice min==max
+        //uint32_t max[3];                  // 8-10
+        uint32_t spell[3];                  // 11-13
+        char* Name;                         // 14-29
+        //uint32_t NameFlags;               // 30
+        uint32_t visual;                    // 31 aura
+        uint32_t EnchantGroups;             // 32 slot
+        uint32_t GemEntry;                  // 33
+        uint32_t ench_condition;            // 34
+        uint32_t req_skill;                 // 35
+        uint32_t req_skill_value;           // 36
+        uint32_t req_level;                 // 37
+    };
+
+    // SpellItemEnchantmentCondition.dbc
+    struct SpellItemEnchantmentConditionEntry
+    {
+        uint32_t ID;                        // 0
+        uint8_t Color[5];                   // 1-5
+        //uint32_t LT_Operand[5];           // 6-10
+        uint8_t Comparator[5];              // 11-15
+        uint8_t CompareColor[5];            // 15-20
+        uint32_t Value[5];                  // 21-25
+        //uint8_t Logic[5]                  // 25-30
+    };
+
+    // SpellLevels.dbc
+    struct SpellLevelsEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t baseLevel;                 // 1
+        uint32_t maxLevel;                  // 2
+        uint32_t spellLevel;                // 3
+    };
+
+    // SpellPower.dbc
+    struct SpellPowerEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t manaCost;                  // 1
+        uint32_t manaCostPerlevel;          // 2
+        uint32_t ManaCostPercentage;        // 3
+        uint32_t manaPerSecond;             // 4
+        uint32_t manaPerSecondPerLevel;     // 5
+        //uint32_t PowerDisplayId;          // 6 
+        float ManaCostPercentageFloat;      // 7
+    };
+
+    // SpellRadius.dbc
+    struct SpellRadiusEntry
+    {
+        uint32_t ID;                        // 0
+        float radius_min;                   // 1
+        float radius_per_level;             // 2
+        float radius_max;                   // 3
+    };
+
+    // SpellRange.dbc
+    struct SpellRangeEntry
+    {
+        uint32_t ID;                        // 0
+        float minRange;                     // 1
+        float minRangeFriendly;             // 2
+        float maxRange;                     // 3
+        float maxRangeFriendly;             // 4
+        uint32_t range_type;                // 5
+        //char* name1[16]                   // 6-21
+        //uint32_t name1_falgs;             // 22
+        //char* name2[16]                   // 23-38
+        //uint32_t name2_falgs;             // 39
+    };
+
+    // SpellReagents.dbc
+    struct SpellReagentsEntry
+    {
+        //uint32_t Id;                              // 0
+        int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
+    };
+
+    // SpellRuneCost.dbc
+    struct SpellRuneCostEntry
+    {
+        uint32_t ID;                        // 0
+        uint32_t bloodRuneCost;             // 1
+        uint32_t frostRuneCost;             // 2
+        uint32_t unholyRuneCost;            // 3
+        uint32_t runePowerGain;             // 4
+    };
+
+    // SpellScaling.dbc
+    struct SpellScalingEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t castTimeMin;               // 1
+        uint32_t castTimeMax;               // 2
+        uint32_t castScalingMaxLevel;       // 3
+        uint32_t playerClass;               // 4
+        float coeff1[3];                    // 5-7
+        float coeff2[3];                    // 8-10
+        float coeff3[3];                    // 11-13
+        float coefBase;                     // 14
+        uint32_t coefLevelBase;             // 15
+
+        bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
+    };
+
+    // SpellShapeshift.dbc
+    struct SpellShapeshiftEntry
+    {
+        //uint32_t Id;                      // 0
+        uint32_t ShapeshiftsExcluded;       // 1
+        //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
+        uint32_t Shapeshifts;               // 3
+        //uint32_t Shapeshifts1;            // 4 unused, all zeros
+        //uint32_t StanceBarOrder;          // 5
+    };
+
+    // SpellTargetRestrictions.dbc
+    struct SpellTargetRestrictionsEntry
+    {
+        //uint32_t Id;                      // 0
+        float MaxTargetRadius;              // 1
+        uint32_t MaxAffectedTargets;        // 2
+        uint32_t MaxTargetLevel;            // 3
+        uint32_t TargetCreatureType;        // 4
+        uint32_t Targets;                   // 5
+    };
+
+    // SpellTotems.dbc
+    struct SpellTotemsEntry
+    {
+        //uint32_t Id;                                         // 0
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
+        uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
+    };
+
+    struct SERVER_DECL SpellEntry
+    {
+        uint32_t Id;                                          // 0
+        uint32_t Attributes;                                  // 1
+        uint32_t AttributesEx;                                // 2
+        uint32_t AttributesExB;                               // 3
+        uint32_t AttributesExC;                               // 4
+        uint32_t AttributesExD;                               // 5
+        uint32_t AttributesExE;                               // 6
+        uint32_t AttributesExF;                               // 7
+        uint32_t AttributesExG;                               // 8
+        uint32_t AttributesExH;                               // 9
+        uint32_t AttributesExI;                               // 10
+        uint32_t AttributesExJ;                               // 11
+        uint32_t CastingTimeIndex;                            // 12
+        uint32_t DurationIndex;                               // 13
+        int32_t powerType;                                    // 14
+        uint32_t rangeIndex;                                  // 15
+        float speed;                                          // 16
+        uint32_t SpellVisual;                                 // 17
+        uint32_t SpellVisual1;                                // 18
+        uint32_t spellIconID;                                 // 19
+        uint32_t activeIconID;                                // 20
+        const char* Name;                                     // 21
+        const char* Rank;                                     // 22
+        //char* Description;                                  // 23 not used
+        //char* BuffDescription;                              // 24 not used
+        uint32_t School;                                      // 25
+        uint32_t RuneCostID;                                  // 26
+        //uint32_t spellMissileID;                            // 27
+        //uint32_t spellDescriptionVariableID;                // 28
+        uint32_t SpellDifficultyId;                           // 29
+        //float unk_1;                                        // 30
+        uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
+        uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
+        uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
+        uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
+        uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
+        uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
+        uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
+        //uint32_t unk_2;                                     // 38 all zeros...
+        uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
+        uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
+        uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
+        uint32_t SpellPowerId;                                // 42 SpellPower.dbc
+        uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
+        uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
+        uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
+        uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
+        //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
+
+        // struct access functions
+        SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
+        SpellAuraRestrictionsEntry const* GetSpellAuraRestrictions() const;
+        SpellCastingRequirementsEntry const* GetSpellCastingRequirements() const;
+        SpellCategoriesEntry const* GetSpellCategories() const;
+        SpellClassOptionsEntry const* GetSpellClassOptions() const;
+        SpellCooldownsEntry const* GetSpellCooldowns() const;
+        SpellEffectEntry const* GetSpellEffect(uint8_t eff) const;
+        SpellEquippedItemsEntry const* GetSpellEquippedItems() const;
+        SpellInterruptsEntry const* GetSpellInterrupts() const;
+        SpellLevelsEntry const* GetSpellLevels() const;
+        SpellPowerEntry const* GetSpellPower() const;
+        SpellReagentsEntry const* GetSpellReagents() const;
+        SpellScalingEntry const* GetSpellScaling() const;
+        SpellShapeshiftEntry const* GetSpellShapeshift() const;
+        SpellTargetRestrictionsEntry const* GetSpellTargetRestrictions() const;
+        SpellTotemsEntry const* GetSpellTotems() const;
+
+        // single fields
+        uint32_t GetManaCost() const;
+        uint32_t GetPreventionType() const;
+        uint32_t GetCategory() const;
+        uint32_t GetStartRecoveryTime() const;
+        uint32_t GetMechanic() const;
+        uint32_t GetRecoveryTime() const;
+        uint32_t GetCategoryRecoveryTime() const;
+        uint32_t GetStartRecoveryCategory() const;
+        uint32_t GetSpellLevel() const;
+        int32_t GetEquippedItemClass() const;
+        uint32_t GetSpellFamilyName() const;
+        uint32_t GetDmgClass() const;
+        uint32_t GetDispel() const;
+        uint32_t GetMaxAffectedTargets() const;
+        uint32_t GetStackAmount() const;
+        uint32_t GetManaCostPercentage() const;
+        uint32_t GetProcCharges() const;
+        uint32_t GetProcChance() const;
+        uint32_t GetMaxLevel() const;
+        uint32_t GetTargetAuraState() const;
+        uint32_t GetManaPerSecond() const;
+        uint32_t GetRequiresSpellFocus() const;
+        uint32_t GetSpellEffectIdByIndex(uint8_t index) const;
+        uint32_t GetAuraInterruptFlags() const;
+        uint32_t GetEffectImplicitTargetAByIndex(uint8_t index) const;
+        int32_t GetAreaGroupId() const;
+        uint32_t GetFacingCasterFlags() const;
+        uint32_t GetBaseLevel() const;
+        uint32_t GetInterruptFlags() const;
+        uint32_t GetTargetCreatureType() const;
+        int32_t GetEffectMiscValue(uint8_t index) const;
+        uint32_t GetStances() const;
+        uint32_t GetStancesNot() const;
+        uint32_t GetProcFlags() const;
+        uint32_t GetChannelInterruptFlags() const;
+        uint32_t GetManaCostPerLevel() const;
+        uint32_t GetCasterAuraState() const;
+        uint32_t GetTargets() const;
+        uint32_t GetEffectApplyAuraNameByIndex(uint8_t index) const;
+
+    private:
+
+        SpellEntry(SpellEntry const&);
+    };
+
+    struct SpellShapeshiftFormEntry
+    {
+        uint32_t id;                  // 0
+        //uint32_t button_pos;        // 1
+        //char* name[16];             // 2-17
+        //uint32_t name_flags;        // 18
+        uint32_t Flags;               // 19
+        uint32_t unit_type;           // 20
+        //uint32_t unk1               // 21
+        uint32_t AttackSpeed;         // 22
+        uint32_t modelId;             // 23 alliance?
+        uint32_t modelId2;            // 24 horde?
+        //uint32_t unk2               // 25
+        //uint32_t unk3               // 26
+        uint32_t spells[8];           // 27-34
+    };
+
+    struct SummonPropertiesEntry
+    {
+        uint32_t ID;                  // 0
+        uint32_t ControlType;         // 1
+        uint32_t FactionID;           // 2
+        uint32_t Type;                // 3
+        uint32_t Slot;                // 4
+        uint32_t Flags;               // 5
+    };
+
+    struct TalentEntry
+    {
+        uint32_t TalentID;            // 0
+        uint32_t TalentTree;          // 1
+        uint32_t Row;                 // 2
+        uint32_t Col;                 // 3
+        uint32_t RankID[5];           // 4-8
+        //uint32_t unk[4];            // 9-12
+        uint32_t DependsOn;           // 13
+        //uint32_t unk1[2];           // 14-15
+        uint32_t DependsOnRank;       // 16
+        //uint32_t unk2[2];           // 17-18
+        //uint32_t unk3;              // 19
+        //uint32_t unk4;              // 20
+        //uint32_t unk5;              // 21
+    };
+
+    struct TalentTabEntry
+    {
+        uint32_t TalentTabID;         // 0
+        //char* Name;                 // 1
+        //uint32_t unk5;              // 2
+        uint32_t ClassMask;           // 3
+        uint32_t PetTalentMask;       // 4
+        uint32_t TabPage;             // 5
+        //char* InternalName;         // 6
+        //char* description;          // 7
+        uint32_t rolesMask;           // 8
+        uint32_t masterySpells[2];    // 9-10
+    };
+
+    struct TalentTreePrimarySpells
+    {
+        uint32_t ID;                  // 0
+        uint32_t tabID;               // 1
+        uint32_t SpellID;             // 2
+        //uint32_t unk                // 3
+    };
+
+    struct TaxiNodesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t mapid;               // 1
+        float x;                      // 2
+        float y;                      // 3
+        float z;                      // 4
+        char* name;                   // 5
+        uint32_t horde_mount;         // 6
+        uint32_t alliance_mount;      // 7
+    };
+
+    struct TaxiPathEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t from;                // 1
+        uint32_t to;                  // 2
+        uint32_t price;               // 3
+    };
+
+    struct TaxiPathNodeEntry
+    {
+        //uint32_t id;                // 0
+        uint32_t path;                // 1
+        uint32_t seq;                 // 2 nodeIndex
+        uint32_t mapid;               // 3
+        float x;                      // 4
+        float y;                      // 5
+        float z;                      // 6
+        uint32_t flags;               // 7
+        uint32_t waittime;            // 8
+        uint32_t arivalEventID;       // 9
+        uint32_t departureEventID;    // 10
+    };
+
+    struct TotemCategoryEntry
+    {
+        uint32_t id;            // 0
+        //char* name;           // 1
+        uint32_t categoryType;  // 2
+        uint32_t categoryMask;  // 3
+    };
+
+    struct TransportAnimationEntry
+    {
+        //uint32_t Id;          // 0
+        uint32_t TransportID;   // 1
+        uint32_t TimeIndex;     // 2
+        DBCPosition3D Pos;      // 3
+        //uint32_t SequenceID;  // 4
+    };
+
+    struct TransportRotationEntry
+    {
+        //uint32_t ID;          // 0
+        uint32_t GameObjectsID; // 1
+        uint32_t TimeIndex;     // 2
+        float X;                // 3
+        float Y;                // 4
+        float Z;                // 5
+        float W;                // 6
+    };
+
+    #define MAX_VEHICLE_SEATS 8
+
+    struct VehicleEntry
+    {
+        uint32_t ID;                                        // 0
+        uint32_t flags;                                     // 1
+        float turnSpeed;                                    // 2
+        float pitchSpeed;                                   // 3
+        float pitchMin;                                     // 4
+        float pitchMax;                                     // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
+        float mouseLookOffsetPitch;                         // 14
+        float cameraFadeDistScalarMin;                      // 15
+        float cameraFadeDistScalarMax;                      // 16
+        float cameraPitchOffset;                            // 17
+        float facingLimitRight;                             // 18
+        float facingLimitLeft;                              // 19
+        float msslTrgtTurnLingering;                        // 20
+        float msslTrgtPitchLingering;                       // 21
+        float msslTrgtMouseLingering;                       // 22
+        float msslTrgtEndOpacity;                           // 23
+        float msslTrgtArcSpeed;                             // 24
+        float msslTrgtArcRepeat;                            // 25
+        float msslTrgtArcWidth;                             // 26
+        float msslTrgtImpactRadius[2];                      // 27-28
+        char* msslTrgtArcTexture;                           // 29
+        char* msslTrgtImpactTexture;                        // 30
+        char* msslTrgtImpactModel[2];                       // 31-32
+        float cameraYawOffset;                              // 33
+        uint32_t uiLocomotionType;                          // 34
+        float msslTrgtImpactTexRadius;                      // 35
+        uint32_t uiSeatIndicatorType;                       // 36
+        uint32_t powerType;                                 // 37
+        //uint32_t unk1;                                    // 38
+        //uint32_t unk2;                                    // 39  
+    };
+
+    enum VehicleSeatFlags
+    {
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+    };
+
+    enum VehicleSeatFlagsB
+    {
+        VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
+    };
+
+    struct VehicleSeatEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        int32_t attachmentID;                                 // 2
+        float attachmentOffsetX;                              // 3
+        float attachmentOffsetY;                              // 4
+        float attachmentOffsetZ;                              // 5
+        float enterPreDelay;                                  // 6
+        float enterSpeed;                                     // 7
+        float enterGravity;                                   // 8
+        float enterMinDuration;                               // 9
+        float enterMaxDuration;                               // 10
+        float enterMinArcHeight;                              // 11
+        float enterMaxArcHeight;                              // 12
+        int32_t enterAnimStart;                               // 13
+        int32_t enterAnimLoop;                                // 14
+        int32_t rideAnimStart;                                // 15
+        int32_t rideAnimLoop;                                 // 16
+        int32_t rideUpperAnimStart;                           // 17
+        int32_t rideUpperAnimLoop;                            // 18
+        float exitPreDelay;                                   // 19
+        float exitSpeed;                                      // 20
+        float exitGravity;                                    // 21
+        float exitMinDuration;                                // 22
+        float exitMaxDuration;                                // 23
+        float exitMinArcHeight;                               // 24
+        float exitMaxArcHeight;                               // 25
+        int32_t exitAnimStart;                                // 26
+        int32_t exitAnimLoop;                                 // 27
+        int32_t exitAnimEnd;                                  // 28
+        float passengerYaw;                                   // 29
+        float passengerPitch;                                 // 30
+        float passengerRoll;                                  // 31
+        int32_t passengerAttachmentID;                        // 32
+        int32_t vehicleEnterAnim;                             // 33
+        int32_t vehicleExitAnim;                              // 34
+        int32_t vehicleRideAnimLoop;                          // 35
+        int32_t vehicleEnterAnimBone;                         // 36
+        int32_t vehicleExitAnimBone;                          // 37
+        int32_t vehicleRideAnimLoopBone;                      // 38
+        float vehicleEnterAnimDelay;                          // 39
+        float vehicleExitAnimDelay;                           // 40
+        uint32_t vehicleAbilityDisplay;                       // 41
+        uint32_t enterUISoundID;                              // 42
+        uint32_t exitUISoundID;                               // 43
+        int32_t uiSkin;                                       // 44
+        uint32_t flagsB;                                      // 45
+
+        bool IsUsable() const
         {
-            uint32_t id;                        // 0
-            char* name_internal;                // 1
-            uint32_t map_type;                  // 2
-            uint32_t map_flags;                 // 3
-            uint32_t unk4;                      // 4
-            uint32_t is_pvp_zone;               // 5
-            char* map_name;                     // 6
-            uint32_t linked_zone;               // 7 common zone for instance and continent map
-            char* horde_intro;                  // 8 horde text for PvP Zones
-            char* alliance_intro;               // 9 alliance text for PvP Zones
-            uint32_t multimap_id;               // 10
-            float battlefield_map_icon;         // 11
-            int32_t parent_map;                 // 12 ghost map_id of parent map
-            float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
-            float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
-            uint32_t dayTime_override;          // 15
-            uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
-            uint32_t unk_time;                  // 17
-            uint32_t max_players;               // 18
-            uint32_t next_phase_map;            // 19
+            if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
+                return true;
+            else
+                return false;
+        }
 
-            bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
-            bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
-            bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isRaid() const { return map_type == MAP_RAID; }
-            bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
-            bool isBattleArena() const { return map_type == MAP_ARENA; }
-            bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isWorldMap() const { return map_type == MAP_COMMON; }
-
-            bool isContinent() const
-            {
-                return id == 0 || id == 1 || id == 530 || id == 571;
-            }
-        };
-
-        struct NameGenEntry
+        bool IsController() const
         {
-            uint32_t ID;                        // 0
-            char* Name;                         // 1
-            uint32_t unk1;                      // 2
-            uint32_t type;                      // 3
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
+                return true;
+            else
+                return false;
+        }
 
-        struct NumTalentsAtLevel
+        bool HidesPassenger() const
         {
-            //uint32_t level;                   // 0
-            float talentPoints;                 // 1
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
+                return true;
+            else
+                return false;
+        }
+    };
 
-        struct PhaseEntry
+    struct WMOAreaTableEntry
+    {
+        uint32_t id;                // 0
+        int32_t rootId;             // 1
+        int32_t adtId;              // 2
+        int32_t groupId;            // 3
+        //uint32_t field4;          // 4
+        //uint32_t field5;          // 5
+        //uint32_t field6;          // 6
+        //uint32_t field7;          // 7
+        //uint32_t field8;          // 8
+        uint32_t flags;             // 9
+        uint32_t areaId;            // 10
+        //char Name[16];            // 11-26
+        //uint32_t nameflags;       // 27
+    };
+
+    struct WorldMapAreaEntry
+    {
+        //uint32_t id;              // 0
+        uint32_t mapId;             // 1
+        uint32_t zoneId;            // 2
+        //const char* name;         // 3
+        //float y1;                 // 4
+        //float y2;                 // 5
+        //float x1;                 // 6
+        //float x2;                 // 7
+        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1             // 9
+        //uint32_t parentId         // 10
+        //uint32_t unk2             // 11
+        //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
+        //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
+    };
+
+    struct WorldMapOverlayEntry
+    {
+        uint32_t ID;                // 0
+        //uint32_t worldMapID;      // 1 WorldMapArea.dbc
+        uint32_t areaID;            // 2
+        uint32_t areaID_2;          // 3
+        uint32_t areaID_3;          // 4
+        uint32_t areaID_4;          // 5
+        //uint32_t unk1[2];         // 6-7
+        //uint32_t unk2;            // 8
+        //uint32_t unk3[7];         // 9-16
+    };
+
+    #pragma pack(pop)
+
+    typedef std::set<uint32_t> SpellCategorySet;
+    typedef std::map<uint32_t, SpellCategorySet> SpellCategoryStore;
+    struct SpellEffect
+    {
+        SpellEffect()
         {
-            uint32_t Id;                        // 0
-            uint32_t PhaseShift;                // 1
-            uint32_t Flags;                     // 2
-        };
-
-        struct QuestSortEntry
-        {
-            uint32_t id;                        // 0
-            //char* name;                       // 1
-        };
-
-        struct QuestXP
-        {
-            uint32_t questLevel;                // 0
-            uint32_t xpIndex[10];               // 1-10
-        };
-
-        struct ScalingStatDistributionEntry
-        {
-            uint32_t id;                        // 0
-            int32_t stat[10];                   // 1-10
-            uint32_t statmodifier[10];          // 11-20
-            //uint32_t unk;                     // 21
-            uint32_t maxlevel;                  // 22
-        };
-
-        struct ScalingStatValuesEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t level;                     // 1
-            uint32_t multiplier[20];            // 
-            //\todo danko Rewrite GetStatScalingStatValueColumn!
-            //uint32_t dpsMod[6];               // 2-7
-            //uint32_t spellBonus;              // 8
-            //uint32_t scalingstatmultipl[5];   // 9-13
-            //uint32_t amor_mod[4];             // 14-17
-            //uint32_t amor_mod2[4];            // 18-21
-            //uint32_t junk[24];                // 22-45
-            //uint32_t unk2;                    // 46
-        };
-
-        struct SkillLineEntry
-        {
-            uint32_t id;                        // 0
-            uint32_t type;                      // 1
-            char* Name;                         // 2
-            //char* Description;                // 3
-            uint32_t spell_icon;                // 4
-            //char* add_name;                   // 5
-            uint32_t linkable;                  // 6
-        };
-
-        struct SkillLineAbilityEntry
-        {
-            uint32_t Id;                        // 0
-            uint32_t skilline;                  // 1 skill id
-            uint32_t spell;                     // 2
-            uint32_t race_mask;                 // 3
-            uint32_t class_mask;                // 4
-            //uint32_t excludeRace;             // 5
-            //uint32_t excludeClass;            // 6
-            uint32_t minSkillLineRank;          // 7 req skill value
-            uint32_t next;                      // 8
-            uint32_t acquireMethod;             // 9 auto learn
-            uint32_t grey;                      // 10 max
-            uint32_t green;                     // 11 min
-            uint32_t characterPoints;           // 12
-            //uint32_t unk;                     // 13
-        };
-
-        //\todo danko
-        //struct StableSlotPrices
-        //{
-        //    uint32_t Id;                      // 0
-        //    uint32_t Price;                   // 1
-        //};
-
-        //\ todo: confirm effect count
-        #define MAX_SPELL_EFFECTS 3
-        #define MAX_SPELL_REAGENTS 8
-        #define MAX_SPELL_TOTEMS 2
-        #define MAX_SPELL_TOTEM_CATEGORIES 2
-
-        // SpellAuraOptions.dbc
-        struct SpellAuraOptionsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t MaxStackAmount;            // 1
-            uint32_t procChance;                // 2
-            uint32_t procCharges;               // 3
-            uint32_t procFlags;                 // 4
-        };
-
-        // SpellAuraRestrictions.dbc
-        struct SpellAuraRestrictionsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t CasterAuraState;           // 1
-            uint32_t TargetAuraState;           // 2
-            uint32_t CasterAuraStateNot;        // 3
-            uint32_t TargetAuraStateNot;        // 4
-            uint32_t casterAuraSpell;           // 5
-            uint32_t targetAuraSpell;           // 6
-            uint32_t CasterAuraSpellNot;        // 7
-            uint32_t TargetAuraSpellNot;        // 8
-        };
-
-        // SpellCastingRequirements.dbc
-        struct SpellCastingRequirementsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t FacingCasterFlags;         // 1
-            //uint32_t MinFactionId;            // 2
-            //uint32_t MinReputation;           // 3
-            int32_t AreaGroupId;                // 4
-            //uint32_t RequiredAuraVision;      // 5
-            uint32_t RequiresSpellFocus;        // 6
-        };
-
-        // SpellCastTimes.dbc
-        struct SpellCastTimesEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t CastTime;                  // 1
-            float CastTimePerLevel;             // 2
-            int32_t MinCastTime;                // 3
-        };
-
-        // SpellCategories.dbc
-        struct SpellCategoriesEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Category;                  // 1
-            uint32_t DmgClass;                  // 2
-            uint32_t DispelType;                // 3
-            uint32_t MechanicsType;             // 4
-            uint32_t PreventionType;            // 5
-            uint32_t StartRecoveryCategory;     // 6
-        };
-
-        // SpellClassOptions.dbc
-        struct SpellClassOptionsEntry
-        {
-            //uint32_t Id;                                  // 0
-            //uint32_t modalNextSpell;                      // 1
-            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
-            uint32_t SpellFamilyName;                       // 5
-            //char* Description;                            // 6
-        };
-
-        // SpellCooldowns.dbc
-        struct SpellCooldownsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t CategoryRecoveryTime;      // 1
-            uint32_t RecoveryTime;              // 2
-            uint32_t StartRecoveryTime;         // 3
-        };
-
-        // SpellDifficulty.dbc
-        struct SpellDifficultyEntry
-        {
-            uint32_t ID;                        // 0
-            int32_t SpellId[MAX_DIFFICULTY];    // 1-4
-        };
-
-        // SpellDuration.dbc
-        struct SpellDurationEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t Duration1;                 // 1
-            uint32_t Duration2;                 // 2
-            uint32_t Duration3;                 // 3
-        };
-
-        // SpellEffect.dbc
-        struct SpellEffectEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t Effect;                    // 1
-            float EffectMultipleValue;          // 2
-            uint32_t EffectApplyAuraName;       // 3
-            uint32_t EffectAmplitude;           // 4
-            int32_t EffectBasePoints;           // 5
-            float EffectBonusMultiplier;        // 6
-            float EffectDamageMultiplier;       // 7
-            uint32_t EffectChainTarget;         // 8
-            int32_t EffectDieSides;             // 9
-            uint32_t EffectItemType;            // 10
-            uint32_t EffectMechanic;            // 11
-            int32_t EffectMiscValue;            // 12
-            int32_t EffectMiscValueB;           // 13
-            float EffectPointsPerComboPoint;    // 14
-            uint32_t EffectRadiusIndex;         // 15
-            uint32_t EffectRadiusMaxIndex;      // 16
-            float EffectRealPointsPerLevel;     // 17
-            uint32_t EffectSpellClassMask[3];   // 18-20
-            //ClassFamilyMask EffectSpellClassMask;
-            uint32_t EffectTriggerSpell;        // 21
-            uint32_t EffectImplicitTargetA;     // 22
-            uint32_t EffectImplicitTargetB;     // 23
-            uint32_t EffectSpellId;             // 24
-            uint32_t EffectIndex;               // 25
-            //uint32_t unk;                     // 26
-
-            uint32_t GetRadiusIndex() const
-            {
-                if (EffectRadiusIndex != 0)
-                    return EffectRadiusIndex;
-
-                return EffectRadiusMaxIndex;
-            }
-        };
-
-        // SpellEquippedItems.dbc
-        struct SpellEquippedItemsEntry
-        {
-            //uint32_t Id;                          // 0
-            int32_t EquippedItemClass;              // 1
-            int32_t EquippedItemInventoryTypeMask;  // 2
-            int32_t EquippedItemSubClassMask;       // 3
-        };
-
-        // SpellFocusObject.dbc
-        struct SpellFocusObjectEntry
-        {
-            uint32_t ID;                        // 0
-            //char* Name;                       // 1
-        };
-
-        // SpellInterrupts.dbc
-        struct SpellInterruptsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t AuraInterruptFlags;        // 1
-            //uint32_t unk2                     // 2
-            uint32_t ChannelInterruptFlags;     // 3
-            //uint32_t unk4                     // 4
-            uint32_t InterruptFlags;            // 5
-        };
-
-        // SpellItemEnchantment.dbc
-        struct SpellItemEnchantmentEntry
-        {
-            uint32_t Id;                        // 0
-            //uint32_t charges;                 // 1
-            uint32_t type[3];                   // 2-4
-            uint32_t min[3];                    // 5-7 for combat, in practice min==max
-            //uint32_t max[3];                  // 8-10
-            uint32_t spell[3];                  // 11-13
-            char* Name;                         // 14-29
-            //uint32_t NameFlags;               // 30
-            uint32_t visual;                    // 31 aura
-            uint32_t EnchantGroups;             // 32 slot
-            uint32_t GemEntry;                  // 33
-            uint32_t ench_condition;            // 34
-            uint32_t req_skill;                 // 35
-            uint32_t req_skill_value;           // 36
-            uint32_t req_level;                 // 37
-        };
-
-        // SpellItemEnchantmentCondition.dbc
-        struct SpellItemEnchantmentConditionEntry
-        {
-            uint32_t ID;                        // 0
-            uint8_t Color[5];                   // 1-5
-            //uint32_t LT_Operand[5];           // 6-10
-            uint8_t Comparator[5];              // 11-15
-            uint8_t CompareColor[5];            // 15-20
-            uint32_t Value[5];                  // 21-25
-            //uint8_t Logic[5]                  // 25-30
-        };
-
-        // SpellLevels.dbc
-        struct SpellLevelsEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t baseLevel;                 // 1
-            uint32_t maxLevel;                  // 2
-            uint32_t spellLevel;                // 3
-        };
-
-        // SpellPower.dbc
-        struct SpellPowerEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t manaCost;                  // 1
-            uint32_t manaCostPerlevel;          // 2
-            uint32_t ManaCostPercentage;        // 3
-            uint32_t manaPerSecond;             // 4
-            uint32_t manaPerSecondPerLevel;     // 5
-            //uint32_t PowerDisplayId;          // 6 
-            float ManaCostPercentageFloat;      // 7
-        };
-
-        // SpellRadius.dbc
-        struct SpellRadiusEntry
-        {
-            uint32_t ID;                        // 0
-            float radius_min;                   // 1
-            float radius_per_level;             // 2
-            float radius_max;                   // 3
-        };
-
-        // SpellRange.dbc
-        struct SpellRangeEntry
-        {
-            uint32_t ID;                        // 0
-            float minRange;                     // 1
-            float minRangeFriendly;             // 2
-            float maxRange;                     // 3
-            float maxRangeFriendly;             // 4
-            uint32_t range_type;                // 5
-            //char* name1[16]                   // 6-21
-            //uint32_t name1_falgs;             // 22
-            //char* name2[16]                   // 23-38
-            //uint32_t name2_falgs;             // 39
-        };
-
-        // SpellReagents.dbc
-        struct SpellReagentsEntry
-        {
-            //uint32_t Id;                              // 0
-            int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
-            uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
-        };
-
-        // SpellRuneCost.dbc
-        struct SpellRuneCostEntry
-        {
-            uint32_t ID;                        // 0
-            uint32_t bloodRuneCost;             // 1
-            uint32_t frostRuneCost;             // 2
-            uint32_t unholyRuneCost;            // 3
-            uint32_t runePowerGain;             // 4
-        };
-
-        // SpellScaling.dbc
-        struct SpellScalingEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t castTimeMin;               // 1
-            uint32_t castTimeMax;               // 2
-            uint32_t castScalingMaxLevel;       // 3
-            uint32_t playerClass;               // 4
-            float coeff1[3];                    // 5-7
-            float coeff2[3];                    // 8-10
-            float coeff3[3];                    // 11-13
-            float coefBase;                     // 14
-            uint32_t coefLevelBase;             // 15
-
-            bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
-        };
-
-        // SpellShapeshift.dbc
-        struct SpellShapeshiftEntry
-        {
-            //uint32_t Id;                      // 0
-            uint32_t ShapeshiftsExcluded;       // 1
-            //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
-            uint32_t Shapeshifts;               // 3
-            //uint32_t Shapeshifts1;            // 4 unused, all zeros
-            //uint32_t StanceBarOrder;          // 5
-        };
-
-        // SpellTargetRestrictions.dbc
-        struct SpellTargetRestrictionsEntry
-        {
-            //uint32_t Id;                      // 0
-            float MaxTargetRadius;              // 1
-            uint32_t MaxAffectedTargets;        // 2
-            uint32_t MaxTargetLevel;            // 3
-            uint32_t TargetCreatureType;        // 4
-            uint32_t Targets;                   // 5
-        };
-
-        // SpellTotems.dbc
-        struct SpellTotemsEntry
-        {
-            //uint32_t Id;                                         // 0
-            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
-            uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
-        };
-
-        struct SERVER_DECL SpellEntry
-        {
-            uint32_t Id;                                          // 0
-            uint32_t Attributes;                                  // 1
-            uint32_t AttributesEx;                                // 2
-            uint32_t AttributesExB;                               // 3
-            uint32_t AttributesExC;                               // 4
-            uint32_t AttributesExD;                               // 5
-            uint32_t AttributesExE;                               // 6
-            uint32_t AttributesExF;                               // 7
-            uint32_t AttributesExG;                               // 8
-            uint32_t AttributesExH;                               // 9
-            uint32_t AttributesExI;                               // 10
-            uint32_t AttributesExJ;                               // 11
-            uint32_t CastingTimeIndex;                            // 12
-            uint32_t DurationIndex;                               // 13
-            int32_t powerType;                                    // 14
-            uint32_t rangeIndex;                                  // 15
-            float speed;                                          // 16
-            uint32_t SpellVisual;                                 // 17
-            uint32_t SpellVisual1;                                // 18
-            uint32_t spellIconID;                                 // 19
-            uint32_t activeIconID;                                // 20
-            const char* Name;                                     // 21
-            const char* Rank;                                     // 22
-            //char* Description;                                  // 23 not used
-            //char* BuffDescription;                              // 24 not used
-            uint32_t School;                                      // 25
-            uint32_t RuneCostID;                                  // 26
-            //uint32_t spellMissileID;                            // 27
-            //uint32_t spellDescriptionVariableID;                // 28
-            uint32_t SpellDifficultyId;                           // 29
-            //float unk_1;                                        // 30
-            uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
-            uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
-            uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
-            uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
-            uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
-            uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
-            uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
-            //uint32_t unk_2;                                     // 38 all zeros...
-            uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
-            uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
-            uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
-            uint32_t SpellPowerId;                                // 42 SpellPower.dbc
-            uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
-            uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
-            uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
-            uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
-            //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
-
-            // struct access functions
-            SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
-            SpellAuraRestrictionsEntry const* GetSpellAuraRestrictions() const;
-            SpellCastingRequirementsEntry const* GetSpellCastingRequirements() const;
-            SpellCategoriesEntry const* GetSpellCategories() const;
-            SpellClassOptionsEntry const* GetSpellClassOptions() const;
-            SpellCooldownsEntry const* GetSpellCooldowns() const;
-            SpellEffectEntry const* GetSpellEffect(uint8_t eff) const;
-            SpellEquippedItemsEntry const* GetSpellEquippedItems() const;
-            SpellInterruptsEntry const* GetSpellInterrupts() const;
-            SpellLevelsEntry const* GetSpellLevels() const;
-            SpellPowerEntry const* GetSpellPower() const;
-            SpellReagentsEntry const* GetSpellReagents() const;
-            SpellScalingEntry const* GetSpellScaling() const;
-            SpellShapeshiftEntry const* GetSpellShapeshift() const;
-            SpellTargetRestrictionsEntry const* GetSpellTargetRestrictions() const;
-            SpellTotemsEntry const* GetSpellTotems() const;
-
-            // single fields
-            uint32_t GetManaCost() const;
-            uint32_t GetPreventionType() const;
-            uint32_t GetCategory() const;
-            uint32_t GetStartRecoveryTime() const;
-            uint32_t GetMechanic() const;
-            uint32_t GetRecoveryTime() const;
-            uint32_t GetCategoryRecoveryTime() const;
-            uint32_t GetStartRecoveryCategory() const;
-            uint32_t GetSpellLevel() const;
-            int32_t GetEquippedItemClass() const;
-            uint32_t GetSpellFamilyName() const;
-            uint32_t GetDmgClass() const;
-            uint32_t GetDispel() const;
-            uint32_t GetMaxAffectedTargets() const;
-            uint32_t GetStackAmount() const;
-            uint32_t GetManaCostPercentage() const;
-            uint32_t GetProcCharges() const;
-            uint32_t GetProcChance() const;
-            uint32_t GetMaxLevel() const;
-            uint32_t GetTargetAuraState() const;
-            uint32_t GetManaPerSecond() const;
-            uint32_t GetRequiresSpellFocus() const;
-            uint32_t GetSpellEffectIdByIndex(uint8_t index) const;
-            uint32_t GetAuraInterruptFlags() const;
-            uint32_t GetEffectImplicitTargetAByIndex(uint8_t index) const;
-            int32_t GetAreaGroupId() const;
-            uint32_t GetFacingCasterFlags() const;
-            uint32_t GetBaseLevel() const;
-            uint32_t GetInterruptFlags() const;
-            uint32_t GetTargetCreatureType() const;
-            int32_t GetEffectMiscValue(uint8_t index) const;
-            uint32_t GetStances() const;
-            uint32_t GetStancesNot() const;
-            uint32_t GetProcFlags() const;
-            uint32_t GetChannelInterruptFlags() const;
-            uint32_t GetManaCostPerLevel() const;
-            uint32_t GetCasterAuraState() const;
-            uint32_t GetTargets() const;
-            uint32_t GetEffectApplyAuraNameByIndex(uint8_t index) const;
-
-        private:
-
-            SpellEntry(SpellEntry const&);
-        };
-
-        struct SpellShapeshiftFormEntry
-        {
-            uint32_t id;                  // 0
-            //uint32_t button_pos;        // 1
-            //char* name[16];             // 2-17
-            //uint32_t name_flags;        // 18
-            uint32_t Flags;               // 19
-            uint32_t unit_type;           // 20
-            //uint32_t unk1               // 21
-            uint32_t AttackSpeed;         // 22
-            uint32_t modelId;             // 23 alliance?
-            uint32_t modelId2;            // 24 horde?
-            //uint32_t unk2               // 25
-            //uint32_t unk3               // 26
-            uint32_t spells[8];           // 27-34
-        };
-
-        struct SummonPropertiesEntry
-        {
-            uint32_t ID;                  // 0
-            uint32_t ControlType;         // 1
-            uint32_t FactionID;           // 2
-            uint32_t Type;                // 3
-            uint32_t Slot;                // 4
-            uint32_t Flags;               // 5
-        };
-
-        struct TalentEntry
-        {
-            uint32_t TalentID;            // 0
-            uint32_t TalentTree;          // 1
-            uint32_t Row;                 // 2
-            uint32_t Col;                 // 3
-            uint32_t RankID[5];           // 4-8
-            //uint32_t unk[4];            // 9-12
-            uint32_t DependsOn;           // 13
-            //uint32_t unk1[2];           // 14-15
-            uint32_t DependsOnRank;       // 16
-            //uint32_t unk2[2];           // 17-18
-            //uint32_t unk3;              // 19
-            //uint32_t unk4;              // 20
-            //uint32_t unk5;              // 21
-        };
-
-        struct TalentTabEntry
-        {
-            uint32_t TalentTabID;         // 0
-            //char* Name;                 // 1
-            //uint32_t unk5;              // 2
-            uint32_t ClassMask;           // 3
-            uint32_t PetTalentMask;       // 4
-            uint32_t TabPage;             // 5
-            //char* InternalName;         // 6
-            //char* description;          // 7
-            uint32_t rolesMask;           // 8
-            uint32_t masterySpells[2];    // 9-10
-        };
-
-        struct TalentTreePrimarySpells
-        {
-            uint32_t ID;                  // 0
-            uint32_t tabID;               // 1
-            uint32_t SpellID;             // 2
-            //uint32_t unk                // 3
-        };
-
-        struct TaxiNodesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t mapid;               // 1
-            float x;                      // 2
-            float y;                      // 3
-            float z;                      // 4
-            char* name;                   // 5
-            uint32_t horde_mount;         // 6
-            uint32_t alliance_mount;      // 7
-        };
-
-        struct TaxiPathEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t from;                // 1
-            uint32_t to;                  // 2
-            uint32_t price;               // 3
-        };
-
-        struct TaxiPathNodeEntry
-        {
-            //uint32_t id;                // 0
-            uint32_t path;                // 1
-            uint32_t seq;                 // 2 nodeIndex
-            uint32_t mapid;               // 3
-            float x;                      // 4
-            float y;                      // 5
-            float z;                      // 6
-            uint32_t flags;               // 7
-            uint32_t waittime;            // 8
-            uint32_t arivalEventID;       // 9
-            uint32_t departureEventID;    // 10
-        };
-
-        struct TotemCategoryEntry
-        {
-            uint32_t id;            // 0
-            //char* name;           // 1
-            uint32_t categoryType;  // 2
-            uint32_t categoryMask;  // 3
-        };
-
-        struct TransportAnimationEntry
-        {
-            //uint32_t Id;          // 0
-            uint32_t TransportID;   // 1
-            uint32_t TimeIndex;     // 2
-            DBCPosition3D Pos;      // 3
-            //uint32_t SequenceID;  // 4
-        };
-
-        struct TransportRotationEntry
-        {
-            //uint32_t ID;          // 0
-            uint32_t GameObjectsID; // 1
-            uint32_t TimeIndex;     // 2
-            float X;                // 3
-            float Y;                // 4
-            float Z;                // 5
-            float W;                // 6
-        };
-
-        #define MAX_VEHICLE_SEATS 8
-
-        struct VehicleEntry
-        {
-            uint32_t ID;                                        // 0
-            uint32_t flags;                                     // 1
-            float turnSpeed;                                    // 2
-            float pitchSpeed;                                   // 3
-            float pitchMin;                                     // 4
-            float pitchMax;                                     // 5
-            uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
-            float mouseLookOffsetPitch;                         // 14
-            float cameraFadeDistScalarMin;                      // 15
-            float cameraFadeDistScalarMax;                      // 16
-            float cameraPitchOffset;                            // 17
-            float facingLimitRight;                             // 18
-            float facingLimitLeft;                              // 19
-            float msslTrgtTurnLingering;                        // 20
-            float msslTrgtPitchLingering;                       // 21
-            float msslTrgtMouseLingering;                       // 22
-            float msslTrgtEndOpacity;                           // 23
-            float msslTrgtArcSpeed;                             // 24
-            float msslTrgtArcRepeat;                            // 25
-            float msslTrgtArcWidth;                             // 26
-            float msslTrgtImpactRadius[2];                      // 27-28
-            char* msslTrgtArcTexture;                           // 29
-            char* msslTrgtImpactTexture;                        // 30
-            char* msslTrgtImpactModel[2];                       // 31-32
-            float cameraYawOffset;                              // 33
-            uint32_t uiLocomotionType;                          // 34
-            float msslTrgtImpactTexRadius;                      // 35
-            uint32_t uiSeatIndicatorType;                       // 36
-            uint32_t powerType;                                 // 37
-            //uint32_t unk1;                                    // 38
-            //uint32_t unk2;                                    // 39  
-        };
-
-        enum VehicleSeatFlags
-        {
-            VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
-            VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-            VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-            VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-            VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-            VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-            VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
-        };
-
-        enum VehicleSeatFlagsB
-        {
-            VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
-        };
-
-        struct VehicleSeatEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            int32_t attachmentID;                                 // 2
-            float attachmentOffsetX;                              // 3
-            float attachmentOffsetY;                              // 4
-            float attachmentOffsetZ;                              // 5
-            float enterPreDelay;                                  // 6
-            float enterSpeed;                                     // 7
-            float enterGravity;                                   // 8
-            float enterMinDuration;                               // 9
-            float enterMaxDuration;                               // 10
-            float enterMinArcHeight;                              // 11
-            float enterMaxArcHeight;                              // 12
-            int32_t enterAnimStart;                               // 13
-            int32_t enterAnimLoop;                                // 14
-            int32_t rideAnimStart;                                // 15
-            int32_t rideAnimLoop;                                 // 16
-            int32_t rideUpperAnimStart;                           // 17
-            int32_t rideUpperAnimLoop;                            // 18
-            float exitPreDelay;                                   // 19
-            float exitSpeed;                                      // 20
-            float exitGravity;                                    // 21
-            float exitMinDuration;                                // 22
-            float exitMaxDuration;                                // 23
-            float exitMinArcHeight;                               // 24
-            float exitMaxArcHeight;                               // 25
-            int32_t exitAnimStart;                                // 26
-            int32_t exitAnimLoop;                                 // 27
-            int32_t exitAnimEnd;                                  // 28
-            float passengerYaw;                                   // 29
-            float passengerPitch;                                 // 30
-            float passengerRoll;                                  // 31
-            int32_t passengerAttachmentID;                        // 32
-            int32_t vehicleEnterAnim;                             // 33
-            int32_t vehicleExitAnim;                              // 34
-            int32_t vehicleRideAnimLoop;                          // 35
-            int32_t vehicleEnterAnimBone;                         // 36
-            int32_t vehicleExitAnimBone;                          // 37
-            int32_t vehicleRideAnimLoopBone;                      // 38
-            float vehicleEnterAnimDelay;                          // 39
-            float vehicleExitAnimDelay;                           // 40
-            uint32_t vehicleAbilityDisplay;                       // 41
-            uint32_t enterUISoundID;                              // 42
-            uint32_t exitUISoundID;                               // 43
-            int32_t uiSkin;                                       // 44
-            uint32_t flagsB;                                      // 45
-
-            bool IsUsable() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool IsController() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool HidesPassenger() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
-                    return true;
-                else
-                    return false;
-            }
-        };
-
-        struct WMOAreaTableEntry
-        {
-            uint32_t id;                // 0
-            int32_t rootId;             // 1
-            int32_t adtId;              // 2
-            int32_t groupId;            // 3
-            //uint32_t field4;          // 4
-            //uint32_t field5;          // 5
-            //uint32_t field6;          // 6
-            //uint32_t field7;          // 7
-            //uint32_t field8;          // 8
-            uint32_t flags;             // 9
-            uint32_t areaId;            // 10
-            //char Name[16];            // 11-26
-            //uint32_t nameflags;       // 27
-        };
-
-        struct WorldMapAreaEntry
-        {
-            //uint32_t id;              // 0
-            uint32_t mapId;             // 1
-            uint32_t zoneId;            // 2
-            //const char* name;         // 3
-            //float y1;                 // 4
-            //float y2;                 // 5
-            //float x1;                 // 6
-            //float x2;                 // 7
-            int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-            //uint32_t unk1             // 9
-            //uint32_t parentId         // 10
-            //uint32_t unk2             // 11
-            //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
-            //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
-        };
-
-        struct WorldMapOverlayEntry
-        {
-            uint32_t ID;                // 0
-            //uint32_t worldMapID;      // 1 WorldMapArea.dbc
-            uint32_t areaID;            // 2
-            uint32_t areaID_2;          // 3
-            uint32_t areaID_3;          // 4
-            uint32_t areaID_4;          // 5
-            //uint32_t unk1[2];         // 6-7
-            //uint32_t unk2;            // 8
-            //uint32_t unk3[7];         // 9-16
-        };
-
-        #pragma pack(pop)
-
-        typedef std::set<uint32_t> SpellCategorySet;
-        typedef std::map<uint32_t, SpellCategorySet> SpellCategoryStore;
-        struct SpellEffect
-        {
-            SpellEffect()
-            {
-                effects[0] = nullptr;
-                effects[1] = nullptr;
-                effects[2] = nullptr;
-            }
-            SpellEffectEntry const* effects[3];
-        };
-        typedef std::map<uint32_t, SpellEffect> SpellEffectMap;
-    }
+            effects[0] = nullptr;
+            effects[1] = nullptr;
+            effects[2] = nullptr;
+        }
+        SpellEffectEntry const* effects[3];
+    };
+    typedef std::map<uint32_t, SpellEffect> SpellEffectMap;
 }

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -835,7 +835,7 @@ namespace DBC::Structures
         //uint32_t state;                                           // 10
     };
 
-    #define OUTFIT_ITEMS 24
+#define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
@@ -1457,11 +1457,11 @@ namespace DBC::Structures
     //    uint32_t Price;                                           // 1
     //};
 
-    //\ todo: confirm effect count
-    #define MAX_SPELL_EFFECTS 3
-    #define MAX_SPELL_REAGENTS 8
-    #define MAX_SPELL_TOTEMS 2
-    #define MAX_SPELL_TOTEM_CATEGORIES 2
+//\ todo: confirm effect count
+#define MAX_SPELL_EFFECTS 3
+#define MAX_SPELL_REAGENTS 8
+#define MAX_SPELL_TOTEMS 2
+#define MAX_SPELL_TOTEM_CATEGORIES 2
 
     // SpellAuraOptions.dbc
     struct SpellAuraOptionsEntry
@@ -2014,7 +2014,7 @@ namespace DBC::Structures
         uint32_t categoryMask;                                      // 3
     };
 
-    #define MAX_VEHICLE_SEATS 8
+#define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -23,6 +23,130 @@ struct WMOAreaTableTripple
     int32_t adtId;
 };
 
+///\ These will be verified and ported to Spell/Definitions/SpellEffectTarget.h when spell targeting is being rewritten -Appled
+enum Targets
+{
+    TARGET_NONE                                 = 0,
+    TARGET_SELF_ONE                             = 1,
+    TARGET_RANDOM_ENEMY_CHAIN_IN_AREA           = 2,  // only one spell has that, but regardless, it's a target type after all
+    TARGET_RANDOM_FRIEND_CHAIN_IN_AREA          = 3,
+    TARGET_RANDOM_UNIT_CHAIN_IN_AREA            = 4,  // some plague spells that are infectious - maybe targets not-infected friends inrange
+    TARGET_PET                                  = 5,
+    TARGET_CHAIN_DAMAGE                         = 6,
+    TARGET_AREAEFFECT_INSTANT                   = 7,  // targets around provided destination point
+    TARGET_AREAEFFECT_CUSTOM                    = 8,
+    TARGET_INNKEEPER_COORDINATES                = 9,  // uses in teleport to innkeeper spells
+    TARGET_11                                   = 11, // used by spell 4 'Word of Recall Other'
+    TARGET_ALL_ENEMY_IN_AREA                    = 15,
+    TARGET_ALL_ENEMY_IN_AREA_INSTANT            = 16,
+    TARGET_TABLE_X_Y_Z_COORDINATES              = 17, // uses in teleport spells and some other
+    TARGET_EFFECT_SELECT                        = 18, // highly depends on the spell effect
+    TARGET_ALL_PARTY_AROUND_CASTER              = 20,
+    TARGET_SINGLE_FRIEND                        = 21,
+    TARGET_CASTER_COORDINATES                   = 22, // used only in TargetA, target selection dependent from TargetB
+    TARGET_GAMEOBJECT                           = 23,
+    TARGET_IN_FRONT_OF_CASTER                   = 24,
+    TARGET_DUELVSPLAYER                         = 25,
+    TARGET_GAMEOBJECT_ITEM                      = 26,
+    TARGET_MASTER                               = 27,
+    TARGET_ALL_ENEMY_IN_AREA_CHANNELED          = 28,
+    TARGET_29                                   = 29,
+    TARGET_ALL_FRIENDLY_UNITS_AROUND_CASTER     = 30, // select friendly for caster object faction (in different original caster faction) in TargetB used only with TARGET_ALL_AROUND_CASTER and in self casting range in TargetA
+    TARGET_ALL_FRIENDLY_UNITS_IN_AREA           = 31,
+    TARGET_MINION                               = 32,
+    TARGET_ALL_PARTY                            = 33,
+    TARGET_ALL_PARTY_AROUND_CASTER_2            = 34, // used in Tranquility
+    TARGET_SINGLE_PARTY                         = 35,
+    TARGET_ALL_HOSTILE_UNITS_AROUND_CASTER      = 36,
+    TARGET_AREAEFFECT_PARTY                     = 37,
+    TARGET_SCRIPT                               = 38,
+    TARGET_SELF_FISHING                         = 39,
+    TARGET_FOCUS_OR_SCRIPTED_GAMEOBJECT         = 40,
+    TARGET_TOTEM_EARTH                          = 41,
+    TARGET_TOTEM_WATER                          = 42,
+    TARGET_TOTEM_AIR                            = 43,
+    TARGET_TOTEM_FIRE                           = 44,
+    TARGET_CHAIN_HEAL                           = 45,
+    TARGET_SCRIPT_COORDINATES                   = 46,
+    TARGET_DYNAMIC_OBJECT_FRONT                 = 47,
+    TARGET_DYNAMIC_OBJECT_BEHIND                = 48,
+    TARGET_DYNAMIC_OBJECT_LEFT_SIDE             = 49,
+    TARGET_DYNAMIC_OBJECT_RIGHT_SIDE            = 50,
+    TARGET_AREAEFFECT_GO_AROUND_SOURCE          = 51,
+    TARGET_AREAEFFECT_GO_AROUND_DEST            = 52, // gameobject around destination, select by spell_script_target
+    TARGET_CURRENT_ENEMY_COORDINATES            = 53, // set unit coordinates as dest, only 16 target B imlemented
+    TARGET_LARGE_FRONTAL_CONE                   = 54,
+    TARGET_ALL_RAID_AROUND_CASTER               = 56,
+    TARGET_SINGLE_FRIEND_2                      = 57,
+    TARGET_58                                   = 58,
+    TARGET_FRIENDLY_FRONTAL_CONE                = 59,
+    TARGET_NARROW_FRONTAL_CONE                  = 60,
+    TARGET_AREAEFFECT_PARTY_AND_CLASS           = 61,
+    TARGET_DUELVSPLAYER_COORDINATES             = 63,
+    TARGET_INFRONT_OF_VICTIM                    = 64,
+    TARGET_BEHIND_VICTIM                        = 65, // used in teleport behind spells, caster/target dependent from spell effect
+    TARGET_RIGHT_FROM_VICTIM                    = 66,
+    TARGET_LEFT_FROM_VICTIM                     = 67,
+    TARGET_68                                   = 68,
+    TARGET_69                                   = 69,
+    TARGET_70                                   = 70,
+    TARGET_RANDOM_NEARBY_LOC                    = 72, // used in teleport onto nearby locations
+    TARGET_RANDOM_CIRCUMFERENCE_POINT           = 73,
+    TARGET_74                                   = 74,
+    TARGET_75                                   = 75,
+    TARGET_DYNAMIC_OBJECT_COORDINATES           = 76,
+    TARGET_SINGLE_ENEMY                         = 77,
+    TARGET_POINT_AT_NORTH                       = 78, // 78-85 possible _COORDINATES at radius with pi/4 step around target in unknown order, N?
+    TARGET_POINT_AT_SOUTH                       = 79, // S?
+    TARGET_POINT_AT_EAST                        = 80, // 80/81 must be symmetric from line caster->target, E (base at 82/83, 84/85 order) ?
+    TARGET_POINT_AT_WEST                        = 81, // 80/81 must be symmetric from line caster->target, W (base at 82/83, 84/85 order) ?
+    TARGET_POINT_AT_NE                          = 82, // from spell desc: "(NE)"
+    TARGET_POINT_AT_NW                          = 83, // from spell desc: "(NW)"
+    TARGET_POINT_AT_SE                          = 84, // from spell desc: "(SE)"
+    TARGET_POINT_AT_SW                          = 85, // from spell desc: "(SW)"
+    TARGET_RANDOM_NEARBY_DEST                   = 86, // "Test Nearby Dest Random" - random around selected destination
+    TARGET_SELF2                                = 87,
+    TARGET_88                                   = 88, // Smoke Flare(s) and Hurricane
+    TARGET_DIRECTLY_FORWARD                     = 89,
+    TARGET_NONCOMBAT_PET                        = 90,
+    TARGET_91                                   = 91,
+    TARGET_SUMMONER                             = 92,
+    TARGET_CONTROLLED_VEHICLE                   = 94,
+    TARGET_VEHICLE_DRIVER                       = 95,
+    TARGET_VEHICLE_PASSENGER_0                  = 96,
+    TARGET_VEHICLE_PASSENGER_1                  = 97,
+    TARGET_VEHICLE_PASSENGER_2                  = 98,
+    TARGET_VEHICLE_PASSENGER_3                  = 99,
+    TARGET_VEHICLE_PASSENGER_4                  = 100,
+    TARGET_VEHICLE_PASSENGER_5                  = 101,
+    TARGET_VEHICLE_PASSENGER_6                  = 102,
+    TARGET_VEHICLE_PASSENGER_7                  = 103,
+    TARGET_IN_FRONT_OF_CASTER_30                = 104,
+    TARGET_105                                  = 105,
+    TARGET_106                                  = 106,
+    TARGET_107                                  = 107, // possible TARGET_WMO(GO?)_IN_FRONT_OF_CASTER(_30 ?) TODO: Verify the angle!
+    TARGET_GO_IN_FRONT_OF_CASTER_90             = 108,
+    TARGET_109                                  = 109, // spell 89008
+    TARGET_NARROW_FRONTAL_CONE_2                = 110,
+    TARGET_111                                  = 111, // not used
+    TARGET_112                                  = 112, // spell 89549
+    TARGET_113                                  = 113, // not used
+    TARGET_114                                  = 114, // not used
+    TARGET_115                                  = 115, // not used
+    TARGET_116                                  = 116, // not used
+    TARGET_117                                  = 117, // test spell 83658
+    TARGET_118                                  = 118, // test spell 79579
+    TARGET_119                                  = 119, // mass ressurection 83968
+    TARGET_120                                  = 120,
+    TARGET_121                                  = 121, // spell 95750
+    TARGET_122                                  = 122, // spell 100661
+    TARGET_123                                  = 123,
+    TARGET_124                                  = 124,
+    TARGET_125                                  = 125,
+    TARGET_126                                  = 126,
+    TARGET_127                                  = 127,
+};
+
 struct DBCPosition3D
 {
     float X;
@@ -37,130 +161,6 @@ enum MapTypes
     MAP_RAID            = 2, // raid
     MAP_BATTLEGROUND    = 3, // pvp
     MAP_ARENA           = 4  // arena
-};
-
-///\ These will be verified and ported to Spell/Definitions/SpellEffectTarget.h when spell targeting is being rewritten -Appled
-enum Targets
-{
-    TARGET_NONE                        = 0,
-    TARGET_SELF_ONE                     = 1,
-    TARGET_RANDOM_ENEMY_CHAIN_IN_AREA  = 2,                 // only one spell has that, but regardless, it's a target type after all
-    TARGET_RANDOM_FRIEND_CHAIN_IN_AREA = 3,
-    TARGET_RANDOM_UNIT_CHAIN_IN_AREA   = 4,                 // some plague spells that are infectious - maybe targets not-infected friends inrange
-    TARGET_PET                         = 5,
-    TARGET_CHAIN_DAMAGE                = 6,
-    TARGET_AREAEFFECT_INSTANT          = 7,                 // targets around provided destination point
-    TARGET_AREAEFFECT_CUSTOM           = 8,
-    TARGET_INNKEEPER_COORDINATES       = 9,                 // uses in teleport to innkeeper spells
-    TARGET_11                          = 11,                // used by spell 4 'Word of Recall Other'
-    TARGET_ALL_ENEMY_IN_AREA           = 15,
-    TARGET_ALL_ENEMY_IN_AREA_INSTANT   = 16,
-    TARGET_TABLE_X_Y_Z_COORDINATES     = 17,                // uses in teleport spells and some other
-    TARGET_EFFECT_SELECT               = 18,                // highly depends on the spell effect
-    TARGET_ALL_PARTY_AROUND_CASTER     = 20,
-    TARGET_SINGLE_FRIEND               = 21,
-    TARGET_CASTER_COORDINATES          = 22,                // used only in TargetA, target selection dependent from TargetB
-    TARGET_GAMEOBJECT                  = 23,
-    TARGET_IN_FRONT_OF_CASTER          = 24,
-    TARGET_DUELVSPLAYER                = 25,
-    TARGET_GAMEOBJECT_ITEM             = 26,
-    TARGET_MASTER                      = 27,
-    TARGET_ALL_ENEMY_IN_AREA_CHANNELED = 28,
-    TARGET_29                          = 29,
-    TARGET_ALL_FRIENDLY_UNITS_AROUND_CASTER = 30,           // select friendly for caster object faction (in different original caster faction) in TargetB used only with TARGET_ALL_AROUND_CASTER and in self casting range in TargetA
-    TARGET_ALL_FRIENDLY_UNITS_IN_AREA  = 31,
-    TARGET_MINION                      = 32,
-    TARGET_ALL_PARTY                   = 33,
-    TARGET_ALL_PARTY_AROUND_CASTER_2   = 34,                // used in Tranquility
-    TARGET_SINGLE_PARTY                = 35,
-    TARGET_ALL_HOSTILE_UNITS_AROUND_CASTER = 36,
-    TARGET_AREAEFFECT_PARTY            = 37,
-    TARGET_SCRIPT                      = 38,
-    TARGET_SELF_FISHING                = 39,
-    TARGET_FOCUS_OR_SCRIPTED_GAMEOBJECT = 40,
-    TARGET_TOTEM_EARTH                 = 41,
-    TARGET_TOTEM_WATER                 = 42,
-    TARGET_TOTEM_AIR                   = 43,
-    TARGET_TOTEM_FIRE                  = 44,
-    TARGET_CHAIN_HEAL                  = 45,
-    TARGET_SCRIPT_COORDINATES          = 46,
-    TARGET_DYNAMIC_OBJECT_FRONT        = 47,
-    TARGET_DYNAMIC_OBJECT_BEHIND       = 48,
-    TARGET_DYNAMIC_OBJECT_LEFT_SIDE    = 49,
-    TARGET_DYNAMIC_OBJECT_RIGHT_SIDE   = 50,
-    TARGET_AREAEFFECT_GO_AROUND_SOURCE = 51,
-    TARGET_AREAEFFECT_GO_AROUND_DEST   = 52,                // gameobject around destination, select by spell_script_target
-    TARGET_CURRENT_ENEMY_COORDINATES   = 53,                // set unit coordinates as dest, only 16 target B imlemented
-    TARGET_LARGE_FRONTAL_CONE          = 54,
-    TARGET_ALL_RAID_AROUND_CASTER      = 56,
-    TARGET_SINGLE_FRIEND_2             = 57,
-    TARGET_58                          = 58,
-    TARGET_FRIENDLY_FRONTAL_CONE       = 59,
-    TARGET_NARROW_FRONTAL_CONE         = 60,
-    TARGET_AREAEFFECT_PARTY_AND_CLASS  = 61,
-    TARGET_DUELVSPLAYER_COORDINATES    = 63,
-    TARGET_INFRONT_OF_VICTIM           = 64,
-    TARGET_BEHIND_VICTIM               = 65,                // used in teleport behind spells, caster/target dependent from spell effect
-    TARGET_RIGHT_FROM_VICTIM           = 66,
-    TARGET_LEFT_FROM_VICTIM            = 67,
-    TARGET_68                          = 68,
-    TARGET_69                          = 69,
-    TARGET_70                          = 70,
-    TARGET_RANDOM_NEARBY_LOC           = 72,                // used in teleport onto nearby locations
-    TARGET_RANDOM_CIRCUMFERENCE_POINT  = 73,
-    TARGET_74                          = 74,
-    TARGET_75                          = 75,
-    TARGET_DYNAMIC_OBJECT_COORDINATES  = 76,
-    TARGET_SINGLE_ENEMY                = 77,
-    TARGET_POINT_AT_NORTH              = 78,                // 78-85 possible _COORDINATES at radius with pi/4 step around target in unknown order, N?
-    TARGET_POINT_AT_SOUTH              = 79,                // S?
-    TARGET_POINT_AT_EAST               = 80,                // 80/81 must be symmetric from line caster->target, E (base at 82/83, 84/85 order) ?
-    TARGET_POINT_AT_WEST               = 81,                // 80/81 must be symmetric from line caster->target, W (base at 82/83, 84/85 order) ?
-    TARGET_POINT_AT_NE                 = 82,                // from spell desc: "(NE)"
-    TARGET_POINT_AT_NW                 = 83,                // from spell desc: "(NW)"
-    TARGET_POINT_AT_SE                 = 84,                // from spell desc: "(SE)"
-    TARGET_POINT_AT_SW                 = 85,                // from spell desc: "(SW)"
-    TARGET_RANDOM_NEARBY_DEST          = 86,                // "Test Nearby Dest Random" - random around selected destination
-    TARGET_SELF2                       = 87,
-    TARGET_88                          = 88,                // Smoke Flare(s) and Hurricane
-    TARGET_DIRECTLY_FORWARD            = 89,
-    TARGET_NONCOMBAT_PET               = 90,
-    TARGET_91                          = 91,
-    TARGET_SUMMONER                    = 92,
-    TARGET_CONTROLLED_VEHICLE          = 94,
-    TARGET_VEHICLE_DRIVER              = 95,
-    TARGET_VEHICLE_PASSENGER_0         = 96,
-    TARGET_VEHICLE_PASSENGER_1         = 97,
-    TARGET_VEHICLE_PASSENGER_2         = 98,
-    TARGET_VEHICLE_PASSENGER_3         = 99,
-    TARGET_VEHICLE_PASSENGER_4         = 100,
-    TARGET_VEHICLE_PASSENGER_5         = 101,
-    TARGET_VEHICLE_PASSENGER_6         = 102,
-    TARGET_VEHICLE_PASSENGER_7         = 103,
-    TARGET_IN_FRONT_OF_CASTER_30       = 104,
-    TARGET_105                         = 105,
-    TARGET_106                         = 106,
-    TARGET_107                         = 107,               // possible TARGET_WMO(GO?)_IN_FRONT_OF_CASTER(_30 ?) TODO: Verify the angle!
-    TARGET_GO_IN_FRONT_OF_CASTER_90    = 108,
-    TARGET_109                         = 109,               // spell 89008
-    TARGET_NARROW_FRONTAL_CONE_2       = 110,
-    TARGET_111                         = 111,               // not used
-    TARGET_112                         = 112,               // spell 89549
-    TARGET_113                         = 113,               // not used
-    TARGET_114                         = 114,               // not used
-    TARGET_115                         = 115,               // not used
-    TARGET_116                         = 116,               // not used
-    TARGET_117                         = 117,               // test spell 83658
-    TARGET_118                         = 118,               // test spell 79579
-    TARGET_119                         = 119,               // mass ressurection 83968
-    TARGET_120                         = 120,
-    TARGET_121                         = 121,               // spell 95750
-    TARGET_122                         = 122,               // spell 100661
-    TARGET_123                         = 123,
-    TARGET_124                         = 124,
-    TARGET_125                         = 125,
-    TARGET_126                         = 126,
-    TARGET_127                         = 127,
 };
 
 #define MAX_DUNGEON_DIFFICULTY     2
@@ -310,676 +310,676 @@ namespace DBC::Structures
     #pragma pack(push, 1)
     struct AchievementCategoryEntry
     {
-        uint32_t ID;                 // 0
-        uint32_t parentCategory;     // 1 -1 for main category
-        const char* name;          // 2-17
-        uint32_t name_flags;         // 18
-        uint32_t sortOrder;          // 19
+        uint32_t ID;                                                // 0
+        uint32_t parentCategory;                                    // 1 -1 for main category
+        const char* name;                                           // 2-17
+        uint32_t name_flags;                                        // 18
+        uint32_t sortOrder;                                         // 19
     };
 
     struct AchievementCriteriaEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t referredAchievement;     // 1
-        uint32_t requiredType;            // 2
+        uint32_t ID;                                                // 0
+        uint32_t referredAchievement;                               // 1
+        uint32_t requiredType;                                      // 2
         union
         {
             // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
             ///\todo also used for player deaths..
             struct
             {
-                uint32_t creatureID;                             // 3
-                uint32_t creatureCount;                          // 4
+                uint32_t creatureID;                                // 3
+                uint32_t creatureCount;                             // 4
             } kill_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
             ///\todo there are further criterias instead just winning
             struct
             {
-                uint32_t bgMapID;                                // 3
-                uint32_t winCount;                               // 4
+                uint32_t bgMapID;                                   // 3
+                uint32_t winCount;                                  // 4
             } win_bg;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t level;                                  // 4
+                uint32_t unused;                                    // 3
+                uint32_t level;                                     // 4
             } reach_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4
             } reach_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
             struct
             {
-                uint32_t linkedAchievement;                      // 3
+                uint32_t linkedAchievement;                         // 3
             } complete_achievement;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t totalQuestCount;                        // 4
+                uint32_t unused;                                    // 3
+                uint32_t totalQuestCount;                           // 4
             } complete_quest_count;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfDays;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfDays;                              // 4
             } complete_daily_quest_daily;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
             struct
             {
-                uint32_t zoneID;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t zoneID;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_quests_in_zone;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_daily_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } complete_battleground;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } death_at_map;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
             struct
             {
-                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+                uint32_t groupSize;                                 // 3 can be 5, 10 or 25
             } complete_raid;
 
             // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
             struct
             {
-                uint32_t creatureEntry;                          // 3
+                uint32_t creatureEntry;                             // 3
             } killed_by_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t fallHeight;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t fallHeight;                                // 4
             } fall_without_dying;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
             struct
             {
-                uint32_t questID;                                // 3
-                uint32_t questCount;                             // 4
+                uint32_t questID;                                   // 3
+                uint32_t questCount;                                // 4
             } complete_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t spellCount;                             // 4
+                uint32_t spellID;                                   // 3
+                uint32_t spellCount;                                // 4
             } be_spell_target;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t castCount;                              // 4
+                uint32_t spellID;                                   // 3
+                uint32_t castCount;                                 // 4
             } cast_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
             struct
             {
-                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                uint32_t killCount;                              // 4
+                uint32_t areaID;                                    // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                                 // 4
             } honorable_kill_at_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } win_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } play_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
             struct
             {
-                uint32_t spellID;                                // 3 Reference to Map.dbc
+                uint32_t spellID;                                   // 3 Reference to Map.dbc
             } learn_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } own_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 4=in a row
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 4=in a row
             } win_rated_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamtype;                                  // 3 {2,3,5}
             } highest_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
-                uint32_t teamrating;                             // 4
+                uint32_t teamtype;                                  // 3 {2,3,5}
+                uint32_t teamrating;                                // 4
             } reach_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
             } learn_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } use_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } loot_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
             struct
             {
-                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+                uint32_t areaReference;                             // 3 - this is an index to WorldMapOverlay
             } explore_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
             struct
             {
                 ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                uint32_t rank;                                   // 3
+                uint32_t rank;                                      // 3
             } own_rank;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfSlots;                          // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfSlots;                             // 4
             } buy_bank_slot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
             struct
             {
-                uint32_t factionID;                              // 3
-                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+                uint32_t factionID;                                 // 3
+                uint32_t reputationAmount;                          // 4 Total reputation amount, so 42000 = exalted
             } gain_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfExaltedFactions;                // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfExaltedFactions;                   // 4
             } gain_exalted_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
             ///\todo where is the required itemlevel stored?
             struct
             {
-                uint32_t itemSlot;                               // 3
+                uint32_t itemSlot;                                  // 3
             } equip_epic_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
             struct
             {
-                uint32_t rollValue;                              // 3
-                uint32_t count;                                  // 4
+                uint32_t rollValue;                                 // 3
+                uint32_t count;                                     // 4
             } roll_need_on_loot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
             struct
             {
-                uint32_t classID;                                // 3
-                uint32_t count;                                  // 4
+                uint32_t classID;                                   // 3
+                uint32_t count;                                     // 4
             } hk_class;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
             struct
             {
-                uint32_t raceID;                                 // 3
-                uint32_t count;                                  // 4
+                uint32_t raceID;                                    // 3
+                uint32_t count;                                     // 4
             } hk_race;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
             ///\todo where is the information about the target stored?
             struct
             {
-                uint32_t emoteID;                                // 3
+                uint32_t emoteID;                                   // 3
             } do_emote;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 =3 for battleground healing
-                uint32_t mapid;                                  // 6
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 =3 for battleground healing
+                uint32_t mapid;                                     // 6
             } healing_done;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
             struct
             {
-                uint32_t itemID;                                 // 3
+                uint32_t itemID;                                    // 3
             } equip_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
             struct
             {
-                uint32_t unknown;                                 // 3
-                uint32_t goldInCopper;                            // 4
+                uint32_t unknown;                                   // 3
+                uint32_t goldInCopper;                              // 4
             } quest_reward_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t goldInCopper;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t goldInCopper;                              // 4
             } loot_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t useCount;                               // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t useCount;                                  // 4
             } use_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
             ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } special_pvp_kill;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t lootCount;                              // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t lootCount;                                 // 4
             } fish_in_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
             struct
             {
-                uint32_t unknown;                                // 3 777=?
-                uint32_t mountCount;                             // 4
+                uint32_t unknown;                                   // 3 777=?
+                uint32_t mountCount;                                // 4
             } number_of_mounts;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t duelCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t duelCount;                                 // 4
             } win_duel;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
             struct
             {
-                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+                uint32_t powerType;                                 // 3 mana= 0, 1=rage, 3=energy, 6=runic power
             } highest_power;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
             struct
             {
-                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+                uint32_t statType;                                  // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
             } highest_stat;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
             struct
             {
-                uint32_t spellSchool;                            // 3
+                uint32_t spellSchool;                               // 3
             } highest_spellpower;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
             struct
             {
-                uint32_t ratingType;                             // 3
+                uint32_t ratingType;                                // 3
             } highest_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
             struct
             {
-                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                uint32_t lootTypeCount;                          // 4
+                uint32_t lootType;                                  // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                             // 4
             } loot_type;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } cast_spell2;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } learn_skill_line;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } honorable_kill;
 
             struct
             {
-                uint32_t field3;                                 // 3 main requirement
-                uint32_t field4;                                 // 4 main requirement count
-                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+                uint32_t field3;                                    // 3 main requirement
+                uint32_t field4;                                    // 4 main requirement count
+                uint32_t additionalRequirement1_type;               // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;              // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;               // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;              // 8 additional requirement 1 value
             } raw;
         };
-        //uint32_t unk                      // 9
-        char* name;                         // 10
-        uint32_t completionFlag;            // 11
-        uint32_t groupFlag;                 // 12 timed criteria
-        uint32_t unk1;                      // 13 timed criteria misc id
-        uint32_t timeLimit;                 // 14 time limit in seconds
-        uint32_t index;                     // 15 order
+        //uint32_t unk                                              // 9
+        char* name;                                                 // 10
+        uint32_t completionFlag;                                    // 11
+        uint32_t groupFlag;                                         // 12 timed criteria
+        uint32_t unk1;                                              // 13 timed criteria misc id
+        uint32_t timeLimit;                                         // 14 time limit in seconds
+        uint32_t index;                                             // 15 order
     };
 
     struct AchievementEntry
     {
-        uint32_t ID;                        // 0
-        int32_t factionFlag;                // 1 -1=all, 0=horde, 1=alliance
-        int32_t mapID;                      // 2 -1=none
-        uint32_t parentAchievement;         // 3
-        char* name;                         // 4
-        char* description;                  // 5
-        uint32_t categoryId;                // 6
-        uint32_t points;                    // 7 reward points
-        uint32_t orderInCategory;           // 8
-        uint32_t flags;                     // 9
-        uint32_t icon;                      // 10
-        char* rewardName;                   // 11 title/item reward name
-        uint32_t count;                     // 12
-        uint32_t refAchievement;            // 13
+        uint32_t ID;                                                // 0
+        int32_t factionFlag;                                        // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                                              // 2 -1=none
+        uint32_t parentAchievement;                                 // 3
+        char* name;                                                 // 4
+        char* description;                                          // 5
+        uint32_t categoryId;                                        // 6
+        uint32_t points;                                            // 7 reward points
+        uint32_t orderInCategory;                                   // 8
+        uint32_t flags;                                             // 9
+        uint32_t icon;                                              // 10
+        char* rewardName;                                           // 11 title/item reward name
+        uint32_t count;                                             // 12
+        uint32_t refAchievement;                                    // 13
     };
 
     struct AreaGroupEntry
     {
-        uint32_t AreaGroupId;               // 0
-        uint32_t AreaId[6];                 // 1-6
-        uint32_t next_group;                // 7
+        uint32_t AreaGroupId;                                       // 0
+        uint32_t AreaId[6];                                         // 1-6
+        uint32_t next_group;                                        // 7
     };
 
     struct AreaTableEntry
     {
-        uint32_t id;                        // 0
-        uint32_t map_id;                    // 1
-        uint32_t zone;                      // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;              // 3, main index
-        uint32_t flags;                     // 4, unknown value but 312 for all cities
-                                            // 5-9 unused
-        int32_t area_level;                 // 10
-        char* area_name;                    // 11
-        uint32_t team;                      // 12
-        uint32_t liquid_type_override[4];   // 13-16 liquid override by type
-        //uint32_t unk17;                   // 17
-        //uint32_t unk18;                   // 18
-        //uint32_t unk19;                   // 19
-        //uint32_t unk20;                   // 20
-        //uint32_t unk21;                   // 21
-        //uint32_t unk22;                   // 22
-        //uint32_t unk23;                   // 23
-        //uint32_t unk24;                   // 24
+        uint32_t id;                                                // 0
+        uint32_t map_id;                                            // 1
+        uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;                                      // 3, main index
+        uint32_t flags;                                             // 4, unknown value but 312 for all cities
+                                                                    // 5-9 unused
+        int32_t area_level;                                         // 10
+        char* area_name;                                            // 11
+        uint32_t team;                                              // 12
+        uint32_t liquid_type_override[4];                           // 13-16 liquid override by type
+        //uint32_t unk17;                                           // 17
+        //uint32_t unk18;                                           // 18
+        //uint32_t unk19;                                           // 19
+        //uint32_t unk20;                                           // 20
+        //uint32_t unk21;                                           // 21
+        //uint32_t unk22;                                           // 22
+        //uint32_t unk23;                                           // 23
+        //uint32_t unk24;                                           // 24
     };
 
     struct AreaTriggerEntry
     {
-        uint32_t id;                        // 0
-        uint32_t mapid;                     // 1
-        float x;                            // 2
-        float y;                            // 3
-        float z;                            // 4
-        //uint32_t                          // 5
-        //uint32_t                          // 6
-        //uint32_t                          // 7
-        float o;                            // 5 radius
-        float box_x;                        // 6 extent x edge
-        float box_y;                        // 7 extent y edge
-        float box_z;                        // 8 extent z edge
-        float box_o;                        // 9
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        //uint32_t                                                  // 5
+        //uint32_t                                                  // 6
+        //uint32_t                                                  // 7
+        float o;                                                    // 5 radius
+        float box_x;                                                // 6 extent x edge
+        float box_y;                                                // 7 extent y edge
+        float box_z;                                                // 8 extent z edge
+        float box_o;                                                // 9
     };
 
     //\todo danko
     //struct ArmorLocationEntry   
     //{
-    //    uint32_t InventoryType;           // 0
-    //    float Value[5];                   // 1-5
+    //    uint32_t InventoryType;                                   // 0
+    //    float Value[5];                                           // 1-5
     //};
 
     struct AuctionHouseEntry
     {
-        uint32_t id;                        // 0
-        uint32_t faction;                   // 1
-        uint32_t fee;                       // 2
-        uint32_t tax;                       // 3
-        //char* name;                       // 4
+        uint32_t id;                                                // 0
+        uint32_t faction;                                           // 1
+        uint32_t fee;                                               // 2
+        uint32_t tax;                                               // 3
+        //char* name;                                               // 4
     };
 
     struct BankBagSlotPrices
     {
-        uint32_t Id;                        // 0
-        uint32_t Price;                     // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct BarberShopStyleEntry
     {
-        uint32_t id;                        // 0
-        uint32_t type;                      // 1 value 0 -> hair, value 2 -> facialhair
-        //char* name;                       // 2
-        //uint32_t unk_name;                // 3
-        //float CostMultiplier;             // 4
-        uint32_t race;                      // 5
-        uint32_t gender;                    // 6 0 male, 1 female
-        uint32_t hair_id;                   // 7 Hair ID
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;                                               // 2
+        //uint32_t unk_name;                                        // 3
+        //float CostMultiplier;                                     // 4
+        uint32_t race;                                              // 5
+        uint32_t gender;                                            // 6 0 male, 1 female
+        uint32_t hair_id;                                           // 7 Hair ID
     };
 
     struct BannedAddOnsEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t nameMD5[4];              // 1-4
-        //uint32_t versionMD5[4];           // 5-8
-        //uint32_t timestamp;               // 9
-        //uint32_t state;                   // 10
+        uint32_t Id;                                                // 0
+        //uint32_t nameMD5[4];                                      // 1-4
+        //uint32_t versionMD5[4];                                   // 5-8
+        //uint32_t timestamp;                                       // 9
+        //uint32_t state;                                           // 10
     };
 
     #define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
-        //uint32_t Id;                                    // 0
-        uint8_t Race;                                     // 1
-        uint8_t Class;                                    // 2
-        uint8_t Gender;                                   // 3
-        //uint8_t Unused;                                 // 4
-        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
-        uint32_t PetDisplayId;                            // 77
-        uint32_t PetFamilyEntry;                          // 78
+        //uint32_t Id;                                              // 0
+        uint8_t Race;                                               // 1
+        uint8_t Class;                                              // 2
+        uint8_t Gender;                                             // 3
+        //uint8_t Unused;                                           // 4
+        int32_t ItemId[OUTFIT_ITEMS];                               // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];                      // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];                  // 53-76
+        uint32_t PetDisplayId;                                      // 77
+        uint32_t PetFamilyEntry;                                    // 78
     };
 
     struct CharTitlesEntry
     {
-        uint32_t ID;                        // 0
-        //uint32_t unk1;                    // 1
-        char* name;                         // 2
-        //char* name2;                      // 3
-        uint32_t bit_index;                 // 4
-        //uint32_t unk                      // 5
+        uint32_t ID;                                                // 0
+        //uint32_t unk1;                                            // 1
+        char* name;                                                 // 2
+        //char* name2;                                              // 3
+        uint32_t bit_index;                                         // 4
+        //uint32_t unk                                              // 5
     };
 
     struct ChatChannelsEntry
     {
-        uint32_t id;                        // 0
-        uint32_t flags;                     // 1
-        //uint32_t faction                  // 2
-        char* name_pattern;                 // 3
-        //char* channel_name;               // 4
+        uint32_t id;                                                // 0
+        uint32_t flags;                                             // 1
+        //uint32_t faction                                          // 2
+        char* name_pattern;                                         // 3
+        //char* channel_name;                                       // 4
     };
 
     struct ChrClassesEntry
     {
-        uint32_t class_id;                  // 0
-        uint32_t power_type;                // 1
-        //uint32_t unk2;                    // 2
-        char* name;                         // 3
-        //char* name_female;                // 4
-        //char* name_neutral;               // 5
-        //char* name_capitalized            // 6
-        uint32_t spellfamily;               // 7
-        //uint32_t unk4;                    // 8
-        uint32_t cinematic_id;              // 9 CinematicSequences.dbc
-        uint32_t apPerStr;                  // 10
-        uint32_t apPerAgi;                  // 11
-        uint32_t rapPerAgi;                 // 12
-        //uint32_t unk1                     // 13 Pandaria
-        //uint32_t unk2                     // 14 Pandaria
-        //uint32_t unk3                     // 15 Pandaria
-        //uint32_t unk4                     // 16 Pandaria
-        //uint32_t unk5                     // 17 Pandaria
+        uint32_t class_id;                                          // 0
+        uint32_t power_type;                                        // 1
+        //uint32_t unk2;                                            // 2
+        char* name;                                                 // 3
+        //char* name_female;                                        // 4
+        //char* name_neutral;                                       // 5
+        //char* name_capitalized                                    // 6
+        uint32_t spellfamily;                                       // 7
+        //uint32_t unk4;                                            // 8
+        uint32_t cinematic_id;                                      // 9 CinematicSequences.dbc
+        uint32_t apPerStr;                                          // 10
+        uint32_t apPerAgi;                                          // 11
+        uint32_t rapPerAgi;                                         // 12
+        //uint32_t unk1                                             // 13 Pandaria
+        //uint32_t unk2                                             // 14 Pandaria
+        //uint32_t unk3                                             // 15 Pandaria
+        //uint32_t unk4                                             // 16 Pandaria
+        //uint32_t unk5                                             // 17 Pandaria
     };
 
     struct ChrRacesEntry
     {
-        uint32_t race_id;                   // 0
-        //uint32_t flags;                   // 1
-        uint32_t faction_id;                // 2
-        //uint32_t unk1;                    // 3
-        uint32_t model_male;                // 4
-        uint32_t model_female;              // 5
-        // uint32_t unk2;                   // 6
-        uint32_t team_id;                   // 7
-        //uint32_t unk3[4];                 // 8-11
-        uint32_t cinematic_id;              // 12 CinematicSequences.dbc
-        //uint32_t unk4                     // 13
-        char* name;                         // 14
-        //char* name_female;                // 15
-        //char* name_neutral;               // 16
-        //uint32_t unk5[2]                  // 17-18
-        //uint32_t unk19                    // 19
-        //uint32_t m_enemyRace;             // 20
-        //uint32_t unk21                    // 21
-        //uint32_t unk22                    // 22
-        //uint32_t unk23                    // 23
-        //uint32_t unk24;                   // 24
-        //uint32_t defaultClassForRace      // 25
-        //uint32_t unk26;                   // 26
-        //uint32_t unk27;                   // 27
-        //float unk28;                      // 28
-        //uint32_t unk29;                   // 29
-        //float unk30;                      // 30
-        //float unk31;                      // 31
-        //uint32_t unk32;                   // 32
-        //float unk33;                      // 33
-        //uint32_t unk34;                   // 34
-        //uint32_t unk35;                   // 35
+        uint32_t race_id;                                           // 0
+        //uint32_t flags;                                           // 1
+        uint32_t faction_id;                                        // 2
+        //uint32_t unk1;                                            // 3
+        uint32_t model_male;                                        // 4
+        uint32_t model_female;                                      // 5
+        // uint32_t unk2;                                           // 6
+        uint32_t team_id;                                           // 7
+        //uint32_t unk3[4];                                         // 8-11
+        uint32_t cinematic_id;                                      // 12 CinematicSequences.dbc
+        //uint32_t unk4                                             // 13
+        char* name;                                                 // 14
+        //char* name_female;                                        // 15
+        //char* name_neutral;                                       // 16
+        //uint32_t unk5[2]                                          // 17-18
+        //uint32_t unk19                                            // 19
+        //uint32_t m_enemyRace;                                     // 20
+        //uint32_t unk21                                            // 21
+        //uint32_t unk22                                            // 22
+        //uint32_t unk23                                            // 23
+        //uint32_t unk24;                                           // 24
+        //uint32_t defaultClassForRace                              // 25
+        //uint32_t unk26;                                           // 26
+        //uint32_t unk27;                                           // 27
+        //float unk28;                                              // 28
+        //uint32_t unk29;                                           // 29
+        //float unk30;                                              // 30
+        //float unk31;                                              // 31
+        //uint32_t unk32;                                           // 32
+        //float unk33;                                              // 33
+        //uint32_t unk34;                                           // 34
+        //uint32_t unk35;                                           // 35
     };
 
     struct ChrPowerTypesEntry
     {
-        uint32_t entry;                     // 0
-        uint32_t classId;                   // 1 class
-        uint32_t power;                     // 2 power type
+        uint32_t entry;                                             // 0
+        uint32_t classId;                                           // 1 class
+        uint32_t power;                                             // 2 power type
     };
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t Displayid;                 // 0
-        uint32_t ModelId;                   // 1
-        //uint32_t sound_id;                // 2
-        uint32_t ExtendedDisplayInfoID;     // 3
-        float scale;                        // 4
-        //uint32_t unk01;                   // 5
-        //uint32_t unk02[2];                // 6-8
-        //uint32_t unk03;                   // 9
-        //uint32_t unk04;                   // 10
-        //uint32_t unk05;                   // 11
-        //uint32_t unk06;                   // 12
-        //uint32_t unk07;                   // 13
-        //uint32_t unk08;                   // 14
-        //uint32_t unk09;                   // 15
-        //uint32_t unk10;                   // 16
+        uint32_t Displayid;                                         // 0
+        uint32_t ModelId;                                           // 1
+        //uint32_t sound_id;                                        // 2
+        uint32_t ExtendedDisplayInfoID;                             // 3
+        float scale;                                                // 4
+        //uint32_t unk01;                                           // 5
+        //uint32_t unk02[2];                                        // 6-8
+        //uint32_t unk03;                                           // 9
+        //uint32_t unk04;                                           // 10
+        //uint32_t unk05;                                           // 11
+        //uint32_t unk06;                                           // 12
+        //uint32_t unk07;                                           // 13
+        //uint32_t unk08;                                           // 14
+        //uint32_t unk09;                                           // 15
+        //uint32_t unk10;                                           // 16
     };
 
     struct CreatureDisplayInfoExtraEntry
     {
-        uint32_t DisplayExtraId;            // 0
-        uint32_t Race;                      // 1
-        //uint32_t Gender;                  // 2
-        //uint32_t SkinColor;               // 3
-        //uint32_t FaceType;                // 4
-        //uint32_t HairType;                // 5
-        //uint32_t HairStyle;               // 6
-        //uint32_t BeardStyle;              // 7
-        //uint32_t Equipment[11];           // 8-18
-        //uint32_t CanEquip;                // 19
-        //char* unk                         // 20
+        uint32_t DisplayExtraId;                                    // 0
+        uint32_t Race;                                              // 1
+        //uint32_t Gender;                                          // 2
+        //uint32_t SkinColor;                                       // 3
+        //uint32_t FaceType;                                        // 4
+        //uint32_t HairType;                                        // 5
+        //uint32_t HairStyle;                                       // 6
+        //uint32_t BeardStyle;                                      // 7
+        //uint32_t Equipment[11];                                   // 8-18
+        //uint32_t CanEquip;                                        // 19
+        //char* unk                                                 // 20
     };
 
     struct CreatureFamilyEntry
     {
-        uint32_t ID;                        // 0
-        float minsize;                      // 1
-        uint32_t minlevel;                  // 2
-        float maxsize;                      // 3
-        uint32_t maxlevel;                  // 4
-        uint32_t skilline;                  // 5
-        uint32_t tameable;                  // 6 second skill line - 270 Generic
-        uint32_t petdietflags;              // 7
-        uint32_t talenttree;                // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-        //uint32_t unk;                     // 9 some index 0 - 63
-        char* name;                         // 10
-        //uint32_t nameflags;               // 11
+        uint32_t ID;                                                // 0
+        float minsize;                                              // 1
+        uint32_t minlevel;                                          // 2
+        float maxsize;                                              // 3
+        uint32_t maxlevel;                                          // 4
+        uint32_t skilline;                                          // 5
+        uint32_t tameable;                                          // 6 second skill line - 270 Generic
+        uint32_t petdietflags;                                      // 7
+        uint32_t talenttree;                                        // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                                             // 9 some index 0 - 63
+        char* name;                                                 // 10
+        //uint32_t nameflags;                                       // 11
     };
 
     struct CreatureSpellDataEntry
     {
-        uint32_t id;                        // 0
+        uint32_t id;                                                // 0
         uint32_t Spells[3];
         uint32_t PHSpell;
         uint32_t Cooldowns[3];
@@ -989,190 +989,190 @@ namespace DBC::Structures
     //\todo danko
     //struct CreatureTypeEntry
     //{
-    //    uint32_t ID;                      // 0
-    //    //char* Name;                     // 1
-    //    //uint32_t no_expirience;         // 2
+    //    uint32_t ID;                                              // 0
+    //    //char* Name;                                             // 1
+    //    //uint32_t no_expirience;                                 // 2
     //};
 
     struct CurrencyTypesEntry
     {
-        uint32_t item_id;                   // 0
-        uint32_t Category;                  // 1
-        char* name;                         // 2
-        //char* unk                         // 3
-        //char* unk2                        // 4
-        //uint32_t unk5;                    // 5
-        //uint32_t unk6;                    // 6
-        uint32_t TotalCap;                  // 7
-        uint32_t WeekCap;                   // 8
-        uint32_t Flags;                     // 9
-        //char* description;                // 10
+        uint32_t item_id;                                           // 0
+        uint32_t Category;                                          // 1
+        char* name;                                                 // 2
+        //char* unk                                                 // 3
+        //char* unk2                                                // 4
+        //uint32_t unk5;                                            // 5
+        //uint32_t unk6;                                            // 6
+        uint32_t TotalCap;                                          // 7
+        uint32_t WeekCap;                                           // 8
+        uint32_t Flags;                                             // 9
+        //char* description;                                        // 10
     };
 
     struct DurabilityCostsEntry
     {
-        uint32_t itemlevel;                 // 0
-        uint32_t modifier[29];              // 1-29
+        uint32_t itemlevel;                                         // 0
+        uint32_t modifier[29];                                      // 1-29
     };
 
     struct DurabilityQualityEntry
     {
-        uint32_t id;                        // 0
-        float quality_modifier;             // 1
+        uint32_t id;                                                // 0
+        float quality_modifier;                                     // 1
     };
 
     struct EmotesEntry
     {
-        uint32_t Id;                        // 0
-        //char* name;                       // 1
-        //uint32_t animationId;             // 2
-        uint32_t Flags;                     // 3
-        uint32_t EmoteType;                 // 4
-        uint32_t UnitStandState;            // 5
-        //uint32_t soundId;                 // 6
-        //uint32_t unk;                     // 7
+        uint32_t Id;                                                // 0
+        //char* name;                                               // 1
+        //uint32_t animationId;                                     // 2
+        uint32_t Flags;                                             // 3
+        uint32_t EmoteType;                                         // 4
+        uint32_t UnitStandState;                                    // 5
+        //uint32_t soundId;                                         // 6
+        //uint32_t unk;                                             // 7
     };
 
     struct EmotesTextEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t name;                    // 1
-        uint32_t textid;                    // 2
-        //uint32_t unk1;                    // 4
+        uint32_t Id;                                                // 0
+        //uint32_t name;                                            // 1
+        uint32_t textid;                                            // 2
+        //uint32_t unk1;                                            // 4
     };
 
     struct FactionEntry
     {
-        uint32_t ID;                        // 0
-        int32_t RepListId;                  // 1
-        uint32_t RaceMask[4];               // 2-5
-        uint32_t ClassMask[4];              // 6-9
-        int32_t baseRepValue[4];            // 10-13
-        uint32_t repFlags[4];               // 14-17
-        uint32_t parentFaction;             // 18
-        float spillover_rate_in;            // 19
-        float spillover_rate_out;           // 20
-        uint32_t spillover_max_in;          // 21
-        //uint32_t unk1;                    // 22
-        char* Name;                         // 23
-        //uint32_t Description;             // 24
-        //uint32_t description_flags;       // 25
+        uint32_t ID;                                                // 0
+        int32_t RepListId;                                          // 1
+        uint32_t RaceMask[4];                                       // 2-5
+        uint32_t ClassMask[4];                                      // 6-9
+        int32_t baseRepValue[4];                                    // 10-13
+        uint32_t repFlags[4];                                       // 14-17
+        uint32_t parentFaction;                                     // 18
+        float spillover_rate_in;                                    // 19
+        float spillover_rate_out;                                   // 20
+        uint32_t spillover_max_in;                                  // 21
+        //uint32_t unk1;                                            // 22
+        char* Name;                                                 // 23
+        //uint32_t Description;                                     // 24
+        //uint32_t description_flags;                               // 25
     };
 
     struct FactionTemplateEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t Faction;                   // 1
-        uint32_t FactionGroup;              // 2
-        uint32_t Mask;                      // 3
-        uint32_t FriendlyMask;              // 4
-        uint32_t HostileMask;               // 5
-        uint32_t EnemyFactions[4];          // 6-9
-        uint32_t FriendlyFactions[4];       // 10-13
+        uint32_t ID;                                                // 0
+        uint32_t Faction;                                           // 1
+        uint32_t FactionGroup;                                      // 2
+        uint32_t Mask;                                              // 3
+        uint32_t FriendlyMask;                                      // 4
+        uint32_t HostileMask;                                       // 5
+        uint32_t EnemyFactions[4];                                  // 6-9
+        uint32_t FriendlyFactions[4];                               // 10-13
     };
 
     struct GameObjectDisplayInfoEntry
     {
-        uint32_t Displayid;                 // 0
-        char* filename;                     // 1
-        //uint32_t  unk1[10];               // 2-11
-        float minX;                         // 12
-        float minY;                         // 13
-        float minZ;                         // 14
-        float maxX;                         // 15
-        float maxY;                         // 16
-        float maxZ;                         // 17
-        //uint32_t transport;               // 18
-        //uint32_t unk;                     // 19
-        //uint32_t unk;                     // 20
+        uint32_t Displayid;                                         // 0
+        char* filename;                                             // 1
+        //uint32_t unk1[10];                                        // 2-11
+        float minX;                                                 // 12
+        float minY;                                                 // 13
+        float minZ;                                                 // 14
+        float maxX;                                                 // 15
+        float maxY;                                                 // 16
+        float maxZ;                                                 // 17
+        //uint32_t transport;                                       // 18
+        //uint32_t unk;                                             // 19
+        //uint32_t unk;                                             // 20
     };
 
     struct GemPropertiesEntry
     {
-        uint32_t Entry;                     // 0
-        uint32_t EnchantmentID;             // 1
-        //uint32_t unk1;                    // 2 bool
-        //uint32_t unk2;                    // 3 bool
-        uint32_t SocketMask;                // 4
+        uint32_t Entry;                                             // 0
+        uint32_t EnchantmentID;                                     // 1
+        //uint32_t unk1;                                            // 2 bool
+        //uint32_t unk2;                                            // 3 bool
+        uint32_t SocketMask;                                        // 4
     };
 
     struct GlyphPropertiesEntry
     {
-        uint32_t Entry;                     // 0
-        uint32_t SpellID;                   // 1
-        uint32_t Type;                      // 2 (0 = Major, 1 = Minor)
-        uint32_t unk;                       // 3 glyph_icon spell.dbc
+        uint32_t Entry;                                             // 0
+        uint32_t SpellID;                                           // 1
+        uint32_t Type;                                              // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                                               // 3 glyph_icon spell.dbc
     };
 
     struct GlyphSlotEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t Type;                      // 1
-        uint32_t Slot;                      // 2
+        uint32_t Id;                                                // 0
+        uint32_t Type;                                              // 1
+        uint32_t Slot;                                              // 2
     };
 
     struct GtBarberShopCostBaseEntry
     {
-        float cost;                         // 0
+        float cost;                                                 // 0
     };
 
     struct GtChanceToMeleeCritEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToMeleeCritBaseEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritBaseEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtCombatRatingsEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     struct GtOCTClassCombatRatingScalarEntry
     {
-        float val;                          // 0
+        float val;                                                  // 0
     };
 
     //\todo danko
     //struct GtOCTRegenHPEntry
     //{
-    //    float ratio;                      // 0
+    //    float ratio;                                              // 0
     //};
 
     struct GtOCTRegenMPEntry
     {
-        float ratio;                        // 0
+        float ratio;                                                // 0
     };
 
     //\todo danko
     //struct GtRegenHPPerSptEntry
     //{
-    //    float ratio;                      // 0
+    //    float ratio;                                              // 0
     //};
 
     struct GtRegenMPPerSptEntry
     {
-        float ratio;                        // 0
+        float ratio;                                                // 0
     };
 
     struct GuildPerkSpellsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Level;                     // 1
-        uint32_t SpellId;                   // 2
+        //uint32_t Id;                                              // 0
+        uint32_t Level;                                             // 1
+        uint32_t SpellId;                                           // 2
     };
 
 #define MAX_HOLIDAY_DURATIONS 10
@@ -1181,79 +1181,79 @@ namespace DBC::Structures
 
     struct HolidaysEntry
     {
-        uint32_t Id;                                    // 0
-        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-        //uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-        //uint32_t Region;                              // 37
-        //uint32_t Looping;                             // 38
-        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-        //uint32_t holidayNameId;                       // 49 HolidayNames.dbc
-        //uint32_t holidayDescriptionId;                // 50 HolidayDescriptions.dbc
-        //char* TextureFilename;                        // 51
-        //uint32_t Priority;                            // 52
-        //uint32_t CalendarFilterType;                  // 53
-        //uint32_t flags;                               // 54
+        uint32_t Id;                                                // 0
+        //uint32_t Duration[MAX_HOLIDAY_DURATIONS];                 // 1-10
+        //uint32_t Date[MAX_HOLIDAY_DATES];                         // 11-36
+        //uint32_t Region;                                          // 37
+        //uint32_t Looping;                                         // 38
+        //uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];                // 39-48
+        //uint32_t holidayNameId;                                   // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;                            // 50 HolidayDescriptions.dbc
+        //char* TextureFilename;                                    // 51
+        //uint32_t Priority;                                        // 52
+        //uint32_t CalendarFilterType;                              // 53
+        //uint32_t flags;                                           // 54
     };
 
     struct ItemLimitCategoryEntry
     {
-        uint32_t Id;                        // 0
-        //char* name;                       // 1
-        uint32_t maxAmount;                 // 2
-        uint32_t equippedFlag;              // 3
+        uint32_t Id;                                                // 0
+        //char* name;                                               // 1
+        uint32_t maxAmount;                                         // 2
+        uint32_t equippedFlag;                                      // 3
     };
 
     struct ItemRandomPropertiesEntry
     {
-        uint32_t ID;                        // 0
-        //char* name1;                      // 1
-        uint32_t spells[5];                 // 2-6 enchant_id
-        char* name_suffix;                  // 7
+        uint32_t ID;                                                // 0
+        //char* name1;                                              // 1
+        uint32_t spells[5];                                         // 2-6 enchant_id
+        char* name_suffix;                                          // 7
     };
 
     struct ItemRandomSuffixEntry
     {
-        uint32_t id;                        // 0
-        char* name_suffix;                  // 1
-        //uint32_t name_suffix_flags;       // 2
-        uint32_t enchantments[5];           // 3-7
-        uint32_t prefixes[5];               // 8-12
+        uint32_t id;                                                // 0
+        char* name_suffix;                                          // 1
+        //uint32_t name_suffix_flags;                               // 2
+        uint32_t enchantments[5];                                   // 3-7
+        uint32_t prefixes[5];                                       // 8-12
     };
 
     struct ItemSetEntry
     {
-        //uint32_t id;                      // 0
-        char* name;                         // 1
-        //uint32_t itemid[17];              // 2-18
-        uint32_t SpellID[8];                // 19-26
-        uint32_t itemscount[8];             // 27-34
-        uint32_t RequiredSkillID;           // 35
-        uint32_t RequiredSkillAmt;          // 36
+        //uint32_t id;                                              // 0
+        char* name;                                                 // 1
+        //uint32_t itemid[17];                                      // 2-18
+        uint32_t SpellID[8];                                        // 19-26
+        uint32_t itemscount[8];                                     // 27-34
+        uint32_t RequiredSkillID;                                   // 35
+        uint32_t RequiredSkillAmt;                                  // 36
     };
 
     struct LFGDungeonEntry
     {
-        uint32_t ID;                        // 0
-        char* name;                         // 1
-        uint32_t minlevel;                  // 2
-        uint32_t maxlevel;                  // 3
-        uint32_t reclevel;                  // 4
-        uint32_t recminlevel;               // 5
-        uint32_t recmaxlevel;               // 6
-        int32_t map;                        // 7
-        uint32_t difficulty;                // 8
-        uint32_t unk;                       // 9
-        uint32_t flags;                     // 10
-        int32_t type;                       // 11
-        char* iconname;                     // 12
-        uint32_t expansion;                 // 13
-        uint32_t unk4;                      // 14
-        uint32_t unk5;                      // 15
-        char* unk_text;                     // 16
-        uint32_t grouptype;                 // 17
-        uint32_t unkflags1;                 // 18
-        uint32_t unkflags2;                 // 19
-        uint32_t unk7;                      // 20
+        uint32_t ID;                                                // 0
+        char* name;                                                 // 1
+        uint32_t minlevel;                                          // 2
+        uint32_t maxlevel;                                          // 3
+        uint32_t reclevel;                                          // 4
+        uint32_t recminlevel;                                       // 5
+        uint32_t recmaxlevel;                                       // 6
+        int32_t map;                                                // 7
+        uint32_t difficulty;                                        // 8
+        uint32_t unk;                                               // 9
+        uint32_t flags;                                             // 10
+        int32_t type;                                               // 11
+        char* iconname;                                             // 12
+        uint32_t expansion;                                         // 13
+        uint32_t unk4;                                              // 14
+        uint32_t unk5;                                              // 15
+        char* unk_text;                                             // 16
+        uint32_t grouptype;                                         // 17
+        uint32_t unkflags1;                                         // 18
+        uint32_t unkflags2;                                         // 19
+        uint32_t unk7;                                              // 20
 
         // Helpers
         uint32_t Entry() const { return ID + (type << 24); }
@@ -1261,79 +1261,79 @@ namespace DBC::Structures
 
     struct DungeonEncounterEntry
     {
-        uint32 id;                                              // 0        unique id
-        uint32 mapId;                                           // 1        map id
-        uint32 difficulty;                                      // 2        instance mode
-        //uint32 unk0;                                          // 3
-        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-        char* encounterName;                                    // 5        encounter name
-        //uint32 nameFlags;                                     // 21
+        uint32 id;                                                  // 0 unique id
+        uint32 mapId;                                               // 1 map id
+        uint32 difficulty;                                          // 2 instance mode
+        //uint32 unk0;                                              // 3
+        uint32 encounterIndex;                                      // 4 encounter index for creating completed mask
+        char* encounterName;                                        // 5 encounter name
+        //uint32 nameFlags;                                         // 21
         //uint32 u
     };
 
     struct LiquidTypeEntry
     {
-        uint32_t Id;                        // 0
-        //char* Name;                       // 1
-        //uint32_t Flags;                   // 2
-        uint32_t Type;                      // 3
-        //uint32_t SoundId;                 // 4
-        uint32_t SpellId;                   // 5
-        //float MaxDarkenDepth;             // 6
-        //float FogDarkenIntensity;         // 7
-        //float AmbDarkenIntensity;         // 8
-        //float DirDarkenIntensity;         // 9
-        //uint32_t LightID;                 // 10
-        //float ParticleScale;              // 11
-        //uint32_t ParticleMovement;        // 12
-        //uint32_t ParticleTexSlots;        // 13
-        //uint32_t LiquidMaterialID;        // 14
-        //char* Texture[6];                 // 15-20
-        //uint32_t Color[2];                // 21-22
-        //float Unk1[18];                   // 23-40
-        //uint32_t Unk2[4];                 // 41-44
+        uint32_t Id;                                                // 0
+        //char* Name;                                               // 1
+        //uint32_t Flags;                                           // 2
+        uint32_t Type;                                              // 3
+        //uint32_t SoundId;                                         // 4
+        uint32_t SpellId;                                           // 5
+        //float MaxDarkenDepth;                                     // 6
+        //float FogDarkenIntensity;                                 // 7
+        //float AmbDarkenIntensity;                                 // 8
+        //float DirDarkenIntensity;                                 // 9
+        //uint32_t LightID;                                         // 10
+        //float ParticleScale;                                      // 11
+        //uint32_t ParticleMovement;                                // 12
+        //uint32_t ParticleTexSlots;                                // 13
+        //uint32_t LiquidMaterialID;                                // 14
+        //char* Texture[6];                                         // 15-20
+        //uint32_t Color[2];                                        // 21-22
+        //float Unk1[18];                                           // 23-40
+        //uint32_t Unk2[4];                                         // 41-44
     };
 
 #define LOCK_NUM_CASES 8
 
     struct LockEntry
     {
-        uint32_t Id;                              // 0
-        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+        uint32_t Id;                                                // 0
+        uint32_t locktype[LOCK_NUM_CASES];                          // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];                          // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];                      // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];                          // 25-32 Something to do with direction / opening / closing.
     };
 
     struct MailTemplateEntry
     {
-        uint32_t ID;                        // 0
-        char* subject;                      // 1
-        char* content;                      // 2
+        uint32_t ID;                                                // 0
+        char* subject;                                              // 1
+        char* content;                                              // 2
     };
 
     struct MapEntry
     {
-        uint32_t id;                        // 0
-        char* name_internal;                // 1
-        uint32_t map_type;                  // 2
-        uint32_t map_flags;                 // 3
-        uint32_t unk4;                      // 4
-        uint32_t is_pvp_zone;               // 5
-        char* map_name;                     // 6
-        uint32_t linked_zone;               // 7 common zone for instance and continent map
-        char* horde_intro;                  // 8 horde text for PvP Zones
-        char* alliance_intro;               // 9 alliance text for PvP Zones
-        uint32_t multimap_id;               // 10
-        float battlefield_map_icon;         // 11
-        int32_t parent_map;                 // 12 ghost map_id of parent map
-        float start_x;                      // 13 ghost enter x coordinate (if exist single entry)
-        float start_y;                      // 14 ghost enter y coordinate (if exist single entry)
-        uint32_t dayTime_override;          // 15
-        uint32_t addon;                     // 16 0-original maps, 1-tbc addon, 2-wotlk addon
-        uint32_t unk_time;                  // 17
-        uint32_t max_players;               // 18
-        uint32_t next_phase_map;            // 19
+        uint32_t id;                                                // 0
+        char* name_internal;                                        // 1
+        uint32_t map_type;                                          // 2
+        uint32_t map_flags;                                         // 3
+        uint32_t unk4;                                              // 4
+        uint32_t is_pvp_zone;                                       // 5
+        char* map_name;                                             // 6
+        uint32_t linked_zone;                                       // 7 common zone for instance and continent map
+        char* horde_intro;                                          // 8 horde text for PvP Zones
+        char* alliance_intro;                                       // 9 alliance text for PvP Zones
+        uint32_t multimap_id;                                       // 10
+        float battlefield_map_icon;                                 // 11
+        int32_t parent_map;                                         // 12 ghost map_id of parent map
+        float start_x;                                              // 13 ghost enter x coordinate (if exist single entry)
+        float start_y;                                              // 14 ghost enter y coordinate (if exist single entry)
+        uint32_t dayTime_override;                                  // 15
+        uint32_t addon;                                             // 16 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                                          // 17
+        uint32_t max_players;                                       // 18
+        uint32_t next_phase_map;                                    // 19
 
         bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
         bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
@@ -1352,95 +1352,95 @@ namespace DBC::Structures
 
     struct NameGenEntry
     {
-        uint32_t ID;                        // 0
-        char* Name;                         // 1
-        uint32_t unk1;                      // 2
-        uint32_t type;                      // 3
+        uint32_t ID;                                                // 0
+        char* Name;                                                 // 1
+        uint32_t unk1;                                              // 2
+        uint32_t type;                                              // 3
     };
 
     struct NumTalentsAtLevel
     {
-        //uint32_t level;                   // 0
-        float talentPoints;                 // 1
+        //uint32_t level;                                           // 0
+        float talentPoints;                                         // 1
     };
 
     struct PhaseEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t PhaseShift;                // 1
-        uint32_t Flags;                     // 2
+        uint32_t Id;                                                // 0
+        uint32_t PhaseShift;                                        // 1
+        uint32_t Flags;                                             // 2
     };
 
     struct QuestSortEntry
     {
-        uint32_t id;                        // 0
-        //char* name;                       // 1
+        uint32_t id;                                                // 0
+        //char* name;                                               // 1
     };
 
     struct QuestXP
     {
-        uint32_t questLevel;                // 0
-        uint32_t xpIndex[10];               // 1-10
+        uint32_t questLevel;                                        // 0
+        uint32_t xpIndex[10];                                       // 1-10
     };
 
     struct ScalingStatDistributionEntry
     {
-        uint32_t id;                        // 0
-        int32_t stat[10];                   // 1-10
-        uint32_t statmodifier[10];          // 11-20
-        //uint32_t unk;                     // 21
-        uint32_t maxlevel;                  // 22
+        uint32_t id;                                                // 0
+        int32_t stat[10];                                           // 1-10
+        uint32_t statmodifier[10];                                  // 11-20
+        //uint32_t unk;                                             // 21
+        uint32_t maxlevel;                                          // 22
     };
 
     struct ScalingStatValuesEntry
     {
-        uint32_t id;                        // 0
-        uint32_t level;                     // 1
-        uint32_t multiplier[20];            // 
+        uint32_t id;                                                // 0
+        uint32_t level;                                             // 1
+        uint32_t multiplier[20];                                    // 
         //\todo danko Rewrite GetStatScalingStatValueColumn!
-        //uint32_t dpsMod[6];               // 2-7
-        //uint32_t spellBonus;              // 8
-        //uint32_t scalingstatmultipl[5];   // 9-13
-        //uint32_t amor_mod[4];             // 14-17
-        //uint32_t amor_mod2[4];            // 18-21
-        //uint32_t junk[24];                // 22-45
-        //uint32_t unk2;                    // 46
+        //uint32_t dpsMod[6];                                       // 2-7
+        //uint32_t spellBonus;                                      // 8
+        //uint32_t scalingstatmultipl[5];                           // 9-13
+        //uint32_t amor_mod[4];                                     // 14-17
+        //uint32_t amor_mod2[4];                                    // 18-21
+        //uint32_t junk[24];                                        // 22-45
+        //uint32_t unk2;                                            // 46
     };
 
     struct SkillLineEntry
     {
-        uint32_t id;                        // 0
-        uint32_t type;                      // 1
-        char* Name;                         // 2
-        //char* Description;                // 3
-        uint32_t spell_icon;                // 4
-        //char* add_name;                   // 5
-        uint32_t linkable;                  // 6
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1
+        char* Name;                                                 // 2
+        //char* Description;                                        // 3
+        uint32_t spell_icon;                                        // 4
+        //char* add_name;                                           // 5
+        uint32_t linkable;                                          // 6
     };
 
     struct SkillLineAbilityEntry
     {
-        uint32_t Id;                        // 0
-        uint32_t skilline;                  // 1 skill id
-        uint32_t spell;                     // 2
-        uint32_t race_mask;                 // 3
-        uint32_t class_mask;                // 4
-        //uint32_t excludeRace;             // 5
-        //uint32_t excludeClass;            // 6
-        uint32_t minSkillLineRank;          // 7 req skill value
-        uint32_t next;                      // 8
-        uint32_t acquireMethod;             // 9 auto learn
-        uint32_t grey;                      // 10 max
-        uint32_t green;                     // 11 min
-        uint32_t characterPoints;           // 12
-        //uint32_t unk;                     // 13
+        uint32_t Id;                                                // 0
+        uint32_t skilline;                                          // 1 skill id
+        uint32_t spell;                                             // 2
+        uint32_t race_mask;                                         // 3
+        uint32_t class_mask;                                        // 4
+        //uint32_t excludeRace;                                     // 5
+        //uint32_t excludeClass;                                    // 6
+        uint32_t minSkillLineRank;                                  // 7 req skill value
+        uint32_t next;                                              // 8
+        uint32_t acquireMethod;                                     // 9 auto learn
+        uint32_t grey;                                              // 10 max
+        uint32_t green;                                             // 11 min
+        uint32_t characterPoints;                                   // 12
+        //uint32_t unk;                                             // 13
     };
 
     //\todo danko
     //struct StableSlotPrices
     //{
-    //    uint32_t Id;                      // 0
-    //    uint32_t Price;                   // 1
+    //    uint32_t Id;                                              // 0
+    //    uint32_t Price;                                           // 1
     //};
 
     //\ todo: confirm effect count
@@ -1452,124 +1452,124 @@ namespace DBC::Structures
     // SpellAuraOptions.dbc
     struct SpellAuraOptionsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t MaxStackAmount;            // 1
-        uint32_t procChance;                // 2
-        uint32_t procCharges;               // 3
-        uint32_t procFlags;                 // 4
+        //uint32_t Id;                                              // 0
+        uint32_t MaxStackAmount;                                    // 1
+        uint32_t procChance;                                        // 2
+        uint32_t procCharges;                                       // 3
+        uint32_t procFlags;                                         // 4
     };
 
     // SpellAuraRestrictions.dbc
     struct SpellAuraRestrictionsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t CasterAuraState;           // 1
-        uint32_t TargetAuraState;           // 2
-        uint32_t CasterAuraStateNot;        // 3
-        uint32_t TargetAuraStateNot;        // 4
-        uint32_t casterAuraSpell;           // 5
-        uint32_t targetAuraSpell;           // 6
-        uint32_t CasterAuraSpellNot;        // 7
-        uint32_t TargetAuraSpellNot;        // 8
+        //uint32_t Id;                                              // 0
+        uint32_t CasterAuraState;                                   // 1
+        uint32_t TargetAuraState;                                   // 2
+        uint32_t CasterAuraStateNot;                                // 3
+        uint32_t TargetAuraStateNot;                                // 4
+        uint32_t casterAuraSpell;                                   // 5
+        uint32_t targetAuraSpell;                                   // 6
+        uint32_t CasterAuraSpellNot;                                // 7
+        uint32_t TargetAuraSpellNot;                                // 8
     };
 
     // SpellCastingRequirements.dbc
     struct SpellCastingRequirementsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t FacingCasterFlags;         // 1
-        //uint32_t MinFactionId;            // 2
-        //uint32_t MinReputation;           // 3
-        int32_t AreaGroupId;                // 4
-        //uint32_t RequiredAuraVision;      // 5
-        uint32_t RequiresSpellFocus;        // 6
+        //uint32_t Id;                                              // 0
+        uint32_t FacingCasterFlags;                                 // 1
+        //uint32_t MinFactionId;                                    // 2
+        //uint32_t MinReputation;                                   // 3
+        int32_t AreaGroupId;                                        // 4
+        //uint32_t RequiredAuraVision;                              // 5
+        uint32_t RequiresSpellFocus;                                // 6
     };
 
     // SpellCastTimes.dbc
     struct SpellCastTimesEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t CastTime;                  // 1
-        float CastTimePerLevel;             // 2
-        int32_t MinCastTime;                // 3
+        uint32_t ID;                                                // 0
+        uint32_t CastTime;                                          // 1
+        float CastTimePerLevel;                                     // 2
+        int32_t MinCastTime;                                        // 3
     };
 
     // SpellCategories.dbc
     struct SpellCategoriesEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Category;                  // 1
-        uint32_t DmgClass;                  // 2
-        uint32_t DispelType;                // 3
-        uint32_t MechanicsType;             // 4
-        uint32_t PreventionType;            // 5
-        uint32_t StartRecoveryCategory;     // 6
+        //uint32_t Id;                                              // 0
+        uint32_t Category;                                          // 1
+        uint32_t DmgClass;                                          // 2
+        uint32_t DispelType;                                        // 3
+        uint32_t MechanicsType;                                     // 4
+        uint32_t PreventionType;                                    // 5
+        uint32_t StartRecoveryCategory;                             // 6
     };
 
     // SpellClassOptions.dbc
     struct SpellClassOptionsEntry
     {
-        //uint32_t Id;                                  // 0
-        //uint32_t modalNextSpell;                      // 1
-        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];   // 2 - 4
-        uint32_t SpellFamilyName;                       // 5
-        //char* Description;                            // 6
+        //uint32_t Id;                                              // 0
+        //uint32_t modalNextSpell;                                  // 1
+        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 2 - 4
+        uint32_t SpellFamilyName;                                   // 5
+        //char* Description;                                        // 6
     };
 
     // SpellCooldowns.dbc
     struct SpellCooldownsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t CategoryRecoveryTime;      // 1
-        uint32_t RecoveryTime;              // 2
-        uint32_t StartRecoveryTime;         // 3
+        //uint32_t Id;                                              // 0
+        uint32_t CategoryRecoveryTime;                              // 1
+        uint32_t RecoveryTime;                                      // 2
+        uint32_t StartRecoveryTime;                                 // 3
     };
 
     // SpellDifficulty.dbc
     struct SpellDifficultyEntry
     {
-        uint32_t ID;                        // 0
-        int32_t SpellId[MAX_DIFFICULTY];    // 1-4
+        uint32_t ID;                                                // 0
+        int32_t SpellId[MAX_DIFFICULTY];                            // 1-4
     };
 
     // SpellDuration.dbc
     struct SpellDurationEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t Duration1;                 // 1
-        uint32_t Duration2;                 // 2
-        uint32_t Duration3;                 // 3
+        uint32_t ID;                                                // 0
+        uint32_t Duration1;                                         // 1
+        uint32_t Duration2;                                         // 2
+        uint32_t Duration3;                                         // 3
     };
 
     // SpellEffect.dbc
     struct SpellEffectEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t Effect;                    // 1
-        float EffectMultipleValue;          // 2
-        uint32_t EffectApplyAuraName;       // 3
-        uint32_t EffectAmplitude;           // 4
-        int32_t EffectBasePoints;           // 5
-        float EffectBonusMultiplier;        // 6
-        float EffectDamageMultiplier;       // 7
-        uint32_t EffectChainTarget;         // 8
-        int32_t EffectDieSides;             // 9
-        uint32_t EffectItemType;            // 10
-        uint32_t EffectMechanic;            // 11
-        int32_t EffectMiscValue;            // 12
-        int32_t EffectMiscValueB;           // 13
-        float EffectPointsPerComboPoint;    // 14
-        uint32_t EffectRadiusIndex;         // 15
-        uint32_t EffectRadiusMaxIndex;      // 16
-        float EffectRealPointsPerLevel;     // 17
-        uint32_t EffectSpellClassMask[3];   // 18-20
+        //uint32_t Id;                                              // 0
+        uint32_t Effect;                                            // 1
+        float EffectMultipleValue;                                  // 2
+        uint32_t EffectApplyAuraName;                               // 3
+        uint32_t EffectAmplitude;                                   // 4
+        int32_t EffectBasePoints;                                   // 5
+        float EffectBonusMultiplier;                                // 6
+        float EffectDamageMultiplier;                               // 7
+        uint32_t EffectChainTarget;                                 // 8
+        int32_t EffectDieSides;                                     // 9
+        uint32_t EffectItemType;                                    // 10
+        uint32_t EffectMechanic;                                    // 11
+        int32_t EffectMiscValue;                                    // 12
+        int32_t EffectMiscValueB;                                   // 13
+        float EffectPointsPerComboPoint;                            // 14
+        uint32_t EffectRadiusIndex;                                 // 15
+        uint32_t EffectRadiusMaxIndex;                              // 16
+        float EffectRealPointsPerLevel;                             // 17
+        uint32_t EffectSpellClassMask[3];                           // 18-20
         //ClassFamilyMask EffectSpellClassMask;
-        uint32_t EffectTriggerSpell;        // 21
-        uint32_t EffectImplicitTargetA;     // 22
-        uint32_t EffectImplicitTargetB;     // 23
-        uint32_t EffectSpellId;             // 24
-        uint32_t EffectIndex;               // 25
-        //uint32_t unk;                     // 26
+        uint32_t EffectTriggerSpell;                                // 21
+        uint32_t EffectImplicitTargetA;                             // 22
+        uint32_t EffectImplicitTargetB;                             // 23
+        uint32_t EffectSpellId;                                     // 24
+        uint32_t EffectIndex;                                       // 25
+        //uint32_t unk;                                             // 26
 
         uint32_t GetRadiusIndex() const
         {
@@ -1583,139 +1583,139 @@ namespace DBC::Structures
     // SpellEquippedItems.dbc
     struct SpellEquippedItemsEntry
     {
-        //uint32_t Id;                          // 0
-        int32_t EquippedItemClass;              // 1
-        int32_t EquippedItemInventoryTypeMask;  // 2
-        int32_t EquippedItemSubClassMask;       // 3
+        //uint32_t Id;                                              // 0
+        int32_t EquippedItemClass;                                  // 1
+        int32_t EquippedItemInventoryTypeMask;                      // 2
+        int32_t EquippedItemSubClassMask;                           // 3
     };
 
     // SpellFocusObject.dbc
     struct SpellFocusObjectEntry
     {
-        uint32_t ID;                        // 0
-        //char* Name;                       // 1
+        uint32_t ID;                                                // 0
+        //char* Name;                                               // 1
     };
 
     // SpellInterrupts.dbc
     struct SpellInterruptsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t AuraInterruptFlags;        // 1
-        //uint32_t unk2                     // 2
-        uint32_t ChannelInterruptFlags;     // 3
-        //uint32_t unk4                     // 4
-        uint32_t InterruptFlags;            // 5
+        //uint32_t Id;                                              // 0
+        uint32_t AuraInterruptFlags;                                // 1
+        //uint32_t unk2                                             // 2
+        uint32_t ChannelInterruptFlags;                             // 3
+        //uint32_t unk4                                             // 4
+        uint32_t InterruptFlags;                                    // 5
     };
 
     // SpellItemEnchantment.dbc
     struct SpellItemEnchantmentEntry
     {
-        uint32_t Id;                        // 0
-        //uint32_t charges;                 // 1
-        uint32_t type[3];                   // 2-4
-        uint32_t min[3];                    // 5-7 for combat, in practice min==max
-        //uint32_t max[3];                  // 8-10
-        uint32_t spell[3];                  // 11-13
-        char* Name;                         // 14-29
-        //uint32_t NameFlags;               // 30
-        uint32_t visual;                    // 31 aura
-        uint32_t EnchantGroups;             // 32 slot
-        uint32_t GemEntry;                  // 33
-        uint32_t ench_condition;            // 34
-        uint32_t req_skill;                 // 35
-        uint32_t req_skill_value;           // 36
-        uint32_t req_level;                 // 37
+        uint32_t Id;                                                // 0
+        //uint32_t charges;                                         // 1
+        uint32_t type[3];                                           // 2-4
+        uint32_t min[3];                                            // 5-7 for combat, in practice min==max
+        //uint32_t max[3];                                          // 8-10
+        uint32_t spell[3];                                          // 11-13
+        char* Name;                                                 // 14-29
+        //uint32_t NameFlags;                                       // 30
+        uint32_t visual;                                            // 31 aura
+        uint32_t EnchantGroups;                                     // 32 slot
+        uint32_t GemEntry;                                          // 33
+        uint32_t ench_condition;                                    // 34
+        uint32_t req_skill;                                         // 35
+        uint32_t req_skill_value;                                   // 36
+        uint32_t req_level;                                         // 37
     };
 
     // SpellItemEnchantmentCondition.dbc
     struct SpellItemEnchantmentConditionEntry
     {
-        uint32_t ID;                        // 0
-        uint8_t Color[5];                   // 1-5
-        //uint32_t LT_Operand[5];           // 6-10
-        uint8_t Comparator[5];              // 11-15
-        uint8_t CompareColor[5];            // 15-20
-        uint32_t Value[5];                  // 21-25
-        //uint8_t Logic[5]                  // 25-30
+        uint32_t ID;                                                // 0
+        uint8_t Color[5];                                           // 1-5
+        //uint32_t LT_Operand[5];                                   // 6-10
+        uint8_t Comparator[5];                                      // 11-15
+        uint8_t CompareColor[5];                                    // 15-20
+        uint32_t Value[5];                                          // 21-25
+        //uint8_t Logic[5]                                          // 25-30
     };
 
     // SpellLevels.dbc
     struct SpellLevelsEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t baseLevel;                 // 1
-        uint32_t maxLevel;                  // 2
-        uint32_t spellLevel;                // 3
+        //uint32_t Id;                                              // 0
+        uint32_t baseLevel;                                         // 1
+        uint32_t maxLevel;                                          // 2
+        uint32_t spellLevel;                                        // 3
     };
 
     // SpellPower.dbc
     struct SpellPowerEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t manaCost;                  // 1
-        uint32_t manaCostPerlevel;          // 2
-        uint32_t ManaCostPercentage;        // 3
-        uint32_t manaPerSecond;             // 4
-        uint32_t manaPerSecondPerLevel;     // 5
-        //uint32_t PowerDisplayId;          // 6 
-        float ManaCostPercentageFloat;      // 7
+        //uint32_t Id;                                              // 0
+        uint32_t manaCost;                                          // 1
+        uint32_t manaCostPerlevel;                                  // 2
+        uint32_t ManaCostPercentage;                                // 3
+        uint32_t manaPerSecond;                                     // 4
+        uint32_t manaPerSecondPerLevel;                             // 5
+        //uint32_t PowerDisplayId;                                  // 6 
+        float ManaCostPercentageFloat;                              // 7
     };
 
     // SpellRadius.dbc
     struct SpellRadiusEntry
     {
-        uint32_t ID;                        // 0
-        float radius_min;                   // 1
-        float radius_per_level;             // 2
-        float radius_max;                   // 3
+        uint32_t ID;                                                // 0
+        float radius_min;                                           // 1
+        float radius_per_level;                                     // 2
+        float radius_max;                                           // 3
     };
 
     // SpellRange.dbc
     struct SpellRangeEntry
     {
-        uint32_t ID;                        // 0
-        float minRange;                     // 1
-        float minRangeFriendly;             // 2
-        float maxRange;                     // 3
-        float maxRangeFriendly;             // 4
-        uint32_t range_type;                // 5
-        //char* name1[16]                   // 6-21
-        //uint32_t name1_falgs;             // 22
-        //char* name2[16]                   // 23-38
-        //uint32_t name2_falgs;             // 39
+        uint32_t ID;                                                // 0
+        float minRange;                                             // 1
+        float minRangeFriendly;                                     // 2
+        float maxRange;                                             // 3
+        float maxRangeFriendly;                                     // 4
+        uint32_t range_type;                                        // 5
+        //char* name1[16]                                           // 6-21
+        //uint32_t name1_falgs;                                     // 22
+        //char* name2[16]                                           // 23-38
+        //uint32_t name2_falgs;                                     // 39
     };
 
     // SpellReagents.dbc
     struct SpellReagentsEntry
     {
-        //uint32_t Id;                              // 0
-        int32_t Reagent[MAX_SPELL_REAGENTS];        // 54-61
-        uint32_t ReagentCount[MAX_SPELL_REAGENTS];  // 62-69
+        //uint32_t Id;                                              // 0
+        int32_t Reagent[MAX_SPELL_REAGENTS];                        // 54-61
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 62-69
     };
 
     // SpellRuneCost.dbc
     struct SpellRuneCostEntry
     {
-        uint32_t ID;                        // 0
-        uint32_t bloodRuneCost;             // 1
-        uint32_t frostRuneCost;             // 2
-        uint32_t unholyRuneCost;            // 3
-        uint32_t runePowerGain;             // 4
+        uint32_t ID;                                                // 0
+        uint32_t bloodRuneCost;                                     // 1
+        uint32_t frostRuneCost;                                     // 2
+        uint32_t unholyRuneCost;                                    // 3
+        uint32_t runePowerGain;                                     // 4
     };
 
     // SpellScaling.dbc
     struct SpellScalingEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t castTimeMin;               // 1
-        uint32_t castTimeMax;               // 2
-        uint32_t castScalingMaxLevel;       // 3
-        uint32_t playerClass;               // 4
-        float coeff1[3];                    // 5-7
-        float coeff2[3];                    // 8-10
-        float coeff3[3];                    // 11-13
-        float coefBase;                     // 14
-        uint32_t coefLevelBase;             // 15
+        //uint32_t Id;                                              // 0
+        uint32_t castTimeMin;                                       // 1
+        uint32_t castTimeMax;                                       // 2
+        uint32_t castScalingMaxLevel;                               // 3
+        uint32_t playerClass;                                       // 4
+        float coeff1[3];                                            // 5-7
+        float coeff2[3];                                            // 8-10
+        float coeff3[3];                                            // 11-13
+        float coefBase;                                             // 14
+        uint32_t coefLevelBase;                                     // 15
 
         bool IsScalableEffect(uint8_t i) const { return coeff1[i] != 0.0f; };
     };
@@ -1723,83 +1723,83 @@ namespace DBC::Structures
     // SpellShapeshift.dbc
     struct SpellShapeshiftEntry
     {
-        //uint32_t Id;                      // 0
-        uint32_t ShapeshiftsExcluded;       // 1
-        //uint32_t ShapeshiftsExcluded1;    // 2 unused, all zeros
-        uint32_t Shapeshifts;               // 3
-        //uint32_t Shapeshifts1;            // 4 unused, all zeros
-        //uint32_t StanceBarOrder;          // 5
+        //uint32_t Id;                                              // 0
+        uint32_t ShapeshiftsExcluded;                               // 1
+        //uint32_t ShapeshiftsExcluded1;                            // 2 unused, all zeros
+        uint32_t Shapeshifts;                                       // 3
+        //uint32_t Shapeshifts1;                                    // 4 unused, all zeros
+        //uint32_t StanceBarOrder;                                  // 5
     };
 
     // SpellTargetRestrictions.dbc
     struct SpellTargetRestrictionsEntry
     {
-        //uint32_t Id;                      // 0
-        float MaxTargetRadius;              // 1
-        uint32_t MaxAffectedTargets;        // 2
-        uint32_t MaxTargetLevel;            // 3
-        uint32_t TargetCreatureType;        // 4
-        uint32_t Targets;                   // 5
+        //uint32_t Id;                                              // 0
+        float MaxTargetRadius;                                      // 1
+        uint32_t MaxAffectedTargets;                                // 2
+        uint32_t MaxTargetLevel;                                    // 3
+        uint32_t TargetCreatureType;                                // 4
+        uint32_t Targets;                                           // 5
     };
 
     // SpellTotems.dbc
     struct SpellTotemsEntry
     {
-        //uint32_t Id;                                         // 0
-        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];    // 1 2
-        uint32_t Totem[MAX_SPELL_TOTEMS];                      // 3 4
+        //uint32_t Id;                                              // 0
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 1 2
+        uint32_t Totem[MAX_SPELL_TOTEMS];                           // 3 4
     };
 
     struct SERVER_DECL SpellEntry
     {
-        uint32_t Id;                                          // 0
-        uint32_t Attributes;                                  // 1
-        uint32_t AttributesEx;                                // 2
-        uint32_t AttributesExB;                               // 3
-        uint32_t AttributesExC;                               // 4
-        uint32_t AttributesExD;                               // 5
-        uint32_t AttributesExE;                               // 6
-        uint32_t AttributesExF;                               // 7
-        uint32_t AttributesExG;                               // 8
-        uint32_t AttributesExH;                               // 9
-        uint32_t AttributesExI;                               // 10
-        uint32_t AttributesExJ;                               // 11
-        uint32_t CastingTimeIndex;                            // 12
-        uint32_t DurationIndex;                               // 13
-        int32_t powerType;                                    // 14
-        uint32_t rangeIndex;                                  // 15
-        float speed;                                          // 16
-        uint32_t SpellVisual;                                 // 17
-        uint32_t SpellVisual1;                                // 18
-        uint32_t spellIconID;                                 // 19
-        uint32_t activeIconID;                                // 20
-        const char* Name;                                     // 21
-        const char* Rank;                                     // 22
-        //char* Description;                                  // 23 not used
-        //char* BuffDescription;                              // 24 not used
-        uint32_t School;                                      // 25
-        uint32_t RuneCostID;                                  // 26
-        //uint32_t spellMissileID;                            // 27
-        //uint32_t spellDescriptionVariableID;                // 28
-        uint32_t SpellDifficultyId;                           // 29
-        //float unk_1;                                        // 30
-        uint32_t SpellScalingId;                              // 31 SpellScaling.dbc
-        uint32_t SpellAuraOptionsId;                          // 32 SpellAuraOptions.dbc
-        uint32_t SpellAuraRestrictionsId;                     // 33 SpellAuraRestrictions.dbc
-        uint32_t SpellCastingRequirementsId;                  // 34 SpellCastingRequirements.dbc
-        uint32_t SpellCategoriesId;                           // 35 SpellCategories.dbc
-        uint32_t SpellClassOptionsId;                         // 36 SpellClassOptions.dbc
-        uint32_t SpellCooldownsId;                            // 37 SpellCooldowns.dbc
-        //uint32_t unk_2;                                     // 38 all zeros...
-        uint32_t SpellEquippedItemsId;                        // 39 SpellEquippedItems.dbc
-        uint32_t SpellInterruptsId;                           // 40 SpellInterrupts.dbc
-        uint32_t SpellLevelsId;                               // 41 SpellLevels.dbc
-        uint32_t SpellPowerId;                                // 42 SpellPower.dbc
-        uint32_t SpellReagentsId;                             // 43 SpellReagents.dbc
-        uint32_t SpellShapeshiftId;                           // 44 SpellShapeshift.dbc
-        uint32_t SpellTargetRestrictionsId;                   // 45 SpellTargetRestrictions.dbc
-        uint32_t SpellTotemsId;                               // 46 SpellTotems.dbc
-        //uint32_t ResearchProject;                           // 47 ResearchProject.dbc
+        uint32_t Id;                                                // 0
+        uint32_t Attributes;                                        // 1
+        uint32_t AttributesEx;                                      // 2
+        uint32_t AttributesExB;                                     // 3
+        uint32_t AttributesExC;                                     // 4
+        uint32_t AttributesExD;                                     // 5
+        uint32_t AttributesExE;                                     // 6
+        uint32_t AttributesExF;                                     // 7
+        uint32_t AttributesExG;                                     // 8
+        uint32_t AttributesExH;                                     // 9
+        uint32_t AttributesExI;                                     // 10
+        uint32_t AttributesExJ;                                     // 11
+        uint32_t CastingTimeIndex;                                  // 12
+        uint32_t DurationIndex;                                     // 13
+        int32_t powerType;                                          // 14
+        uint32_t rangeIndex;                                        // 15
+        float speed;                                                // 16
+        uint32_t SpellVisual;                                       // 17
+        uint32_t SpellVisual1;                                      // 18
+        uint32_t spellIconID;                                       // 19
+        uint32_t activeIconID;                                      // 20
+        const char* Name;                                           // 21
+        const char* Rank;                                           // 22
+        //char* Description;                                        // 23 not used
+        //char* BuffDescription;                                    // 24 not used
+        uint32_t School;                                            // 25
+        uint32_t RuneCostID;                                        // 26
+        //uint32_t spellMissileID;                                  // 27
+        //uint32_t spellDescriptionVariableID;                      // 28
+        uint32_t SpellDifficultyId;                                 // 29
+        //float unk_1;                                              // 30
+        uint32_t SpellScalingId;                                    // 31 SpellScaling.dbc
+        uint32_t SpellAuraOptionsId;                                // 32 SpellAuraOptions.dbc
+        uint32_t SpellAuraRestrictionsId;                           // 33 SpellAuraRestrictions.dbc
+        uint32_t SpellCastingRequirementsId;                        // 34 SpellCastingRequirements.dbc
+        uint32_t SpellCategoriesId;                                 // 35 SpellCategories.dbc
+        uint32_t SpellClassOptionsId;                               // 36 SpellClassOptions.dbc
+        uint32_t SpellCooldownsId;                                  // 37 SpellCooldowns.dbc
+        //uint32_t unk_2;                                           // 38 all zeros...
+        uint32_t SpellEquippedItemsId;                              // 39 SpellEquippedItems.dbc
+        uint32_t SpellInterruptsId;                                 // 40 SpellInterrupts.dbc
+        uint32_t SpellLevelsId;                                     // 41 SpellLevels.dbc
+        uint32_t SpellPowerId;                                      // 42 SpellPower.dbc
+        uint32_t SpellReagentsId;                                   // 43 SpellReagents.dbc
+        uint32_t SpellShapeshiftId;                                 // 44 SpellShapeshift.dbc
+        uint32_t SpellTargetRestrictionsId;                         // 45 SpellTargetRestrictions.dbc
+        uint32_t SpellTotemsId;                                     // 46 SpellTotems.dbc
+        //uint32_t ResearchProject;                                 // 47 ResearchProject.dbc
 
         // struct access functions
         SpellAuraOptionsEntry const* GetSpellAuraOptions() const;
@@ -1867,237 +1867,237 @@ namespace DBC::Structures
 
     struct SpellShapeshiftFormEntry
     {
-        uint32_t id;                  // 0
-        //uint32_t button_pos;        // 1
-        //char* name[16];             // 2-17
-        //uint32_t name_flags;        // 18
-        uint32_t Flags;               // 19
-        uint32_t unit_type;           // 20
-        //uint32_t unk1               // 21
-        uint32_t AttackSpeed;         // 22
-        uint32_t modelId;             // 23 alliance?
-        uint32_t modelId2;            // 24 horde?
-        //uint32_t unk2               // 25
-        //uint32_t unk3               // 26
-        uint32_t spells[8];           // 27-34
+        uint32_t id;                                                // 0
+        //uint32_t button_pos;                                      // 1
+        //char* name[16];                                           // 2-17
+        //uint32_t name_flags;                                      // 18
+        uint32_t Flags;                                             // 19
+        uint32_t unit_type;                                         // 20
+        //uint32_t unk1                                             // 21
+        uint32_t AttackSpeed;                                       // 22
+        uint32_t modelId;                                           // 23 alliance?
+        uint32_t modelId2;                                          // 24 horde?
+        //uint32_t unk2                                             // 25
+        //uint32_t unk3                                             // 26
+        uint32_t spells[8];                                         // 27-34
     };
 
     struct SummonPropertiesEntry
     {
-        uint32_t ID;                  // 0
-        uint32_t ControlType;         // 1
-        uint32_t FactionID;           // 2
-        uint32_t Type;                // 3
-        uint32_t Slot;                // 4
-        uint32_t Flags;               // 5
+        uint32_t ID;                                                // 0
+        uint32_t ControlType;                                       // 1
+        uint32_t FactionID;                                         // 2
+        uint32_t Type;                                              // 3
+        uint32_t Slot;                                              // 4
+        uint32_t Flags;                                             // 5
     };
 
     struct TalentEntry
     {
-        uint32_t TalentID;            // 0
-        uint32_t TalentTree;          // 1
-        uint32_t Row;                 // 2
-        uint32_t Col;                 // 3
-        uint32_t RankID[5];           // 4-8
-        //uint32_t unk[4];            // 9-12
-        uint32_t DependsOn;           // 13
-        //uint32_t unk1[2];           // 14-15
-        uint32_t DependsOnRank;       // 16
-        //uint32_t unk2[2];           // 17-18
-        //uint32_t unk3;              // 19
-        //uint32_t unk4;              // 20
-        //uint32_t unk5;              // 21
+        uint32_t TalentID;                                          // 0
+        uint32_t TalentTree;                                        // 1
+        uint32_t Row;                                               // 2
+        uint32_t Col;                                               // 3
+        uint32_t RankID[5];                                         // 4-8
+        //uint32_t unk[4];                                          // 9-12
+        uint32_t DependsOn;                                         // 13
+        //uint32_t unk1[2];                                         // 14-15
+        uint32_t DependsOnRank;                                     // 16
+        //uint32_t unk2[2];                                         // 17-18
+        //uint32_t unk3;                                            // 19
+        //uint32_t unk4;                                            // 20
+        //uint32_t unk5;                                            // 21
     };
 
     struct TalentTabEntry
     {
-        uint32_t TalentTabID;         // 0
-        //char* Name;                 // 1
-        //uint32_t unk5;              // 2
-        uint32_t ClassMask;           // 3
-        uint32_t PetTalentMask;       // 4
-        uint32_t TabPage;             // 5
-        //char* InternalName;         // 6
-        //char* description;          // 7
-        uint32_t rolesMask;           // 8
-        uint32_t masterySpells[2];    // 9-10
+        uint32_t TalentTabID;                                       // 0
+        //char* Name;                                               // 1
+        //uint32_t unk5;                                            // 2
+        uint32_t ClassMask;                                         // 3
+        uint32_t PetTalentMask;                                     // 4
+        uint32_t TabPage;                                           // 5
+        //char* InternalName;                                       // 6
+        //char* description;                                        // 7
+        uint32_t rolesMask;                                         // 8
+        uint32_t masterySpells[2];                                  // 9-10
     };
 
     struct TalentTreePrimarySpells
     {
-        uint32_t ID;                  // 0
-        uint32_t tabID;               // 1
-        uint32_t SpellID;             // 2
-        //uint32_t unk                // 3
+        uint32_t ID;                                                // 0
+        uint32_t tabID;                                             // 1
+        uint32_t SpellID;                                           // 2
+        //uint32_t unk                                              // 3
     };
 
     struct TaxiNodesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t mapid;               // 1
-        float x;                      // 2
-        float y;                      // 3
-        float z;                      // 4
-        char* name;                   // 5
-        uint32_t horde_mount;         // 6
-        uint32_t alliance_mount;      // 7
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        char* name;                                                 // 5
+        uint32_t horde_mount;                                       // 6
+        uint32_t alliance_mount;                                    // 7
     };
 
     struct TaxiPathEntry
     {
-        uint32_t id;                  // 0
-        uint32_t from;                // 1
-        uint32_t to;                  // 2
-        uint32_t price;               // 3
+        uint32_t id;                                                // 0
+        uint32_t from;                                              // 1
+        uint32_t to;                                                // 2
+        uint32_t price;                                             // 3
     };
 
     struct TaxiPathNodeEntry
     {
-        //uint32_t id;                // 0
-        uint32_t path;                // 1
-        uint32_t seq;                 // 2 nodeIndex
-        uint32_t mapid;               // 3
-        float x;                      // 4
-        float y;                      // 5
-        float z;                      // 6
-        uint32_t flags;               // 7
-        uint32_t waittime;            // 8
-        uint32_t arivalEventID;       // 9
-        uint32_t departureEventID;    // 10
-    };
-
-    struct TotemCategoryEntry
-    {
-        uint32_t id;            // 0
-        //char* name;           // 1
-        uint32_t categoryType;  // 2
-        uint32_t categoryMask;  // 3
+        //uint32_t id;                                              // 0
+        uint32_t path;                                              // 1
+        uint32_t seq;                                               // 2 nodeIndex
+        uint32_t mapid;                                             // 3
+        float x;                                                    // 4
+        float y;                                                    // 5
+        float z;                                                    // 6
+        uint32_t flags;                                             // 7
+        uint32_t waittime;                                          // 8
+        uint32_t arivalEventID;                                     // 9
+        uint32_t departureEventID;                                  // 10
     };
 
     struct TransportAnimationEntry
     {
-        //uint32_t Id;          // 0
-        uint32_t TransportID;   // 1
-        uint32_t TimeIndex;     // 2
-        DBCPosition3D Pos;      // 3
-        //uint32_t SequenceID;  // 4
+        //uint32_t Id;                                              // 0
+        uint32_t TransportID;                                       // 1
+        uint32_t TimeIndex;                                         // 2
+        DBCPosition3D Pos;                                          // 3
+        //uint32_t SequenceID;                                      // 4
     };
 
     struct TransportRotationEntry
     {
-        //uint32_t ID;          // 0
-        uint32_t GameObjectsID; // 1
-        uint32_t TimeIndex;     // 2
-        float X;                // 3
-        float Y;                // 4
-        float Z;                // 5
-        float W;                // 6
+        //uint32_t ID;                                              // 0
+        uint32_t GameObjectsID;                                     // 1
+        uint32_t TimeIndex;                                         // 2
+        float X;                                                    // 3
+        float Y;                                                    // 4
+        float Z;                                                    // 5
+        float W;                                                    // 6
+    };
+
+    struct TotemCategoryEntry
+    {
+        uint32_t id;                                                // 0
+        //char* name;                                               // 1
+        uint32_t categoryType;                                      // 2
+        uint32_t categoryMask;                                      // 3
     };
 
     #define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {
-        uint32_t ID;                                        // 0
-        uint32_t flags;                                     // 1
-        float turnSpeed;                                    // 2
-        float pitchSpeed;                                   // 3
-        float pitchMin;                                     // 4
-        float pitchMax;                                     // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                 // 6-13
-        float mouseLookOffsetPitch;                         // 14
-        float cameraFadeDistScalarMin;                      // 15
-        float cameraFadeDistScalarMax;                      // 16
-        float cameraPitchOffset;                            // 17
-        float facingLimitRight;                             // 18
-        float facingLimitLeft;                              // 19
-        float msslTrgtTurnLingering;                        // 20
-        float msslTrgtPitchLingering;                       // 21
-        float msslTrgtMouseLingering;                       // 22
-        float msslTrgtEndOpacity;                           // 23
-        float msslTrgtArcSpeed;                             // 24
-        float msslTrgtArcRepeat;                            // 25
-        float msslTrgtArcWidth;                             // 26
-        float msslTrgtImpactRadius[2];                      // 27-28
-        char* msslTrgtArcTexture;                           // 29
-        char* msslTrgtImpactTexture;                        // 30
-        char* msslTrgtImpactModel[2];                       // 31-32
-        float cameraYawOffset;                              // 33
-        uint32_t uiLocomotionType;                          // 34
-        float msslTrgtImpactTexRadius;                      // 35
-        uint32_t uiSeatIndicatorType;                       // 36
-        uint32_t powerType;                                 // 37
-        //uint32_t unk1;                                    // 38
-        //uint32_t unk2;                                    // 39  
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        float turnSpeed;                                            // 2
+        float pitchSpeed;                                           // 3
+        float pitchMin;                                             // 4
+        float pitchMax;                                             // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
+        float mouseLookOffsetPitch;                                 // 14
+        float cameraFadeDistScalarMin;                              // 15
+        float cameraFadeDistScalarMax;                              // 16
+        float cameraPitchOffset;                                    // 17
+        float facingLimitRight;                                     // 18
+        float facingLimitLeft;                                      // 19
+        float msslTrgtTurnLingering;                                // 20
+        float msslTrgtPitchLingering;                               // 21
+        float msslTrgtMouseLingering;                               // 22
+        float msslTrgtEndOpacity;                                   // 23
+        float msslTrgtArcSpeed;                                     // 24
+        float msslTrgtArcRepeat;                                    // 25
+        float msslTrgtArcWidth;                                     // 26
+        float msslTrgtImpactRadius[2];                              // 27-28
+        char* msslTrgtArcTexture;                                   // 29
+        char* msslTrgtImpactTexture;                                // 30
+        char* msslTrgtImpactModel[2];                               // 31-32
+        float cameraYawOffset;                                      // 33
+        uint32_t uiLocomotionType;                                  // 34
+        float msslTrgtImpactTexRadius;                              // 35
+        uint32_t uiSeatIndicatorType;                               // 36
+        uint32_t powerType;                                         // 37
+        //uint32_t unk1;                                            // 38
+        //uint32_t unk2;                                            // 39
     };
 
     enum VehicleSeatFlags
     {
-        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,  // Passenger is hidden
         VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,  // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,  // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,  // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,  // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,  // Lua_UnitHasVehicleUI
     };
 
     enum VehicleSeatFlagsB
     {
         VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002,
         VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
         VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
     };
 
     struct VehicleSeatEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        int32_t attachmentID;                                 // 2
-        float attachmentOffsetX;                              // 3
-        float attachmentOffsetY;                              // 4
-        float attachmentOffsetZ;                              // 5
-        float enterPreDelay;                                  // 6
-        float enterSpeed;                                     // 7
-        float enterGravity;                                   // 8
-        float enterMinDuration;                               // 9
-        float enterMaxDuration;                               // 10
-        float enterMinArcHeight;                              // 11
-        float enterMaxArcHeight;                              // 12
-        int32_t enterAnimStart;                               // 13
-        int32_t enterAnimLoop;                                // 14
-        int32_t rideAnimStart;                                // 15
-        int32_t rideAnimLoop;                                 // 16
-        int32_t rideUpperAnimStart;                           // 17
-        int32_t rideUpperAnimLoop;                            // 18
-        float exitPreDelay;                                   // 19
-        float exitSpeed;                                      // 20
-        float exitGravity;                                    // 21
-        float exitMinDuration;                                // 22
-        float exitMaxDuration;                                // 23
-        float exitMinArcHeight;                               // 24
-        float exitMaxArcHeight;                               // 25
-        int32_t exitAnimStart;                                // 26
-        int32_t exitAnimLoop;                                 // 27
-        int32_t exitAnimEnd;                                  // 28
-        float passengerYaw;                                   // 29
-        float passengerPitch;                                 // 30
-        float passengerRoll;                                  // 31
-        int32_t passengerAttachmentID;                        // 32
-        int32_t vehicleEnterAnim;                             // 33
-        int32_t vehicleExitAnim;                              // 34
-        int32_t vehicleRideAnimLoop;                          // 35
-        int32_t vehicleEnterAnimBone;                         // 36
-        int32_t vehicleExitAnimBone;                          // 37
-        int32_t vehicleRideAnimLoopBone;                      // 38
-        float vehicleEnterAnimDelay;                          // 39
-        float vehicleExitAnimDelay;                           // 40
-        uint32_t vehicleAbilityDisplay;                       // 41
-        uint32_t enterUISoundID;                              // 42
-        uint32_t exitUISoundID;                               // 43
-        int32_t uiSkin;                                       // 44
-        uint32_t flagsB;                                      // 45
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        int32_t attachmentID;                                       // 2
+        float attachmentOffsetX;                                    // 3
+        float attachmentOffsetY;                                    // 4
+        float attachmentOffsetZ;                                    // 5
+        float enterPreDelay;                                        // 6
+        float enterSpeed;                                           // 7
+        float enterGravity;                                         // 8
+        float enterMinDuration;                                     // 9
+        float enterMaxDuration;                                     // 10
+        float enterMinArcHeight;                                    // 11
+        float enterMaxArcHeight;                                    // 12
+        int32_t enterAnimStart;                                     // 13
+        int32_t enterAnimLoop;                                      // 14
+        int32_t rideAnimStart;                                      // 15
+        int32_t rideAnimLoop;                                       // 16
+        int32_t rideUpperAnimStart;                                 // 17
+        int32_t rideUpperAnimLoop;                                  // 18
+        float exitPreDelay;                                         // 19
+        float exitSpeed;                                            // 20
+        float exitGravity;                                          // 21
+        float exitMinDuration;                                      // 22
+        float exitMaxDuration;                                      // 23
+        float exitMinArcHeight;                                     // 24
+        float exitMaxArcHeight;                                     // 25
+        int32_t exitAnimStart;                                      // 26
+        int32_t exitAnimLoop;                                       // 27
+        int32_t exitAnimEnd;                                        // 28
+        float passengerYaw;                                         // 29
+        float passengerPitch;                                       // 30
+        float passengerRoll;                                        // 31
+        int32_t passengerAttachmentID;                              // 32
+        int32_t vehicleEnterAnim;                                   // 33
+        int32_t vehicleExitAnim;                                    // 34
+        int32_t vehicleRideAnimLoop;                                // 35
+        int32_t vehicleEnterAnimBone;                               // 36
+        int32_t vehicleExitAnimBone;                                // 37
+        int32_t vehicleRideAnimLoopBone;                            // 38
+        float vehicleEnterAnimDelay;                                // 39
+        float vehicleExitAnimDelay;                                 // 40
+        uint32_t vehicleAbilityDisplay;                             // 41
+        uint32_t enterUISoundID;                                    // 42
+        uint32_t exitUISoundID;                                     // 43
+        int32_t uiSkin;                                             // 44
+        uint32_t flagsB;                                            // 45
 
         bool IsUsable() const
         {
@@ -2126,50 +2126,50 @@ namespace DBC::Structures
 
     struct WMOAreaTableEntry
     {
-        uint32_t id;                // 0
-        int32_t rootId;             // 1
-        int32_t adtId;              // 2
-        int32_t groupId;            // 3
-        //uint32_t field4;          // 4
-        //uint32_t field5;          // 5
-        //uint32_t field6;          // 6
-        //uint32_t field7;          // 7
-        //uint32_t field8;          // 8
-        uint32_t flags;             // 9
-        uint32_t areaId;            // 10
-        //char Name[16];            // 11-26
-        //uint32_t nameflags;       // 27
+        uint32_t id;                                                // 0
+        int32_t rootId;                                             // 1
+        int32_t adtId;                                              // 2
+        int32_t groupId;                                            // 3
+        //uint32_t field4;                                          // 4
+        //uint32_t field5;                                          // 5
+        //uint32_t field6;                                          // 6
+        //uint32_t field7;                                          // 7
+        //uint32_t field8;                                          // 8
+        uint32_t flags;                                             // 9
+        uint32_t areaId;                                            // 10
+        //char Name[16];                                            // 11-26
+        //uint32_t nameflags;                                       // 27
     };
 
     struct WorldMapAreaEntry
     {
-        //uint32_t id;              // 0
-        uint32_t mapId;             // 1
-        uint32_t zoneId;            // 2
-        //const char* name;         // 3
-        //float y1;                 // 4
-        //float y2;                 // 5
-        //float x1;                 // 6
-        //float x2;                 // 7
-        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-        //uint32_t unk1             // 9
-        //uint32_t parentId         // 10
-        //uint32_t unk2             // 11
-        //uint32_t minLevel         // 12 looks like this is the recommended minimum level for the zone
-        //uint32_t maxLevel         // 13 looks like this is the recommended maximum level for the zone
+        //uint32_t id;                                              // 0
+        uint32_t mapId;                                             // 1
+        uint32_t zoneId;                                            // 2
+        //const char* name;                                         // 3
+        //float y1;                                                 // 4
+        //float y2;                                                 // 5
+        //float x1;                                                 // 6
+        //float x2;                                                 // 7
+        int32_t continentMapId;                                     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1                                             // 9
+        //uint32_t parentId                                         // 10
+        //uint32_t unk2                                             // 11
+        //uint32_t minLevel                                         // 12 looks like this is the recommended minimum level for the zone
+        //uint32_t maxLevel                                         // 13 looks like this is the recommended maximum level for the zone
     };
 
     struct WorldMapOverlayEntry
     {
-        uint32_t ID;                // 0
-        //uint32_t worldMapID;      // 1 WorldMapArea.dbc
-        uint32_t areaID;            // 2
-        uint32_t areaID_2;          // 3
-        uint32_t areaID_3;          // 4
-        uint32_t areaID_4;          // 5
-        //uint32_t unk1[2];         // 6-7
-        //uint32_t unk2;            // 8
-        //uint32_t unk3[7];         // 9-16
+        uint32_t ID;                                                // 0
+        //uint32_t worldMapID;                                      // 1 WorldMapArea.dbc
+        uint32_t areaID;                                            // 2
+        uint32_t areaID_2;                                          // 3
+        uint32_t areaID_3;                                          // 4
+        uint32_t areaID_4;                                          // 5
+        //uint32_t unk1[2];                                         // 6-7
+        //uint32_t unk2;                                            // 8
+        //uint32_t unk3[7];                                         // 9-16
     };
 
     #pragma pack(pop)

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -271,7 +271,7 @@ namespace DBC::Structures
         char const spell_entry_format[] = "niiiiiiiiiiiiiiifiiiissxxiixxixiiiiiiixiiiiiiiix";
         char const spell_item_enchantment_format[] = "nxiiiiiixxxiiisiiiiiiix";
         //char const skill_race_class_info_format[] = "diiiiixxx"; new
-        char const spell_radius_format[] = "nfff";
+        char const spell_radius_format[] = "nffxf";
         char const spell_range_format[] = "nffffixx";
         char const spell_rune_cost_format[] = "niiii";
         char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
@@ -1671,7 +1671,8 @@ namespace DBC::Structures
         uint32_t ID;                                                // 0
         float radius_min;                                           // 1
         float radius_per_level;                                     // 2
-        float radius_max;                                           // 3
+        //float unkRadius;                                          // 3
+        float radius_max;                                           // 4
     };
 
     // SpellRange.dbc

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -174,7 +174,7 @@ namespace DBC::Structures
         char const achievement_format[] = "niiissiiiiisii";
         char const achievement_criteria_format[] = "niiiiiiiixsiiiiixxxxxxx";
         char const area_group_format[] = "niiiiiii";
-        char const area_table_entry_format[] = "iiinixxxxxisiiiiixxxxxxxxx";
+        char const area_table_entry_format[] = "iiinixxxxxxxisiiiiiffixxxxxxxx";
         char const area_trigger_entry_format[] = "nifffxxxfffff";
         //char const armor_location_format[] = "nfffff"; new
         char const auction_house_format[] = "niiix";
@@ -202,7 +202,7 @@ namespace DBC::Structures
         char const durability_quality_format[] = "nf";
         char const emotes_entry_format[] = "nxxiiixx";
         char const emotes_text_format[] = "nxixxxxxxxxxxxxxxxx";
-        char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixsxxxx";
         char const faction_template_format[] = "niiiiiiiiiiiii";
         char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffxxx";
         char const gem_properties_format[] = "nixxix";
@@ -292,7 +292,7 @@ namespace DBC::Structures
         char const talent_format[] = "niiiiiiiiixxixxxxxx";
         char const talent_tab_format[] = "nxxiiixxiii";
         char const talent_tree_primary_spells_format[] = "iiix";
-        char const taxi_nodes_format[] = "nifffsiixxx";
+        char const taxi_nodes_format[] = "nifffsiixixx";
         char const taxi_path_format[] = "niii";
         char const taxi_path_node_format[] = "diiifffiiii";
         char const totem_category_entry_format[] = "nxii";
@@ -750,21 +750,29 @@ namespace DBC::Structures
         uint32_t id;                                                // 0
         uint32_t map_id;                                            // 1
         uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;                                      // 3, main index
-        uint32_t flags;                                             // 4, unknown value but 312 for all cities
-                                                                    // 5-9 unused
-        int32_t area_level;                                         // 10
-        char* area_name;                                            // 11
-        uint32_t team;                                              // 12
-        uint32_t liquid_type_override[4];                           // 13-16 liquid override by type
-        //uint32_t unk17;                                           // 17
-        //uint32_t unk18;                                           // 18
-        //uint32_t unk19;                                           // 19
-        //uint32_t unk20;                                           // 20
-        //uint32_t unk21;                                           // 21
-        //uint32_t unk22;                                           // 22
-        //uint32_t unk23;                                           // 23
-        //uint32_t unk24;                                           // 24
+        uint32_t explore_flag;                                      // 3 main index
+        uint32_t flags;                                             // 4 unknown value but 312 for all cities
+        //uint32_t unk1;                                            // 5 Pandaria
+        //uint32_t soundPreferences;                                // 6
+        //uint32_t SoundPreferencesUnderwater;                      // 7
+        //uint32_t SoundAmbience;                                   // 8
+        //char* areaName2;                                          // 9
+        //uint32_t ZoneMusic;                                       // 10
+        //uint32_t ZoneIntroMusicTable;                             // 11
+        int32_t area_level;                                         // 12
+        char* area_name;                                            // 13
+        uint32_t team;                                              // 14
+        uint32_t liquid_type_override[4];                           // 14-18 liquid override by type
+        float MaxDepth;                                             // 19
+        float AmbientMultiplier;                                    // 20
+        uint32_t LightId;                                           // 21 
+        //uint32_t unk20;                                           // 22 4.0.0
+        //uint32_t unk21;                                           // 23 4.0.0
+        //uint32_t unk22;                                           // 24 4.0.0
+        //uint32_t unk23;                                           // 25 4.0.0
+        //uint32_t unk24;                                           // 26
+        //uint32_t unk25;                                           // 27 Pandaria
+        //uint32_t unk26;                                           // 28 Pandaria
     };
 
     struct AreaTriggerEntry
@@ -1058,6 +1066,8 @@ namespace DBC::Structures
         char* Name;                                                 // 23
         //uint32_t Description;                                     // 24
         //uint32_t description_flags;                               // 25
+        // unk1                                                     // 26 Pandaria
+        // unk2                                                     // 27 Pandaria
     };
 
     struct FactionTemplateEntry
@@ -1412,7 +1422,7 @@ namespace DBC::Structures
     {
         uint32_t id;                                                // 0
         uint32_t type;                                              // 1
-        //uint32 unk2                                               // 2 skillCostID
+        //uint32 unk2                                               // 2
         char* Name;                                                 // 3
         //char* Description;                                        // 4
         uint32_t spell_icon;                                        // 5
@@ -1945,8 +1955,12 @@ namespace DBC::Structures
         float y;                                                    // 3
         float z;                                                    // 4
         char* name;                                                 // 5
-        uint32_t horde_mount;                                       // 6
-        uint32_t alliance_mount;                                    // 7
+        uint32_t horde_mount;                                       // [6-7]
+        uint32_t alliance_mount;                                    //
+        //uint32 unk1                                               // 8 Pandaria
+        uint32_t nameflags;                                         // 9
+        //uint32 unk1                                               // 10 4.0.0
+        //uint32 unk1                                               // 11 4.0.0
     };
 
     struct TaxiPathEntry
@@ -2143,8 +2157,10 @@ namespace DBC::Structures
         //uint32_t field8;                                          // 8
         uint32_t flags;                                             // 9
         uint32_t areaId;                                            // 10
-        //char Name[16];                                            // 11-26
-        //uint32_t nameflags;                                       // 27
+        //char *Name;                                               // 11
+        //uint32_t field12;                                         // 12
+        //uint32_t field13;                                         // 13
+        //uint32_t field14;                                         // 14
     };
 
     struct WorldMapAreaEntry

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -195,7 +195,7 @@ namespace DBC::Structures
         //char const creature_model_data_format[] = "nxxxxxxxxxxxxxxffxxxxxxxxxxxxxx"; new
         char const creature_spell_data_format[] = "niiiiiiii";  //niiiixxxx
         //char const creature_type_format[]="nxx"; new
-        char const currency_types_format[] = "nisxxxxiiix";
+        char const currency_types_format[] = "nixxxiiiiixx";
         //char const destructible_model_data_format[] = "nixxxixxxxixxxxixxxxixxx"; new
         char const dungeon_encounter_format[] = "niixisxx";
         char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
@@ -998,15 +998,16 @@ namespace DBC::Structures
     {
         uint32_t item_id;                                           // 0
         uint32_t Category;                                          // 1
-        char* name;                                                 // 2
+        //char* name;                                               // 2
         //char* unk                                                 // 3
-        //char* unk2                                                // 4
-        //uint32_t unk5;                                            // 5
-        //uint32_t unk6;                                            // 6
+        //uint32_t unk4                                             // 4
+        uint32_t HasSubstitution;                                   // 5 Pandaria (Archaeology)
+        uint32_t SubstitutionId;                                    // 6
         uint32_t TotalCap;                                          // 7
         uint32_t WeekCap;                                           // 8
         uint32_t Flags;                                             // 9
-        //char* description;                                        // 10
+        //uint32_t unk10                                            // 10 Pandaria
+        //char* description;                                        // 11
     };
 
     struct DurabilityCostsEntry

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -273,7 +273,7 @@ namespace DBC::Structures
         //char const skill_race_class_info_format[] = "diiiiixxx"; new
         char const spell_radius_format[] = "nffxf";
         char const spell_range_format[] = "nffffixx";
-        char const spell_rune_cost_format[] = "niiii";
+        char const spell_rune_cost_format[] = "niiixi";
         char const spell_shapeshift_form_format[] = "nxxiixiiixxiiiiiiiixx";
         char const spell_effect_format[] = "difiiiffiiiiiifiifiiiiiiiix";
         char const spell_equipped_items_format[] = "diii";
@@ -1702,10 +1702,11 @@ namespace DBC::Structures
     struct SpellRuneCostEntry
     {
         uint32_t ID;                                                // 0
-        uint32_t bloodRuneCost;                                     // 1
-        uint32_t frostRuneCost;                                     // 2
-        uint32_t unholyRuneCost;                                    // 3
-        uint32_t runePowerGain;                                     // 4
+        uint32_t bloodRuneCost;                                     // [1-3]
+        uint32_t frostRuneCost;                                     //
+        uint32_t unholyRuneCost;                                    //
+        //uint32_t unk4                                             // 4
+        uint32_t runePowerGain;                                     // 5
     };
 
     // SpellScaling.dbc

--- a/src/world/GameMop/Storage/DBCStructures.h
+++ b/src/world/GameMop/Storage/DBCStructures.h
@@ -187,8 +187,8 @@ namespace DBC
             char const char_start_outfit_format[]="dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxii"; 
             char const char_titles_format[] = "nxsxix";
             char const chat_channels_format[] = "iixsx";
-            char const chr_classes_format[] = "nixsxxxixiiiii";
-            char const chr_races_format[] = "nxixiixixxxxixsxxxxxixxx";
+            char const chr_classes_format[] = "nixsxxxixiiiixxxxx";
+            char const chr_races_format[] = "nxixiixixxxxixsxxxxxxxxxxxxxxxxxxxxx";
             char const chr_classes_xpower_types_format[]="nii";
             //char const cinematic_sequences_format[]="nxxxxxxxxx"; new
             char const creature_display_info_format[]="nixifxxxxxxxxxxxx";
@@ -876,10 +876,14 @@ namespace DBC
             uint32_t spellfamily;               // 7
             //uint32_t unk4;                    // 8
             uint32_t cinematic_id;              // 9 CinematicSequences.dbc
-            uint32_t expansion;                 // 10
-            uint32_t apPerStr;                  // 11
-            uint32_t apPerAgi;                  // 12
-            uint32_t rapPerAgi;                 // 13
+            uint32_t apPerStr;                  // 10
+            uint32_t apPerAgi;                  // 11
+            uint32_t rapPerAgi;                 // 12
+            //uint32_t unk1                     // 13 Pandaria
+            //uint32_t unk2                     // 14 Pandaria
+            //uint32_t unk3                     // 15 Pandaria
+            //uint32_t unk4                     // 16 Pandaria
+            //uint32_t unk5                     // 17 Pandaria
         };
 
         struct ChrRacesEntry
@@ -900,10 +904,22 @@ namespace DBC
             //char* name_neutral;               // 16
             //uint32_t unk5[2]                  // 17-18
             //uint32_t unk19                    // 19
-            uint32_t expansion;                 // 20
+            //uint32_t m_enemyRace;             // 20
             //uint32_t unk21                    // 21
             //uint32_t unk22                    // 22
             //uint32_t unk23                    // 23
+            //uint32_t unk24;                   // 24
+            //uint32_t defaultClassForRace      // 25
+            //uint32_t unk26;                   // 26
+            //uint32_t unk27;                   // 27
+            //float unk28;                      // 28
+            //uint32_t unk29;                   // 29
+            //float unk30;                      // 30
+            //float unk31;                      // 31
+            //uint32_t unk32;                   // 32
+            //float unk33;                      // 33
+            //uint32_t unk34;                   // 34
+            //uint32_t unk35;                   // 35
         };
 
         struct ChrPowerTypesEntry
@@ -2148,7 +2164,7 @@ namespace DBC
         struct WorldMapOverlayEntry
         {
             uint32_t ID;                // 0
-            //uint32_t worldMapID;      // 1
+            //uint32_t worldMapID;      // 1 WorldMapArea.dbc
             uint32_t areaID;            // 2
             uint32_t areaID_2;          // 3
             uint32_t areaID_3;          // 4

--- a/src/world/GameTBC/Storage/DBCStructures.h
+++ b/src/world/GameTBC/Storage/DBCStructures.h
@@ -111,376 +111,376 @@ namespace DBC::Structures
     #pragma pack(push, 1)
     struct AchievementCategoryEntry
     {
-        uint32_t ID;                 // 0
-        uint32_t parentCategory;     // 1 -1 for main category
-        const char* name;          // 2-17
-        uint32_t name_flags;         // 18
-        uint32_t sortOrder;          // 19
+        uint32_t ID;                                                // 0
+        uint32_t parentCategory;                                    // 1 -1 for main category
+        const char* name;                                           // 2-17
+        uint32_t name_flags;                                        // 18
+        uint32_t sortOrder;                                         // 19
     };
 
     struct AreaTableEntry
     {
-        uint32_t id;                      // 0
-        uint32_t map_id;                  // 1
-        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;            // 3, main index
-        uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                        // 5-9 unused
-        int32_t area_level;               // 10
-        char* area_name[16];            // 11-26
-                                        // 27, string flags, unused
-        uint32_t team;                    // 28
-        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+        uint32_t id;                                                // 0
+        uint32_t map_id;                                            // 1
+        uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;                                      // 3, main index
+        uint32_t flags;                                             // 4, unknown value but 312 for all cities
+                                                                    // 5-9 unused
+        int32_t area_level;                                         // 10
+        char* area_name[16];                                        // 11-26
+                                                                    // 27, string flags, unused
+        uint32_t team;                                              // 28
+        uint32_t liquid_type_override[4];                           // 29-32 liquid override by type
     };
 
     struct AreaTriggerEntry
     {
-        uint32_t id;              // 0
-        uint32_t mapid;           // 1
-        float x;                // 2
-        float y;                // 3
-        float z;                // 4
-        float o;                // 5 radius?
-        float box_x;            // 6 extent x edge
-        float box_y;            // 7 extent y edge
-        float box_z;            // 8 extent z edge
-        float box_o;            // 9 extent rotation by about z axis
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        float o;                                                    // 5 radius?
+        float box_x;                                                // 6 extent x edge
+        float box_y;                                                // 7 extent y edge
+        float box_z;                                                // 8 extent z edge
+        float box_o;                                                // 9 extent rotation by about z axis
     };
 
     struct AuctionHouseEntry
     {
-        uint32_t id;              // 0
-        uint32_t faction;         // 1
-        uint32_t fee;             // 2
-        uint32_t tax;             // 3
-        //char* name[16];       // 4-19
-        //uint32_t name_flags;    // 20
+        uint32_t id;                                                // 0
+        uint32_t faction;                                           // 1
+        uint32_t fee;                                               // 2
+        uint32_t tax;                                               // 3
+        //char* name[16];                                           // 4-19
+        //uint32_t name_flags;                                      // 20
     };
 
     struct BankBagSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     #define OUTFIT_ITEMS 12
 
     struct CharStartOutfitEntry
     {
-        //uint32_t Id;                                    // 0
-        uint8_t Race;                                     // 1
-        uint8_t Class;                                    // 2
-        uint8_t Gender;                                   // 3
-        //uint8_t Unused;                                 // 4
-        int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
-        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
-        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
+        //uint32_t Id;                                              // 0
+        uint8_t Race;                                               // 1
+        uint8_t Class;                                              // 2
+        uint8_t Gender;                                             // 3
+        //uint8_t Unused;                                           // 4
+        int32_t ItemId[OUTFIT_ITEMS];                               // 5-16
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];                      // 17-28
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];                  // 29-40
     };
 
 
     struct CharTitlesEntry
     {
-        uint32_t ID;                      // 0, title ids
-        //uint32_t unk1;                  // 1 flags?
-        char* name_male[16];            // 2-17
-        //uint32_t name_flag;             // 18 string flag, unused
-        char* name_female[16];          // 19-34
-        //const char* name2_flag;       // 35 string flag, unused
-        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+        uint32_t ID;                                                // 0, title ids
+        //uint32_t unk1;                                            // 1 flags?
+        char* name_male[16];                                        // 2-17
+        //uint32_t name_flag;                                       // 18 string flag, unused
+        char* name_female[16];                                      // 19-34
+        //const char* name2_flag;                                   // 35 string flag, unused
+        uint32_t bit_index;                                         // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
     };
 
     struct ChatChannelsEntry
     {
-        uint32_t id;                      // 0
-        uint32_t flags;                   // 1
-        char* name_pattern[16];         // 3-18
-        //uint32_t name_pattern_flags;    // 19
-        //char* channel_name[16];       // 20-35
-        //uint32_t channel_name_flags;    // 36
+        uint32_t id;                                                // 0
+        uint32_t flags;                                             // 1
+        char* name_pattern[16];                                     // 3-18
+        //uint32_t name_pattern_flags;                              // 19
+        //char* channel_name[16];                                   // 20-35
+        //uint32_t channel_name_flags;                              // 36
     };
 
     struct ChrClassesEntry
     {
-        uint32_t class_id;                // 0
-        //uint32_t unk1;                  // 1
-        uint32_t power_type;              // 2
-        //uint32_t unk2[2];               // 3-4
-        char* name[16];                 // 5-20
-        //uint32_t nameflags;             // 21
-        //char* name_female[16];        // 22-36
-        //uint32_t name_female_flags;     // 37
-        //char* name_neutral[16];       // 38-53
-        //uint32_t name_neutral_flags;    // 54
-        //uint32_t unk3;                  // 55
-        uint32_t spellfamily;             // 56
-        //uint32_t unk4;                  // 57
+        uint32_t class_id;                                          // 0
+        //uint32_t unk1;                                            // 1
+        uint32_t power_type;                                        // 2
+        //uint32_t unk2[2];                                         // 3-4
+        char* name[16];                                             // 5-20
+        //uint32_t nameflags;                                       // 21
+        //char* name_female[16];                                    // 22-36
+        //uint32_t name_female_flags;                               // 37
+        //char* name_neutral[16];                                   // 38-53
+        //uint32_t name_neutral_flags;                              // 54
+        //uint32_t unk3;                                            // 55
+        uint32_t spellfamily;                                       // 56
+        //uint32_t unk4;                                            // 57
     };
 
     struct ChrRacesEntry
     {
-        uint32_t race_id;                 // 0
-        uint32_t flags;                   // 1
-        uint32_t faction_id;              // 2
-        //uint32_t unk1;                  // 3
-        uint32_t model_male;              // 4
-        uint32_t model_female;            // 5
-        // uint32_t unk2;                 // 6
-        uint32_t team_id;                 // 7
-        //uint32_t unk3[4];               // 8-11
-        uint32_t cinematic_id;            // 12 CinematicSequences.dbc
-        //uint32_t unk4                   // 13
-        char* name[16];                 // 14-29
-        //uint32_t name_flags             // 30
-        //char* name_female[16];        // 31-46
-        //uint32_t name_female_flags      // 47
-        //char* name_neutral[16];       // 48-63
-        //uint32_t name_neutral_flags     // 64 string flags, unused
-        //uint32_t unk5[3]                // 65-67 unused
-        uint32_t expansion;               // 68
+        uint32_t race_id;                                           // 0
+        uint32_t flags;                                             // 1
+        uint32_t faction_id;                                        // 2
+        //uint32_t unk1;                                            // 3
+        uint32_t model_male;                                        // 4
+        uint32_t model_female;                                      // 5
+        // uint32_t unk2;                                           // 6
+        uint32_t team_id;                                           // 7
+        //uint32_t unk3[4];                                         // 8-11
+        uint32_t cinematic_id;                                      // 12 CinematicSequences.dbc
+        //uint32_t unk4                                             // 13
+        char* name[16];                                             // 14-29
+        //uint32_t name_flags                                       // 30
+        //char* name_female[16];                                    // 31-46
+        //uint32_t name_female_flags                                // 47
+        //char* name_neutral[16];                                   // 48-63
+        //uint32_t name_neutral_flags                               // 64 string flags, unused
+        //uint32_t unk5[3]                                          // 65-67 unused
+        uint32_t expansion;                                         // 68
     };
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t display_id;            // 0
-        //uint32_t model;               // 1
-        //uint32_t unk0                 // 2
-        //uint32_t InfoExtra;           // 3
-        //float size;                   // 4
-                                        // 5 - 15 unk
+        uint32_t display_id;                                        // 0
+        //uint32_t model;                                           // 1
+        //uint32_t unk0                                             // 2
+        //uint32_t InfoExtra;                                       // 3
+        //float size;                                               // 4
+                                                                    // 5 - 15 unk
     };
 
     struct CreatureFamilyEntry
     {
-        uint32_t ID;                      // 0
-        float minsize;                  // 1
-        uint32_t minlevel;                // 2
-        float maxsize;                  // 3
-        uint32_t maxlevel;                // 4
-        uint32_t skilline;                // 5
-        uint32_t tameable;                // 6 second skill line - 270 Generic
-        uint32_t petdietflags;            // 7
-        char* name[16];                 // 8-23
-        //uint32_t nameflags;             // 24
-        //uint32_t iconFile;              // 25
+        uint32_t ID;                                                // 0
+        float minsize;                                              // 1
+        uint32_t minlevel;                                          // 2
+        float maxsize;                                              // 3
+        uint32_t maxlevel;                                          // 4
+        uint32_t skilline;                                          // 5
+        uint32_t tameable;                                          // 6 second skill line - 270 Generic
+        uint32_t petdietflags;                                      // 7
+        char* name[16];                                             // 8-23
+        //uint32_t nameflags;                                       // 24
+        //uint32_t iconFile;                                        // 25
     };
 
     struct CreatureSpellDataEntry
     {
-        uint32_t id;                      // 0
-        uint32_t Spells[3];               // 1-3
-        uint32_t PHSpell;                 // 4
-        uint32_t Cooldowns[3];            // 5-7
-        uint32_t PH;                      // 8
+        uint32_t id;                                                // 0
+        uint32_t Spells[3];                                         // 1-3
+        uint32_t PHSpell;                                           // 4
+        uint32_t Cooldowns[3];                                      // 5-7
+        uint32_t PH;                                                // 8
     };
 
     struct DurabilityCostsEntry
     {
-        uint32_t itemlevel;       // 0
-        uint32_t modifier[29];    // 1-29
+        uint32_t itemlevel;                                         // 0
+        uint32_t modifier[29];                                      // 1-29
     };
 
     struct DurabilityQualityEntry
     {
-        uint32_t id;              // 0
-        float quality_modifier; // 1
+        uint32_t id;                                                // 0
+        float quality_modifier;                                     // 1
     };
 
     struct EmotesTextEntry
     {
-        uint32_t Id;              // 0
-        //uint32_t name;          // 1
-        uint32_t textid;          // 2
-        uint32_t textid2;         // 3
-        uint32_t textid3;         // 4
-        uint32_t textid4;         // 5
-        //uint32_t unk1;          // 6
-        uint32_t textid5;         // 7
-        //uint32_t unk2;          // 8
-        uint32_t textid6;         // 9
-        //uint32_t unk3;          // 10
-        //uint32_t unk4;          // 11
-        //uint32_t unk5;          // 12
-        //uint32_t unk6;          // 13
-        //uint32_t unk7;          // 14
-        //uint32_t unk8;          // 15
-        //uint32_t unk9;          // 16
-        //uint32_t unk10;         // 17
-        //uint32_t unk11;         // 18
+        uint32_t Id;                                                // 0
+        //uint32_t name;                                            // 1
+        uint32_t textid;                                            // 2
+        uint32_t textid2;                                           // 3
+        uint32_t textid3;                                           // 4
+        uint32_t textid4;                                           // 5
+        //uint32_t unk1;                                            // 6
+        uint32_t textid5;                                           // 7
+        //uint32_t unk2;                                            // 8
+        uint32_t textid6;                                           // 9
+        //uint32_t unk3;                                            // 10
+        //uint32_t unk4;                                            // 11
+        //uint32_t unk5;                                            // 12
+        //uint32_t unk6;                                            // 13
+        //uint32_t unk7;                                            // 14
+        //uint32_t unk8;                                            // 15
+        //uint32_t unk9;                                            // 16
+        //uint32_t unk10;                                           // 17
+        //uint32_t unk11;                                           // 18
     };
 
     struct FactionEntry
     {
-        uint32_t ID;                      // 0
-        int32_t RepListId;                // 1
-        uint32_t RaceMask[4];             // 2-5
-        uint32_t ClassMask[4];            // 6-9
-        int32_t baseRepValue[4];          // 10-13
-        uint32_t repFlags[4];             // 14-17
-        uint32_t parentFaction;           // 18
-        char* Name[16];                 // 19-34
-        //uint32_t name_flags;            // 35
-        //uint32_t Description[16];       // 36-51
-        //uint32_t description_flags;     // 52
+        uint32_t ID;                                                // 0
+        int32_t RepListId;                                          // 1
+        uint32_t RaceMask[4];                                       // 2-5
+        uint32_t ClassMask[4];                                      // 6-9
+        int32_t baseRepValue[4];                                    // 10-13
+        uint32_t repFlags[4];                                       // 14-17
+        uint32_t parentFaction;                                     // 18
+        char* Name[16];                                             // 19-34
+        //uint32_t name_flags;                                      // 35
+        //uint32_t Description[16];                                 // 36-51
+        //uint32_t description_flags;                               // 52
     };
 
     struct FactionTemplateEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t Faction;                 // 1
-        uint32_t FactionGroup;            // 2
-        uint32_t Mask;                    // 3
-        uint32_t FriendlyMask;            // 4
-        uint32_t HostileMask;             // 5
-        uint32_t EnemyFactions[4];        // 6-9
-        uint32_t FriendlyFactions[4];     // 10-13
+        uint32_t ID;                                                // 0
+        uint32_t Faction;                                           // 1
+        uint32_t FactionGroup;                                      // 2
+        uint32_t Mask;                                              // 3
+        uint32_t FriendlyMask;                                      // 4
+        uint32_t HostileMask;                                       // 5
+        uint32_t EnemyFactions[4];                                  // 6-9
+        uint32_t FriendlyFactions[4];                               // 10-13
     };
 
     struct GameObjectDisplayInfoEntry
     {
-        uint32_t Displayid;               // 0
-        char* filename;                 // 1
-        //uint32_t  unk1[10];             // 2-11
-        float minX;                     // 12
-        float minY;                     // 13
-        float minZ;                     // 14
-        float maxX;                     // 15
-        float maxY;                     // 16
-        float maxZ;                     // 17
+        uint32_t Displayid;                                         // 0
+        char* filename;                                             // 1
+        //uint32_t unk1[10];                                        // 2-11
+        float minX;                                                 // 12
+        float minY;                                                 // 13
+        float minZ;                                                 // 14
+        float maxX;                                                 // 15
+        float maxY;                                                 // 16
+        float maxZ;                                                 // 17
     };
 
     struct GemPropertiesEntry
     {
-        uint32_t Entry;                   // 0
-        uint32_t EnchantmentID;           // 1
-        //uint32_t unk1;                  // 2 bool
-        //uint32_t unk2;                  // 3 bool
-        uint32_t SocketMask;              // 4
+        uint32_t Entry;                                             // 0
+        uint32_t EnchantmentID;                                     // 1
+        //uint32_t unk1;                                            // 2 bool
+        //uint32_t unk2;                                            // 3 bool
+        uint32_t SocketMask;                                        // 4
     };
 
     struct GtChanceToMeleeCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToMeleeCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtCombatRatingsEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtOCTRegenHPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtOCTRegenMPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtRegenHPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
     struct GtRegenMPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
     struct ItemEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t DisplayId;               // 1
-        uint32_t InventoryType;           // 2
-        uint32_t Sheath;                  // 3
+        uint32_t ID;                                                // 0
+        uint32_t DisplayId;                                         // 1
+        uint32_t InventoryType;                                     // 2
+        uint32_t Sheath;                                            // 3
     };
 
     struct ItemDisplayInfo
     {
-        uint32_t ID;                     // 0
-        uint32_t randomPropertyChance;   // 1
+        uint32_t ID;                                                // 0
+        uint32_t randomPropertyChance;                              // 1
     };
 
     struct ItemExtendedCostEntry
     {
-        uint32_t costid;                  // 0
-        uint32_t honor_points;            // 1
-        uint32_t arena_points;            // 2
-        uint32_t item[5];                 // 4-8
-        uint32_t count[5];                // 9-13
-        uint32_t personalrating;          // 14
+        uint32_t costid;                                            // 0
+        uint32_t honor_points;                                      // 1
+        uint32_t arena_points;                                      // 2
+        uint32_t item[5];                                           // 4-8
+        uint32_t count[5];                                          // 9-13
+        uint32_t personalrating;                                    // 14
     };
 
     struct ItemRandomPropertiesEntry
     {
-        uint32_t ID;                      // 0
-        //uint32_t name1;                 // 1
-        uint32_t spells[3];               // 2-4
-        //uint32_t unk1;                  // 5
-        //uint32_t unk2;                  // 6
-        char* name_suffix[16];          // 7-22
-        //uint32_t name_suffix_flags;     // 23
+        uint32_t ID;                                                // 0
+        //uint32_t name1;                                           // 1
+        uint32_t spells[3];                                         // 2-4
+        //uint32_t unk1;                                            // 5
+        //uint32_t unk2;                                            // 6
+        char* name_suffix[16];                                      // 7-22
+        //uint32_t name_suffix_flags;                               // 23
     };
 
     struct ItemRandomSuffixEntry
     {
-        uint32_t id;                      // 0
-        char* name_suffix[16];          // 1-16
-        //uint32_t name_suffix_flags;     // 17
-        //uint32_t unk1;                  // 18
-        uint32_t enchantments[3];         // 19-21
-        //uint32_t unk2[2];               // 22-23
-        uint32_t prefixes[3];             // 24-26
-        //uint32_t[2];                    // 27-28
+        uint32_t id;                                                // 0
+        char* name_suffix[16];                                      // 1-16
+        //uint32_t name_suffix_flags;                               // 17
+        //uint32_t unk1;                                            // 18
+        uint32_t enchantments[3];                                   // 19-21
+        //uint32_t unk2[2];                                         // 22-23
+        uint32_t prefixes[3];                                       // 24-26
+        //uint32_t[2];                                              // 27-28
     };
 
     struct ItemSetEntry
     {
-        uint32_t id;                      // 1
-        char* name[16];                 // 1-16 name (lang)
-        //uint32_t localeflag;            // 17 constant
-        uint32_t itemid[10];              // 18-27 item set items
-        //uint32_t unk[7];                // 28-34 all 0
-        uint32_t SpellID[8];              // 35-42
-        uint32_t itemscount[8];           // 43-50
-        uint32_t RequiredSkillID;         // 51
-        uint32_t RequiredSkillAmt;        // 52
+        uint32_t id;                                                // 1
+        char* name[16];                                             // 1-16 name (lang)
+        //uint32_t localeflag;                                      // 17 constant
+        uint32_t itemid[10];                                        // 18-27 item set items
+        //uint32_t unk[7];                                          // 28-34 all 0
+        uint32_t SpellID[8];                                        // 35-42
+        uint32_t itemscount[8];                                     // 43-50
+        uint32_t RequiredSkillID;                                   // 51
+        uint32_t RequiredSkillAmt;                                  // 52
     };
 
     struct LFGDungeonEntry
     {
-        uint32_t ID;              // 0
-        char* name[16];         // 1-17 Name lang
-        uint32_t minlevel;        // 18
-        uint32_t maxlevel;        // 19
-        uint32_t reclevel;        // 20
-        uint32_t recminlevel;     // 21
-        uint32_t recmaxlevel;     // 22
-        int32_t map;              // 23
-        uint32_t difficulty;      // 24
-        uint32_t flags;           // 25
-        uint32_t type;            // 26
-        //uint32_t  unk;          // 27
-        //char* iconname;       // 28
-        uint32_t expansion;       // 29
-        //uint32_t unk4;          // 30
-        uint32_t grouptype;       // 31
-        //char* desc[16];       // 32-47 Description
+        uint32_t ID;                                                // 0
+        char* name[16];                                             // 1-17 Name lang
+        uint32_t minlevel;                                          // 18
+        uint32_t maxlevel;                                          // 19
+        uint32_t reclevel;                                          // 20
+        uint32_t recminlevel;                                       // 21
+        uint32_t recmaxlevel;                                       // 22
+        int32_t map;                                                // 23
+        uint32_t difficulty;                                        // 24
+        uint32_t flags;                                             // 25
+        uint32_t type;                                              // 26
+        //uint32_t unk;                                             // 27
+        //char* iconname;                                           // 28
+        uint32_t expansion;                                         // 29
+        //uint32_t unk4;                                            // 30
+        uint32_t grouptype;                                         // 31
+        //char* desc[16];                                           // 32-47 Description
 
         // Helpers
         uint32_t Entry() const { return ID + (type << 24); }
@@ -488,56 +488,56 @@ namespace DBC::Structures
 
     struct LiquidTypeEntry
     {
-        uint32_t Id;                  // 0
-        uint32_t liquid_id;           // 1
-        uint32_t Type;                // 2
-        uint32_t SpellId;             // 3
+        uint32_t Id;                                                // 0
+        uint32_t liquid_id;                                         // 1
+        uint32_t Type;                                              // 2
+        uint32_t SpellId;                                           // 3
     };
 
 #define LOCK_NUM_CASES 8
 
     struct LockEntry
     {
-        uint32_t Id;                              // 0
-        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+        uint32_t Id;                                                // 0
+        uint32_t locktype[LOCK_NUM_CASES];                          // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];                          // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];                      // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];                          // 25-32 Something to do with direction / opening / closing.
     };
 
     struct MailTemplateEntry
     {
-        uint32_t ID;              // 0
-        char* subject;          // 1
-        //float unused1[15]     // 2-16
-        //uint32_t flags1         // 17 name flags, unused
-        char* content;          // 18
-        //float unused2[15]     // 19-34
-        //uint32_t flags2         // 35 name flags, unused
+        uint32_t ID;                                                // 0
+        char* subject;                                              // 1
+        //float unused1[15]                                         // 2-16
+        //uint32_t flags1                                           // 17 name flags, unused
+        char* content;                                              // 18
+        //float unused2[15]                                         // 19-34
+        //uint32_t flags2                                           // 35 name flags, unused
     };
 
     struct MapEntry
     {
-        uint32_t id;                      // 0
-        //char* name_internal;          // 1
-        uint32_t map_type;                // 2
-        //uint32_t is_pvp_zone;           // 3 -0 false -1 true
-        char* map_name[16];             // 4-19
-        //uint32_t name_flags;            // 20
-        uint32_t linked_zone;             // 22 common zone for instance and continent map
-        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-        //uint32_t hordeIntro_flags;      // 39
-        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-        //uint32_t allianceIntro_flags;   // 56
-        uint32_t multimap_id;             // 57
-        //uint32_t battlefield_map_icon;  // 58
-        int32_t parent_map;               // 59 map_id of parent map
-        float start_x;                  // 60 enter x coordinate (if exist single entry)
-        float start_y;                  // 61 enter y coordinate (if exist single entry)
-        //uint32_t dayTime;               // 62
+        uint32_t id;                                                // 0
+        //char* name_internal;                                      // 1
+        uint32_t map_type;                                          // 2
+        //uint32_t is_pvp_zone;                                     // 3 -0 false -1 true
+        char* map_name[16];                                         // 4-19
+        //uint32_t name_flags;                                      // 20
+        uint32_t linked_zone;                                       // 22 common zone for instance and continent map
+        //char* horde_intro[16];                                    // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;                                // 39
+        //char* alliance_intro[16];                                 // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;                             // 56
+        uint32_t multimap_id;                                       // 57
+        //uint32_t battlefield_map_icon;                            // 58
+        int32_t parent_map;                                         // 59 map_id of parent map
+        float start_x;                                              // 60 enter x coordinate (if exist single entry)
+        float start_y;                                              // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;                                         // 62
         uint32_t reset_raid_time;
         uint32_t reset_heroic_tim;
-        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t addon;                                             // 63 0-original maps, 1-tbc addon, 2-wotlk addon
 
         bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
         bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
@@ -556,64 +556,64 @@ namespace DBC::Structures
 
     struct NameGenEntry
     {
-        uint32_t ID;              // 0
-        char* Name;             // 1
-        uint32_t unk1;            // 2
-        uint32_t type;            // 3
+        uint32_t ID;                                                // 0
+        char* Name;                                                 // 1
+        uint32_t unk1;                                              // 2
+        uint32_t type;                                              // 3
     };
 
     struct SkillLineEntry
     {
-        uint32_t id;                  // 0
-        uint32_t type;                // 1
-        uint32_t skillCostsID;      // 2
-        char* Name[16];             // 3-18
-        //uint32_t NameFlags;         // 19
-        //char* Description[16];    // 20-35
-        //uint32_t DescriptionFlags;  // 36
-        uint32_t spell_icon;          // 37
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1
+        uint32_t skillCostsID;                                      // 2
+        char* Name[16];                                             // 3-18
+        //uint32_t NameFlags;                                       // 19
+        //char* Description[16];                                    // 20-35
+        //uint32_t DescriptionFlags;                                // 36
+        uint32_t spell_icon;                                        // 37
     };
 
     //"iiiiiiiiiiiiiii"
     struct SkillLineAbilityEntry
     {
-        uint32_t Id;                      // 0
-        uint32_t skilline;                // 1 skill id
-        uint32_t spell;                   // 2
-        uint32_t race_mask;               // 3
-        uint32_t class_mask;              // 4
-        uint32_t excludeRace;           // 5
-        uint32_t excludeClass;          // 6
-        uint32_t minSkillLineRank;        // 7 req skill value
-        uint32_t next;                    // 8
-        uint32_t acquireMethod;           // 9 auto learn
-        uint32_t grey;                    // 10 max
-        uint32_t green;                   // 11 min
-        uint32_t abandonable;           // 12
-        uint32_t reqTP;                 // 13
-        uint32_t reqtrainpoints;          // 14
+        uint32_t Id;                                                // 0
+        uint32_t skilline;                                          // 1 skill id
+        uint32_t spell;                                             // 2
+        uint32_t race_mask;                                         // 3
+        uint32_t class_mask;                                        // 4
+        uint32_t excludeRace;                                       // 5
+        uint32_t excludeClass;                                      // 6
+        uint32_t minSkillLineRank;                                  // 7 req skill value
+        uint32_t next;                                              // 8
+        uint32_t acquireMethod;                                     // 9 auto learn
+        uint32_t grey;                                              // 10 max
+        uint32_t green;                                             // 11 min
+        uint32_t abandonable;                                       // 12
+        uint32_t reqTP;                                             // 13
+        uint32_t reqtrainpoints;                                    // 14
     };
 
     struct StableSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct SpellCastTimesEntry
     {
-        uint32_t ID;              // 0
-        uint32_t CastTime;        // 1
-        //uint32_t unk1;          // 2
-        //uint32_t unk2;          // 3
+        uint32_t ID;                                                // 0
+        uint32_t CastTime;                                          // 1
+        //uint32_t unk1;                                            // 2
+        //uint32_t unk2;                                            // 3
     };
 
     struct SpellDurationEntry
     {
-        uint32_t ID;              // 0
-        uint32_t Duration1;       // 1
-        uint32_t Duration2;       // 2
-        uint32_t Duration3;       // 3
+        uint32_t ID;                                                // 0
+        uint32_t Duration1;                                         // 1
+        uint32_t Duration2;                                         // 2
+        uint32_t Duration3;                                         // 3
     };
 
     #define MAX_SPELL_EFFECTS 3
@@ -726,194 +726,194 @@ namespace DBC::Structures
 
     struct SpellItemEnchantmentEntry
     {
-        uint32_t Id;                  // 0
-        uint32_t type[3];             // 1-3
-        uint32_t min[3];              // 4-6 for combat, in practice min==max
-        uint32_t max[3];              // 7-9
-        uint32_t spell[3];            // 10-12
-        char* Name;                   // 13
-        //uint32_t NameAlt[16]       // 14-29
-        uint32_t visual;              // 30 aura
-        uint32_t EnchantGroups;       // 31 slot
-        uint32_t GemEntry;            // 32
-        uint32_t ench_condition;      // 33
+        uint32_t Id;                                                // 0
+        uint32_t type[3];                                           // 1-3
+        uint32_t min[3];                                            // 4-6 for combat, in practice min==max
+        uint32_t max[3];                                            // 7-9
+        uint32_t spell[3];                                          // 10-12
+        char* Name;                                                 // 13
+        //uint32_t NameAlt[16]                                      // 14-29
+        uint32_t visual;                                            // 30 aura
+        uint32_t EnchantGroups;                                     // 31 slot
+        uint32_t GemEntry;                                          // 32
+        uint32_t ench_condition;                                    // 33
     };
 
     struct SpellRadiusEntry
     {
-        uint32_t ID;                  // 0
-        float radius_min;           // 1 Radius
-        float radius_per_level;     // 2
-        float radius_max;           // 3 Radius2
+        uint32_t ID;                                                // 0
+        float radius_min;                                           // 1 Radius
+        float radius_per_level;                                     // 2
+        float radius_max;                                           // 3 Radius2
     };
 
     struct SpellRangeEntry
     {
-        uint32_t ID;                  // 0
-        float minRange;             // 1
-        float maxRange;             // 3
-        uint32_t range_type;          // 4
-        //char* name1[16]           // 6-21
-        //uint32_t name1_falgs;       // 22
-        //char* name2[16]           // 23-38
-        //uint32_t name2_falgs;       // 39
+        uint32_t ID;                                                // 0
+        float minRange;                                             // 1
+        float maxRange;                                             // 3
+        uint32_t range_type;                                        // 4
+        //char* name1[16]                                           // 6-21
+        //uint32_t name1_falgs;                                     // 22
+        //char* name2[16]                                           // 23-38
+        //uint32_t name2_falgs;                                     // 39
     };
 
     struct SpellShapeshiftFormEntry
     {
-        uint32_t id;                  // 0
-        //uint32_t button_pos;        // 1
-        //char* name[16];           // 2-17
-        //uint32_t name_flags;        // 18
-        uint32_t Flags;               // 19
-        uint32_t unit_type;           // 20
-        //uint32_t unk1               // 21
-        uint32_t AttackSpeed;         // 22
-        uint32_t modelId;             // 23 alliance?
-        uint32_t modelId2;            // 24 horde?
-        //uint32_t unk2               // 25
-        //uint32_t unk3               // 26
-        uint32_t spells[8];           // 27-34
+        uint32_t id;                                                // 0
+        //uint32_t button_pos;                                      // 1
+        //char* name[16];                                           // 2-17
+        //uint32_t name_flags;                                      // 18
+        uint32_t Flags;                                             // 19
+        uint32_t unit_type;                                         // 20
+        //uint32_t unk1                                             // 21
+        uint32_t AttackSpeed;                                       // 22
+        uint32_t modelId;                                           // 23 alliance?
+        uint32_t modelId2;                                          // 24 horde?
+        //uint32_t unk2                                             // 25
+        //uint32_t unk3                                             // 26
+        uint32_t spells[8];                                         // 27-34
     };
 
     struct SummonPropertiesEntry
     {
-        uint32_t ID;                  // 0
-        uint32_t ControlType;         // 1
-        uint32_t FactionID;           // 2
-        uint32_t Type;                // 3
-        uint32_t Slot;                // 4
-        uint32_t Flags;               // 5
+        uint32_t ID;                                                // 0
+        uint32_t ControlType;                                       // 1
+        uint32_t FactionID;                                         // 2
+        uint32_t Type;                                              // 3
+        uint32_t Slot;                                              // 4
+        uint32_t Flags;                                             // 5
     };
 
     struct TalentEntry
     {
-        uint32_t TalentID;            // 0
-        uint32_t TalentTree;          // 1
-        uint32_t Row;                 // 2
-        uint32_t Col;                 // 3
-        uint32_t RankID[5];           // 4-8
-        //uint32_t unk[4];            // 9-12
-        uint32_t DependsOn;           // 13
-        //uint32_t unk1[2];           // 14-15
-        uint32_t DependsOnRank;       // 16
-        //uint32_t unk2[2];           // 17-18
-        //uint32_t unk3;              // 19
-        uint32_t DependsOnSpell;      // 20
+        uint32_t TalentID;                                          // 0
+        uint32_t TalentTree;                                        // 1
+        uint32_t Row;                                               // 2
+        uint32_t Col;                                               // 3
+        uint32_t RankID[5];                                         // 4-8
+        //uint32_t unk[4];                                          // 9-12
+        uint32_t DependsOn;                                         // 13
+        //uint32_t unk1[2];                                         // 14-15
+        uint32_t DependsOnRank;                                     // 16
+        //uint32_t unk2[2];                                         // 17-18
+        //uint32_t unk3;                                            // 19
+        uint32_t DependsOnSpell;                                    // 20
     };
 
     struct TalentTabEntry
     {
-        uint32_t TalentTabID;         // 0
-        //char* Name[16];           // 1-16
-        //uint32_t name_flags;        // 17
-        //uint32_t unk4;              // 18
-        //uint32_t unk5;              // 19
-        uint32_t ClassMask;           // 20
-        uint32_t TabPage;             // 21
-        //char* InternalName;       // 22
+        uint32_t TalentTabID;                                       // 0
+        //char* Name[16];                                           // 1-16
+        //uint32_t name_flags;                                      // 17
+        //uint32_t unk4;                                            // 18
+        //uint32_t unk5;                                            // 19
+        uint32_t ClassMask;                                         // 20
+        uint32_t TabPage;                                           // 21
+        //char* InternalName;                                       // 22
     };
 
     struct TaxiNodesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t mapid;               // 1
-        float x;                    // 2
-        float y;                    // 3
-        float z;                    // 4
-        char* name[16];             // 5-21
-        //uint32_t nameflags;         // 22
-        uint32_t horde_mount;         // 23
-        uint32_t alliance_mount;      // 24
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        char* name[16];                                             // 5-21
+        //uint32_t nameflags;                                       // 22
+        uint32_t horde_mount;                                       // 23
+        uint32_t alliance_mount;                                    // 24
     };
 
     struct TaxiPathEntry
     {
-        uint32_t id;                  // 0
-        uint32_t from;                // 1
-        uint32_t to;                  // 2
-        uint32_t price;               // 3
+        uint32_t id;                                                // 0
+        uint32_t from;                                              // 1
+        uint32_t to;                                                // 2
+        uint32_t price;                                             // 3
     };
 
     struct TaxiPathNodeEntry
     {
-        uint32_t id;                  // 0
-        uint32_t path;                // 1
-        uint32_t seq;                 // 2 nodeIndex
-        uint32_t mapid;               // 3
-        float x;                      // 4
-        float y;                      // 5
-        float z;                      // 6
-        uint32_t flags;               // 7
-        uint32_t waittime;            // 8
-        uint32_t arivalEventID;       // 9
-        uint32_t departureEventID;    // 10
+        uint32_t id;                                                // 0
+        uint32_t path;                                              // 1
+        uint32_t seq;                                               // 2 nodeIndex
+        uint32_t mapid;                                             // 3
+        float x;                                                    // 4
+        float y;                                                    // 5
+        float z;                                                    // 6
+        uint32_t flags;                                             // 7
+        uint32_t waittime;                                          // 8
+        uint32_t arivalEventID;                                     // 9
+        uint32_t departureEventID;                                  // 10
     };
 
     struct TotemCategoryEntry
     {
-        uint32_t id;            // 0
-        //char* name[16];       // 1-16
-        //uint32_t unk;         // 17
-        uint32_t categoryType;  // 18
-        uint32_t categoryMask;  // 19
+        uint32_t id;                                                // 0
+        //char* name[16];                                           // 1-16
+        //uint32_t unk;                                             // 17
+        uint32_t categoryType;                                      // 18
+        uint32_t categoryMask;                                      // 19
     };
 
     struct TransportAnimationEntry
     {
-        //uint32_t Id;          // 0
-        uint32_t TransportID;   // 1
-        uint32_t TimeIndex;     // 2
-        DBCPosition3D Pos;      // 3
-        //uint32_t SequenceID;  // 4
+        //uint32_t Id;                                              // 0
+        uint32_t TransportID;                                       // 1
+        uint32_t TimeIndex;                                         // 2
+        DBCPosition3D Pos;                                          // 3
+        //uint32_t SequenceID;                                      // 4
     };
 
     #define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        float turnSpeed;                                    // 2
-        float pitchSpeed;                                   // 3
-        float pitchMin;                                     // 4
-        float pitchMax;                                     // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-        float mouseLookOffsetPitch;                         // 14
-        float cameraFadeDistScalarMin;                      // 15
-        float cameraFadeDistScalarMax;                      // 16
-        float cameraPitchOffset;                            // 17
-        float facingLimitRight;                             // 18
-        float facingLimitLeft;                              // 19
-        float msslTrgtTurnLingering;                        // 20
-        float msslTrgtPitchLingering;                       // 21
-        float msslTrgtMouseLingering;                       // 22
-        float msslTrgtEndOpacity;                           // 23
-        float msslTrgtArcSpeed;                             // 24
-        float msslTrgtArcRepeat;                            // 25
-        float msslTrgtArcWidth;                             // 26
-        float msslTrgtImpactRadius[2];                      // 27-28
-        char* msslTrgtArcTexture;                           // 29
-        char* msslTrgtImpactTexture;                        // 30
-        char* msslTrgtImpactModel[2];                       // 31-32
-        float cameraYawOffset;                              // 33
-        uint32_t uiLocomotionType;                            // 34
-        float msslTrgtImpactTexRadius;                      // 35
-        uint32_t uiSeatIndicatorType;                         // 36
-        uint32_t powerType;                                   // 37, new in 3.1
-        //uint32_t unk1;                                      // 38
-        //uint32_t unk2;                                      // 39
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        float turnSpeed;                                            // 2
+        float pitchSpeed;                                           // 3
+        float pitchMin;                                             // 4
+        float pitchMax;                                             // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
+        float mouseLookOffsetPitch;                                 // 14
+        float cameraFadeDistScalarMin;                              // 15
+        float cameraFadeDistScalarMax;                              // 16
+        float cameraPitchOffset;                                    // 17
+        float facingLimitRight;                                     // 18
+        float facingLimitLeft;                                      // 19
+        float msslTrgtTurnLingering;                                // 20
+        float msslTrgtPitchLingering;                               // 21
+        float msslTrgtMouseLingering;                               // 22
+        float msslTrgtEndOpacity;                                   // 23
+        float msslTrgtArcSpeed;                                     // 24
+        float msslTrgtArcRepeat;                                    // 25
+        float msslTrgtArcWidth;                                     // 26
+        float msslTrgtImpactRadius[2];                              // 27-28
+        char* msslTrgtArcTexture;                                   // 29
+        char* msslTrgtImpactTexture;                                // 30
+        char* msslTrgtImpactModel[2];                               // 31-32
+        float cameraYawOffset;                                      // 33
+        uint32_t uiLocomotionType;                                  // 34
+        float msslTrgtImpactTexRadius;                              // 35
+        uint32_t uiSeatIndicatorType;                               // 36
+        uint32_t powerType;                                         // 37, new in 3.1
+        //uint32_t unk1;                                            // 38
+        //uint32_t unk2;                                            // 39
     };
 
     enum VehicleSeatFlags
     {
-        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,  // Passenger is hidden
         VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,  // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,  // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,  // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,  // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,  // Lua_UnitHasVehicleUI
     };
 
     enum VehicleSeatFlagsB
@@ -926,52 +926,52 @@ namespace DBC::Structures
 
     struct VehicleSeatEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        int32_t attachmentID;                                 // 2
-        float attachmentOffsetX;                            // 3
-        float attachmentOffsetY;                            // 4
-        float attachmentOffsetZ;                            // 5
-        float enterPreDelay;                                // 6
-        float enterSpeed;                                   // 7
-        float enterGravity;                                 // 8
-        float enterMinDuration;                             // 9
-        float enterMaxDuration;                             // 10
-        float enterMinArcHeight;                            // 11
-        float enterMaxArcHeight;                            // 12
-        int32_t enterAnimStart;                               // 13
-        int32_t enterAnimLoop;                                // 14
-        int32_t rideAnimStart;                                // 15
-        int32_t rideAnimLoop;                                 // 16
-        int32_t rideUpperAnimStart;                           // 17
-        int32_t rideUpperAnimLoop;                            // 18
-        float exitPreDelay;                                 // 19
-        float exitSpeed;                                    // 20
-        float exitGravity;                                  // 21
-        float exitMinDuration;                              // 22
-        float exitMaxDuration;                              // 23
-        float exitMinArcHeight;                             // 24
-        float exitMaxArcHeight;                             // 25
-        int32_t exitAnimStart;                                // 26
-        int32_t exitAnimLoop;                                 // 27
-        int32_t exitAnimEnd;                                  // 28
-        float passengerYaw;                                 // 29
-        float passengerPitch;                               // 30
-        float passengerRoll;                                // 31
-        int32_t passengerAttachmentID;                        // 32
-        int32_t vehicleEnterAnim;                             // 33
-        int32_t vehicleExitAnim;                              // 34
-        int32_t vehicleRideAnimLoop;                          // 35
-        int32_t vehicleEnterAnimBone;                         // 36
-        int32_t vehicleExitAnimBone;                          // 37
-        int32_t vehicleRideAnimLoopBone;                      // 38
-        float vehicleEnterAnimDelay;                        // 39
-        float vehicleExitAnimDelay;                         // 40
-        uint32_t vehicleAbilityDisplay;                       // 41
-        uint32_t enterUISoundID;                              // 42
-        uint32_t exitUISoundID;                               // 43
-        int32_t uiSkin;                                       // 44
-        uint32_t flagsB;                                      // 45
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        int32_t attachmentID;                                       // 2
+        float attachmentOffsetX;                                    // 3
+        float attachmentOffsetY;                                    // 4
+        float attachmentOffsetZ;                                    // 5
+        float enterPreDelay;                                        // 6
+        float enterSpeed;                                           // 7
+        float enterGravity;                                         // 8
+        float enterMinDuration;                                     // 9
+        float enterMaxDuration;                                     // 10
+        float enterMinArcHeight;                                    // 11
+        float enterMaxArcHeight;                                    // 12
+        int32_t enterAnimStart;                                     // 13
+        int32_t enterAnimLoop;                                      // 14
+        int32_t rideAnimStart;                                      // 15
+        int32_t rideAnimLoop;                                       // 16
+        int32_t rideUpperAnimStart;                                 // 17
+        int32_t rideUpperAnimLoop;                                  // 18
+        float exitPreDelay;                                         // 19
+        float exitSpeed;                                            // 20
+        float exitGravity;                                          // 21
+        float exitMinDuration;                                      // 22
+        float exitMaxDuration;                                      // 23
+        float exitMinArcHeight;                                     // 24
+        float exitMaxArcHeight;                                     // 25
+        int32_t exitAnimStart;                                      // 26
+        int32_t exitAnimLoop;                                       // 27
+        int32_t exitAnimEnd;                                        // 28
+        float passengerYaw;                                         // 29
+        float passengerPitch;                                       // 30
+        float passengerRoll;                                        // 31
+        int32_t passengerAttachmentID;                              // 32
+        int32_t vehicleEnterAnim;                                   // 33
+        int32_t vehicleExitAnim;                                    // 34
+        int32_t vehicleRideAnimLoop;                                // 35
+        int32_t vehicleEnterAnimBone;                               // 36
+        int32_t vehicleExitAnimBone;                                // 37
+        int32_t vehicleRideAnimLoopBone;                            // 38
+        float vehicleEnterAnimDelay;                                // 39
+        float vehicleExitAnimDelay;                                 // 40
+        uint32_t vehicleAbilityDisplay;                             // 41
+        uint32_t enterUISoundID;                                    // 42
+        uint32_t exitUISoundID;                                     // 43
+        int32_t uiSkin;                                             // 44
+        uint32_t flagsB;                                            // 45
 
         bool IsUsable() const
         {
@@ -1000,46 +1000,45 @@ namespace DBC::Structures
 
     struct WMOAreaTableEntry
     {
-        uint32_t id;              // 0
-        int32_t rootId;           // 1
-        int32_t adtId;            // 2
-        int32_t groupId;          // 3
-        //uint32_t field4;        // 4
-        //uint32_t field5;        // 5
-        //uint32_t field6;        // 6
-        //uint32_t field7;        // 7
-        //uint32_t field8;        // 8
-        uint32_t flags;           // 9
-        uint32_t areaId;          // 10  ref -> AreaTableEntry
-        //char Name[16];        // 11-26
-        //uint32_t nameflags;     // 27
+        uint32_t id;                                                // 0
+        int32_t rootId;                                             // 1
+        int32_t adtId;                                              // 2
+        int32_t groupId;                                            // 3
+        //uint32_t field4;                                          // 4
+        //uint32_t field5;                                          // 5
+        //uint32_t field6;                                          // 6
+        //uint32_t field7;                                          // 7
+        //uint32_t field8;                                          // 8
+        uint32_t flags;                                             // 9
+        uint32_t areaId;                                            // 10 ref -> AreaTableEntry
+        //char Name[16];                                            // 11-26
+        //uint32_t nameflags;                                       // 27
     };
 
     struct WorldMapAreaEntry
     {
-        //uint32_t id;              // 0
-        uint32_t mapId;             // 1
-        uint32_t zoneId;            // 2
-        //char const* name;         // 3
-        //float y1;                 // 4
-        //float y2;                 // 5
-        //float x1;                 // 6
-        //float x2;                 // 7
-        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t id;                                              // 0
+        uint32_t mapId;                                             // 1
+        uint32_t zoneId;                                            // 2
+        //char const* name;                                         // 3
+        //float y1;                                                 // 4
+        //float y2;                                                 // 5
+        //float x1;                                                 // 6
+        //float x2;                                                 // 7
+        int32_t continentMapId;                                     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
     };
 
     struct WorldMapOverlayEntry
     {
-        uint32_t ID;              // 0
-        //uint32_t worldMapID;    // 1
-        uint32_t areaID;          // 2 - index to AreaTable
-        uint32_t areaID_2;        // 3 - index to AreaTable
-        uint32_t areaID_3;        // 4 - index to AreaTable
-        uint32_t areaID_4;        // 5 - index to AreaTable
-        //uint32_t unk1[2];       // 6-7
-        //uint32_t unk2;          // 8
-        //uint32_t unk3[7];       // 9-16
+        uint32_t ID;                                                // 0
+        //uint32_t worldMapID;                                      // 1 WorldMapArea.dbc
+        uint32_t areaID;                                            // 2 - index to AreaTable
+        uint32_t areaID_2;                                          // 3 - index to AreaTable
+        uint32_t areaID_3;                                          // 4 - index to AreaTable
+        uint32_t areaID_4;                                          // 5 - index to AreaTable
+        //uint32_t unk1[2];                                         // 6-7
+        //uint32_t unk2;                                            // 8
+        //uint32_t unk3[7];                                         // 9-16
     };
-
     #pragma pack(pop)
 }

--- a/src/world/GameTBC/Storage/DBCStructures.h
+++ b/src/world/GameTBC/Storage/DBCStructures.h
@@ -140,7 +140,7 @@ namespace DBC::Structures
         float x;                                                    // 2
         float y;                                                    // 3
         float z;                                                    // 4
-        float o;                                                    // 5 radius?
+        float box_radius;                                           // 5 radius
         float box_x;                                                // 6 extent x edge
         float box_y;                                                // 7 extent y edge
         float box_z;                                                // 8 extent z edge

--- a/src/world/GameTBC/Storage/DBCStructures.h
+++ b/src/world/GameTBC/Storage/DBCStructures.h
@@ -39,1010 +39,1007 @@ enum MapTypes
     MAP_ARENA           = 4  // arena
 };
 
-namespace DBC
+namespace DBC::Structures
 {
-    namespace Structures
+    namespace
     {
-        namespace
-        {
-            char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixx";
-            char const area_trigger_entry_format[] = "niffffffff";
-            char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
-            char const bank_bag_slot_prices_format[] = "ni";
-            char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxx";
-            char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
-            char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const chr_classes_format[] = "nxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxix";
-            char const chr_races_format[] = "niixiixixxxxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxi";
-            char const creature_display_info_format[] = "nxxxxxxxxxxxxx";
-            char const creature_family_format[] = "nfifiiiissssssssssssssssxx";
-            char const creature_spell_data_format[] = "niiiiiiii";
-            char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-            char const durability_quality_format[] = "nf";
-            char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
-            char const faction_format[] = "niiiiiiiiiiiiiiiiiissssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const faction_template_format[] = "niiiiiiiiiiiii";
-            char const game_object_display_info_format[] = "nsxxxxxxxxxxffffff";
-            char const gem_properties_format[] = "nixxi";
-            char const gt_chance_to_melee_crit_format[] = "f";
-            char const gt_chance_to_melee_crit_base_format[] = "f";
-            char const gt_chance_to_spell_crit_format[] = "f";
-            char const gt_chance_to_spell_crit_base_format[] = "f";
-            char const gt_combat_ratings_format[] = "f";
-            char const gt_oct_regen_hp_format[] = "f";
-            char const gt_oct_regen_mp_format[] = "f";
-            char const gt_regen_hp_per_spt_format[] = "f";
-            char const gt_regen_mp_per_spt_format[] = "f";
-            char const item_entry_format[] = "niii";
-            char const item_display_info[] = "ni";
-            char const item_extended_cost_format[] = "niiiiiiiiiiiii";
-            char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
-            char const item_random_suffix_format[] = "nssssssssssssssssxxiiiiii";
-            char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
-            char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
-            char const liquid_type_entry_format[] = "niii";
-            char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
-            char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
-            char const map_format[] = "nxixssssssssssssssssxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiffiixxi";
-            char const name_gen_format[] = "nsii";
-            char const skill_line_format[] = "niissssssssssssssssxxxxxxxxxxxxxxxxxxi";
-            char const skill_line_ability_format[] = "iiiiiiiiiiiiiii";
-            char const stable_slot_prices_format[] = "ni";
-            char const spell_cast_times_format[] = "nixx";
-            char const spell_duration_format[] = "niii";
-            char const spell_entry_format[] = "nixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiifffiiiiissssssssssssssssxssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiixfffxxxiiii";
-            char const spell_item_enchantment_format[] = "niiiiiiiiiiiisxxxxxxxxxxxxxxxxiiii";
-            char const spell_radius_format[] = "nfff";
-            char const spell_range_format[] = "nffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
-            char const summon_properties_format[] = "niiiii";
-            char const talent_format[] = "niiiiiiiixxxxixxixxxi";
-            char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiix";
-            char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
-            char const taxi_path_format[] = "niii";
-            char const taxi_path_node_format[] = "niiifffiiii";
-            char const totem_category_format[] = "nxxxxxxxxxxxxxxxxxii";
-            char const transport_animation_format[] = "diifffx";
-            char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
-            char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
-            char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
-            char const world_map_area_entry_format[] = "xinxxxxxi";
-            char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
-        }
+        char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixx";
+        char const area_trigger_entry_format[] = "niffffffff";
+        char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
+        char const bank_bag_slot_prices_format[] = "ni";
+        char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxx";
+        char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
+        char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const chr_classes_format[] = "nxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxix";
+        char const chr_races_format[] = "niixiixixxxxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxi";
+        char const creature_display_info_format[] = "nxxxxxxxxxxxxx";
+        char const creature_family_format[] = "nfifiiiissssssssssssssssxx";
+        char const creature_spell_data_format[] = "niiiiiiii";
+        char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+        char const durability_quality_format[] = "nf";
+        char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiissssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const faction_template_format[] = "niiiiiiiiiiiii";
+        char const game_object_display_info_format[] = "nsxxxxxxxxxxffffff";
+        char const gem_properties_format[] = "nixxi";
+        char const gt_chance_to_melee_crit_format[] = "f";
+        char const gt_chance_to_melee_crit_base_format[] = "f";
+        char const gt_chance_to_spell_crit_format[] = "f";
+        char const gt_chance_to_spell_crit_base_format[] = "f";
+        char const gt_combat_ratings_format[] = "f";
+        char const gt_oct_regen_hp_format[] = "f";
+        char const gt_oct_regen_mp_format[] = "f";
+        char const gt_regen_hp_per_spt_format[] = "f";
+        char const gt_regen_mp_per_spt_format[] = "f";
+        char const item_entry_format[] = "niii";
+        char const item_display_info[] = "ni";
+        char const item_extended_cost_format[] = "niiiiiiiiiiiii";
+        char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
+        char const item_random_suffix_format[] = "nssssssssssssssssxxiiiiii";
+        char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
+        char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
+        char const liquid_type_entry_format[] = "niii";
+        char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
+        char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
+        char const map_format[] = "nxixssssssssssssssssxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiffiixxi";
+        char const name_gen_format[] = "nsii";
+        char const skill_line_format[] = "niissssssssssssssssxxxxxxxxxxxxxxxxxxi";
+        char const skill_line_ability_format[] = "iiiiiiiiiiiiiii";
+        char const stable_slot_prices_format[] = "ni";
+        char const spell_cast_times_format[] = "nixx";
+        char const spell_duration_format[] = "niii";
+        char const spell_entry_format[] = "nixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiffffffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiifffiiiiissssssssssssssssxssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiixfffxxxiiii";
+        char const spell_item_enchantment_format[] = "niiiiiiiiiiiisxxxxxxxxxxxxxxxxiiii";
+        char const spell_radius_format[] = "nfff";
+        char const spell_range_format[] = "nffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
+        char const summon_properties_format[] = "niiiii";
+        char const talent_format[] = "niiiiiiiixxxxixxixxxi";
+        char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiix";
+        char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
+        char const taxi_path_format[] = "niii";
+        char const taxi_path_node_format[] = "niiifffiiii";
+        char const totem_category_format[] = "nxxxxxxxxxxxxxxxxxii";
+        char const transport_animation_format[] = "diifffx";
+        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
+        char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
+        char const world_map_area_entry_format[] = "xinxxxxxi";
+        char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
+    }
 
-        #pragma pack(push, 1)
-        struct AchievementCategoryEntry
-        {
-            uint32_t ID;                 // 0
-            uint32_t parentCategory;     // 1 -1 for main category
-            const char* name;          // 2-17
-            uint32_t name_flags;         // 18
-            uint32_t sortOrder;          // 19
-        };
+    #pragma pack(push, 1)
+    struct AchievementCategoryEntry
+    {
+        uint32_t ID;                 // 0
+        uint32_t parentCategory;     // 1 -1 for main category
+        const char* name;          // 2-17
+        uint32_t name_flags;         // 18
+        uint32_t sortOrder;          // 19
+    };
 
-        struct AreaTableEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t map_id;                  // 1
-            uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-            uint32_t explore_flag;            // 3, main index
-            uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                            // 5-9 unused
-            int32_t area_level;               // 10
-            char* area_name[16];            // 11-26
-                                            // 27, string flags, unused
-            uint32_t team;                    // 28
-            uint32_t liquid_type_override[4]; // 29-32 liquid override by type
-        };
+    struct AreaTableEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t map_id;                  // 1
+        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;            // 3, main index
+        uint32_t flags;                   // 4, unknown value but 312 for all cities
+                                        // 5-9 unused
+        int32_t area_level;               // 10
+        char* area_name[16];            // 11-26
+                                        // 27, string flags, unused
+        uint32_t team;                    // 28
+        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+    };
 
-        struct AreaTriggerEntry
-        {
-            uint32_t id;              // 0
-            uint32_t mapid;           // 1
-            float x;                // 2
-            float y;                // 3
-            float z;                // 4
-            float o;                // 5 radius?
-            float box_x;            // 6 extent x edge
-            float box_y;            // 7 extent y edge
-            float box_z;            // 8 extent z edge
-            float box_o;            // 9 extent rotation by about z axis
-        };
+    struct AreaTriggerEntry
+    {
+        uint32_t id;              // 0
+        uint32_t mapid;           // 1
+        float x;                // 2
+        float y;                // 3
+        float z;                // 4
+        float o;                // 5 radius?
+        float box_x;            // 6 extent x edge
+        float box_y;            // 7 extent y edge
+        float box_z;            // 8 extent z edge
+        float box_o;            // 9 extent rotation by about z axis
+    };
 
-        struct AuctionHouseEntry
-        {
-            uint32_t id;              // 0
-            uint32_t faction;         // 1
-            uint32_t fee;             // 2
-            uint32_t tax;             // 3
-            //char* name[16];       // 4-19
-            //uint32_t name_flags;    // 20
-        };
+    struct AuctionHouseEntry
+    {
+        uint32_t id;              // 0
+        uint32_t faction;         // 1
+        uint32_t fee;             // 2
+        uint32_t tax;             // 3
+        //char* name[16];       // 4-19
+        //uint32_t name_flags;    // 20
+    };
 
-        struct BankBagSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
+    struct BankBagSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
 
-        #define OUTFIT_ITEMS 12
+    #define OUTFIT_ITEMS 12
 
-        struct CharStartOutfitEntry
-        {
-            //uint32_t Id;                                    // 0
-            uint8_t Race;                                     // 1
-            uint8_t Class;                                    // 2
-            uint8_t Gender;                                   // 3
-            //uint8_t Unused;                                 // 4
-            int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
-            //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
-            //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
-        };
+    struct CharStartOutfitEntry
+    {
+        //uint32_t Id;                                    // 0
+        uint8_t Race;                                     // 1
+        uint8_t Class;                                    // 2
+        uint8_t Gender;                                   // 3
+        //uint8_t Unused;                                 // 4
+        int32_t ItemId[OUTFIT_ITEMS];                     // 5-16
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 17-28
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 29-40
+    };
 
 
-        struct CharTitlesEntry
-        {
-            uint32_t ID;                      // 0, title ids
-            //uint32_t unk1;                  // 1 flags?
-            char* name_male[16];            // 2-17
-            //uint32_t name_flag;             // 18 string flag, unused
-            char* name_female[16];          // 19-34
-            //const char* name2_flag;       // 35 string flag, unused
-            uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
-        };
+    struct CharTitlesEntry
+    {
+        uint32_t ID;                      // 0, title ids
+        //uint32_t unk1;                  // 1 flags?
+        char* name_male[16];            // 2-17
+        //uint32_t name_flag;             // 18 string flag, unused
+        char* name_female[16];          // 19-34
+        //const char* name2_flag;       // 35 string flag, unused
+        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+    };
 
-        struct ChatChannelsEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t flags;                   // 1
-            char* name_pattern[16];         // 3-18
-            //uint32_t name_pattern_flags;    // 19
-            //char* channel_name[16];       // 20-35
-            //uint32_t channel_name_flags;    // 36
-        };
+    struct ChatChannelsEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t flags;                   // 1
+        char* name_pattern[16];         // 3-18
+        //uint32_t name_pattern_flags;    // 19
+        //char* channel_name[16];       // 20-35
+        //uint32_t channel_name_flags;    // 36
+    };
 
-        struct ChrClassesEntry
-        {
-            uint32_t class_id;                // 0
-            //uint32_t unk1;                  // 1
-            uint32_t power_type;              // 2
-            //uint32_t unk2[2];               // 3-4
-            char* name[16];                 // 5-20
-            //uint32_t nameflags;             // 21
-            //char* name_female[16];        // 22-36
-            //uint32_t name_female_flags;     // 37
-            //char* name_neutral[16];       // 38-53
-            //uint32_t name_neutral_flags;    // 54
-            //uint32_t unk3;                  // 55
-            uint32_t spellfamily;             // 56
-            //uint32_t unk4;                  // 57
-        };
+    struct ChrClassesEntry
+    {
+        uint32_t class_id;                // 0
+        //uint32_t unk1;                  // 1
+        uint32_t power_type;              // 2
+        //uint32_t unk2[2];               // 3-4
+        char* name[16];                 // 5-20
+        //uint32_t nameflags;             // 21
+        //char* name_female[16];        // 22-36
+        //uint32_t name_female_flags;     // 37
+        //char* name_neutral[16];       // 38-53
+        //uint32_t name_neutral_flags;    // 54
+        //uint32_t unk3;                  // 55
+        uint32_t spellfamily;             // 56
+        //uint32_t unk4;                  // 57
+    };
 
-        struct ChrRacesEntry
-        {
-            uint32_t race_id;                 // 0
-            uint32_t flags;                   // 1
-            uint32_t faction_id;              // 2
-            //uint32_t unk1;                  // 3
-            uint32_t model_male;              // 4
-            uint32_t model_female;            // 5
-            // uint32_t unk2;                 // 6
-            uint32_t team_id;                 // 7
-            //uint32_t unk3[4];               // 8-11
-            uint32_t cinematic_id;            // 12 CinematicSequences.dbc
-            //uint32_t unk4                   // 13
-            char* name[16];                 // 14-29
-            //uint32_t name_flags             // 30
-            //char* name_female[16];        // 31-46
-            //uint32_t name_female_flags      // 47
-            //char* name_neutral[16];       // 48-63
-            //uint32_t name_neutral_flags     // 64 string flags, unused
-            //uint32_t unk5[3]                // 65-67 unused
-            uint32_t expansion;               // 68
-        };
+    struct ChrRacesEntry
+    {
+        uint32_t race_id;                 // 0
+        uint32_t flags;                   // 1
+        uint32_t faction_id;              // 2
+        //uint32_t unk1;                  // 3
+        uint32_t model_male;              // 4
+        uint32_t model_female;            // 5
+        // uint32_t unk2;                 // 6
+        uint32_t team_id;                 // 7
+        //uint32_t unk3[4];               // 8-11
+        uint32_t cinematic_id;            // 12 CinematicSequences.dbc
+        //uint32_t unk4                   // 13
+        char* name[16];                 // 14-29
+        //uint32_t name_flags             // 30
+        //char* name_female[16];        // 31-46
+        //uint32_t name_female_flags      // 47
+        //char* name_neutral[16];       // 48-63
+        //uint32_t name_neutral_flags     // 64 string flags, unused
+        //uint32_t unk5[3]                // 65-67 unused
+        uint32_t expansion;               // 68
+    };
 
-        struct CreatureDisplayInfoEntry
-        {
-            uint32_t display_id;            // 0
-            //uint32_t model;               // 1
-            //uint32_t unk0                 // 2
-            //uint32_t InfoExtra;           // 3
-            //float size;                   // 4
-                                            // 5 - 15 unk
-        };
+    struct CreatureDisplayInfoEntry
+    {
+        uint32_t display_id;            // 0
+        //uint32_t model;               // 1
+        //uint32_t unk0                 // 2
+        //uint32_t InfoExtra;           // 3
+        //float size;                   // 4
+                                        // 5 - 15 unk
+    };
 
-        struct CreatureFamilyEntry
-        {
-            uint32_t ID;                      // 0
-            float minsize;                  // 1
-            uint32_t minlevel;                // 2
-            float maxsize;                  // 3
-            uint32_t maxlevel;                // 4
-            uint32_t skilline;                // 5
-            uint32_t tameable;                // 6 second skill line - 270 Generic
-            uint32_t petdietflags;            // 7
-            char* name[16];                 // 8-23
-            //uint32_t nameflags;             // 24
-            //uint32_t iconFile;              // 25
-        };
+    struct CreatureFamilyEntry
+    {
+        uint32_t ID;                      // 0
+        float minsize;                  // 1
+        uint32_t minlevel;                // 2
+        float maxsize;                  // 3
+        uint32_t maxlevel;                // 4
+        uint32_t skilline;                // 5
+        uint32_t tameable;                // 6 second skill line - 270 Generic
+        uint32_t petdietflags;            // 7
+        char* name[16];                 // 8-23
+        //uint32_t nameflags;             // 24
+        //uint32_t iconFile;              // 25
+    };
 
-        struct CreatureSpellDataEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t Spells[3];               // 1-3
-            uint32_t PHSpell;                 // 4
-            uint32_t Cooldowns[3];            // 5-7
-            uint32_t PH;                      // 8
-        };
+    struct CreatureSpellDataEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t Spells[3];               // 1-3
+        uint32_t PHSpell;                 // 4
+        uint32_t Cooldowns[3];            // 5-7
+        uint32_t PH;                      // 8
+    };
 
-        struct DurabilityCostsEntry
-        {
-            uint32_t itemlevel;       // 0
-            uint32_t modifier[29];    // 1-29
-        };
+    struct DurabilityCostsEntry
+    {
+        uint32_t itemlevel;       // 0
+        uint32_t modifier[29];    // 1-29
+    };
 
-        struct DurabilityQualityEntry
-        {
-            uint32_t id;              // 0
-            float quality_modifier; // 1
-        };
+    struct DurabilityQualityEntry
+    {
+        uint32_t id;              // 0
+        float quality_modifier; // 1
+    };
 
-        struct EmotesTextEntry
-        {
-            uint32_t Id;              // 0
-            //uint32_t name;          // 1
-            uint32_t textid;          // 2
-            uint32_t textid2;         // 3
-            uint32_t textid3;         // 4
-            uint32_t textid4;         // 5
-            //uint32_t unk1;          // 6
-            uint32_t textid5;         // 7
-            //uint32_t unk2;          // 8
-            uint32_t textid6;         // 9
-            //uint32_t unk3;          // 10
-            //uint32_t unk4;          // 11
-            //uint32_t unk5;          // 12
-            //uint32_t unk6;          // 13
-            //uint32_t unk7;          // 14
-            //uint32_t unk8;          // 15
-            //uint32_t unk9;          // 16
-            //uint32_t unk10;         // 17
-            //uint32_t unk11;         // 18
-        };
+    struct EmotesTextEntry
+    {
+        uint32_t Id;              // 0
+        //uint32_t name;          // 1
+        uint32_t textid;          // 2
+        uint32_t textid2;         // 3
+        uint32_t textid3;         // 4
+        uint32_t textid4;         // 5
+        //uint32_t unk1;          // 6
+        uint32_t textid5;         // 7
+        //uint32_t unk2;          // 8
+        uint32_t textid6;         // 9
+        //uint32_t unk3;          // 10
+        //uint32_t unk4;          // 11
+        //uint32_t unk5;          // 12
+        //uint32_t unk6;          // 13
+        //uint32_t unk7;          // 14
+        //uint32_t unk8;          // 15
+        //uint32_t unk9;          // 16
+        //uint32_t unk10;         // 17
+        //uint32_t unk11;         // 18
+    };
 
-        struct FactionEntry
-        {
-            uint32_t ID;                      // 0
-            int32_t RepListId;                // 1
-            uint32_t RaceMask[4];             // 2-5
-            uint32_t ClassMask[4];            // 6-9
-            int32_t baseRepValue[4];          // 10-13
-            uint32_t repFlags[4];             // 14-17
-            uint32_t parentFaction;           // 18
-            char* Name[16];                 // 19-34
-            //uint32_t name_flags;            // 35
-            //uint32_t Description[16];       // 36-51
-            //uint32_t description_flags;     // 52
-        };
+    struct FactionEntry
+    {
+        uint32_t ID;                      // 0
+        int32_t RepListId;                // 1
+        uint32_t RaceMask[4];             // 2-5
+        uint32_t ClassMask[4];            // 6-9
+        int32_t baseRepValue[4];          // 10-13
+        uint32_t repFlags[4];             // 14-17
+        uint32_t parentFaction;           // 18
+        char* Name[16];                 // 19-34
+        //uint32_t name_flags;            // 35
+        //uint32_t Description[16];       // 36-51
+        //uint32_t description_flags;     // 52
+    };
 
-        struct FactionTemplateEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t Faction;                 // 1
-            uint32_t FactionGroup;            // 2
-            uint32_t Mask;                    // 3
-            uint32_t FriendlyMask;            // 4
-            uint32_t HostileMask;             // 5
-            uint32_t EnemyFactions[4];        // 6-9
-            uint32_t FriendlyFactions[4];     // 10-13
-        };
+    struct FactionTemplateEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t Faction;                 // 1
+        uint32_t FactionGroup;            // 2
+        uint32_t Mask;                    // 3
+        uint32_t FriendlyMask;            // 4
+        uint32_t HostileMask;             // 5
+        uint32_t EnemyFactions[4];        // 6-9
+        uint32_t FriendlyFactions[4];     // 10-13
+    };
 
-        struct GameObjectDisplayInfoEntry
-        {
-            uint32_t Displayid;               // 0
-            char* filename;                 // 1
-            //uint32_t  unk1[10];             // 2-11
-            float minX;                     // 12
-            float minY;                     // 13
-            float minZ;                     // 14
-            float maxX;                     // 15
-            float maxY;                     // 16
-            float maxZ;                     // 17
-        };
+    struct GameObjectDisplayInfoEntry
+    {
+        uint32_t Displayid;               // 0
+        char* filename;                 // 1
+        //uint32_t  unk1[10];             // 2-11
+        float minX;                     // 12
+        float minY;                     // 13
+        float minZ;                     // 14
+        float maxX;                     // 15
+        float maxY;                     // 16
+        float maxZ;                     // 17
+    };
 
-        struct GemPropertiesEntry
-        {
-            uint32_t Entry;                   // 0
-            uint32_t EnchantmentID;           // 1
-            //uint32_t unk1;                  // 2 bool
-            //uint32_t unk2;                  // 3 bool
-            uint32_t SocketMask;              // 4
-        };
+    struct GemPropertiesEntry
+    {
+        uint32_t Entry;                   // 0
+        uint32_t EnchantmentID;           // 1
+        //uint32_t unk1;                  // 2 bool
+        //uint32_t unk2;                  // 3 bool
+        uint32_t SocketMask;              // 4
+    };
 
-        struct GtChanceToMeleeCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToMeleeCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtCombatRatingsEntry
-        {
-            float val;              // 0
-        };
+    struct GtCombatRatingsEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtOCTRegenHPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenHPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtOCTRegenMPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenMPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtRegenHPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenHPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
-        struct GtRegenMPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenMPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
-        struct ItemEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t DisplayId;               // 1
-            uint32_t InventoryType;           // 2
-            uint32_t Sheath;                  // 3
-        };
+    struct ItemEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t DisplayId;               // 1
+        uint32_t InventoryType;           // 2
+        uint32_t Sheath;                  // 3
+    };
 
-        struct ItemDisplayInfo
-        {
-            uint32_t ID;                     // 0
-            uint32_t randomPropertyChance;   // 1
-        };
+    struct ItemDisplayInfo
+    {
+        uint32_t ID;                     // 0
+        uint32_t randomPropertyChance;   // 1
+    };
 
-        struct ItemExtendedCostEntry
-        {
-            uint32_t costid;                  // 0
-            uint32_t honor_points;            // 1
-            uint32_t arena_points;            // 2
-            uint32_t item[5];                 // 4-8
-            uint32_t count[5];                // 9-13
-            uint32_t personalrating;          // 14
-        };
+    struct ItemExtendedCostEntry
+    {
+        uint32_t costid;                  // 0
+        uint32_t honor_points;            // 1
+        uint32_t arena_points;            // 2
+        uint32_t item[5];                 // 4-8
+        uint32_t count[5];                // 9-13
+        uint32_t personalrating;          // 14
+    };
 
-        struct ItemRandomPropertiesEntry
-        {
-            uint32_t ID;                      // 0
-            //uint32_t name1;                 // 1
-            uint32_t spells[3];               // 2-4
-            //uint32_t unk1;                  // 5
-            //uint32_t unk2;                  // 6
-            char* name_suffix[16];          // 7-22
-            //uint32_t name_suffix_flags;     // 23
-        };
+    struct ItemRandomPropertiesEntry
+    {
+        uint32_t ID;                      // 0
+        //uint32_t name1;                 // 1
+        uint32_t spells[3];               // 2-4
+        //uint32_t unk1;                  // 5
+        //uint32_t unk2;                  // 6
+        char* name_suffix[16];          // 7-22
+        //uint32_t name_suffix_flags;     // 23
+    };
 
-        struct ItemRandomSuffixEntry
-        {
-            uint32_t id;                      // 0
-            char* name_suffix[16];          // 1-16
-            //uint32_t name_suffix_flags;     // 17
-            //uint32_t unk1;                  // 18
-            uint32_t enchantments[3];         // 19-21
-            //uint32_t unk2[2];               // 22-23
-            uint32_t prefixes[3];             // 24-26
-            //uint32_t[2];                    // 27-28
-        };
+    struct ItemRandomSuffixEntry
+    {
+        uint32_t id;                      // 0
+        char* name_suffix[16];          // 1-16
+        //uint32_t name_suffix_flags;     // 17
+        //uint32_t unk1;                  // 18
+        uint32_t enchantments[3];         // 19-21
+        //uint32_t unk2[2];               // 22-23
+        uint32_t prefixes[3];             // 24-26
+        //uint32_t[2];                    // 27-28
+    };
 
-        struct ItemSetEntry
-        {
-            uint32_t id;                      // 1
-            char* name[16];                 // 1-16 name (lang)
-            //uint32_t localeflag;            // 17 constant
-            uint32_t itemid[10];              // 18-27 item set items
-            //uint32_t unk[7];                // 28-34 all 0
-            uint32_t SpellID[8];              // 35-42
-            uint32_t itemscount[8];           // 43-50
-            uint32_t RequiredSkillID;         // 51
-            uint32_t RequiredSkillAmt;        // 52
-        };
+    struct ItemSetEntry
+    {
+        uint32_t id;                      // 1
+        char* name[16];                 // 1-16 name (lang)
+        //uint32_t localeflag;            // 17 constant
+        uint32_t itemid[10];              // 18-27 item set items
+        //uint32_t unk[7];                // 28-34 all 0
+        uint32_t SpellID[8];              // 35-42
+        uint32_t itemscount[8];           // 43-50
+        uint32_t RequiredSkillID;         // 51
+        uint32_t RequiredSkillAmt;        // 52
+    };
 
-        struct LFGDungeonEntry
-        {
-            uint32_t ID;              // 0
-            char* name[16];         // 1-17 Name lang
-            uint32_t minlevel;        // 18
-            uint32_t maxlevel;        // 19
-            uint32_t reclevel;        // 20
-            uint32_t recminlevel;     // 21
-            uint32_t recmaxlevel;     // 22
-            int32_t map;              // 23
-            uint32_t difficulty;      // 24
-            uint32_t flags;           // 25
-            uint32_t type;            // 26
-            //uint32_t  unk;          // 27
-            //char* iconname;       // 28
-            uint32_t expansion;       // 29
-            //uint32_t unk4;          // 30
-            uint32_t grouptype;       // 31
-            //char* desc[16];       // 32-47 Description
+    struct LFGDungeonEntry
+    {
+        uint32_t ID;              // 0
+        char* name[16];         // 1-17 Name lang
+        uint32_t minlevel;        // 18
+        uint32_t maxlevel;        // 19
+        uint32_t reclevel;        // 20
+        uint32_t recminlevel;     // 21
+        uint32_t recmaxlevel;     // 22
+        int32_t map;              // 23
+        uint32_t difficulty;      // 24
+        uint32_t flags;           // 25
+        uint32_t type;            // 26
+        //uint32_t  unk;          // 27
+        //char* iconname;       // 28
+        uint32_t expansion;       // 29
+        //uint32_t unk4;          // 30
+        uint32_t grouptype;       // 31
+        //char* desc[16];       // 32-47 Description
 
-            // Helpers
-            uint32_t Entry() const { return ID + (type << 24); }
-        };
+        // Helpers
+        uint32_t Entry() const { return ID + (type << 24); }
+    };
 
-        struct LiquidTypeEntry
-        {
-            uint32_t Id;                  // 0
-            uint32_t liquid_id;           // 1
-            uint32_t Type;                // 2
-            uint32_t SpellId;             // 3
-        };
+    struct LiquidTypeEntry
+    {
+        uint32_t Id;                  // 0
+        uint32_t liquid_id;           // 1
+        uint32_t Type;                // 2
+        uint32_t SpellId;             // 3
+    };
 
 #define LOCK_NUM_CASES 8
 
-        struct LockEntry
+    struct LockEntry
+    {
+        uint32_t Id;                              // 0
+        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+    };
+
+    struct MailTemplateEntry
+    {
+        uint32_t ID;              // 0
+        char* subject;          // 1
+        //float unused1[15]     // 2-16
+        //uint32_t flags1         // 17 name flags, unused
+        char* content;          // 18
+        //float unused2[15]     // 19-34
+        //uint32_t flags2         // 35 name flags, unused
+    };
+
+    struct MapEntry
+    {
+        uint32_t id;                      // 0
+        //char* name_internal;          // 1
+        uint32_t map_type;                // 2
+        //uint32_t is_pvp_zone;           // 3 -0 false -1 true
+        char* map_name[16];             // 4-19
+        //uint32_t name_flags;            // 20
+        uint32_t linked_zone;             // 22 common zone for instance and continent map
+        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;      // 39
+        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;   // 56
+        uint32_t multimap_id;             // 57
+        //uint32_t battlefield_map_icon;  // 58
+        int32_t parent_map;               // 59 map_id of parent map
+        float start_x;                  // 60 enter x coordinate (if exist single entry)
+        float start_y;                  // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;               // 62
+        uint32_t reset_raid_time;
+        uint32_t reset_heroic_tim;
+        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+
+        bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
+        bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
+        bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isRaid() const { return map_type == MAP_RAID; }
+        bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
+        bool isBattleArena() const { return map_type == MAP_ARENA; }
+        bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isWorldMap() const { return map_type == MAP_COMMON; }
+
+        bool isContinent() const
         {
-            uint32_t Id;                              // 0
-            uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-            uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-            uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-            //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
-        };
+            return id == 0 || id == 1 || id == 530 || id == 571;
+        }
+    };
 
-        struct MailTemplateEntry
+    struct NameGenEntry
+    {
+        uint32_t ID;              // 0
+        char* Name;             // 1
+        uint32_t unk1;            // 2
+        uint32_t type;            // 3
+    };
+
+    struct SkillLineEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t type;                // 1
+        uint32_t skillCostsID;      // 2
+        char* Name[16];             // 3-18
+        //uint32_t NameFlags;         // 19
+        //char* Description[16];    // 20-35
+        //uint32_t DescriptionFlags;  // 36
+        uint32_t spell_icon;          // 37
+    };
+
+    //"iiiiiiiiiiiiiii"
+    struct SkillLineAbilityEntry
+    {
+        uint32_t Id;                      // 0
+        uint32_t skilline;                // 1 skill id
+        uint32_t spell;                   // 2
+        uint32_t race_mask;               // 3
+        uint32_t class_mask;              // 4
+        uint32_t excludeRace;           // 5
+        uint32_t excludeClass;          // 6
+        uint32_t minSkillLineRank;        // 7 req skill value
+        uint32_t next;                    // 8
+        uint32_t acquireMethod;           // 9 auto learn
+        uint32_t grey;                    // 10 max
+        uint32_t green;                   // 11 min
+        uint32_t abandonable;           // 12
+        uint32_t reqTP;                 // 13
+        uint32_t reqtrainpoints;          // 14
+    };
+
+    struct StableSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
+
+    struct SpellCastTimesEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t CastTime;        // 1
+        //uint32_t unk1;          // 2
+        //uint32_t unk2;          // 3
+    };
+
+    struct SpellDurationEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t Duration1;       // 1
+        uint32_t Duration2;       // 2
+        uint32_t Duration3;       // 3
+    };
+
+    #define MAX_SPELL_EFFECTS 3
+    #define MAX_SPELL_REAGENTS 8
+    #define MAX_SPELL_TOTEMS 2
+    #define MAX_SPELL_TOTEM_CATEGORIES 2
+
+    struct SpellEntry
+    {
+        uint32_t Id;                                                // 0
+        uint32_t Category;                                          // 1
+        //uint32_t castUI;                                          // 2 not used
+        uint32_t DispelType;                                        // 3
+        uint32_t MechanicsType;                                     // 4
+        uint32_t Attributes;                                        // 5
+        uint32_t AttributesEx;                                      // 6
+        uint32_t AttributesExB;                                     // 7
+        uint32_t AttributesExC;                                     // 8
+        uint32_t AttributesExD;                                     // 9
+        uint32_t AttributesExE;                                     // 10
+        uint32_t AttributesExF;                                     // 11
+        uint32_t Shapeshifts;                                       // 12
+        uint32_t ShapeshiftsExcluded;                               // 13
+        uint32_t Targets;                                           // 14
+        uint32_t TargetCreatureType;                                // 15
+        uint32_t RequiresSpellFocus;                                // 16
+        uint32_t FacingCasterFlags;                                 // 17
+        uint32_t CasterAuraState;                                   // 18
+        uint32_t TargetAuraState;                                   // 19
+        uint32_t CasterAuraStateNot;                                // 20
+        uint32_t TargetAuraStateNot;                                // 21
+        uint32_t CastingTimeIndex;                                  // 22
+        uint32_t RecoveryTime;                                      // 23
+        uint32_t CategoryRecoveryTime;                              // 24
+        uint32_t InterruptFlags;                                    // 25
+        uint32_t AuraInterruptFlags;                                // 26
+        uint32_t ChannelInterruptFlags;                             // 27
+        uint32_t procFlags;                                         // 28
+        uint32_t procChance;                                        // 29
+        uint32_t procCharges;                                       // 30
+        uint32_t maxLevel;                                          // 31
+        uint32_t baseLevel;                                         // 32
+        uint32_t spellLevel;                                        // 33
+        uint32_t DurationIndex;                                     // 34
+        int32_t powerType;                                          // 35
+        uint32_t manaCost;                                          // 36
+        uint32_t manaCostPerlevel;                                  // 37
+        uint32_t manaPerSecond;                                     // 38
+        uint32_t manaPerSecondPerLevel;                             // 39
+        uint32_t rangeIndex;                                        // 40
+        float speed;                                                // 41
+        //uint32_t modalNextSpell;                                  // 42 not used
+        uint32_t MaxStackAmount;                                    // 43
+        uint32_t Totem[MAX_SPELL_TOTEMS];                           // 44 - 45
+        int32_t Reagent[MAX_SPELL_REAGENTS];                        // 46 - 53
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 54 - 61
+        int32_t EquippedItemClass;                                  // 62
+        int32_t EquippedItemSubClass;                               // 63
+        int32_t EquippedItemInventoryTypeMask;                      // 64
+        uint32_t Effect[MAX_SPELL_EFFECTS];                         // 65 - 67
+        int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 68 - 70
+        uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 71 - 73
+        float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 74 - 76
+        float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
+        int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
+        uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
+        uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
+        uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
+        uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
+        uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
+        uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
+        float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
+        uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
+        uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109
+        int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
+        int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
+        uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
+        float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
+        uint32_t SpellVisual;                                       // 122
+        uint32_t SpellVisual1;                                      // 123
+        uint32_t spellIconID;                                       // 124
+        uint32_t activeIconID;                                      // 125 activeIconID;
+        uint32_t spellPriority;                                     // 126
+        const char* Name[16];                                       // 127 - 142
+        //uint32_t NameFlags;                                       // 143 not used
+        const char* Rank[16];                                       // 144 - 159
+        //uint32_t RankFlags;                                       // 160 not used
+        //const char* Description[16];                              // 161 - 176 not used
+        //uint32_t DescriptionFlags;                                // 177 not used
+        //const char* BuffDescription[16];                          // 178 - 193 not used
+        //uint32_t buffdescflags;                                   // 194 not used
+        uint32_t ManaCostPercentage;                                // 195
+        uint32_t StartRecoveryCategory;                             // 196
+        uint32_t StartRecoveryTime;                                 // 197
+        uint32_t MaxTargetLevel;                                    // 198
+        uint32_t SpellFamilyName;                                   // 199
+        uint32_t SpellFamilyFlags[2];                               // 200 - 201
+        uint32_t MaxTargets;                                        // 202
+        uint32_t DmgClass;                                          // 203
+        uint32_t PreventionType;                                    // 204
+        //int32_t StanceBarOrder;                                   // 205 not used
+        float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 206 - 208
+        //uint32_t MinFactionID;                                    // 209 not used
+        //uint32_t MinReputation;                                   // 210 not used
+        //uint32_t RequiredAuraVision;                              // 211 not used
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 212 - 213
+        int32_t AreaGroupId;                                        // 214
+        uint32_t School;                                            // 215
+    };
+
+    struct SpellItemEnchantmentEntry
+    {
+        uint32_t Id;                  // 0
+        uint32_t type[3];             // 1-3
+        uint32_t min[3];              // 4-6 for combat, in practice min==max
+        uint32_t max[3];              // 7-9
+        uint32_t spell[3];            // 10-12
+        char* Name;                   // 13
+        //uint32_t NameAlt[16]       // 14-29
+        uint32_t visual;              // 30 aura
+        uint32_t EnchantGroups;       // 31 slot
+        uint32_t GemEntry;            // 32
+        uint32_t ench_condition;      // 33
+    };
+
+    struct SpellRadiusEntry
+    {
+        uint32_t ID;                  // 0
+        float radius_min;           // 1 Radius
+        float radius_per_level;     // 2
+        float radius_max;           // 3 Radius2
+    };
+
+    struct SpellRangeEntry
+    {
+        uint32_t ID;                  // 0
+        float minRange;             // 1
+        float maxRange;             // 3
+        uint32_t range_type;          // 4
+        //char* name1[16]           // 6-21
+        //uint32_t name1_falgs;       // 22
+        //char* name2[16]           // 23-38
+        //uint32_t name2_falgs;       // 39
+    };
+
+    struct SpellShapeshiftFormEntry
+    {
+        uint32_t id;                  // 0
+        //uint32_t button_pos;        // 1
+        //char* name[16];           // 2-17
+        //uint32_t name_flags;        // 18
+        uint32_t Flags;               // 19
+        uint32_t unit_type;           // 20
+        //uint32_t unk1               // 21
+        uint32_t AttackSpeed;         // 22
+        uint32_t modelId;             // 23 alliance?
+        uint32_t modelId2;            // 24 horde?
+        //uint32_t unk2               // 25
+        //uint32_t unk3               // 26
+        uint32_t spells[8];           // 27-34
+    };
+
+    struct SummonPropertiesEntry
+    {
+        uint32_t ID;                  // 0
+        uint32_t ControlType;         // 1
+        uint32_t FactionID;           // 2
+        uint32_t Type;                // 3
+        uint32_t Slot;                // 4
+        uint32_t Flags;               // 5
+    };
+
+    struct TalentEntry
+    {
+        uint32_t TalentID;            // 0
+        uint32_t TalentTree;          // 1
+        uint32_t Row;                 // 2
+        uint32_t Col;                 // 3
+        uint32_t RankID[5];           // 4-8
+        //uint32_t unk[4];            // 9-12
+        uint32_t DependsOn;           // 13
+        //uint32_t unk1[2];           // 14-15
+        uint32_t DependsOnRank;       // 16
+        //uint32_t unk2[2];           // 17-18
+        //uint32_t unk3;              // 19
+        uint32_t DependsOnSpell;      // 20
+    };
+
+    struct TalentTabEntry
+    {
+        uint32_t TalentTabID;         // 0
+        //char* Name[16];           // 1-16
+        //uint32_t name_flags;        // 17
+        //uint32_t unk4;              // 18
+        //uint32_t unk5;              // 19
+        uint32_t ClassMask;           // 20
+        uint32_t TabPage;             // 21
+        //char* InternalName;       // 22
+    };
+
+    struct TaxiNodesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t mapid;               // 1
+        float x;                    // 2
+        float y;                    // 3
+        float z;                    // 4
+        char* name[16];             // 5-21
+        //uint32_t nameflags;         // 22
+        uint32_t horde_mount;         // 23
+        uint32_t alliance_mount;      // 24
+    };
+
+    struct TaxiPathEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t from;                // 1
+        uint32_t to;                  // 2
+        uint32_t price;               // 3
+    };
+
+    struct TaxiPathNodeEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t path;                // 1
+        uint32_t seq;                 // 2 nodeIndex
+        uint32_t mapid;               // 3
+        float x;                      // 4
+        float y;                      // 5
+        float z;                      // 6
+        uint32_t flags;               // 7
+        uint32_t waittime;            // 8
+        uint32_t arivalEventID;       // 9
+        uint32_t departureEventID;    // 10
+    };
+
+    struct TotemCategoryEntry
+    {
+        uint32_t id;            // 0
+        //char* name[16];       // 1-16
+        //uint32_t unk;         // 17
+        uint32_t categoryType;  // 18
+        uint32_t categoryMask;  // 19
+    };
+
+    struct TransportAnimationEntry
+    {
+        //uint32_t Id;          // 0
+        uint32_t TransportID;   // 1
+        uint32_t TimeIndex;     // 2
+        DBCPosition3D Pos;      // 3
+        //uint32_t SequenceID;  // 4
+    };
+
+    #define MAX_VEHICLE_SEATS 8
+
+    struct VehicleEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        float turnSpeed;                                    // 2
+        float pitchSpeed;                                   // 3
+        float pitchMin;                                     // 4
+        float pitchMax;                                     // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
+        float mouseLookOffsetPitch;                         // 14
+        float cameraFadeDistScalarMin;                      // 15
+        float cameraFadeDistScalarMax;                      // 16
+        float cameraPitchOffset;                            // 17
+        float facingLimitRight;                             // 18
+        float facingLimitLeft;                              // 19
+        float msslTrgtTurnLingering;                        // 20
+        float msslTrgtPitchLingering;                       // 21
+        float msslTrgtMouseLingering;                       // 22
+        float msslTrgtEndOpacity;                           // 23
+        float msslTrgtArcSpeed;                             // 24
+        float msslTrgtArcRepeat;                            // 25
+        float msslTrgtArcWidth;                             // 26
+        float msslTrgtImpactRadius[2];                      // 27-28
+        char* msslTrgtArcTexture;                           // 29
+        char* msslTrgtImpactTexture;                        // 30
+        char* msslTrgtImpactModel[2];                       // 31-32
+        float cameraYawOffset;                              // 33
+        uint32_t uiLocomotionType;                            // 34
+        float msslTrgtImpactTexRadius;                      // 35
+        uint32_t uiSeatIndicatorType;                         // 36
+        uint32_t powerType;                                   // 37, new in 3.1
+        //uint32_t unk1;                                      // 38
+        //uint32_t unk2;                                      // 39
+    };
+
+    enum VehicleSeatFlags
+    {
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+    };
+
+    enum VehicleSeatFlagsB
+    {
+        VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
+    };
+
+    struct VehicleSeatEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        int32_t attachmentID;                                 // 2
+        float attachmentOffsetX;                            // 3
+        float attachmentOffsetY;                            // 4
+        float attachmentOffsetZ;                            // 5
+        float enterPreDelay;                                // 6
+        float enterSpeed;                                   // 7
+        float enterGravity;                                 // 8
+        float enterMinDuration;                             // 9
+        float enterMaxDuration;                             // 10
+        float enterMinArcHeight;                            // 11
+        float enterMaxArcHeight;                            // 12
+        int32_t enterAnimStart;                               // 13
+        int32_t enterAnimLoop;                                // 14
+        int32_t rideAnimStart;                                // 15
+        int32_t rideAnimLoop;                                 // 16
+        int32_t rideUpperAnimStart;                           // 17
+        int32_t rideUpperAnimLoop;                            // 18
+        float exitPreDelay;                                 // 19
+        float exitSpeed;                                    // 20
+        float exitGravity;                                  // 21
+        float exitMinDuration;                              // 22
+        float exitMaxDuration;                              // 23
+        float exitMinArcHeight;                             // 24
+        float exitMaxArcHeight;                             // 25
+        int32_t exitAnimStart;                                // 26
+        int32_t exitAnimLoop;                                 // 27
+        int32_t exitAnimEnd;                                  // 28
+        float passengerYaw;                                 // 29
+        float passengerPitch;                               // 30
+        float passengerRoll;                                // 31
+        int32_t passengerAttachmentID;                        // 32
+        int32_t vehicleEnterAnim;                             // 33
+        int32_t vehicleExitAnim;                              // 34
+        int32_t vehicleRideAnimLoop;                          // 35
+        int32_t vehicleEnterAnimBone;                         // 36
+        int32_t vehicleExitAnimBone;                          // 37
+        int32_t vehicleRideAnimLoopBone;                      // 38
+        float vehicleEnterAnimDelay;                        // 39
+        float vehicleExitAnimDelay;                         // 40
+        uint32_t vehicleAbilityDisplay;                       // 41
+        uint32_t enterUISoundID;                              // 42
+        uint32_t exitUISoundID;                               // 43
+        int32_t uiSkin;                                       // 44
+        uint32_t flagsB;                                      // 45
+
+        bool IsUsable() const
         {
-            uint32_t ID;              // 0
-            char* subject;          // 1
-            //float unused1[15]     // 2-16
-            //uint32_t flags1         // 17 name flags, unused
-            char* content;          // 18
-            //float unused2[15]     // 19-34
-            //uint32_t flags2         // 35 name flags, unused
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
+                return true;
+            else
+                return false;
+        }
 
-        struct MapEntry
+        bool IsController() const
         {
-            uint32_t id;                      // 0
-            //char* name_internal;          // 1
-            uint32_t map_type;                // 2
-            //uint32_t is_pvp_zone;           // 3 -0 false -1 true
-            char* map_name[16];             // 4-19
-            //uint32_t name_flags;            // 20
-            uint32_t linked_zone;             // 22 common zone for instance and continent map
-            //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-            //uint32_t hordeIntro_flags;      // 39
-            //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-            //uint32_t allianceIntro_flags;   // 56
-            uint32_t multimap_id;             // 57
-            //uint32_t battlefield_map_icon;  // 58
-            int32_t parent_map;               // 59 map_id of parent map
-            float start_x;                  // 60 enter x coordinate (if exist single entry)
-            float start_y;                  // 61 enter y coordinate (if exist single entry)
-            //uint32_t dayTime;               // 62
-            uint32_t reset_raid_time;
-            uint32_t reset_heroic_tim;
-            uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+            if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
+                return true;
+            else
+                return false;
+        }
 
-            bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
-            bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
-            bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isRaid() const { return map_type == MAP_RAID; }
-            bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
-            bool isBattleArena() const { return map_type == MAP_ARENA; }
-            bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isWorldMap() const { return map_type == MAP_COMMON; }
-
-            bool isContinent() const
-            {
-                return id == 0 || id == 1 || id == 530 || id == 571;
-            }
-        };
-
-        struct NameGenEntry
+        bool HidesPassenger() const
         {
-            uint32_t ID;              // 0
-            char* Name;             // 1
-            uint32_t unk1;            // 2
-            uint32_t type;            // 3
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
+                return true;
+            else
+                return false;
+        }
+    };
 
-        struct SkillLineEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t type;                // 1
-            uint32_t skillCostsID;      // 2
-            char* Name[16];             // 3-18
-            //uint32_t NameFlags;         // 19
-            //char* Description[16];    // 20-35
-            //uint32_t DescriptionFlags;  // 36
-            uint32_t spell_icon;          // 37
-        };
+    struct WMOAreaTableEntry
+    {
+        uint32_t id;              // 0
+        int32_t rootId;           // 1
+        int32_t adtId;            // 2
+        int32_t groupId;          // 3
+        //uint32_t field4;        // 4
+        //uint32_t field5;        // 5
+        //uint32_t field6;        // 6
+        //uint32_t field7;        // 7
+        //uint32_t field8;        // 8
+        uint32_t flags;           // 9
+        uint32_t areaId;          // 10  ref -> AreaTableEntry
+        //char Name[16];        // 11-26
+        //uint32_t nameflags;     // 27
+    };
 
-        //"iiiiiiiiiiiiiii"
-        struct SkillLineAbilityEntry
-        {
-            uint32_t Id;                      // 0
-            uint32_t skilline;                // 1 skill id
-            uint32_t spell;                   // 2
-            uint32_t race_mask;               // 3
-            uint32_t class_mask;              // 4
-            uint32_t excludeRace;           // 5
-            uint32_t excludeClass;          // 6
-            uint32_t minSkillLineRank;        // 7 req skill value
-            uint32_t next;                    // 8
-            uint32_t acquireMethod;           // 9 auto learn
-            uint32_t grey;                    // 10 max
-            uint32_t green;                   // 11 min
-            uint32_t abandonable;           // 12
-            uint32_t reqTP;                 // 13
-            uint32_t reqtrainpoints;          // 14
-        };
+    struct WorldMapAreaEntry
+    {
+        //uint32_t id;              // 0
+        uint32_t mapId;             // 1
+        uint32_t zoneId;            // 2
+        //char const* name;         // 3
+        //float y1;                 // 4
+        //float y2;                 // 5
+        //float x1;                 // 6
+        //float x2;                 // 7
+        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+    };
 
-        struct StableSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
+    struct WorldMapOverlayEntry
+    {
+        uint32_t ID;              // 0
+        //uint32_t worldMapID;    // 1
+        uint32_t areaID;          // 2 - index to AreaTable
+        uint32_t areaID_2;        // 3 - index to AreaTable
+        uint32_t areaID_3;        // 4 - index to AreaTable
+        uint32_t areaID_4;        // 5 - index to AreaTable
+        //uint32_t unk1[2];       // 6-7
+        //uint32_t unk2;          // 8
+        //uint32_t unk3[7];       // 9-16
+    };
 
-        struct SpellCastTimesEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t CastTime;        // 1
-            //uint32_t unk1;          // 2
-            //uint32_t unk2;          // 3
-        };
-
-        struct SpellDurationEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t Duration1;       // 1
-            uint32_t Duration2;       // 2
-            uint32_t Duration3;       // 3
-        };
-
-        #define MAX_SPELL_EFFECTS 3
-        #define MAX_SPELL_REAGENTS 8
-        #define MAX_SPELL_TOTEMS 2
-        #define MAX_SPELL_TOTEM_CATEGORIES 2
-
-        struct SpellEntry
-        {
-            uint32_t Id;                                                // 0
-            uint32_t Category;                                          // 1
-            //uint32_t castUI;                                          // 2 not used
-            uint32_t DispelType;                                        // 3
-            uint32_t MechanicsType;                                     // 4
-            uint32_t Attributes;                                        // 5
-            uint32_t AttributesEx;                                      // 6
-            uint32_t AttributesExB;                                     // 7
-            uint32_t AttributesExC;                                     // 8
-            uint32_t AttributesExD;                                     // 9
-            uint32_t AttributesExE;                                     // 10
-            uint32_t AttributesExF;                                     // 11
-            uint32_t Shapeshifts;                                       // 12
-            uint32_t ShapeshiftsExcluded;                               // 13
-            uint32_t Targets;                                           // 14
-            uint32_t TargetCreatureType;                                // 15
-            uint32_t RequiresSpellFocus;                                // 16
-            uint32_t FacingCasterFlags;                                 // 17
-            uint32_t CasterAuraState;                                   // 18
-            uint32_t TargetAuraState;                                   // 19
-            uint32_t CasterAuraStateNot;                                // 20
-            uint32_t TargetAuraStateNot;                                // 21
-            uint32_t CastingTimeIndex;                                  // 22
-            uint32_t RecoveryTime;                                      // 23
-            uint32_t CategoryRecoveryTime;                              // 24
-            uint32_t InterruptFlags;                                    // 25
-            uint32_t AuraInterruptFlags;                                // 26
-            uint32_t ChannelInterruptFlags;                             // 27
-            uint32_t procFlags;                                         // 28
-            uint32_t procChance;                                        // 29
-            uint32_t procCharges;                                       // 30
-            uint32_t maxLevel;                                          // 31
-            uint32_t baseLevel;                                         // 32
-            uint32_t spellLevel;                                        // 33
-            uint32_t DurationIndex;                                     // 34
-            int32_t powerType;                                          // 35
-            uint32_t manaCost;                                          // 36
-            uint32_t manaCostPerlevel;                                  // 37
-            uint32_t manaPerSecond;                                     // 38
-            uint32_t manaPerSecondPerLevel;                             // 39
-            uint32_t rangeIndex;                                        // 40
-            float speed;                                                // 41
-            //uint32_t modalNextSpell;                                  // 42 not used
-            uint32_t MaxStackAmount;                                    // 43
-            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 44 - 45
-            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 46 - 53
-            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 54 - 61
-            int32_t EquippedItemClass;                                  // 62
-            int32_t EquippedItemSubClass;                               // 63
-            int32_t EquippedItemInventoryTypeMask;                      // 64
-            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 65 - 67
-            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 68 - 70
-            uint32_t EffectBaseDice[MAX_SPELL_EFFECTS];                 // 71 - 73
-            float EffectDicePerLevel[MAX_SPELL_EFFECTS];                // 74 - 76
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
-            int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
-            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
-            uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
-            uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
-            uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
-            uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
-            uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
-            uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
-            uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109
-            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
-            int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
-            uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
-            uint32_t SpellVisual;                                       // 122
-            uint32_t SpellVisual1;                                      // 123
-            uint32_t spellIconID;                                       // 124
-            uint32_t activeIconID;                                      // 125 activeIconID;
-            uint32_t spellPriority;                                     // 126
-            const char* Name[16];                                       // 127 - 142
-            //uint32_t NameFlags;                                       // 143 not used
-            const char* Rank[16];                                       // 144 - 159
-            //uint32_t RankFlags;                                       // 160 not used
-            //const char* Description[16];                              // 161 - 176 not used
-            //uint32_t DescriptionFlags;                                // 177 not used
-            //const char* BuffDescription[16];                          // 178 - 193 not used
-            //uint32_t buffdescflags;                                   // 194 not used
-            uint32_t ManaCostPercentage;                                // 195
-            uint32_t StartRecoveryCategory;                             // 196
-            uint32_t StartRecoveryTime;                                 // 197
-            uint32_t MaxTargetLevel;                                    // 198
-            uint32_t SpellFamilyName;                                   // 199
-            uint32_t SpellFamilyFlags[2];                               // 200 - 201
-            uint32_t MaxTargets;                                        // 202
-            uint32_t DmgClass;                                          // 203
-            uint32_t PreventionType;                                    // 204
-            //int32_t StanceBarOrder;                                   // 205 not used
-            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 206 - 208
-            //uint32_t MinFactionID;                                    // 209 not used
-            //uint32_t MinReputation;                                   // 210 not used
-            //uint32_t RequiredAuraVision;                              // 211 not used
-            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 212 - 213
-            int32_t AreaGroupId;                                        // 214
-            uint32_t School;                                            // 215
-        };
-
-        struct SpellItemEnchantmentEntry
-        {
-            uint32_t Id;                  // 0
-            uint32_t type[3];             // 1-3
-            uint32_t min[3];              // 4-6 for combat, in practice min==max
-            uint32_t max[3];              // 7-9
-            uint32_t spell[3];            // 10-12
-            char* Name;                   // 13
-            //uint32_t NameAlt[16]       // 14-29
-            uint32_t visual;              // 30 aura
-            uint32_t EnchantGroups;       // 31 slot
-            uint32_t GemEntry;            // 32
-            uint32_t ench_condition;      // 33
-        };
-
-        struct SpellRadiusEntry
-        {
-            uint32_t ID;                  // 0
-            float radius_min;           // 1 Radius
-            float radius_per_level;     // 2
-            float radius_max;           // 3 Radius2
-        };
-
-        struct SpellRangeEntry
-        {
-            uint32_t ID;                  // 0
-            float minRange;             // 1
-            float maxRange;             // 3
-            uint32_t range_type;          // 4
-            //char* name1[16]           // 6-21
-            //uint32_t name1_falgs;       // 22
-            //char* name2[16]           // 23-38
-            //uint32_t name2_falgs;       // 39
-        };
-
-        struct SpellShapeshiftFormEntry
-        {
-            uint32_t id;                  // 0
-            //uint32_t button_pos;        // 1
-            //char* name[16];           // 2-17
-            //uint32_t name_flags;        // 18
-            uint32_t Flags;               // 19
-            uint32_t unit_type;           // 20
-            //uint32_t unk1               // 21
-            uint32_t AttackSpeed;         // 22
-            uint32_t modelId;             // 23 alliance?
-            uint32_t modelId2;            // 24 horde?
-            //uint32_t unk2               // 25
-            //uint32_t unk3               // 26
-            uint32_t spells[8];           // 27-34
-        };
-
-        struct SummonPropertiesEntry
-        {
-            uint32_t ID;                  // 0
-            uint32_t ControlType;         // 1
-            uint32_t FactionID;           // 2
-            uint32_t Type;                // 3
-            uint32_t Slot;                // 4
-            uint32_t Flags;               // 5
-        };
-
-        struct TalentEntry
-        {
-            uint32_t TalentID;            // 0
-            uint32_t TalentTree;          // 1
-            uint32_t Row;                 // 2
-            uint32_t Col;                 // 3
-            uint32_t RankID[5];           // 4-8
-            //uint32_t unk[4];            // 9-12
-            uint32_t DependsOn;           // 13
-            //uint32_t unk1[2];           // 14-15
-            uint32_t DependsOnRank;       // 16
-            //uint32_t unk2[2];           // 17-18
-            //uint32_t unk3;              // 19
-            uint32_t DependsOnSpell;      // 20
-        };
-
-        struct TalentTabEntry
-        {
-            uint32_t TalentTabID;         // 0
-            //char* Name[16];           // 1-16
-            //uint32_t name_flags;        // 17
-            //uint32_t unk4;              // 18
-            //uint32_t unk5;              // 19
-            uint32_t ClassMask;           // 20
-            uint32_t TabPage;             // 21
-            //char* InternalName;       // 22
-        };
-
-        struct TaxiNodesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t mapid;               // 1
-            float x;                    // 2
-            float y;                    // 3
-            float z;                    // 4
-            char* name[16];             // 5-21
-            //uint32_t nameflags;         // 22
-            uint32_t horde_mount;         // 23
-            uint32_t alliance_mount;      // 24
-        };
-
-        struct TaxiPathEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t from;                // 1
-            uint32_t to;                  // 2
-            uint32_t price;               // 3
-        };
-
-        struct TaxiPathNodeEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t path;                // 1
-            uint32_t seq;                 // 2 nodeIndex
-            uint32_t mapid;               // 3
-            float x;                      // 4
-            float y;                      // 5
-            float z;                      // 6
-            uint32_t flags;               // 7
-            uint32_t waittime;            // 8
-            uint32_t arivalEventID;       // 9
-            uint32_t departureEventID;    // 10
-        };
-
-        struct TotemCategoryEntry
-        {
-            uint32_t id;            // 0
-            //char* name[16];       // 1-16
-            //uint32_t unk;         // 17
-            uint32_t categoryType;  // 18
-            uint32_t categoryMask;  // 19
-        };
-
-        struct TransportAnimationEntry
-        {
-            //uint32_t Id;          // 0
-            uint32_t TransportID;   // 1
-            uint32_t TimeIndex;     // 2
-            DBCPosition3D Pos;      // 3
-            //uint32_t SequenceID;  // 4
-        };
-
-        #define MAX_VEHICLE_SEATS 8
-
-        struct VehicleEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            float turnSpeed;                                    // 2
-            float pitchSpeed;                                   // 3
-            float pitchMin;                                     // 4
-            float pitchMax;                                     // 5
-            uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-            float mouseLookOffsetPitch;                         // 14
-            float cameraFadeDistScalarMin;                      // 15
-            float cameraFadeDistScalarMax;                      // 16
-            float cameraPitchOffset;                            // 17
-            float facingLimitRight;                             // 18
-            float facingLimitLeft;                              // 19
-            float msslTrgtTurnLingering;                        // 20
-            float msslTrgtPitchLingering;                       // 21
-            float msslTrgtMouseLingering;                       // 22
-            float msslTrgtEndOpacity;                           // 23
-            float msslTrgtArcSpeed;                             // 24
-            float msslTrgtArcRepeat;                            // 25
-            float msslTrgtArcWidth;                             // 26
-            float msslTrgtImpactRadius[2];                      // 27-28
-            char* msslTrgtArcTexture;                           // 29
-            char* msslTrgtImpactTexture;                        // 30
-            char* msslTrgtImpactModel[2];                       // 31-32
-            float cameraYawOffset;                              // 33
-            uint32_t uiLocomotionType;                            // 34
-            float msslTrgtImpactTexRadius;                      // 35
-            uint32_t uiSeatIndicatorType;                         // 36
-            uint32_t powerType;                                   // 37, new in 3.1
-            //uint32_t unk1;                                      // 38
-            //uint32_t unk2;                                      // 39
-        };
-
-        enum VehicleSeatFlags
-        {
-            VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
-            VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-            VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-            VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-            VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-            VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-            VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
-        };
-
-        enum VehicleSeatFlagsB
-        {
-            VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
-        };
-
-        struct VehicleSeatEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            int32_t attachmentID;                                 // 2
-            float attachmentOffsetX;                            // 3
-            float attachmentOffsetY;                            // 4
-            float attachmentOffsetZ;                            // 5
-            float enterPreDelay;                                // 6
-            float enterSpeed;                                   // 7
-            float enterGravity;                                 // 8
-            float enterMinDuration;                             // 9
-            float enterMaxDuration;                             // 10
-            float enterMinArcHeight;                            // 11
-            float enterMaxArcHeight;                            // 12
-            int32_t enterAnimStart;                               // 13
-            int32_t enterAnimLoop;                                // 14
-            int32_t rideAnimStart;                                // 15
-            int32_t rideAnimLoop;                                 // 16
-            int32_t rideUpperAnimStart;                           // 17
-            int32_t rideUpperAnimLoop;                            // 18
-            float exitPreDelay;                                 // 19
-            float exitSpeed;                                    // 20
-            float exitGravity;                                  // 21
-            float exitMinDuration;                              // 22
-            float exitMaxDuration;                              // 23
-            float exitMinArcHeight;                             // 24
-            float exitMaxArcHeight;                             // 25
-            int32_t exitAnimStart;                                // 26
-            int32_t exitAnimLoop;                                 // 27
-            int32_t exitAnimEnd;                                  // 28
-            float passengerYaw;                                 // 29
-            float passengerPitch;                               // 30
-            float passengerRoll;                                // 31
-            int32_t passengerAttachmentID;                        // 32
-            int32_t vehicleEnterAnim;                             // 33
-            int32_t vehicleExitAnim;                              // 34
-            int32_t vehicleRideAnimLoop;                          // 35
-            int32_t vehicleEnterAnimBone;                         // 36
-            int32_t vehicleExitAnimBone;                          // 37
-            int32_t vehicleRideAnimLoopBone;                      // 38
-            float vehicleEnterAnimDelay;                        // 39
-            float vehicleExitAnimDelay;                         // 40
-            uint32_t vehicleAbilityDisplay;                       // 41
-            uint32_t enterUISoundID;                              // 42
-            uint32_t exitUISoundID;                               // 43
-            int32_t uiSkin;                                       // 44
-            uint32_t flagsB;                                      // 45
-
-            bool IsUsable() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool IsController() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool HidesPassenger() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
-                    return true;
-                else
-                    return false;
-            }
-        };
-
-        struct WMOAreaTableEntry
-        {
-            uint32_t id;              // 0
-            int32_t rootId;           // 1
-            int32_t adtId;            // 2
-            int32_t groupId;          // 3
-            //uint32_t field4;        // 4
-            //uint32_t field5;        // 5
-            //uint32_t field6;        // 6
-            //uint32_t field7;        // 7
-            //uint32_t field8;        // 8
-            uint32_t flags;           // 9
-            uint32_t areaId;          // 10  ref -> AreaTableEntry
-            //char Name[16];        // 11-26
-            //uint32_t nameflags;     // 27
-        };
-
-        struct WorldMapAreaEntry
-        {
-            //uint32_t id;              // 0
-            uint32_t mapId;             // 1
-            uint32_t zoneId;            // 2
-            //char const* name;         // 3
-            //float y1;                 // 4
-            //float y2;                 // 5
-            //float x1;                 // 6
-            //float x2;                 // 7
-            int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-        };
-
-        struct WorldMapOverlayEntry
-        {
-            uint32_t ID;              // 0
-            //uint32_t worldMapID;    // 1
-            uint32_t areaID;          // 2 - index to AreaTable
-            uint32_t areaID_2;        // 3 - index to AreaTable
-            uint32_t areaID_3;        // 4 - index to AreaTable
-            uint32_t areaID_4;        // 5 - index to AreaTable
-            //uint32_t unk1[2];       // 6-7
-            //uint32_t unk2;          // 8
-            //uint32_t unk3[7];       // 9-16
-        };
-
-        #pragma pack(pop)
-    }
+    #pragma pack(pop)
 }

--- a/src/world/GameTBC/Storage/DBCStructures.h
+++ b/src/world/GameTBC/Storage/DBCStructures.h
@@ -163,7 +163,7 @@ namespace DBC::Structures
         uint32_t Price;                                             // 1
     };
 
-    #define OUTFIT_ITEMS 12
+#define OUTFIT_ITEMS 12
 
     struct CharStartOutfitEntry
     {
@@ -616,10 +616,10 @@ namespace DBC::Structures
         uint32_t Duration3;                                         // 3
     };
 
-    #define MAX_SPELL_EFFECTS 3
-    #define MAX_SPELL_REAGENTS 8
-    #define MAX_SPELL_TOTEMS 2
-    #define MAX_SPELL_TOTEM_CATEGORIES 2
+#define MAX_SPELL_EFFECTS 3
+#define MAX_SPELL_REAGENTS 8
+#define MAX_SPELL_TOTEMS 2
+#define MAX_SPELL_TOTEM_CATEGORIES 2
 
     struct SpellEntry
     {
@@ -868,7 +868,7 @@ namespace DBC::Structures
         //uint32_t SequenceID;                                      // 4
     };
 
-    #define MAX_VEHICLE_SEATS 8
+#define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {

--- a/src/world/GameWotLK/Storage/DBCStructures.h
+++ b/src/world/GameWotLK/Storage/DBCStructures.h
@@ -586,7 +586,7 @@ namespace DBC::Structures
         float x;                                                    // 2
         float y;                                                    // 3
         float z;                                                    // 4
-        float o;                                                    // 5 radius?
+        float box_radius;                                           // 5 radius
         float box_x;                                                // 6 extent x edge
         float box_y;                                                // 7 extent y edge
         float box_z;                                                // 8 extent z edge

--- a/src/world/GameWotLK/Storage/DBCStructures.h
+++ b/src/world/GameWotLK/Storage/DBCStructures.h
@@ -31,1644 +31,1641 @@ struct DBCPosition3D
 
 enum MapTypes
 {
-    MAP_COMMON = 0,                                // none
-    MAP_INSTANCE = 1,                                // party
-    MAP_RAID = 2,                                // raid
-    MAP_BATTLEGROUND = 3,                                // pvp
-    MAP_ARENA = 4                                 // arena
+    MAP_COMMON = 0,             // none
+    MAP_INSTANCE = 1,           // party
+    MAP_RAID = 2,               // raid
+    MAP_BATTLEGROUND = 3,       // pvp
+    MAP_ARENA = 4               // arena
 };
 
-namespace DBC
+namespace DBC::Structures
 {
-    namespace Structures
+    namespace
     {
-        namespace
-        {
-            char const achievement_format[] = "niixssssssssssssssssxssssssssssssssssxiixixssssssssssssssssxii";
-            char const achievement_criteria_format[] = "niiiiiiiissssssssssssssssxiiiii";
-            char const area_group_format[] = "niiiiiii";
-            char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixxx";
-            char const area_trigger_entry_format[] = "niffffffff";
-            char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
-            char const bank_bag_slot_prices_format[] = "ni";
-            char const barber_shop_style_entry_format[] = "nixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiii";
-            char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
-            char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const chr_classes_format[] = "nxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixii";
-            char const chr_races_format[] = "niixiixixxxxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxi";
-            char const creature_display_info_format[] = "nxxxxxxxxxxxxxxx";
-            char const creature_family_format[] = "nfifiiiiixssssssssssssssssxx";
-            char const creature_spell_data_format[] = "niiiiiiii";
-            char const currency_types_format[] = "xnxi";
-            char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-            char const durability_quality_format[] = "nf";
-            char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
-            char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixssssssssssssssssxxxxxxxxxxxxxxxxxx";
-            char const faction_template_format[] = "niiiiiiiiiiiii";
-            char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffx";
-            char const gem_properties_format[] = "nixxi";
-            char const glyph_properties_format[] = "niii";
-            char const glyph_slot_format[] = "nii";
-            char const gt_barber_shop_cost_format[] = "f";
-            char const gt_chance_to_melee_crit_format[] = "f";
-            char const gt_chance_to_melee_crit_base_format[] = "f";
-            char const gt_chance_to_spell_crit_format[] = "f";
-            char const gt_chance_to_spell_crit_base_format[] = "f";
-            char const gt_combat_ratings_format[] = "f";
-            char const gt_oct_regen_hp_format[] = "f";
-            char const gt_oct_regen_mp_format[] = "f";
-            char const gt_regen_hp_per_spt_format[] = "f";
-            char const gt_regen_mp_per_spt_format[] = "f";
-            char const holidays_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiixxsiix";
-            char const item_entry_format[] = "niiiiiii";
-            char const item_extended_cost_format[] = "niiiiiiiiiiiiiix";
-            char const item_limit_category_format[] = "nxxxxxxxxxxxxxxxxxii";
-            char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
-            char const item_random_suffix_format[] = "nssssssssssssssssxxiiixxiiixx";
-            char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
-            char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
-            char const dungeon_encounter_format[] = "niixissssssssssssssssxx";
-            char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
-            char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
-            char const map_format[] = "nxiixssssssssssssssssxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixiffxiii";
-            char const name_gen_format[] = "nsii";
-            char const quest_xp_format[] = "niiiiiiiiii";
-            char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiii";
-            char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiiii";
-            char const skill_line_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxi";
-            char const skill_line_ability_format[] = "niiiixxiiiiixx";
-            char const stable_slot_prices_format[] = "ni";
-            char const spell_cast_times_format[] = "nixx";
-            char const spell_difficulty_format[] = "niiii";
-            char const spell_duration_format[] = "niii";
-            char const spell_entry_format[] = "niiiiiiiiiiiixixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiifffiiiiiiiiiiiiiissssssssssssssssxssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiiixfffxxxiiiiixxfffxi";
-            char const spell_item_enchantment_format[] = "nxiiiiiiiiiiiissssssssssssssssxiiiiiii";
-            char const spell_radius_format[] = "nfff";
-            char const spell_range_format[] = "nffffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-            char const spell_rune_cost_format[] = "niiii";
-            char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
-            char const summon_properties_format[] = "niiiii";
-            char const talent_format[] = "niiiiiiiixxxxixxixxxxxx";
-            char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiiix";
-            char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
-            char const taxi_path_format[] = "niii";
-            char const taxi_path_node_format[] = "niiifffiiii";
-            char const totem_category_format[] = "nxxxxxxxxxxxxxxxxxii";
-            char const transport_animation_format[] = "diifffx";
-            char const transport_rotation_format[] = "diiffff";
-            char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
-            char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
-            char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
-            char const world_map_area_entry_format[] = "xinxxxxxixx";
-            char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
-        }
+        char const achievement_format[] = "niixssssssssssssssssxssssssssssssssssxiixixssssssssssssssssxii";
+        char const achievement_criteria_format[] = "niiiiiiiissssssssssssssssxiiiii";
+        char const area_group_format[] = "niiiiiii";
+        char const area_table_entry_format[] = "iiinixxxxxissssssssssssssssxiiiiixxx";
+        char const area_trigger_entry_format[] = "niffffffff";
+        char const auction_house_format[] = "niiixxxxxxxxxxxxxxxxx";
+        char const bank_bag_slot_prices_format[] = "ni";
+        char const barber_shop_style_entry_format[] = "nixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiii";
+        char const char_start_outfit_format[] = "dbbbXiiiiiiiiiiiiiiiiiiiiiiiixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const char_titles_format[] = "nxssssssssssssssssxssssssssssssssssxi";
+        char const chat_channels_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const chr_classes_format[] = "nxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixii";
+        char const chr_races_format[] = "niixiixixxxxixssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxi";
+        char const creature_display_info_format[] = "nxxxxxxxxxxxxxxx";
+        char const creature_family_format[] = "nfifiiiiixssssssssssssssssxx";
+        char const creature_spell_data_format[] = "niiiiiiii";
+        char const currency_types_format[] = "xnxi";
+        char const durability_costs_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+        char const durability_quality_format[] = "nf";
+        char const emotes_text_format[] = "nxiiiixixixxxxxxxxx";
+        char const faction_format[] = "niiiiiiiiiiiiiiiiiiffixssssssssssssssssxxxxxxxxxxxxxxxxxx";
+        char const faction_template_format[] = "niiiiiiiiiiiii";
+        char const game_object_display_info_format[] = "nsxxxxxxxxxxffffffx";
+        char const gem_properties_format[] = "nixxi";
+        char const glyph_properties_format[] = "niii";
+        char const glyph_slot_format[] = "nii";
+        char const gt_barber_shop_cost_format[] = "f";
+        char const gt_chance_to_melee_crit_format[] = "f";
+        char const gt_chance_to_melee_crit_base_format[] = "f";
+        char const gt_chance_to_spell_crit_format[] = "f";
+        char const gt_chance_to_spell_crit_base_format[] = "f";
+        char const gt_combat_ratings_format[] = "f";
+        char const gt_oct_regen_hp_format[] = "f";
+        char const gt_oct_regen_mp_format[] = "f";
+        char const gt_regen_hp_per_spt_format[] = "f";
+        char const gt_regen_mp_per_spt_format[] = "f";
+        char const holidays_format[] = "niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiixxsiix";
+        char const item_entry_format[] = "niiiiiii";
+        char const item_extended_cost_format[] = "niiiiiiiiiiiiiix";
+        char const item_limit_category_format[] = "nxxxxxxxxxxxxxxxxxii";
+        char const item_random_properties_format[] = "nxiiixxssssssssssssssssx";
+        char const item_random_suffix_format[] = "nssssssssssssssssxxiiixxiiixx";
+        char const item_set_format[] = "nssssssssssssssssxiiiiiiiiiixxxxxxxiiiiiiiiiiiiiiiiii";
+        char const lfg_dungeon_entry_format[] = "nssssssssssssssssxiiiiiiiiixxixixxxxxxxxxxxxxxxxx";
+        char const dungeon_encounter_format[] = "niixissssssssssssssssxx";
+        char const liquid_type_entry_format[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const lock_format[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
+        char const mail_template_format[] = "nsxxxxxxxxxxxxxxxxsxxxxxxxxxxxxxxxx";
+        char const map_format[] = "nxiixssssssssssssssssxixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxixiffxiii";
+        char const name_gen_format[] = "nsii";
+        char const quest_xp_format[] = "niiiiiiiiii";
+        char const scaling_stat_distribution_format[] = "niiiiiiiiiiiiiiiiiiiii";
+        char const scaling_stat_values_format[] = "iniiiiiiiiiiiiiiiiiiiiii";
+        char const skill_line_format[] = "nixssssssssssssssssxxxxxxxxxxxxxxxxxxixxxxxxxxxxxxxxxxxi";
+        char const skill_line_ability_format[] = "niiiixxiiiiixx";
+        char const stable_slot_prices_format[] = "ni";
+        char const spell_cast_times_format[] = "nixx";
+        char const spell_difficulty_format[] = "niiii";
+        char const spell_duration_format[] = "niii";
+        char const spell_entry_format[] = "niiiiiiiiiiiixixiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifxiiiiiiiiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiiiiiiiifffiiiiiiiiiiiiiiifffiiiiiiiiiiiiiissssssssssssssssxssssssssssssssssxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiiixfffxxxiiiiixxfffxi";
+        char const spell_item_enchantment_format[] = "nxiiiiiiiiiiiissssssssssssssssxiiiiiii";
+        char const spell_radius_format[] = "nfff";
+        char const spell_range_format[] = "nffffixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        char const spell_rune_cost_format[] = "niiii";
+        char const spell_shapeshift_form_format[] = "nxxxxxxxxxxxxxxxxxxiixiiixxiiiiiiii";
+        char const summon_properties_format[] = "niiiii";
+        char const talent_format[] = "niiiiiiiixxxxixxixxxxxx";
+        char const talent_tab_format[] = "nxxxxxxxxxxxxxxxxxxxiiix";
+        char const taxi_nodes_format[] = "nifffssssssssssssssssxii";
+        char const taxi_path_format[] = "niii";
+        char const taxi_path_node_format[] = "niiifffiiii";
+        char const totem_category_format[] = "nxxxxxxxxxxxxxxxxxii";
+        char const transport_animation_format[] = "diifffx";
+        char const transport_rotation_format[] = "diiffff";
+        char const vehicle_format[] = "niffffiiiiiiiifffffffffffffffssssfifiixx";
+        char const vehicle_seat_format[] = "niiffffffffffiiiiiifffffffiiifffiiiiiiiffiiiiixxxxxxxxxxxx";
+        char const wmo_area_table_format[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
+        char const world_map_area_entry_format[] = "xinxxxxxixx";
+        char const world_map_overlay_format[] = "nxiiiixxxxxxxxxxx";
+    }
 
-        #pragma pack(push, 1)
-        struct AchievementCategoryEntry
-        {
-            uint32_t ID;                 // 0
-            uint32_t parentCategory;     // 1 -1 for main category
-            const char* name;          // 2-17
-            uint32_t name_flags;         // 18
-            uint32_t sortOrder;          // 19
-        };
+    #pragma pack(push, 1)
+    struct AchievementCategoryEntry
+    {
+        uint32_t ID;                 // 0
+        uint32_t parentCategory;     // 1 -1 for main category
+        const char* name;          // 2-17
+        uint32_t name_flags;         // 18
+        uint32_t sortOrder;          // 19
+    };
 
-        struct AchievementCriteriaEntry
+    struct AchievementCriteriaEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t referredAchievement;     // 1
+        uint32_t requiredType;            // 2
+        union
         {
-            uint32_t ID;                      // 0
-            uint32_t referredAchievement;     // 1
-            uint32_t requiredType;            // 2
-            union
+            // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
+            ///\todo also used for player deaths..
+            struct
             {
-                // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
-                ///\todo also used for player deaths..
-                struct
-                {
-                    uint32_t creatureID;                             // 3
-                    uint32_t creatureCount;                          // 4
-                } kill_creature;
+                uint32_t creatureID;                             // 3
+                uint32_t creatureCount;                          // 4
+            } kill_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
-                ///\todo there are further criterias instead just winning
-                struct
-                {
-                    uint32_t bgMapID;                                // 3
-                    uint32_t winCount;                               // 4
-                } win_bg;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
+            ///\todo there are further criterias instead just winning
+            struct
+            {
+                uint32_t bgMapID;                                // 3
+                uint32_t winCount;                               // 4
+            } win_bg;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t level;                                  // 4
-                } reach_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t level;                                  // 4
+            } reach_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4
-                } reach_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4
+            } reach_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
-                struct
-                {
-                    uint32_t linkedAchievement;                      // 3
-                } complete_achievement;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
+            struct
+            {
+                uint32_t linkedAchievement;                      // 3
+            } complete_achievement;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t totalQuestCount;                        // 4
-                } complete_quest_count;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t totalQuestCount;                        // 4
+            } complete_quest_count;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfDays;                           // 4
-                } complete_daily_quest_daily;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfDays;                           // 4
+            } complete_daily_quest_daily;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
-                struct
-                {
-                    uint32_t zoneID;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_quests_in_zone;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
+            struct
+            {
+                uint32_t zoneID;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_quests_in_zone;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t questCount;                             // 4
-                } complete_daily_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t questCount;                             // 4
+            } complete_daily_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } complete_battleground;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } complete_battleground;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
-                struct
-                {
-                    uint32_t mapID;                                  // 3
-                } death_at_map;
+            // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
+            struct
+            {
+                uint32_t mapID;                                  // 3
+            } death_at_map;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
-                struct
-                {
-                    uint32_t groupSize;                              // 3 can be 5, 10 or 25
-                } complete_raid;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
+            struct
+            {
+                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+            } complete_raid;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
-                struct
-                {
-                    uint32_t creatureEntry;                          // 3
-                } killed_by_creature;
+            // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
+            struct
+            {
+                uint32_t creatureEntry;                          // 3
+            } killed_by_creature;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t fallHeight;                             // 4
-                } fall_without_dying;
+            // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t fallHeight;                             // 4
+            } fall_without_dying;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
-                struct
-                {
-                    uint32_t questID;                                // 3
-                    uint32_t questCount;                             // 4
-                } complete_quest;
+            // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
+            struct
+            {
+                uint32_t questID;                                // 3
+                uint32_t questCount;                             // 4
+            } complete_quest;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
-                // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t spellCount;                             // 4
-                } be_spell_target;
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
+            // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t spellCount;                             // 4
+            } be_spell_target;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
-                struct
-                {
-                    uint32_t spellID;                                // 3
-                    uint32_t castCount;                              // 4
-                } cast_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
+            struct
+            {
+                uint32_t spellID;                                // 3
+                uint32_t castCount;                              // 4
+            } cast_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
-                struct
-                {
-                    uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                    uint32_t killCount;                              // 4
-                } honorable_kill_at_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
+            struct
+            {
+                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                              // 4
+            } honorable_kill_at_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } win_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } win_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
-                struct
-                {
-                    uint32_t mapID;                                  // 3 Reference to Map.dbc
-                } play_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
+            struct
+            {
+                uint32_t mapID;                                  // 3 Reference to Map.dbc
+            } play_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
-                struct
-                {
-                    uint32_t spellID;                                // 3 Reference to Map.dbc
-                } learn_spell;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
+            struct
+            {
+                uint32_t spellID;                                // 3 Reference to Map.dbc
+            } learn_spell;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } own_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } own_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 4=in a row
-                } win_rated_arena;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 4=in a row
+            } win_rated_arena;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                } highest_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+            } highest_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
-                struct
-                {
-                    uint32_t teamtype;                               // 3 {2,3,5}
-                    uint32_t teamrating;                             // 4
-                } reach_team_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
+            struct
+            {
+                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamrating;                             // 4
+            } reach_team_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
-                struct
-                {
-                    uint32_t skillID;                                // 3
-                    uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
-                } learn_skill_level;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
+            struct
+            {
+                uint32_t skillID;                                // 3
+                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+            } learn_skill_level;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } use_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } use_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                    uint32_t itemCount;                              // 4
-                } loot_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
+            struct
+            {
+                uint32_t itemID;                                 // 3
+                uint32_t itemCount;                              // 4
+            } loot_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
-                struct
-                {
-                    uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
-                } explore_area;
+            // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
+            struct
+            {
+                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+            } explore_area;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
-                struct
-                {
-                    ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                    uint32_t rank;                                   // 3
-                } own_rank;
+            // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
+            struct
+            {
+                ///\todo This rank is _NOT_ the index from CharTitles.dbc
+                uint32_t rank;                                   // 3
+            } own_rank;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfSlots;                          // 4
-                } buy_bank_slot;
+            // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfSlots;                          // 4
+            } buy_bank_slot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
-                struct
-                {
-                    uint32_t factionID;                              // 3
-                    uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
-                } gain_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
+            struct
+            {
+                uint32_t factionID;                              // 3
+                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+            } gain_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t numberOfExaltedFactions;                // 4
-                } gain_exalted_reputation;
+            // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t numberOfExaltedFactions;                // 4
+            } gain_exalted_reputation;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
-                ///\todo where is the required itemlevel stored?
-                struct
-                {
-                    uint32_t itemSlot;                               // 3
-                } equip_epic_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
+            ///\todo where is the required itemlevel stored?
+            struct
+            {
+                uint32_t itemSlot;                               // 3
+            } equip_epic_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
-                struct
-                {
-                    uint32_t rollValue;                              // 3
-                    uint32_t count;                                  // 4
-                } roll_need_on_loot;
+            // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
+            struct
+            {
+                uint32_t rollValue;                              // 3
+                uint32_t count;                                  // 4
+            } roll_need_on_loot;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
-                struct
-                {
-                    uint32_t classID;                                // 3
-                    uint32_t count;                                  // 4
-                } hk_class;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
+            struct
+            {
+                uint32_t classID;                                // 3
+                uint32_t count;                                  // 4
+            } hk_class;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
-                struct
-                {
-                    uint32_t raceID;                                 // 3
-                    uint32_t count;                                  // 4
-                } hk_race;
+            // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
+            struct
+            {
+                uint32_t raceID;                                 // 3
+                uint32_t count;                                  // 4
+            } hk_race;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
-                ///\todo where is the information about the target stored?
-                struct
-                {
-                    uint32_t emoteID;                                // 3
-                } do_emote;
+            // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
+            ///\todo where is the information about the target stored?
+            struct
+            {
+                uint32_t emoteID;                                // 3
+            } do_emote;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t count;                                  // 4
-                    uint32_t flag;                                   // 5 =3 for battleground healing
-                    uint32_t mapid;                                  // 6
-                } healing_done;
+            // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t count;                                  // 4
+                uint32_t flag;                                   // 5 =3 for battleground healing
+                uint32_t mapid;                                  // 6
+            } healing_done;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
-                struct
-                {
-                    uint32_t itemID;                                 // 3
-                } equip_item;
+            // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
+            struct
+            {
+                uint32_t itemID;                                 // 3
+            } equip_item;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
-                struct
-                {
-                    uint32_t unknown;                                 // 3
-                    uint32_t goldInCopper;                            // 4
-                } quest_reward_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
+            struct
+            {
+                uint32_t unknown;                                 // 3
+                uint32_t goldInCopper;                            // 4
+            } quest_reward_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t goldInCopper;                           // 4
-                } loot_money;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t goldInCopper;                           // 4
+            } loot_money;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t useCount;                               // 4
-                } use_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t useCount;                               // 4
+            } use_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
-                ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } special_pvp_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
+            ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } special_pvp_kill;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
-                struct
-                {
-                    uint32_t goEntry;                                // 3
-                    uint32_t lootCount;                              // 4
-                } fish_in_gameobject;
+            // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
+            struct
+            {
+                uint32_t goEntry;                                // 3
+                uint32_t lootCount;                              // 4
+            } fish_in_gameobject;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
-                struct
-                {
-                    uint32_t unknown;                                // 3 777=?
-                    uint32_t mountCount;                             // 4
-                } number_of_mounts;
+            // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
+            struct
+            {
+                uint32_t unknown;                                // 3 777=?
+                uint32_t mountCount;                             // 4
+            } number_of_mounts;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t duelCount;                              // 4
-                } win_duel;
+            // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t duelCount;                              // 4
+            } win_duel;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
-                struct
-                {
-                    uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
-                } highest_power;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
+            struct
+            {
+                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+            } highest_power;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
-                struct
-                {
-                    uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
-                } highest_stat;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
+            struct
+            {
+                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+            } highest_stat;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
-                struct
-                {
-                    uint32_t spellSchool;                            // 3
-                } highest_spellpower;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
+            struct
+            {
+                uint32_t spellSchool;                            // 3
+            } highest_spellpower;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
-                struct
-                {
-                    uint32_t ratingType;                             // 3
-                } highest_rating;
+            // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
+            struct
+            {
+                uint32_t ratingType;                             // 3
+            } highest_rating;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
-                struct
-                {
-                    uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                    uint32_t lootTypeCount;                          // 4
-                } loot_type;
+            // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
+            struct
+            {
+                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                          // 4
+            } loot_type;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } cast_spell2;
+            // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } cast_spell2;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
-                struct
-                {
-                    uint32_t skillLine;                              // 3
-                    uint32_t spellCount;                             // 4
-                } learn_skill_line;
+            // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
+            struct
+            {
+                uint32_t skillLine;                              // 3
+                uint32_t spellCount;                             // 4
+            } learn_skill_line;
 
-                // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
-                struct
-                {
-                    uint32_t unused;                                 // 3
-                    uint32_t killCount;                              // 4
-                } honorable_kill;
+            // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
+            struct
+            {
+                uint32_t unused;                                 // 3
+                uint32_t killCount;                              // 4
+            } honorable_kill;
 
-                struct
-                {
-                    uint32_t field3;                                 // 3 main requirement
-                    uint32_t field4;                                 // 4 main requirement count
-                    uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                    uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                    uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                    uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
-                } raw;
-            };
-            char* name[16];                 // 9-24
-                                            //uint32_t name_flags;            // 25
-            uint32_t completionFlag;          // 26
-            uint32_t groupFlag;               // 27
-            uint32_t unk1;                    // 28
-            uint32_t timeLimit;               // 29 time limit in seconds
-            uint32_t index;                   // 30
+            struct
+            {
+                uint32_t field3;                                 // 3 main requirement
+                uint32_t field4;                                 // 4 main requirement count
+                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+            } raw;
         };
+        char* name[16];                 // 9-24
+                                        //uint32_t name_flags;            // 25
+        uint32_t completionFlag;          // 26
+        uint32_t groupFlag;               // 27
+        uint32_t unk1;                    // 28
+        uint32_t timeLimit;               // 29 time limit in seconds
+        uint32_t index;                   // 30
+    };
 
-        struct AchievementEntry
-        {
-            uint32_t ID;                      // 0
-            int32_t factionFlag;              // 1 -1=all, 0=horde, 1=alliance
-            int32_t mapID;                    // 2 -1=none
-            //uint32_t unknown1;              // 3
-            char* name[16];                 // 4-19
-            //uint32_t name_flags;            // 20
-            char* description[16];          // 21-36
-            //uint32_t desc_flags;            // 37
-            uint32_t categoryId;              // 38
-            uint32_t points;                  // 39 reward points
-            //uint32_t orderInCategory;       // 40
-            uint32_t flags;                   // 41
-            //uint32_t unknown2;              // 42
-            char* rewardName[16];           // 43-58 title/item reward name
-            //uint32_t rewardName_flags;      // 59
-            uint32_t count;                   // 60
-            uint32_t refAchievement;          // 61
-        };
+    struct AchievementEntry
+    {
+        uint32_t ID;                      // 0
+        int32_t factionFlag;              // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                    // 2 -1=none
+        //uint32_t unknown1;              // 3
+        char* name[16];                 // 4-19
+        //uint32_t name_flags;            // 20
+        char* description[16];          // 21-36
+        //uint32_t desc_flags;            // 37
+        uint32_t categoryId;              // 38
+        uint32_t points;                  // 39 reward points
+        //uint32_t orderInCategory;       // 40
+        uint32_t flags;                   // 41
+        //uint32_t unknown2;              // 42
+        char* rewardName[16];           // 43-58 title/item reward name
+        //uint32_t rewardName_flags;      // 59
+        uint32_t count;                   // 60
+        uint32_t refAchievement;          // 61
+    };
 
-        struct AreaGroupEntry
-        {
-            uint32_t AreaGroupId;             // 0
-            uint32_t AreaId[6];               // 1-6
-            uint32_t next_group;              // 7
-        };
+    struct AreaGroupEntry
+    {
+        uint32_t AreaGroupId;             // 0
+        uint32_t AreaId[6];               // 1-6
+        uint32_t next_group;              // 7
+    };
 
-        struct AreaTableEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t map_id;                  // 1
-            uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-            uint32_t explore_flag;            // 3, main index
-            uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                            // 5-9 unused
-            int32_t area_level;               // 10
-            char* area_name[16];            // 11-26
-                                            // 27, string flags, unused
-            uint32_t team;                    // 28
-            uint32_t liquid_type_override[4]; // 29-32 liquid override by type
-        };
+    struct AreaTableEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t map_id;                  // 1
+        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;            // 3, main index
+        uint32_t flags;                   // 4, unknown value but 312 for all cities
+                                        // 5-9 unused
+        int32_t area_level;               // 10
+        char* area_name[16];            // 11-26
+                                        // 27, string flags, unused
+        uint32_t team;                    // 28
+        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+    };
 
-        struct AreaTriggerEntry
-        {
-            uint32_t id;              // 0
-            uint32_t mapid;           // 1
-            float x;                // 2
-            float y;                // 3
-            float z;                // 4
-            float o;                // 5 radius?
-            float box_x;            // 6 extent x edge
-            float box_y;            // 7 extent y edge
-            float box_z;            // 8 extent z edge
-            float box_o;            // 9 extent rotation by about z axis
-        };
+    struct AreaTriggerEntry
+    {
+        uint32_t id;              // 0
+        uint32_t mapid;           // 1
+        float x;                // 2
+        float y;                // 3
+        float z;                // 4
+        float o;                // 5 radius?
+        float box_x;            // 6 extent x edge
+        float box_y;            // 7 extent y edge
+        float box_z;            // 8 extent z edge
+        float box_o;            // 9 extent rotation by about z axis
+    };
 
-        struct AuctionHouseEntry
-        {
-            uint32_t id;              // 0
-            uint32_t faction;         // 1
-            uint32_t fee;             // 2
-            uint32_t tax;             // 3
-            //char* name[16];       // 4-19
-            //uint32_t name_flags;    // 20
-        };
+    struct AuctionHouseEntry
+    {
+        uint32_t id;              // 0
+        uint32_t faction;         // 1
+        uint32_t fee;             // 2
+        uint32_t tax;             // 3
+        //char* name[16];       // 4-19
+        //uint32_t name_flags;    // 20
+    };
 
-        struct BankBagSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
+    struct BankBagSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
 
-        struct BarberShopStyleEntry
-        {
-            uint32_t id;              // 0
-            uint32_t type;            // 1 value 0 -> hair, value 2 -> facialhair
-            //char* name;           // 2 string hairstyle name
-            //char* name[15];       // 3-17 name of hair style
-            //uint32_t name_flags;    // 18
-            //uint32_t unk_name[16];  // 19-34, all empty
-            //uint32_t unk_flags;     // 35
-            //float unk3;           // 36 values 1 and 0,75
-            uint32_t race;            // 37 race
-            uint32_t gender;          // 38 0 male, 1 female
-            uint32_t hair_id;         // 39 Hair ID
-        };
+    struct BarberShopStyleEntry
+    {
+        uint32_t id;              // 0
+        uint32_t type;            // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;           // 2 string hairstyle name
+        //char* name[15];       // 3-17 name of hair style
+        //uint32_t name_flags;    // 18
+        //uint32_t unk_name[16];  // 19-34, all empty
+        //uint32_t unk_flags;     // 35
+        //float unk3;           // 36 values 1 and 0,75
+        uint32_t race;            // 37 race
+        uint32_t gender;          // 38 0 male, 1 female
+        uint32_t hair_id;         // 39 Hair ID
+    };
 
-        #define OUTFIT_ITEMS 24
+    #define OUTFIT_ITEMS 24
 
-        struct CharStartOutfitEntry
-        {
-            //uint32_t Id;                                    // 0
-            uint8_t Race;                                     // 1
-            uint8_t Class;                                    // 2
-            uint8_t Gender;                                   // 3
-            //uint8_t Unused;                                 // 4
-            int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-            //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-            //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
-        };
+    struct CharStartOutfitEntry
+    {
+        //uint32_t Id;                                    // 0
+        uint8_t Race;                                     // 1
+        uint8_t Class;                                    // 2
+        uint8_t Gender;                                   // 3
+        //uint8_t Unused;                                 // 4
+        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
+    };
 
 
-        struct CharTitlesEntry
-        {
-            uint32_t ID;                      // 0, title ids
-            //uint32_t unk1;                  // 1 flags?
-            char* name_male[16];            // 2-17
-            //uint32_t name_flag;             // 18 string flag, unused
-            char* name_female[16];          // 19-34
-            //const char* name2_flag;       // 35 string flag, unused
-            uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
-        };
+    struct CharTitlesEntry
+    {
+        uint32_t ID;                      // 0, title ids
+        //uint32_t unk1;                  // 1 flags?
+        char* name_male[16];            // 2-17
+        //uint32_t name_flag;             // 18 string flag, unused
+        char* name_female[16];          // 19-34
+        //const char* name2_flag;       // 35 string flag, unused
+        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+    };
 
-        struct ChatChannelsEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t flags;                   // 1
-            char* name_pattern[16];         // 3-18
-            //uint32_t name_pattern_flags;    // 19
-            //char* channel_name[16];       // 20-35
-            //uint32_t channel_name_flags;    // 36
-        };
+    struct ChatChannelsEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t flags;                   // 1
+        char* name_pattern[16];         // 3-18
+        //uint32_t name_pattern_flags;    // 19
+        //char* channel_name[16];       // 20-35
+        //uint32_t channel_name_flags;    // 36
+    };
 
-        struct ChrClassesEntry
-        {
-            uint32_t class_id;                // 0
-            //uint32_t unk1;                  // 1
-            uint32_t power_type;              // 2
-            //uint32_t unk2[2];               // 3-4
-            char* name[16];                 // 5-20
-            //uint32_t nameflags;             // 21
-            //char* name_female[16];        // 22-36
-            //uint32_t name_female_flags;     // 37
-            //char* name_neutral[16];       // 38-53
-            //uint32_t name_neutral_flags;    // 54
-            //uint32_t unk3;                  // 55
-            uint32_t spellfamily;             // 56
-            //uint32_t unk4;                  // 57
-            uint32_t cinematic_id;            // 58 CinematicSequences.dbc
-            uint32_t expansion;               // 59
-        };
+    struct ChrClassesEntry
+    {
+        uint32_t class_id;                // 0
+        //uint32_t unk1;                  // 1
+        uint32_t power_type;              // 2
+        //uint32_t unk2[2];               // 3-4
+        char* name[16];                 // 5-20
+        //uint32_t nameflags;             // 21
+        //char* name_female[16];        // 22-36
+        //uint32_t name_female_flags;     // 37
+        //char* name_neutral[16];       // 38-53
+        //uint32_t name_neutral_flags;    // 54
+        //uint32_t unk3;                  // 55
+        uint32_t spellfamily;             // 56
+        //uint32_t unk4;                  // 57
+        uint32_t cinematic_id;            // 58 CinematicSequences.dbc
+        uint32_t expansion;               // 59
+    };
 
-        struct ChrRacesEntry
-        {
-            uint32_t race_id;                 // 0
-            uint32_t flags;                   // 1
-            uint32_t faction_id;              // 2
-            //uint32_t unk1;                  // 3
-            uint32_t model_male;              // 4
-            uint32_t model_female;            // 5
-            // uint32_t unk2;                 // 6
-            uint32_t team_id;                 // 7
-            //uint32_t unk3[4];               // 8-11
-            uint32_t cinematic_id;            // 12 CinematicSequences.dbc
-            //uint32_t unk4                   // 13
-            char* name[16];                 // 14-29
-            //uint32_t name_flags             // 30
-            //char* name_female[16];        // 31-46
-            //uint32_t name_female_flags      // 47
-            //char* name_neutral[16];       // 48-63
-            //uint32_t name_neutral_flags     // 64 string flags, unused
-            //uint32_t unk5[3]                // 65-67 unused
-            uint32_t expansion;               // 68
-        };
+    struct ChrRacesEntry
+    {
+        uint32_t race_id;                 // 0
+        uint32_t flags;                   // 1
+        uint32_t faction_id;              // 2
+        //uint32_t unk1;                  // 3
+        uint32_t model_male;              // 4
+        uint32_t model_female;            // 5
+        // uint32_t unk2;                 // 6
+        uint32_t team_id;                 // 7
+        //uint32_t unk3[4];               // 8-11
+        uint32_t cinematic_id;            // 12 CinematicSequences.dbc
+        //uint32_t unk4                   // 13
+        char* name[16];                 // 14-29
+        //uint32_t name_flags             // 30
+        //char* name_female[16];        // 31-46
+        //uint32_t name_female_flags      // 47
+        //char* name_neutral[16];       // 48-63
+        //uint32_t name_neutral_flags     // 64 string flags, unused
+        //uint32_t unk5[3]                // 65-67 unused
+        uint32_t expansion;               // 68
+    };
 
-        struct CreatureDisplayInfoEntry
-        {
-            uint32_t display_id;            // 0
-            //uint32_t model;               // 1
-            //uint32_t unk0                 // 2
-            //uint32_t InfoExtra;           // 3
-            //float size;                   // 4
-                                            // 5 - 15 unk
-        };
+    struct CreatureDisplayInfoEntry
+    {
+        uint32_t display_id;            // 0
+        //uint32_t model;               // 1
+        //uint32_t unk0                 // 2
+        //uint32_t InfoExtra;           // 3
+        //float size;                   // 4
+                                        // 5 - 15 unk
+    };
 
-        struct CreatureFamilyEntry
-        {
-            uint32_t ID;                      // 0
-            float minsize;                  // 1
-            uint32_t minlevel;                // 2
-            float maxsize;                  // 3
-            uint32_t maxlevel;                // 4
-            uint32_t skilline;                // 5
-            uint32_t tameable;                // 6 second skill line - 270 Generic
-            uint32_t petdietflags;            // 7
-            uint32_t talenttree;              // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-            //uint32_t unk;                   // 9 some index 0 - 63
-            char* name[16];                 // 10-25
-            //uint32_t nameflags;             // 26
-            //uint32_t iconFile;              // 27
-        };
+    struct CreatureFamilyEntry
+    {
+        uint32_t ID;                      // 0
+        float minsize;                  // 1
+        uint32_t minlevel;                // 2
+        float maxsize;                  // 3
+        uint32_t maxlevel;                // 4
+        uint32_t skilline;                // 5
+        uint32_t tameable;                // 6 second skill line - 270 Generic
+        uint32_t petdietflags;            // 7
+        uint32_t talenttree;              // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                   // 9 some index 0 - 63
+        char* name[16];                 // 10-25
+        //uint32_t nameflags;             // 26
+        //uint32_t iconFile;              // 27
+    };
 
-        struct CreatureSpellDataEntry
-        {
-            uint32_t id;                      // 0
-            uint32_t Spells[3];               // 1-3
-            uint32_t PHSpell;                 // 4
-            uint32_t Cooldowns[3];            // 5-7
-            uint32_t PH;                      // 8
-        };
+    struct CreatureSpellDataEntry
+    {
+        uint32_t id;                      // 0
+        uint32_t Spells[3];               // 1-3
+        uint32_t PHSpell;                 // 4
+        uint32_t Cooldowns[3];            // 5-7
+        uint32_t PH;                      // 8
+    };
 
-        struct CurrencyTypesEntry
-        {
-            //uint32_t ID;            // 0 not used
-            uint32_t item_id;         // 1 used as index
-            //uint32_t Category;      // 2 may be category
-            uint32_t bit_index;       // 3 bit index in PLAYER_FIELD_KNOWN_CURRENCIES (1 << (index-1))
-        };
+    struct CurrencyTypesEntry
+    {
+        //uint32_t ID;            // 0 not used
+        uint32_t item_id;         // 1 used as index
+        //uint32_t Category;      // 2 may be category
+        uint32_t bit_index;       // 3 bit index in PLAYER_FIELD_KNOWN_CURRENCIES (1 << (index-1))
+    };
 
-        struct DurabilityCostsEntry
-        {
-            uint32_t itemlevel;       // 0
-            uint32_t modifier[29];    // 1-29
-        };
+    struct DurabilityCostsEntry
+    {
+        uint32_t itemlevel;       // 0
+        uint32_t modifier[29];    // 1-29
+    };
 
-        struct DurabilityQualityEntry
-        {
-            uint32_t id;              // 0
-            float quality_modifier; // 1
-        };
+    struct DurabilityQualityEntry
+    {
+        uint32_t id;              // 0
+        float quality_modifier; // 1
+    };
 
-        struct EmotesTextEntry
-        {
-            uint32_t Id;              // 0
-            //uint32_t name;          // 1
-            uint32_t textid;          // 2
-            uint32_t textid2;         // 3
-            uint32_t textid3;         // 4
-            uint32_t textid4;         // 5
-            //uint32_t unk1;          // 6
-            uint32_t textid5;         // 7
-            //uint32_t unk2;          // 8
-            uint32_t textid6;         // 9
-            //uint32_t unk3;          // 10
-            //uint32_t unk4;          // 11
-            //uint32_t unk5;          // 12
-            //uint32_t unk6;          // 13
-            //uint32_t unk7;          // 14
-            //uint32_t unk8;          // 15
-            //uint32_t unk9;          // 16
-            //uint32_t unk10;         // 17
-            //uint32_t unk11;         // 18
-        };
+    struct EmotesTextEntry
+    {
+        uint32_t Id;              // 0
+        //uint32_t name;          // 1
+        uint32_t textid;          // 2
+        uint32_t textid2;         // 3
+        uint32_t textid3;         // 4
+        uint32_t textid4;         // 5
+        //uint32_t unk1;          // 6
+        uint32_t textid5;         // 7
+        //uint32_t unk2;          // 8
+        uint32_t textid6;         // 9
+        //uint32_t unk3;          // 10
+        //uint32_t unk4;          // 11
+        //uint32_t unk5;          // 12
+        //uint32_t unk6;          // 13
+        //uint32_t unk7;          // 14
+        //uint32_t unk8;          // 15
+        //uint32_t unk9;          // 16
+        //uint32_t unk10;         // 17
+        //uint32_t unk11;         // 18
+    };
 
-        struct FactionEntry
-        {
-            uint32_t ID;                      // 0
-            int32_t RepListId;                // 1
-            uint32_t RaceMask[4];             // 2-5
-            uint32_t ClassMask[4];            // 6-9
-            int32_t baseRepValue[4];          // 10-13
-            uint32_t repFlags[4];             // 14-17
-            uint32_t parentFaction;           // 18
-            float spillover_rate_in;        // 19
-            float spillover_rate_out;       // 20
-            uint32_t spillover_max_in;        // 21
-            //uint32_t unk1;                  // 22
-            char* Name[16];                 // 23-38
-            //uint32_t name_flags;            // 39
-            //uint32_t Description[16];       // 40-55
-            //uint32_t description_flags;     // 56
-        };
+    struct FactionEntry
+    {
+        uint32_t ID;                      // 0
+        int32_t RepListId;                // 1
+        uint32_t RaceMask[4];             // 2-5
+        uint32_t ClassMask[4];            // 6-9
+        int32_t baseRepValue[4];          // 10-13
+        uint32_t repFlags[4];             // 14-17
+        uint32_t parentFaction;           // 18
+        float spillover_rate_in;        // 19
+        float spillover_rate_out;       // 20
+        uint32_t spillover_max_in;        // 21
+        //uint32_t unk1;                  // 22
+        char* Name[16];                 // 23-38
+        //uint32_t name_flags;            // 39
+        //uint32_t Description[16];       // 40-55
+        //uint32_t description_flags;     // 56
+    };
 
-        struct FactionTemplateEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t Faction;                 // 1
-            uint32_t FactionGroup;            // 2
-            uint32_t Mask;                    // 3
-            uint32_t FriendlyMask;            // 4
-            uint32_t HostileMask;             // 5
-            uint32_t EnemyFactions[4];        // 6-9
-            uint32_t FriendlyFactions[4];     // 10-13
-        };
+    struct FactionTemplateEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t Faction;                 // 1
+        uint32_t FactionGroup;            // 2
+        uint32_t Mask;                    // 3
+        uint32_t FriendlyMask;            // 4
+        uint32_t HostileMask;             // 5
+        uint32_t EnemyFactions[4];        // 6-9
+        uint32_t FriendlyFactions[4];     // 10-13
+    };
 
-        struct GameObjectDisplayInfoEntry
-        {
-            uint32_t Displayid;               // 0
-            char* filename;                 // 1
-            //uint32_t  unk1[10];             // 2-11
-            float minX;                     // 12
-            float minY;                     // 13
-            float minZ;                     // 14
-            float maxX;                     // 15
-            float maxY;                     // 16
-            float maxZ;                     // 17
-            //uint32_t transport;             // 18
-        };
+    struct GameObjectDisplayInfoEntry
+    {
+        uint32_t Displayid;               // 0
+        char* filename;                 // 1
+        //uint32_t  unk1[10];             // 2-11
+        float minX;                     // 12
+        float minY;                     // 13
+        float minZ;                     // 14
+        float maxX;                     // 15
+        float maxY;                     // 16
+        float maxZ;                     // 17
+        //uint32_t transport;             // 18
+    };
 
-        struct GemPropertiesEntry
-        {
-            uint32_t Entry;                   // 0
-            uint32_t EnchantmentID;           // 1
-            //uint32_t unk1;                  // 2 bool
-            //uint32_t unk2;                  // 3 bool
-            uint32_t SocketMask;              // 4
-        };
+    struct GemPropertiesEntry
+    {
+        uint32_t Entry;                   // 0
+        uint32_t EnchantmentID;           // 1
+        //uint32_t unk1;                  // 2 bool
+        //uint32_t unk2;                  // 3 bool
+        uint32_t SocketMask;              // 4
+    };
 
-        struct GlyphPropertiesEntry
-        {
-            uint32_t Entry;                   // 0
-            uint32_t SpellID;                 // 1
-            uint32_t Type;                    // 2 (0 = Major, 1 = Minor)
-            uint32_t unk;                     // 3 glyph_icon spell.dbc
-        };
+    struct GlyphPropertiesEntry
+    {
+        uint32_t Entry;                   // 0
+        uint32_t SpellID;                 // 1
+        uint32_t Type;                    // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                     // 3 glyph_icon spell.dbc
+    };
 
-        struct GlyphSlotEntry
-        {
-            uint32_t Id;              // 0
-            uint32_t Type;            // 1
-            uint32_t Slot;            // 2
-        };
+    struct GlyphSlotEntry
+    {
+        uint32_t Id;              // 0
+        uint32_t Type;            // 1
+        uint32_t Slot;            // 2
+    };
 
-        struct GtBarberShopCostBaseEntry
-        {
-            float cost;             // 0 cost base
-        };
+    struct GtBarberShopCostBaseEntry
+    {
+        float cost;             // 0 cost base
+    };
 
-        struct GtChanceToMeleeCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToMeleeCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToMeleeCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtChanceToSpellCritBaseEntry
-        {
-            float val;              // 0
-        };
+    struct GtChanceToSpellCritBaseEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtCombatRatingsEntry
-        {
-            float val;              // 0
-        };
+    struct GtCombatRatingsEntry
+    {
+        float val;              // 0
+    };
 
-        struct GtOCTRegenHPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenHPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtOCTRegenMPEntry
-        {
-            float ratio;            // 0
-        };
+    struct GtOCTRegenMPEntry
+    {
+        float ratio;            // 0
+    };
 
-        struct GtRegenHPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenHPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
-        struct GtRegenMPPerSptEntry
-        {
-            float ratio;            // 0 regen base
-        };
+    struct GtRegenMPPerSptEntry
+    {
+        float ratio;            // 0 regen base
+    };
 
 #define MAX_HOLIDAY_DURATIONS 10
 #define MAX_HOLIDAY_DATES 26
 #define MAX_HOLIDAY_FLAGS 10
 
-        struct HolidaysEntry
-        {
-            uint32_t Id;                                  // 0
-            uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-            uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-            uint32_t Region;                              // 37
-            uint32_t Looping;                             // 38
-            uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-            //uint32_t holidayNameId;                     // 49 HolidayNames.dbc
-            //uint32_t holidayDescriptionId;              // 50 HolidayDescriptions.dbc
-            char* TextureFilename;                      // 51
-            uint32_t Priority;                            // 52
-            uint32_t CalendarFilterType;                  // 53
-            //uint32_t flags;                             // 54
-        };
+    struct HolidaysEntry
+    {
+        uint32_t Id;                                  // 0
+        uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
+        uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
+        uint32_t Region;                              // 37
+        uint32_t Looping;                             // 38
+        uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
+        //uint32_t holidayNameId;                     // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;              // 50 HolidayDescriptions.dbc
+        char* TextureFilename;                      // 51
+        uint32_t Priority;                            // 52
+        uint32_t CalendarFilterType;                  // 53
+        //uint32_t flags;                             // 54
+    };
 
-        struct ItemEntry
-        {
-            uint32_t ID;                      // 0
-            uint32_t Class;                   // 1
-            uint32_t SubClass;                // 2 some items have strange subclasses
-            int32_t SoundOverrideSubclass;    // 3
-            int32_t Material;                 // 4
-            uint32_t DisplayId;               // 5
-            uint32_t InventoryType;           // 6
-            uint32_t Sheath;                  // 7
-        };
+    struct ItemEntry
+    {
+        uint32_t ID;                      // 0
+        uint32_t Class;                   // 1
+        uint32_t SubClass;                // 2 some items have strange subclasses
+        int32_t SoundOverrideSubclass;    // 3
+        int32_t Material;                 // 4
+        uint32_t DisplayId;               // 5
+        uint32_t InventoryType;           // 6
+        uint32_t Sheath;                  // 7
+    };
 
-        struct ItemExtendedCostEntry
-        {
-            uint32_t costid;                  // 0
-            uint32_t honor_points;            // 1
-            uint32_t arena_points;            // 2
-            uint32_t arena_slot;              // 3
-            uint32_t item[5];                 // 4-8
-            uint32_t count[5];                // 9-13
-            uint32_t personalrating;          // 14
-            //uint32_t unk;                   // 15
-        };
+    struct ItemExtendedCostEntry
+    {
+        uint32_t costid;                  // 0
+        uint32_t honor_points;            // 1
+        uint32_t arena_points;            // 2
+        uint32_t arena_slot;              // 3
+        uint32_t item[5];                 // 4-8
+        uint32_t count[5];                // 9-13
+        uint32_t personalrating;          // 14
+        //uint32_t unk;                   // 15
+    };
 
-        struct ItemLimitCategoryEntry
-        {
-            uint32_t Id;                      // 0
-            //char* name[16];               // 1-16 name langs
-            //uint32_t name_flags             // 17
-            uint32_t maxAmount;               // 18
-            uint32_t equippedFlag;            // 19 - equipped (bool?)
-        };
+    struct ItemLimitCategoryEntry
+    {
+        uint32_t Id;                      // 0
+        //char* name[16];               // 1-16 name langs
+        //uint32_t name_flags             // 17
+        uint32_t maxAmount;               // 18
+        uint32_t equippedFlag;            // 19 - equipped (bool?)
+    };
 
-        struct ItemRandomPropertiesEntry
-        {
-            uint32_t ID;                      // 0
-            //uint32_t name1;                 // 1
-            uint32_t spells[3];               // 2-4
-            //uint32_t unk1;                  // 5
-            //uint32_t unk2;                  // 6
-            char* name_suffix[16];          // 7-22
-            //uint32_t name_suffix_flags;     // 23
-        };
+    struct ItemRandomPropertiesEntry
+    {
+        uint32_t ID;                      // 0
+        //uint32_t name1;                 // 1
+        uint32_t spells[3];               // 2-4
+        //uint32_t unk1;                  // 5
+        //uint32_t unk2;                  // 6
+        char* name_suffix[16];          // 7-22
+        //uint32_t name_suffix_flags;     // 23
+    };
 
-        struct ItemRandomSuffixEntry
-        {
-            uint32_t id;                      // 0
-            char* name_suffix[16];          // 1-16
-            //uint32_t name_suffix_flags;     // 17
-            //uint32_t unk1;                  // 18
-            uint32_t enchantments[3];         // 19-21
-            //uint32_t unk2[2];               // 22-23
-            uint32_t prefixes[3];             // 24-26
-            //uint32_t[2];                    // 27-28
-        };
+    struct ItemRandomSuffixEntry
+    {
+        uint32_t id;                      // 0
+        char* name_suffix[16];          // 1-16
+        //uint32_t name_suffix_flags;     // 17
+        //uint32_t unk1;                  // 18
+        uint32_t enchantments[3];         // 19-21
+        //uint32_t unk2[2];               // 22-23
+        uint32_t prefixes[3];             // 24-26
+        //uint32_t[2];                    // 27-28
+    };
 
-        struct ItemSetEntry
-        {
-            uint32_t id;                      // 1
-            char* name[16];                 // 1-16 name (lang)
-            //uint32_t localeflag;            // 17 constant
-            uint32_t itemid[10];              // 18-27 item set items
-            //uint32_t unk[7];                // 28-34 all 0
-            uint32_t SpellID[8];              // 35-42
-            uint32_t itemscount[8];           // 43-50
-            uint32_t RequiredSkillID;         // 51
-            uint32_t RequiredSkillAmt;        // 52
-        };
+    struct ItemSetEntry
+    {
+        uint32_t id;                      // 1
+        char* name[16];                 // 1-16 name (lang)
+        //uint32_t localeflag;            // 17 constant
+        uint32_t itemid[10];              // 18-27 item set items
+        //uint32_t unk[7];                // 28-34 all 0
+        uint32_t SpellID[8];              // 35-42
+        uint32_t itemscount[8];           // 43-50
+        uint32_t RequiredSkillID;         // 51
+        uint32_t RequiredSkillAmt;        // 52
+    };
 
-        struct LFGDungeonEntry
-        {
-            uint32_t ID;              // 0
-            char* name[16];         // 1-17 Name lang
-            uint32_t minlevel;        // 18
-            uint32_t maxlevel;        // 19
-            uint32_t reclevel;        // 20
-            uint32_t recminlevel;     // 21
-            uint32_t recmaxlevel;     // 22
-            int32_t map;              // 23
-            uint32_t difficulty;      // 24
-            uint32_t flags;           // 25
-            uint32_t type;            // 26
-            //uint32_t  unk;          // 27
-            //char* iconname;       // 28
-            uint32_t expansion;       // 29
-            //uint32_t unk4;          // 30
-            uint32_t grouptype;       // 31
-            //char* desc[16];       // 32-47 Description
+    struct LFGDungeonEntry
+    {
+        uint32_t ID;              // 0
+        char* name[16];         // 1-17 Name lang
+        uint32_t minlevel;        // 18
+        uint32_t maxlevel;        // 19
+        uint32_t reclevel;        // 20
+        uint32_t recminlevel;     // 21
+        uint32_t recmaxlevel;     // 22
+        int32_t map;              // 23
+        uint32_t difficulty;      // 24
+        uint32_t flags;           // 25
+        uint32_t type;            // 26
+        //uint32_t  unk;          // 27
+        //char* iconname;       // 28
+        uint32_t expansion;       // 29
+        //uint32_t unk4;          // 30
+        uint32_t grouptype;       // 31
+        //char* desc[16];       // 32-47 Description
 
-            // Helpers
-            uint32_t Entry() const { return ID + (type << 24); }
-        };
+        // Helpers
+        uint32_t Entry() const { return ID + (type << 24); }
+    };
 
-        struct DungeonEncounterEntry
-        {
-            uint32 id;                                              // 0        unique id
-            uint32 mapId;                                           // 1        map id
-            uint32 difficulty;                                      // 2        instance mode
-            //uint32 unk0;                                          // 3
-            uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-            char* encounterName[16];                                // 5        encounter name
-            //uint32 nameFlags;                                     // 21
-            //uint32 unk1;                                          // 22
-        };
+    struct DungeonEncounterEntry
+    {
+        uint32 id;                                              // 0        unique id
+        uint32 mapId;                                           // 1        map id
+        uint32 difficulty;                                      // 2        instance mode
+        //uint32 unk0;                                          // 3
+        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
+        char* encounterName[16];                                // 5        encounter name
+        //uint32 nameFlags;                                     // 21
+        //uint32 unk1;                                          // 22
+    };
 
-        struct LiquidTypeEntry
-        {
-            uint32_t Id;                  // 0
-            //char* Name;               // 1
-            //uint32_t Flags;             // 2
-            uint32_t Type;                // 3
-            //uint32_t SoundId;           // 4
-            uint32_t SpellId;             // 5
-            //float MaxDarkenDepth;     // 6
-            //float FogDarkenIntensity; // 7
-            //float AmbDarkenIntensity; // 8
-            //float DirDarkenIntensity; // 9
-            //uint32_t LightID;           // 10
-            //float ParticleScale;      // 11
-            //uint32_t ParticleMovement;  // 12
-            //uint32_t ParticleTexSlots;  // 13
-            //uint32_t LiquidMaterialID;  // 14
-            //char* Texture[6];         // 15-20
-            //uint32_t Color[2];          // 21-22
-            //float Unk1[18];           // 23-40
-            //uint32_t Unk2[4];           // 41-44
-        };
+    struct LiquidTypeEntry
+    {
+        uint32_t Id;                  // 0
+        //char* Name;               // 1
+        //uint32_t Flags;             // 2
+        uint32_t Type;                // 3
+        //uint32_t SoundId;           // 4
+        uint32_t SpellId;             // 5
+        //float MaxDarkenDepth;     // 6
+        //float FogDarkenIntensity; // 7
+        //float AmbDarkenIntensity; // 8
+        //float DirDarkenIntensity; // 9
+        //uint32_t LightID;           // 10
+        //float ParticleScale;      // 11
+        //uint32_t ParticleMovement;  // 12
+        //uint32_t ParticleTexSlots;  // 13
+        //uint32_t LiquidMaterialID;  // 14
+        //char* Texture[6];         // 15-20
+        //uint32_t Color[2];          // 21-22
+        //float Unk1[18];           // 23-40
+        //uint32_t Unk2[4];           // 41-44
+    };
 
 #define LOCK_NUM_CASES 8
 
-        struct LockEntry
+    struct LockEntry
+    {
+        uint32_t Id;                              // 0
+        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+    };
+
+    struct MailTemplateEntry
+    {
+        uint32_t ID;              // 0
+        char* subject;          // 1
+        //float unused1[15]     // 2-16
+        //uint32_t flags1         // 17 name flags, unused
+        char* content;          // 18
+        //float unused2[15]     // 19-34
+        //uint32_t flags2         // 35 name flags, unused
+    };
+
+    struct MapEntry
+    {
+        uint32_t id;                      // 0
+        //char* name_internal;          // 1
+        uint32_t map_type;                // 2
+        uint32_t map_flags;               // 3
+        //uint32_t is_pvp_zone;           // 4 -0 false -1 true
+        char* map_name[16];             // 5-20
+        //uint32_t name_flags;            // 21
+        uint32_t linked_zone;             // 22 common zone for instance and continent map
+        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;      // 39
+        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;   // 56
+        uint32_t multimap_id;             // 57
+        //uint32_t battlefield_map_icon;  // 58
+        int32_t parent_map;               // 59 map_id of parent map
+        float start_x;                  // 60 enter x coordinate (if exist single entry)
+        float start_y;                  // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;               // 62 
+        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                // 64
+        uint32_t max_players;             // 65
+
+        bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
+        bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
+        bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isRaid() const { return map_type == MAP_RAID; }
+        bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
+        bool isBattleArena() const { return map_type == MAP_ARENA; }
+        bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
+        bool isWorldMap() const { return map_type == MAP_COMMON; }
+
+        bool isContinent() const
         {
-            uint32_t Id;                              // 0
-            uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-            uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-            uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-            //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
-        };
+            return id == 0 || id == 1 || id == 530 || id == 571;
+        }
+    };
 
-        struct MailTemplateEntry
+    struct NameGenEntry
+    {
+        uint32_t ID;              // 0
+        char* Name;             // 1
+        uint32_t unk1;            // 2
+        uint32_t type;            // 3
+    };
+
+    struct QuestXP
+    {
+        uint32_t questLevel;     // 0
+        uint32_t xpIndex[10];    // 1-10
+    };
+
+    struct ScalingStatDistributionEntry
+    {
+        uint32_t id;                  // 0
+        int32_t stat[10];             // 1-10
+        uint32_t statmodifier[10];    // 11-20
+        uint32_t maxlevel;            // 21
+    };
+
+    struct ScalingStatValuesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t level;               // 1
+        uint32_t multiplier[16];      // 2-17 ///\todo split this
+        uint32_t unk1;                // 18
+        uint32_t amor_mod[5];         // 19-23
+    };
+
+    struct SkillLineEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t type;                // 1
+        //uint32_t skillCostsID;      // 2
+        char* Name[16];             // 3-18
+        //uint32_t NameFlags;         // 19
+        //char* Description[16];    // 20-35
+        //uint32_t DescriptionFlags;  // 36
+        uint32_t spell_icon;          // 37
+        //char* add_name[16];       // 38-53
+        //uint32_t add_name_flags;    // 54
+        uint32_t linkable;            // 55
+    };
+
+    struct SkillLineAbilityEntry
+    {
+        uint32_t Id;                      // 0
+        uint32_t skilline;                // 1 skill id
+        uint32_t spell;                   // 2
+        uint32_t race_mask;               // 3
+        uint32_t class_mask;              // 4
+        //uint32_t excludeRace;           // 5
+        //uint32_t excludeClass;          // 6
+        uint32_t minSkillLineRank;        // 7 req skill value
+        uint32_t next;                    // 8
+        uint32_t acquireMethod;           // 9 auto learn
+        uint32_t grey;                    // 10 max
+        uint32_t green;                   // 11 min
+        //uint32_t abandonable;           // 12
+        //uint32_t reqTP;                 // 13
+    };
+
+    struct StableSlotPrices
+    {
+        uint32_t Id;              // 0
+        uint32_t Price;           // 1
+    };
+
+    struct SpellCastTimesEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t CastTime;        // 1
+        //uint32_t unk1;          // 2
+        //uint32_t unk2;          // 3
+    };
+
+    struct SpellDifficultyEntry
+    {
+        uint32_t ID;              // 0
+        int32_t SpellId[4];       // 1-4 (instance modes)
+    };
+
+    struct SpellDurationEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t Duration1;       // 1
+        uint32_t Duration2;       // 2
+        uint32_t Duration3;       // 3
+    };
+
+    #define MAX_SPELL_EFFECTS 3
+    #define MAX_SPELL_REAGENTS 8
+    #define MAX_SPELL_TOTEMS 2
+    #define MAX_SPELL_TOTEM_CATEGORIES 2
+
+    struct SpellEntry
+    {
+        uint32_t Id;                                                // 0
+        uint32_t Category;                                          // 1
+        uint32_t DispelType;                                        // 2
+        uint32_t MechanicsType;                                     // 3
+        uint32_t Attributes;                                        // 4
+        uint32_t AttributesEx;                                      // 5
+        uint32_t AttributesExB;                                     // 6
+        uint32_t AttributesExC;                                     // 7
+        uint32_t AttributesExD;                                     // 8
+        uint32_t AttributesExE;                                     // 9
+        uint32_t AttributesExF;                                     // 10
+        uint32_t AttributesExG;                                     // 11 
+        uint32_t Shapeshifts;                                       // 12
+        //uint32_t Shapeshifts1;                                    // 13 not used, all zeros
+        uint32_t ShapeshiftsExcluded;                               // 14
+        //uint32_t ShapeshiftsExcluded1;                            // 15 not used, all zeros
+        uint32_t Targets;                                           // 16
+        uint32_t TargetCreatureType;                                // 17
+        uint32_t RequiresSpellFocus;                                // 18
+        uint32_t FacingCasterFlags;                                 // 19
+        uint32_t CasterAuraState;                                   // 20
+        uint32_t TargetAuraState;                                   // 21
+        uint32_t CasterAuraStateNot;                                // 22
+        uint32_t TargetAuraStateNot;                                // 23
+        uint32_t casterAuraSpell;                                   // 24
+        uint32_t targetAuraSpell;                                   // 25
+        uint32_t casterAuraSpellNot;                                // 26
+        uint32_t targetAuraSpellNot;                                // 27
+        uint32_t CastingTimeIndex;                                  // 28
+        uint32_t RecoveryTime;                                      // 29
+        uint32_t CategoryRecoveryTime;                              // 30
+        uint32_t InterruptFlags;                                    // 31
+        uint32_t AuraInterruptFlags;                                // 32
+        uint32_t ChannelInterruptFlags;                             // 33
+        uint32_t procFlags;                                         // 34
+        uint32_t procChance;                                        // 35
+        uint32_t procCharges;                                       // 36
+        uint32_t maxLevel;                                          // 37
+        uint32_t baseLevel;                                         // 38
+        uint32_t spellLevel;                                        // 39
+        uint32_t DurationIndex;                                     // 40
+        int32_t powerType;                                          // 41
+        uint32_t manaCost;                                          // 42
+        uint32_t manaCostPerlevel;                                  // 43
+        uint32_t manaPerSecond;                                     // 44
+        uint32_t manaPerSecondPerLevel;                             // 45
+        uint32_t rangeIndex;                                        // 46
+        float speed;                                                // 47
+        //uint32_t modalNextSpell;                                  // 48 not used
+        uint32_t MaxStackAmount;                                    // 49
+        uint32_t Totem[MAX_SPELL_TOTEMS];                           // 50 - 51
+        int32_t Reagent[MAX_SPELL_REAGENTS];                        // 52 - 59
+        uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 60 - 67
+        int32_t EquippedItemClass;                                  // 68
+        int32_t EquippedItemSubClass;                               // 69
+        int32_t EquippedItemInventoryTypeMask;                      // 70
+        uint32_t Effect[MAX_SPELL_EFFECTS];                         // 71 - 73
+        int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 74 - 76
+        float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
+        int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
+        uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
+        uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
+        uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
+        uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
+        uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
+        uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
+        float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
+        uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
+        uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109 
+        int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
+        int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
+        uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
+        float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
+        uint32_t EffectSpellClassMask[MAX_SPELL_EFFECTS][3];        // 122 - 130
+        uint32_t SpellVisual;                                       // 131
+        uint32_t SpellVisual1;                                      // 132
+        uint32_t spellIconID;                                       // 133
+        uint32_t activeIconID;                                      // 134 activeIconID;
+        uint32_t spellPriority;                                     // 135
+        const char* Name[16];                                       // 136 - 151
+        //uint32_t NameFlags;                                       // 152 not used
+        const char* Rank[16];                                       // 153 - 168
+        //uint32_t RankFlags;                                       // 169 not used
+        //const char* Description[16];                              // 170 - 185 not used
+        //uint32_t DescriptionFlags;                                // 186 not used
+        //const char* BuffDescription[16];                          // 187 - 202 not used
+        //uint32_t buffdescflags;                                   // 203 not used
+        uint32_t ManaCostPercentage;                                // 204
+        uint32_t StartRecoveryCategory;                             // 205
+        uint32_t StartRecoveryTime;                                 // 206
+        uint32_t MaxTargetLevel;                                    // 207
+        uint32_t SpellFamilyName;                                   // 208
+        uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 209 - 211
+        uint32_t MaxTargets;                                        // 212
+        uint32_t DmgClass;                                          // 213
+        uint32_t PreventionType;                                    // 214
+        //int32_t StanceBarOrder;                                   // 215 not used
+        float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 216 - 218
+        //uint32_t MinFactionID;                                    // 219 not used
+        //uint32_t MinReputation;                                   // 220 not used
+        //uint32_t RequiredAuraVision;                              // 221 not used
+        uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 222 - 223
+        int32_t AreaGroupId;                                        // 224
+        uint32_t School;                                            // 225
+        uint32_t RuneCostID;                                        // 226
+        //uint32_t SpellMissileID;                                  // 227 not used
+        //uint32_t PowerDisplayId;                                  // 228 not used
+        float EffectBonusMultiplier[MAX_SPELL_EFFECTS];             // 229 - 231
+        //uint32_t SpellDescriptionVariable;                        // 232 not used
+        uint32_t SpellDifficultyId;                                 // 233
+    };
+
+    struct SpellItemEnchantmentEntry
+    {
+        uint32_t Id;                  // 0
+        //uint32_t charges;           // 1
+        uint32_t type[3];             // 2-4
+        int32_t min[3];               // 5-7 for combat, in practice min==max
+        int32_t max[3];               // 8-10
+        uint32_t spell[3];            // 11-13
+        char* Name[16];             // 14-29
+        //uint32_t NameFlags;         // 30
+        uint32_t visual;              // 31 aura
+        uint32_t EnchantGroups;       // 32 slot
+        uint32_t GemEntry;            // 33
+        uint32_t ench_condition;      // 34
+        uint32_t req_skill;           // 35
+        uint32_t req_skill_value;     // 36
+        uint32_t req_level;           // 37
+    };
+
+    struct SpellRadiusEntry
+    {
+        uint32_t ID;                  // 0
+        float radius_min;           // 1 Radius
+        float radius_per_level;     // 2
+        float radius_max;           // 3 Radius2
+    };
+
+    struct SpellRangeEntry
+    {
+        uint32_t ID;                  // 0
+        float minRange;             // 1
+        float minRangeFriendly;     // 2
+        float maxRange;             // 3
+        float maxRangeFriendly;     // 4
+        uint32_t range_type;          // 5
+        //char* name1[16]           // 6-21
+        //uint32_t name1_falgs;       // 22
+        //char* name2[16]           // 23-38
+        //uint32_t name2_falgs;       // 39
+    };
+
+    struct SpellRuneCostEntry
+    {
+        uint32_t ID;              // 0
+        uint32_t bloodRuneCost;   // 1
+        uint32_t frostRuneCost;   // 2
+        uint32_t unholyRuneCost;  // 3
+        uint32_t runePowerGain;   // 4
+    };
+
+    struct SpellShapeshiftFormEntry
+    {
+        uint32_t id;                  // 0
+        //uint32_t button_pos;        // 1
+        //char* name[16];           // 2-17
+        //uint32_t name_flags;        // 18
+        uint32_t Flags;               // 19
+        uint32_t unit_type;           // 20
+        //uint32_t unk1               // 21
+        uint32_t AttackSpeed;         // 22
+        uint32_t modelId;             // 23 alliance?
+        uint32_t modelId2;            // 24 horde?
+        //uint32_t unk2               // 25
+        //uint32_t unk3               // 26
+        uint32_t spells[8];           // 27-34
+    };
+
+    struct SummonPropertiesEntry
+    {
+        uint32_t ID;                  // 0
+        uint32_t ControlType;         // 1
+        uint32_t FactionID;           // 2
+        uint32_t Type;                // 3
+        uint32_t Slot;                // 4
+        uint32_t Flags;               // 5
+    };
+
+    struct TalentEntry
+    {
+        uint32_t TalentID;            // 0
+        uint32_t TalentTree;          // 1
+        uint32_t Row;                 // 2
+        uint32_t Col;                 // 3
+        uint32_t RankID[5];           // 4-8
+        //uint32_t unk[4];            // 9-12
+        uint32_t DependsOn;           // 13
+        //uint32_t unk1[2];           // 14-15
+        uint32_t DependsOnRank;       // 16
+        //uint32_t unk2[2];           // 17-18
+        //uint32_t unk3;              // 19
+        //uint32_t unk4;              // 20
+        //uint32_t unk5;              // 21
+    };
+
+    struct TalentTabEntry
+    {
+        uint32_t TalentTabID;         // 0
+        //char* Name[16];           // 1-16
+        //uint32_t name_flags;        // 17
+        //uint32_t unk4;              // 18
+        //uint32_t unk5;              // 19
+        uint32_t ClassMask;           // 20
+        uint32_t PetTalentMask;       // 21
+        uint32_t TabPage;             // 22
+        //char* InternalName;       // 23
+    };
+
+    struct TaxiNodesEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t mapid;               // 1
+        float x;                    // 2
+        float y;                    // 3
+        float z;                    // 4
+        char* name[16];             // 5-21
+        //uint32_t nameflags;         // 22
+        uint32_t horde_mount;         // 23
+        uint32_t alliance_mount;      // 24
+    };
+
+    struct TaxiPathEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t from;                // 1
+        uint32_t to;                  // 2
+        uint32_t price;               // 3
+    };
+
+    struct TaxiPathNodeEntry
+    {
+        uint32_t id;                  // 0
+        uint32_t path;                // 1
+        uint32_t seq;                 // 2 nodeIndex
+        uint32_t mapid;               // 3
+        float x;                    // 4
+        float y;                    // 5
+        float z;                    // 6
+        uint32_t flags;               // 7
+        uint32_t waittime;            // 8
+        uint32_t arivalEventID;       // 9
+        uint32_t departureEventID;    // 10
+    };
+
+    struct TotemCategoryEntry
+    {
+        uint32_t id;            // 0
+        //char* name[16];       // 1-16
+        //uint32_t unk;         // 17
+        uint32_t categoryType;  // 18
+        uint32_t categoryMask;  // 19
+    };
+
+    struct TransportAnimationEntry
+    {
+        //uint32_t ID;          // 0
+        uint32_t TransportID;   // 1
+        uint32_t TimeIndex;     // 2
+        DBCPosition3D Pos;      // 3
+        //uint32_t SequenceID;  // 4
+    };
+
+    struct TransportRotationEntry
+    {
+        //uint32_t ID;          // 0
+        uint32_t GameObjectsID; // 1
+        uint32_t TimeIndex;     // 2
+        float X;                // 3
+        float Y;                // 4
+        float Z;                // 5
+        float W;                // 6
+    };
+
+    #define MAX_VEHICLE_SEATS 8
+
+    struct VehicleEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        float turnSpeed;                                    // 2
+        float pitchSpeed;                                   // 3
+        float pitchMin;                                     // 4
+        float pitchMax;                                     // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
+        float mouseLookOffsetPitch;                         // 14
+        float cameraFadeDistScalarMin;                      // 15
+        float cameraFadeDistScalarMax;                      // 16
+        float cameraPitchOffset;                            // 17
+        float facingLimitRight;                             // 18
+        float facingLimitLeft;                              // 19
+        float msslTrgtTurnLingering;                        // 20
+        float msslTrgtPitchLingering;                       // 21
+        float msslTrgtMouseLingering;                       // 22
+        float msslTrgtEndOpacity;                           // 23
+        float msslTrgtArcSpeed;                             // 24
+        float msslTrgtArcRepeat;                            // 25
+        float msslTrgtArcWidth;                             // 26
+        float msslTrgtImpactRadius[2];                      // 27-28
+        char* msslTrgtArcTexture;                           // 29
+        char* msslTrgtImpactTexture;                        // 30
+        char* msslTrgtImpactModel[2];                       // 31-32
+        float cameraYawOffset;                              // 33
+        uint32_t uiLocomotionType;                            // 34
+        float msslTrgtImpactTexRadius;                      // 35
+        uint32_t uiSeatIndicatorType;                         // 36
+        uint32_t powerType;                                   // 37, new in 3.1
+        //uint32_t unk1;                                      // 38
+        //uint32_t unk2;                                      // 39  
+    };
+
+    enum VehicleSeatFlags
+    {
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+    };
+
+    enum VehicleSeatFlagsB
+    {
+        VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
+        VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
+    };
+
+    struct VehicleSeatEntry
+    {
+        uint32_t ID;                                          // 0
+        uint32_t flags;                                       // 1
+        int32_t attachmentID;                                 // 2
+        float attachmentOffsetX;                            // 3
+        float attachmentOffsetY;                            // 4
+        float attachmentOffsetZ;                            // 5
+        float enterPreDelay;                                // 6
+        float enterSpeed;                                   // 7
+        float enterGravity;                                 // 8
+        float enterMinDuration;                             // 9
+        float enterMaxDuration;                             // 10
+        float enterMinArcHeight;                            // 11
+        float enterMaxArcHeight;                            // 12
+        int32_t enterAnimStart;                               // 13
+        int32_t enterAnimLoop;                                // 14
+        int32_t rideAnimStart;                                // 15
+        int32_t rideAnimLoop;                                 // 16
+        int32_t rideUpperAnimStart;                           // 17
+        int32_t rideUpperAnimLoop;                            // 18
+        float exitPreDelay;                                 // 19
+        float exitSpeed;                                    // 20
+        float exitGravity;                                  // 21
+        float exitMinDuration;                              // 22
+        float exitMaxDuration;                              // 23
+        float exitMinArcHeight;                             // 24
+        float exitMaxArcHeight;                             // 25
+        int32_t exitAnimStart;                                // 26
+        int32_t exitAnimLoop;                                 // 27
+        int32_t exitAnimEnd;                                  // 28
+        float passengerYaw;                                 // 29
+        float passengerPitch;                               // 30
+        float passengerRoll;                                // 31
+        int32_t passengerAttachmentID;                        // 32
+        int32_t vehicleEnterAnim;                             // 33
+        int32_t vehicleExitAnim;                              // 34
+        int32_t vehicleRideAnimLoop;                          // 35
+        int32_t vehicleEnterAnimBone;                         // 36
+        int32_t vehicleExitAnimBone;                          // 37
+        int32_t vehicleRideAnimLoopBone;                      // 38
+        float vehicleEnterAnimDelay;                        // 39
+        float vehicleExitAnimDelay;                         // 40
+        uint32_t vehicleAbilityDisplay;                       // 41
+        uint32_t enterUISoundID;                              // 42
+        uint32_t exitUISoundID;                               // 43
+        int32_t uiSkin;                                       // 44
+        uint32_t flagsB;                                      // 45
+
+        bool IsUsable() const
         {
-            uint32_t ID;              // 0
-            char* subject;          // 1
-            //float unused1[15]     // 2-16
-            //uint32_t flags1         // 17 name flags, unused
-            char* content;          // 18
-            //float unused2[15]     // 19-34
-            //uint32_t flags2         // 35 name flags, unused
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
+                return true;
+            else
+                return false;
+        }
 
-        struct MapEntry
+        bool IsController() const
         {
-            uint32_t id;                      // 0
-            //char* name_internal;          // 1
-            uint32_t map_type;                // 2
-            uint32_t map_flags;               // 3
-            //uint32_t is_pvp_zone;           // 4 -0 false -1 true
-            char* map_name[16];             // 5-20
-            //uint32_t name_flags;            // 21
-            uint32_t linked_zone;             // 22 common zone for instance and continent map
-            //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-            //uint32_t hordeIntro_flags;      // 39
-            //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-            //uint32_t allianceIntro_flags;   // 56
-            uint32_t multimap_id;             // 57
-            //uint32_t battlefield_map_icon;  // 58
-            int32_t parent_map;               // 59 map_id of parent map
-            float start_x;                  // 60 enter x coordinate (if exist single entry)
-            float start_y;                  // 61 enter y coordinate (if exist single entry)
-            //uint32_t dayTime;               // 62 
-            uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
-            uint32_t unk_time;                // 64
-            uint32_t max_players;             // 65
+            if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
+                return true;
+            else
+                return false;
+        }
 
-            bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
-            bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
-            bool instanceable() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID || map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isRaid() const { return map_type == MAP_RAID; }
-            bool isBattleground() const { return map_type == MAP_BATTLEGROUND; }
-            bool isBattleArena() const { return map_type == MAP_ARENA; }
-            bool isBattlegroundOrArena() const { return map_type == MAP_BATTLEGROUND || map_type == MAP_ARENA; }
-            bool isWorldMap() const { return map_type == MAP_COMMON; }
-
-            bool isContinent() const
-            {
-                return id == 0 || id == 1 || id == 530 || id == 571;
-            }
-        };
-
-        struct NameGenEntry
+        bool HidesPassenger() const
         {
-            uint32_t ID;              // 0
-            char* Name;             // 1
-            uint32_t unk1;            // 2
-            uint32_t type;            // 3
-        };
+            if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
+                return true;
+            else
+                return false;
+        }
+    };
 
-        struct QuestXP
-        {
-            uint32_t questLevel;     // 0
-            uint32_t xpIndex[10];    // 1-10
-        };
+    struct WMOAreaTableEntry
+    {
+        uint32_t id;              // 0
+        int32_t rootId;           // 1
+        int32_t adtId;            // 2
+        int32_t groupId;          // 3
+        //uint32_t field4;        // 4
+        //uint32_t field5;        // 5
+        //uint32_t field6;        // 6
+        //uint32_t field7;        // 7
+        //uint32_t field8;        // 8
+        uint32_t flags;           // 9
+        uint32_t areaId;          // 10  ref -> AreaTableEntry
+        //char Name[16];        // 11-26
+        //uint32_t nameflags;     // 27
+    };
 
-        struct ScalingStatDistributionEntry
-        {
-            uint32_t id;                  // 0
-            int32_t stat[10];             // 1-10
-            uint32_t statmodifier[10];    // 11-20
-            uint32_t maxlevel;            // 21
-        };
+    struct WorldMapAreaEntry
+    {
+        //uint32_t id;              // 0
+        uint32_t mapId;             // 1
+        uint32_t zoneId;            // 2
+        //const char* name;         // 3
+        //float y1;                 // 4
+        //float y2;                 // 5
+        //float x1;                 // 6
+        //float x2;                 // 7
+        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1             // 9
+        //uint32_t parentId         // 10
+    };
 
-        struct ScalingStatValuesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t level;               // 1
-            uint32_t multiplier[16];      // 2-17 ///\todo split this
-            uint32_t unk1;                // 18
-            uint32_t amor_mod[5];         // 19-23
-        };
+    struct WorldMapOverlayEntry
+    {
+        uint32_t ID;              // 0
+        //uint32_t worldMapID;    // 1
+        uint32_t areaID;          // 2 - index to AreaTable
+        uint32_t areaID_2;        // 3 - index to AreaTable
+        uint32_t areaID_3;        // 4 - index to AreaTable
+        uint32_t areaID_4;        // 5 - index to AreaTable
+        //uint32_t unk1[2];       // 6-7
+        //uint32_t unk2;          // 8
+        //uint32_t unk3[7];       // 9-16
+    };
 
-        struct SkillLineEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t type;                // 1
-            //uint32_t skillCostsID;      // 2
-            char* Name[16];             // 3-18
-            //uint32_t NameFlags;         // 19
-            //char* Description[16];    // 20-35
-            //uint32_t DescriptionFlags;  // 36
-            uint32_t spell_icon;          // 37
-            //char* add_name[16];       // 38-53
-            //uint32_t add_name_flags;    // 54
-            uint32_t linkable;            // 55
-        };
-
-        struct SkillLineAbilityEntry
-        {
-            uint32_t Id;                      // 0
-            uint32_t skilline;                // 1 skill id
-            uint32_t spell;                   // 2
-            uint32_t race_mask;               // 3
-            uint32_t class_mask;              // 4
-            //uint32_t excludeRace;           // 5
-            //uint32_t excludeClass;          // 6
-            uint32_t minSkillLineRank;        // 7 req skill value
-            uint32_t next;                    // 8
-            uint32_t acquireMethod;           // 9 auto learn
-            uint32_t grey;                    // 10 max
-            uint32_t green;                   // 11 min
-            //uint32_t abandonable;           // 12
-            //uint32_t reqTP;                 // 13
-        };
-
-        struct StableSlotPrices
-        {
-            uint32_t Id;              // 0
-            uint32_t Price;           // 1
-        };
-
-        struct SpellCastTimesEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t CastTime;        // 1
-            //uint32_t unk1;          // 2
-            //uint32_t unk2;          // 3
-        };
-
-        struct SpellDifficultyEntry
-        {
-            uint32_t ID;              // 0
-            int32_t SpellId[4];       // 1-4 (instance modes)
-        };
-
-        struct SpellDurationEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t Duration1;       // 1
-            uint32_t Duration2;       // 2
-            uint32_t Duration3;       // 3
-        };
-
-        #define MAX_SPELL_EFFECTS 3
-        #define MAX_SPELL_REAGENTS 8
-        #define MAX_SPELL_TOTEMS 2
-        #define MAX_SPELL_TOTEM_CATEGORIES 2
-
-        struct SpellEntry
-        {
-            uint32_t Id;                                                // 0
-            uint32_t Category;                                          // 1
-            uint32_t DispelType;                                        // 2
-            uint32_t MechanicsType;                                     // 3
-            uint32_t Attributes;                                        // 4
-            uint32_t AttributesEx;                                      // 5
-            uint32_t AttributesExB;                                     // 6
-            uint32_t AttributesExC;                                     // 7
-            uint32_t AttributesExD;                                     // 8
-            uint32_t AttributesExE;                                     // 9
-            uint32_t AttributesExF;                                     // 10
-            uint32_t AttributesExG;                                     // 11 
-            uint32_t Shapeshifts;                                       // 12
-            //uint32_t Shapeshifts1;                                    // 13 not used, all zeros
-            uint32_t ShapeshiftsExcluded;                               // 14
-            //uint32_t ShapeshiftsExcluded1;                            // 15 not used, all zeros
-            uint32_t Targets;                                           // 16
-            uint32_t TargetCreatureType;                                // 17
-            uint32_t RequiresSpellFocus;                                // 18
-            uint32_t FacingCasterFlags;                                 // 19
-            uint32_t CasterAuraState;                                   // 20
-            uint32_t TargetAuraState;                                   // 21
-            uint32_t CasterAuraStateNot;                                // 22
-            uint32_t TargetAuraStateNot;                                // 23
-            uint32_t casterAuraSpell;                                   // 24
-            uint32_t targetAuraSpell;                                   // 25
-            uint32_t casterAuraSpellNot;                                // 26
-            uint32_t targetAuraSpellNot;                                // 27
-            uint32_t CastingTimeIndex;                                  // 28
-            uint32_t RecoveryTime;                                      // 29
-            uint32_t CategoryRecoveryTime;                              // 30
-            uint32_t InterruptFlags;                                    // 31
-            uint32_t AuraInterruptFlags;                                // 32
-            uint32_t ChannelInterruptFlags;                             // 33
-            uint32_t procFlags;                                         // 34
-            uint32_t procChance;                                        // 35
-            uint32_t procCharges;                                       // 36
-            uint32_t maxLevel;                                          // 37
-            uint32_t baseLevel;                                         // 38
-            uint32_t spellLevel;                                        // 39
-            uint32_t DurationIndex;                                     // 40
-            int32_t powerType;                                          // 41
-            uint32_t manaCost;                                          // 42
-            uint32_t manaCostPerlevel;                                  // 43
-            uint32_t manaPerSecond;                                     // 44
-            uint32_t manaPerSecondPerLevel;                             // 45
-            uint32_t rangeIndex;                                        // 46
-            float speed;                                                // 47
-            //uint32_t modalNextSpell;                                  // 48 not used
-            uint32_t MaxStackAmount;                                    // 49
-            uint32_t Totem[MAX_SPELL_TOTEMS];                           // 50 - 51
-            int32_t Reagent[MAX_SPELL_REAGENTS];                        // 52 - 59
-            uint32_t ReagentCount[MAX_SPELL_REAGENTS];                  // 60 - 67
-            int32_t EquippedItemClass;                                  // 68
-            int32_t EquippedItemSubClass;                               // 69
-            int32_t EquippedItemInventoryTypeMask;                      // 70
-            uint32_t Effect[MAX_SPELL_EFFECTS];                         // 71 - 73
-            int32_t EffectDieSides[MAX_SPELL_EFFECTS];                  // 74 - 76
-            float EffectRealPointsPerLevel[MAX_SPELL_EFFECTS];          // 77 - 79
-            int32_t EffectBasePoints[MAX_SPELL_EFFECTS];                // 80 - 82
-            uint32_t EffectMechanic[MAX_SPELL_EFFECTS];                 // 83 - 85
-            uint32_t EffectImplicitTargetA[MAX_SPELL_EFFECTS];          // 86 - 88
-            uint32_t EffectImplicitTargetB[MAX_SPELL_EFFECTS];          // 89 - 91
-            uint32_t EffectRadiusIndex[MAX_SPELL_EFFECTS];              // 92 - 94
-            uint32_t EffectApplyAuraName[MAX_SPELL_EFFECTS];            // 95 - 97
-            uint32_t EffectAmplitude[MAX_SPELL_EFFECTS];                // 98 - 100
-            float EffectMultipleValue[MAX_SPELL_EFFECTS];               // 101 - 103
-            uint32_t EffectChainTarget[MAX_SPELL_EFFECTS];              // 104 - 106
-            uint32_t EffectItemType[MAX_SPELL_EFFECTS];                 // 107 - 109 
-            int32_t EffectMiscValue[MAX_SPELL_EFFECTS];                 // 110 - 112
-            int32_t EffectMiscValueB[MAX_SPELL_EFFECTS];                // 113 - 115
-            uint32_t EffectTriggerSpell[MAX_SPELL_EFFECTS];             // 116 - 118
-            float EffectPointsPerComboPoint[MAX_SPELL_EFFECTS];         // 119 - 121
-            uint32_t EffectSpellClassMask[MAX_SPELL_EFFECTS][3];        // 122 - 130
-            uint32_t SpellVisual;                                       // 131
-            uint32_t SpellVisual1;                                      // 132
-            uint32_t spellIconID;                                       // 133
-            uint32_t activeIconID;                                      // 134 activeIconID;
-            uint32_t spellPriority;                                     // 135
-            const char* Name[16];                                       // 136 - 151
-            //uint32_t NameFlags;                                       // 152 not used
-            const char* Rank[16];                                       // 153 - 168
-            //uint32_t RankFlags;                                       // 169 not used
-            //const char* Description[16];                              // 170 - 185 not used
-            //uint32_t DescriptionFlags;                                // 186 not used
-            //const char* BuffDescription[16];                          // 187 - 202 not used
-            //uint32_t buffdescflags;                                   // 203 not used
-            uint32_t ManaCostPercentage;                                // 204
-            uint32_t StartRecoveryCategory;                             // 205
-            uint32_t StartRecoveryTime;                                 // 206
-            uint32_t MaxTargetLevel;                                    // 207
-            uint32_t SpellFamilyName;                                   // 208
-            uint32_t SpellFamilyFlags[MAX_SPELL_EFFECTS];               // 209 - 211
-            uint32_t MaxTargets;                                        // 212
-            uint32_t DmgClass;                                          // 213
-            uint32_t PreventionType;                                    // 214
-            //int32_t StanceBarOrder;                                   // 215 not used
-            float EffectDamageMultiplier[MAX_SPELL_EFFECTS];            // 216 - 218
-            //uint32_t MinFactionID;                                    // 219 not used
-            //uint32_t MinReputation;                                   // 220 not used
-            //uint32_t RequiredAuraVision;                              // 221 not used
-            uint32_t TotemCategory[MAX_SPELL_TOTEM_CATEGORIES];         // 222 - 223
-            int32_t AreaGroupId;                                        // 224
-            uint32_t School;                                            // 225
-            uint32_t RuneCostID;                                        // 226
-            //uint32_t SpellMissileID;                                  // 227 not used
-            //uint32_t PowerDisplayId;                                  // 228 not used
-            float EffectBonusMultiplier[MAX_SPELL_EFFECTS];             // 229 - 231
-            //uint32_t SpellDescriptionVariable;                        // 232 not used
-            uint32_t SpellDifficultyId;                                 // 233
-        };
-
-        struct SpellItemEnchantmentEntry
-        {
-            uint32_t Id;                  // 0
-            //uint32_t charges;           // 1
-            uint32_t type[3];             // 2-4
-            int32_t min[3];               // 5-7 for combat, in practice min==max
-            int32_t max[3];               // 8-10
-            uint32_t spell[3];            // 11-13
-            char* Name[16];             // 14-29
-            //uint32_t NameFlags;         // 30
-            uint32_t visual;              // 31 aura
-            uint32_t EnchantGroups;       // 32 slot
-            uint32_t GemEntry;            // 33
-            uint32_t ench_condition;      // 34
-            uint32_t req_skill;           // 35
-            uint32_t req_skill_value;     // 36
-            uint32_t req_level;           // 37
-        };
-
-        struct SpellRadiusEntry
-        {
-            uint32_t ID;                  // 0
-            float radius_min;           // 1 Radius
-            float radius_per_level;     // 2
-            float radius_max;           // 3 Radius2
-        };
-
-        struct SpellRangeEntry
-        {
-            uint32_t ID;                  // 0
-            float minRange;             // 1
-            float minRangeFriendly;     // 2
-            float maxRange;             // 3
-            float maxRangeFriendly;     // 4
-            uint32_t range_type;          // 5
-            //char* name1[16]           // 6-21
-            //uint32_t name1_falgs;       // 22
-            //char* name2[16]           // 23-38
-            //uint32_t name2_falgs;       // 39
-        };
-
-        struct SpellRuneCostEntry
-        {
-            uint32_t ID;              // 0
-            uint32_t bloodRuneCost;   // 1
-            uint32_t frostRuneCost;   // 2
-            uint32_t unholyRuneCost;  // 3
-            uint32_t runePowerGain;   // 4
-        };
-
-        struct SpellShapeshiftFormEntry
-        {
-            uint32_t id;                  // 0
-            //uint32_t button_pos;        // 1
-            //char* name[16];           // 2-17
-            //uint32_t name_flags;        // 18
-            uint32_t Flags;               // 19
-            uint32_t unit_type;           // 20
-            //uint32_t unk1               // 21
-            uint32_t AttackSpeed;         // 22
-            uint32_t modelId;             // 23 alliance?
-            uint32_t modelId2;            // 24 horde?
-            //uint32_t unk2               // 25
-            //uint32_t unk3               // 26
-            uint32_t spells[8];           // 27-34
-        };
-
-        struct SummonPropertiesEntry
-        {
-            uint32_t ID;                  // 0
-            uint32_t ControlType;         // 1
-            uint32_t FactionID;           // 2
-            uint32_t Type;                // 3
-            uint32_t Slot;                // 4
-            uint32_t Flags;               // 5
-        };
-
-        struct TalentEntry
-        {
-            uint32_t TalentID;            // 0
-            uint32_t TalentTree;          // 1
-            uint32_t Row;                 // 2
-            uint32_t Col;                 // 3
-            uint32_t RankID[5];           // 4-8
-            //uint32_t unk[4];            // 9-12
-            uint32_t DependsOn;           // 13
-            //uint32_t unk1[2];           // 14-15
-            uint32_t DependsOnRank;       // 16
-            //uint32_t unk2[2];           // 17-18
-            //uint32_t unk3;              // 19
-            //uint32_t unk4;              // 20
-            //uint32_t unk5;              // 21
-        };
-
-        struct TalentTabEntry
-        {
-            uint32_t TalentTabID;         // 0
-            //char* Name[16];           // 1-16
-            //uint32_t name_flags;        // 17
-            //uint32_t unk4;              // 18
-            //uint32_t unk5;              // 19
-            uint32_t ClassMask;           // 20
-            uint32_t PetTalentMask;       // 21
-            uint32_t TabPage;             // 22
-            //char* InternalName;       // 23
-        };
-
-        struct TaxiNodesEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t mapid;               // 1
-            float x;                    // 2
-            float y;                    // 3
-            float z;                    // 4
-            char* name[16];             // 5-21
-            //uint32_t nameflags;         // 22
-            uint32_t horde_mount;         // 23
-            uint32_t alliance_mount;      // 24
-        };
-
-        struct TaxiPathEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t from;                // 1
-            uint32_t to;                  // 2
-            uint32_t price;               // 3
-        };
-
-        struct TaxiPathNodeEntry
-        {
-            uint32_t id;                  // 0
-            uint32_t path;                // 1
-            uint32_t seq;                 // 2 nodeIndex
-            uint32_t mapid;               // 3
-            float x;                    // 4
-            float y;                    // 5
-            float z;                    // 6
-            uint32_t flags;               // 7
-            uint32_t waittime;            // 8
-            uint32_t arivalEventID;       // 9
-            uint32_t departureEventID;    // 10
-        };
-
-        struct TotemCategoryEntry
-        {
-            uint32_t id;            // 0
-            //char* name[16];       // 1-16
-            //uint32_t unk;         // 17
-            uint32_t categoryType;  // 18
-            uint32_t categoryMask;  // 19
-        };
-
-        struct TransportAnimationEntry
-        {
-            //uint32_t ID;          // 0
-            uint32_t TransportID;   // 1
-            uint32_t TimeIndex;     // 2
-            DBCPosition3D Pos;      // 3
-            //uint32_t SequenceID;  // 4
-        };
-
-        struct TransportRotationEntry
-        {
-            //uint32_t ID;          // 0
-            uint32_t GameObjectsID; // 1
-            uint32_t TimeIndex;     // 2
-            float X;                // 3
-            float Y;                // 4
-            float Z;                // 5
-            float W;                // 6
-        };
-
-        #define MAX_VEHICLE_SEATS 8
-
-        struct VehicleEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            float turnSpeed;                                    // 2
-            float pitchSpeed;                                   // 3
-            float pitchMin;                                     // 4
-            float pitchMax;                                     // 5
-            uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-            float mouseLookOffsetPitch;                         // 14
-            float cameraFadeDistScalarMin;                      // 15
-            float cameraFadeDistScalarMax;                      // 16
-            float cameraPitchOffset;                            // 17
-            float facingLimitRight;                             // 18
-            float facingLimitLeft;                              // 19
-            float msslTrgtTurnLingering;                        // 20
-            float msslTrgtPitchLingering;                       // 21
-            float msslTrgtMouseLingering;                       // 22
-            float msslTrgtEndOpacity;                           // 23
-            float msslTrgtArcSpeed;                             // 24
-            float msslTrgtArcRepeat;                            // 25
-            float msslTrgtArcWidth;                             // 26
-            float msslTrgtImpactRadius[2];                      // 27-28
-            char* msslTrgtArcTexture;                           // 29
-            char* msslTrgtImpactTexture;                        // 30
-            char* msslTrgtImpactModel[2];                       // 31-32
-            float cameraYawOffset;                              // 33
-            uint32_t uiLocomotionType;                            // 34
-            float msslTrgtImpactTexRadius;                      // 35
-            uint32_t uiSeatIndicatorType;                         // 36
-            uint32_t powerType;                                   // 37, new in 3.1
-            //uint32_t unk1;                                      // 38
-            //uint32_t unk2;                                      // 39  
-        };
-
-        enum VehicleSeatFlags
-        {
-            VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
-            VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-            VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-            VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-            VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-            VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-            VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
-        };
-
-        enum VehicleSeatFlagsB
-        {
-            VEHICLE_SEAT_FLAG_B_NONE                     = 0x00000000,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED            = 0x00000002, 
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2          = 0x00000040,
-            VEHICLE_SEAT_FLAG_B_USABLE_FORCED_3          = 0x00000100,
-        };
-
-        struct VehicleSeatEntry
-        {
-            uint32_t ID;                                          // 0
-            uint32_t flags;                                       // 1
-            int32_t attachmentID;                                 // 2
-            float attachmentOffsetX;                            // 3
-            float attachmentOffsetY;                            // 4
-            float attachmentOffsetZ;                            // 5
-            float enterPreDelay;                                // 6
-            float enterSpeed;                                   // 7
-            float enterGravity;                                 // 8
-            float enterMinDuration;                             // 9
-            float enterMaxDuration;                             // 10
-            float enterMinArcHeight;                            // 11
-            float enterMaxArcHeight;                            // 12
-            int32_t enterAnimStart;                               // 13
-            int32_t enterAnimLoop;                                // 14
-            int32_t rideAnimStart;                                // 15
-            int32_t rideAnimLoop;                                 // 16
-            int32_t rideUpperAnimStart;                           // 17
-            int32_t rideUpperAnimLoop;                            // 18
-            float exitPreDelay;                                 // 19
-            float exitSpeed;                                    // 20
-            float exitGravity;                                  // 21
-            float exitMinDuration;                              // 22
-            float exitMaxDuration;                              // 23
-            float exitMinArcHeight;                             // 24
-            float exitMaxArcHeight;                             // 25
-            int32_t exitAnimStart;                                // 26
-            int32_t exitAnimLoop;                                 // 27
-            int32_t exitAnimEnd;                                  // 28
-            float passengerYaw;                                 // 29
-            float passengerPitch;                               // 30
-            float passengerRoll;                                // 31
-            int32_t passengerAttachmentID;                        // 32
-            int32_t vehicleEnterAnim;                             // 33
-            int32_t vehicleExitAnim;                              // 34
-            int32_t vehicleRideAnimLoop;                          // 35
-            int32_t vehicleEnterAnimBone;                         // 36
-            int32_t vehicleExitAnimBone;                          // 37
-            int32_t vehicleRideAnimLoopBone;                      // 38
-            float vehicleEnterAnimDelay;                        // 39
-            float vehicleExitAnimDelay;                         // 40
-            uint32_t vehicleAbilityDisplay;                       // 41
-            uint32_t enterUISoundID;                              // 42
-            uint32_t exitUISoundID;                               // 43
-            int32_t uiSkin;                                       // 44
-            uint32_t flagsB;                                      // 45
-
-            bool IsUsable() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_USABLE) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool IsController() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_CAN_CONTROL) != 0)
-                    return true;
-                else
-                    return false;
-            }
-
-            bool HidesPassenger() const
-            {
-                if ((flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER) != 0)
-                    return true;
-                else
-                    return false;
-            }
-        };
-
-        struct WMOAreaTableEntry
-        {
-            uint32_t id;              // 0
-            int32_t rootId;           // 1
-            int32_t adtId;            // 2
-            int32_t groupId;          // 3
-            //uint32_t field4;        // 4
-            //uint32_t field5;        // 5
-            //uint32_t field6;        // 6
-            //uint32_t field7;        // 7
-            //uint32_t field8;        // 8
-            uint32_t flags;           // 9
-            uint32_t areaId;          // 10  ref -> AreaTableEntry
-            //char Name[16];        // 11-26
-            //uint32_t nameflags;     // 27
-        };
-
-        struct WorldMapAreaEntry
-        {
-            //uint32_t id;              // 0
-            uint32_t mapId;             // 1
-            uint32_t zoneId;            // 2
-            //const char* name;         // 3
-            //float y1;                 // 4
-            //float y2;                 // 5
-            //float x1;                 // 6
-            //float x2;                 // 7
-            int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-            //uint32_t unk1             // 9
-            //uint32_t parentId         // 10
-        };
-
-        struct WorldMapOverlayEntry
-        {
-            uint32_t ID;              // 0
-            //uint32_t worldMapID;    // 1
-            uint32_t areaID;          // 2 - index to AreaTable
-            uint32_t areaID_2;        // 3 - index to AreaTable
-            uint32_t areaID_3;        // 4 - index to AreaTable
-            uint32_t areaID_4;        // 5 - index to AreaTable
-            //uint32_t unk1[2];       // 6-7
-            //uint32_t unk2;          // 8
-            //uint32_t unk3[7];       // 9-16
-        };
-
-        #pragma pack(pop)
-    }
+    #pragma pack(pop)
 }

--- a/src/world/GameWotLK/Storage/DBCStructures.h
+++ b/src/world/GameWotLK/Storage/DBCStructures.h
@@ -624,7 +624,7 @@ namespace DBC::Structures
         uint32_t hair_id;                                           // 39 Hair ID
     };
 
-    #define OUTFIT_ITEMS 24
+#define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
@@ -1201,10 +1201,10 @@ namespace DBC::Structures
         uint32_t Duration3;                                         // 3
     };
 
-    #define MAX_SPELL_EFFECTS 3
-    #define MAX_SPELL_REAGENTS 8
-    #define MAX_SPELL_TOTEMS 2
-    #define MAX_SPELL_TOTEM_CATEGORIES 2
+#define MAX_SPELL_EFFECTS 3
+#define MAX_SPELL_REAGENTS 8
+#define MAX_SPELL_TOTEMS 2
+#define MAX_SPELL_TOTEM_CATEGORIES 2
 
     struct SpellEntry
     {
@@ -1492,7 +1492,7 @@ namespace DBC::Structures
         float W;                                                    // 6
     };
 
-    #define MAX_VEHICLE_SEATS 8
+#define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {

--- a/src/world/GameWotLK/Storage/DBCStructures.h
+++ b/src/world/GameWotLK/Storage/DBCStructures.h
@@ -31,11 +31,11 @@ struct DBCPosition3D
 
 enum MapTypes
 {
-    MAP_COMMON = 0,             // none
-    MAP_INSTANCE = 1,           // party
-    MAP_RAID = 2,               // raid
-    MAP_BATTLEGROUND = 3,       // pvp
-    MAP_ARENA = 4               // arena
+    MAP_COMMON          = 0, // none
+    MAP_INSTANCE        = 1, // party
+    MAP_RAID            = 2, // raid
+    MAP_BATTLEGROUND    = 3, // pvp
+    MAP_ARENA           = 4  // arena
 };
 
 namespace DBC::Structures
@@ -126,778 +126,778 @@ namespace DBC::Structures
     #pragma pack(push, 1)
     struct AchievementCategoryEntry
     {
-        uint32_t ID;                 // 0
-        uint32_t parentCategory;     // 1 -1 for main category
-        const char* name;          // 2-17
-        uint32_t name_flags;         // 18
-        uint32_t sortOrder;          // 19
+        uint32_t ID;                                                // 0
+        uint32_t parentCategory;                                    // 1 -1 for main category
+        const char* name;                                           // 2-17
+        uint32_t name_flags;                                        // 18
+        uint32_t sortOrder;                                         // 19
     };
 
     struct AchievementCriteriaEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t referredAchievement;     // 1
-        uint32_t requiredType;            // 2
+        uint32_t ID;                                                // 0
+        uint32_t referredAchievement;                               // 1
+        uint32_t requiredType;                                      // 2
         union
         {
             // ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE = 0
             ///\todo also used for player deaths..
             struct
             {
-                uint32_t creatureID;                             // 3
-                uint32_t creatureCount;                          // 4
+                uint32_t creatureID;                                // 3
+                uint32_t creatureCount;                             // 4
             } kill_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_BG = 1
             ///\todo there are further criterias instead just winning
             struct
             {
-                uint32_t bgMapID;                                // 3
-                uint32_t winCount;                               // 4
+                uint32_t bgMapID;                                   // 3
+                uint32_t winCount;                                  // 4
             } win_bg;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_LEVEL = 5
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t level;                                  // 4
+                uint32_t unused;                                    // 3
+                uint32_t level;                                     // 4
             } reach_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL = 7
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4
             } reach_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT = 8
             struct
             {
-                uint32_t linkedAchievement;                      // 3
+                uint32_t linkedAchievement;                         // 3
             } complete_achievement;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST_COUNT = 9
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t totalQuestCount;                        // 4
+                uint32_t unused;                                    // 3
+                uint32_t totalQuestCount;                           // 4
             } complete_quest_count;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST_DAILY = 10
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfDays;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfDays;                              // 4
             } complete_daily_quest_daily;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE = 11
             struct
             {
-                uint32_t zoneID;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t zoneID;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_quests_in_zone;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_DAILY_QUEST = 14
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t questCount;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t questCount;                                // 4
             } complete_daily_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_BATTLEGROUND= 15
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } complete_battleground;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP= 16
             struct
             {
-                uint32_t mapID;                                  // 3
+                uint32_t mapID;                                     // 3
             } death_at_map;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_RAID = 19
             struct
             {
-                uint32_t groupSize;                              // 3 can be 5, 10 or 25
+                uint32_t groupSize;                                 // 3 can be 5, 10 or 25
             } complete_raid;
 
             // ACHIEVEMENT_CRITERIA_TYPE_KILLED_BY_CREATURE = 20
             struct
             {
-                uint32_t creatureEntry;                          // 3
+                uint32_t creatureEntry;                             // 3
             } killed_by_creature;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING = 24
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t fallHeight;                             // 4
+                uint32_t unused;                                    // 3
+                uint32_t fallHeight;                                // 4
             } fall_without_dying;
 
             // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST = 27
             struct
             {
-                uint32_t questID;                                // 3
-                uint32_t questCount;                             // 4
+                uint32_t questID;                                   // 3
+                uint32_t questCount;                                // 4
             } complete_quest;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET = 28
             // ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2= 69
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t spellCount;                             // 4
+                uint32_t spellID;                                   // 3
+                uint32_t spellCount;                                // 4
             } be_spell_target;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL= 29
             struct
             {
-                uint32_t spellID;                                // 3
-                uint32_t castCount;                              // 4
+                uint32_t spellID;                                   // 3
+                uint32_t castCount;                                 // 4
             } cast_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA = 31
             struct
             {
-                uint32_t areaID;                                 // 3 Reference to AreaTable.dbc
-                uint32_t killCount;                              // 4
+                uint32_t areaID;                                    // 3 Reference to AreaTable.dbc
+                uint32_t killCount;                                 // 4
             } honorable_kill_at_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA = 32
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } win_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_PLAY_ARENA = 33
             struct
             {
-                uint32_t mapID;                                  // 3 Reference to Map.dbc
+                uint32_t mapID;                                     // 3 Reference to Map.dbc
             } play_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL = 34
             struct
             {
-                uint32_t spellID;                                // 3 Reference to Map.dbc
+                uint32_t spellID;                                   // 3 Reference to Map.dbc
             } learn_spell;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM = 36
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } own_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA = 37
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 4=in a row
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 4=in a row
             } win_rated_arena;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_TEAM_RATING = 38
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
+                uint32_t teamtype;                                  // 3 {2,3,5}
             } highest_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_REACH_TEAM_RATING = 39
             struct
             {
-                uint32_t teamtype;                               // 3 {2,3,5}
-                uint32_t teamrating;                             // 4
+                uint32_t teamtype;                                  // 3 {2,3,5}
+                uint32_t teamrating;                                // 4
             } reach_team_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL = 40
             struct
             {
-                uint32_t skillID;                                // 3
-                uint32_t skillLevel;                             // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
+                uint32_t skillID;                                   // 3
+                uint32_t skillLevel;                                // 4 apprentice=1, journeyman=2, expert=3, artisan=4, master=5, grand master=6
             } learn_skill_level;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_ITEM = 41
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } use_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM = 42
             struct
             {
-                uint32_t itemID;                                 // 3
-                uint32_t itemCount;                              // 4
+                uint32_t itemID;                                    // 3
+                uint32_t itemCount;                                 // 4
             } loot_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA = 43
             struct
             {
-                uint32_t areaReference;                          // 3 - this is an index to WorldMapOverlay
+                uint32_t areaReference;                             // 3 - this is an index to WorldMapOverlay
             } explore_area;
 
             // ACHIEVEMENT_CRITERIA_TYPE_OWN_RANK= 44
             struct
             {
                 ///\todo This rank is _NOT_ the index from CharTitles.dbc
-                uint32_t rank;                                   // 3
+                uint32_t rank;                                      // 3
             } own_rank;
 
             // ACHIEVEMENT_CRITERIA_TYPE_BUY_BANK_SLOT= 45
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfSlots;                          // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfSlots;                             // 4
             } buy_bank_slot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_REPUTATION= 46
             struct
             {
-                uint32_t factionID;                              // 3
-                uint32_t reputationAmount;                       // 4 Total reputation amount, so 42000 = exalted
+                uint32_t factionID;                                 // 3
+                uint32_t reputationAmount;                          // 4 Total reputation amount, so 42000 = exalted
             } gain_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_GAIN_EXALTED_REPUTATION= 47
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t numberOfExaltedFactions;                // 4
+                uint32_t unused;                                    // 3
+                uint32_t numberOfExaltedFactions;                   // 4
             } gain_exalted_reputation;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM = 49
             ///\todo where is the required itemlevel stored?
             struct
             {
-                uint32_t itemSlot;                               // 3
+                uint32_t itemSlot;                                  // 3
             } equip_epic_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_ROLL_NEED_ON_LOOT= 50
             struct
             {
-                uint32_t rollValue;                              // 3
-                uint32_t count;                                  // 4
+                uint32_t rollValue;                                 // 3
+                uint32_t count;                                     // 4
             } roll_need_on_loot;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS = 52
             struct
             {
-                uint32_t classID;                                // 3
-                uint32_t count;                                  // 4
+                uint32_t classID;                                   // 3
+                uint32_t count;                                     // 4
             } hk_class;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HK_RACE = 53
             struct
             {
-                uint32_t raceID;                                 // 3
-                uint32_t count;                                  // 4
+                uint32_t raceID;                                    // 3
+                uint32_t count;                                     // 4
             } hk_race;
 
             // ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE = 54
             ///\todo where is the information about the target stored?
             struct
             {
-                uint32_t emoteID;                                // 3
+                uint32_t emoteID;                                   // 3
             } do_emote;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HEALING_DONE = 55
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t count;                                  // 4
-                uint32_t flag;                                   // 5 =3 for battleground healing
-                uint32_t mapid;                                  // 6
+                uint32_t unused;                                    // 3
+                uint32_t count;                                     // 4
+                uint32_t flag;                                      // 5 =3 for battleground healing
+                uint32_t mapid;                                     // 6
             } healing_done;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EQUIP_ITEM = 57
             struct
             {
-                uint32_t itemID;                                 // 3
+                uint32_t itemID;                                    // 3
             } equip_item;
 
             // ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD = 62
             struct
             {
-                uint32_t unknown;                                 // 3
-                uint32_t goldInCopper;                            // 4
+                uint32_t unknown;                                   // 3
+                uint32_t goldInCopper;                              // 4
             } quest_reward_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY = 67
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t goldInCopper;                           // 4
+                uint32_t unused;                                    // 3
+                uint32_t goldInCopper;                              // 4
             } loot_money;
 
             // ACHIEVEMENT_CRITERIA_TYPE_USE_GAMEOBJECT = 68
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t useCount;                               // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t useCount;                                  // 4
             } use_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL= 70
             ///\todo are those special criteria stored in the dbc or do we have to add another sql table?
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } special_pvp_kill;
 
             // ACHIEVEMENT_CRITERIA_TYPE_FISH_IN_GAMEOBJECT = 72
             struct
             {
-                uint32_t goEntry;                                // 3
-                uint32_t lootCount;                              // 4
+                uint32_t goEntry;                                   // 3
+                uint32_t lootCount;                                 // 4
             } fish_in_gameobject;
 
             // ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS= 75
             struct
             {
-                uint32_t unknown;                                // 3 777=?
-                uint32_t mountCount;                             // 4
+                uint32_t unknown;                                   // 3 777=?
+                uint32_t mountCount;                                // 4
             } number_of_mounts;
 
             // ACHIEVEMENT_CRITERIA_TYPE_WIN_DUEL = 76
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t duelCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t duelCount;                                 // 4
             } win_duel;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_POWER = 96
             struct
             {
-                uint32_t powerType;                              // 3 mana= 0, 1=rage, 3=energy, 6=runic power
+                uint32_t powerType;                                 // 3 mana= 0, 1=rage, 3=energy, 6=runic power
             } highest_power;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_STAT = 97
             struct
             {
-                uint32_t statType;                               // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
+                uint32_t statType;                                  // 3 4=spirit, 3=int, 2=stamina, 1=agi, 0=strength
             } highest_stat;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_SPELLPOWER = 98
             struct
             {
-                uint32_t spellSchool;                            // 3
+                uint32_t spellSchool;                               // 3
             } highest_spellpower;
 
             // ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_RATING = 100
             struct
             {
-                uint32_t ratingType;                             // 3
+                uint32_t ratingType;                                // 3
             } highest_rating;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE = 109
             struct
             {
-                uint32_t lootType;                               // 3 3=fishing, 2=pickpocket, 4=disentchant
-                uint32_t lootTypeCount;                          // 4
+                uint32_t lootType;                                  // 3 3=fishing, 2=pickpocket, 4=disentchant
+                uint32_t lootTypeCount;                             // 4
             } loot_type;
 
             // ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2 = 110
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } cast_spell2;
 
             // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE= 112
             struct
             {
-                uint32_t skillLine;                              // 3
-                uint32_t spellCount;                             // 4
+                uint32_t skillLine;                                 // 3
+                uint32_t spellCount;                                // 4
             } learn_skill_line;
 
             // ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL = 113
             struct
             {
-                uint32_t unused;                                 // 3
-                uint32_t killCount;                              // 4
+                uint32_t unused;                                    // 3
+                uint32_t killCount;                                 // 4
             } honorable_kill;
 
             struct
             {
-                uint32_t field3;                                 // 3 main requirement
-                uint32_t field4;                                 // 4 main requirement count
-                uint32_t additionalRequirement1_type;            // 5 additional requirement 1 type
-                uint32_t additionalRequirement1_value;           // 6 additional requirement 1 value
-                uint32_t additionalRequirement2_type;            // 7 additional requirement 2 type
-                uint32_t additionalRequirement2_value;           // 8 additional requirement 1 value
+                uint32_t field3;                                    // 3 main requirement
+                uint32_t field4;                                    // 4 main requirement count
+                uint32_t additionalRequirement1_type;               // 5 additional requirement 1 type
+                uint32_t additionalRequirement1_value;              // 6 additional requirement 1 value
+                uint32_t additionalRequirement2_type;               // 7 additional requirement 2 type
+                uint32_t additionalRequirement2_value;              // 8 additional requirement 1 value
             } raw;
         };
-        char* name[16];                 // 9-24
-                                        //uint32_t name_flags;            // 25
-        uint32_t completionFlag;          // 26
-        uint32_t groupFlag;               // 27
-        uint32_t unk1;                    // 28
-        uint32_t timeLimit;               // 29 time limit in seconds
-        uint32_t index;                   // 30
+        char* name[16];                                             // 9-24
+        //uint32_t name_flags;                                      // 25
+        uint32_t completionFlag;                                    // 26
+        uint32_t groupFlag;                                         // 27
+        uint32_t unk1;                                              // 28
+        uint32_t timeLimit;                                         // 29 time limit in seconds
+        uint32_t index;                                             // 30
     };
 
     struct AchievementEntry
     {
-        uint32_t ID;                      // 0
-        int32_t factionFlag;              // 1 -1=all, 0=horde, 1=alliance
-        int32_t mapID;                    // 2 -1=none
-        //uint32_t unknown1;              // 3
-        char* name[16];                 // 4-19
-        //uint32_t name_flags;            // 20
-        char* description[16];          // 21-36
-        //uint32_t desc_flags;            // 37
-        uint32_t categoryId;              // 38
-        uint32_t points;                  // 39 reward points
-        //uint32_t orderInCategory;       // 40
-        uint32_t flags;                   // 41
-        //uint32_t unknown2;              // 42
-        char* rewardName[16];           // 43-58 title/item reward name
-        //uint32_t rewardName_flags;      // 59
-        uint32_t count;                   // 60
-        uint32_t refAchievement;          // 61
+        uint32_t ID;                                                // 0
+        int32_t factionFlag;                                        // 1 -1=all, 0=horde, 1=alliance
+        int32_t mapID;                                              // 2 -1=none
+        //uint32_t unknown1;                                        // 3
+        char* name[16];                                             // 4-19
+        //uint32_t name_flags;                                      // 20
+        char* description[16];                                      // 21-36
+        //uint32_t desc_flags;                                      // 37
+        uint32_t categoryId;                                        // 38
+        uint32_t points;                                            // 39 reward points
+        //uint32_t orderInCategory;                                 // 40
+        uint32_t flags;                                             // 41
+        //uint32_t unknown2;                                        // 42
+        char* rewardName[16];                                       // 43-58 title/item reward name
+        //uint32_t rewardName_flags;                                // 59
+        uint32_t count;                                             // 60
+        uint32_t refAchievement;                                    // 61
     };
 
     struct AreaGroupEntry
     {
-        uint32_t AreaGroupId;             // 0
-        uint32_t AreaId[6];               // 1-6
-        uint32_t next_group;              // 7
+        uint32_t AreaGroupId;                                       // 0
+        uint32_t AreaId[6];                                         // 1-6
+        uint32_t next_group;                                        // 7
     };
 
     struct AreaTableEntry
     {
-        uint32_t id;                      // 0
-        uint32_t map_id;                  // 1
-        uint32_t zone;                    // 2 if 0 then it's zone, else it's zone id of this area
-        uint32_t explore_flag;            // 3, main index
-        uint32_t flags;                   // 4, unknown value but 312 for all cities
-                                        // 5-9 unused
-        int32_t area_level;               // 10
-        char* area_name[16];            // 11-26
-                                        // 27, string flags, unused
-        uint32_t team;                    // 28
-        uint32_t liquid_type_override[4]; // 29-32 liquid override by type
+        uint32_t id;                                                // 0
+        uint32_t map_id;                                            // 1
+        uint32_t zone;                                              // 2 if 0 then it's zone, else it's zone id of this area
+        uint32_t explore_flag;                                      // 3, main index
+        uint32_t flags;                                             // 4, unknown value but 312 for all cities
+                                                                    // 5-9 unused
+        int32_t area_level;                                         // 10
+        char* area_name[16];                                        // 11-26
+                                                                    // 27, string flags, unused
+        uint32_t team;                                              // 28
+        uint32_t liquid_type_override[4];                           // 29-32 liquid override by type
     };
 
     struct AreaTriggerEntry
     {
-        uint32_t id;              // 0
-        uint32_t mapid;           // 1
-        float x;                // 2
-        float y;                // 3
-        float z;                // 4
-        float o;                // 5 radius?
-        float box_x;            // 6 extent x edge
-        float box_y;            // 7 extent y edge
-        float box_z;            // 8 extent z edge
-        float box_o;            // 9 extent rotation by about z axis
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        float o;                                                    // 5 radius?
+        float box_x;                                                // 6 extent x edge
+        float box_y;                                                // 7 extent y edge
+        float box_z;                                                // 8 extent z edge
+        float box_o;                                                // 9 extent rotation by about z axis
     };
 
     struct AuctionHouseEntry
     {
-        uint32_t id;              // 0
-        uint32_t faction;         // 1
-        uint32_t fee;             // 2
-        uint32_t tax;             // 3
-        //char* name[16];       // 4-19
-        //uint32_t name_flags;    // 20
+        uint32_t id;                                                // 0
+        uint32_t faction;                                           // 1
+        uint32_t fee;                                               // 2
+        uint32_t tax;                                               // 3
+        //char* name[16];                                           // 4-19
+        //uint32_t name_flags;                                      // 20
     };
 
     struct BankBagSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct BarberShopStyleEntry
     {
-        uint32_t id;              // 0
-        uint32_t type;            // 1 value 0 -> hair, value 2 -> facialhair
-        //char* name;           // 2 string hairstyle name
-        //char* name[15];       // 3-17 name of hair style
-        //uint32_t name_flags;    // 18
-        //uint32_t unk_name[16];  // 19-34, all empty
-        //uint32_t unk_flags;     // 35
-        //float unk3;           // 36 values 1 and 0,75
-        uint32_t race;            // 37 race
-        uint32_t gender;          // 38 0 male, 1 female
-        uint32_t hair_id;         // 39 Hair ID
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1 value 0 -> hair, value 2 -> facialhair
+        //char* name;                                               // 2 string hairstyle name
+        //char* name[15];                                           // 3-17 name of hair style
+        //uint32_t name_flags;                                      // 18
+        //uint32_t unk_name[16];                                    // 19-34, all empty
+        //uint32_t unk_flags;                                       // 35
+        //float unk3;                                               // 36 values 1 and 0,75
+        uint32_t race;                                              // 37 race
+        uint32_t gender;                                            // 38 0 male, 1 female
+        uint32_t hair_id;                                           // 39 Hair ID
     };
 
     #define OUTFIT_ITEMS 24
 
     struct CharStartOutfitEntry
     {
-        //uint32_t Id;                                    // 0
-        uint8_t Race;                                     // 1
-        uint8_t Class;                                    // 2
-        uint8_t Gender;                                   // 3
-        //uint8_t Unused;                                 // 4
-        int32_t ItemId[OUTFIT_ITEMS];                     // 5-28
-        //int32_t ItemDisplayId[OUTFIT_ITEMS];            // 29-52
-        //int32_t ItemInventorySlot[OUTFIT_ITEMS];        // 53-76
+        //uint32_t Id;                                              // 0
+        uint8_t Race;                                               // 1
+        uint8_t Class;                                              // 2
+        uint8_t Gender;                                             // 3
+        //uint8_t Unused;                                           // 4
+        int32_t ItemId[OUTFIT_ITEMS];                               // 5-28
+        //int32_t ItemDisplayId[OUTFIT_ITEMS];                      // 29-52
+        //int32_t ItemInventorySlot[OUTFIT_ITEMS];                  // 53-76
     };
 
 
     struct CharTitlesEntry
     {
-        uint32_t ID;                      // 0, title ids
-        //uint32_t unk1;                  // 1 flags?
-        char* name_male[16];            // 2-17
-        //uint32_t name_flag;             // 18 string flag, unused
-        char* name_female[16];          // 19-34
-        //const char* name2_flag;       // 35 string flag, unused
-        uint32_t bit_index;               // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
+        uint32_t ID;                                                // 0, title ids
+        //uint32_t unk1;                                            // 1 flags?
+        char* name_male[16];                                        // 2-17
+        //uint32_t name_flag;                                       // 18 string flag, unused
+        char* name_female[16];                                      // 19-34
+        //const char* name2_flag;                                   // 35 string flag, unused
+        uint32_t bit_index;                                         // 36 used in PLAYER_CHOSEN_TITLE and 1<<index in PLAYER__FIELD_KNOWN_TITLES
     };
 
     struct ChatChannelsEntry
     {
-        uint32_t id;                      // 0
-        uint32_t flags;                   // 1
-        char* name_pattern[16];         // 3-18
-        //uint32_t name_pattern_flags;    // 19
-        //char* channel_name[16];       // 20-35
-        //uint32_t channel_name_flags;    // 36
+        uint32_t id;                                                // 0
+        uint32_t flags;                                             // 1
+        char* name_pattern[16];                                     // 3-18
+        //uint32_t name_pattern_flags;                              // 19
+        //char* channel_name[16];                                   // 20-35
+        //uint32_t channel_name_flags;                              // 36
     };
 
     struct ChrClassesEntry
     {
-        uint32_t class_id;                // 0
-        //uint32_t unk1;                  // 1
-        uint32_t power_type;              // 2
-        //uint32_t unk2[2];               // 3-4
-        char* name[16];                 // 5-20
-        //uint32_t nameflags;             // 21
-        //char* name_female[16];        // 22-36
-        //uint32_t name_female_flags;     // 37
-        //char* name_neutral[16];       // 38-53
-        //uint32_t name_neutral_flags;    // 54
-        //uint32_t unk3;                  // 55
-        uint32_t spellfamily;             // 56
-        //uint32_t unk4;                  // 57
-        uint32_t cinematic_id;            // 58 CinematicSequences.dbc
-        uint32_t expansion;               // 59
+        uint32_t class_id;                                          // 0
+        //uint32_t unk1;                                            // 1
+        uint32_t power_type;                                        // 2
+        //uint32_t unk2[2];                                         // 3-4
+        char* name[16];                                             // 5-20
+        //uint32_t nameflags;                                       // 21
+        //char* name_female[16];                                    // 22-36
+        //uint32_t name_female_flags;                               // 37
+        //char* name_neutral[16];                                   // 38-53
+        //uint32_t name_neutral_flags;                              // 54
+        //uint32_t unk3;                                            // 55
+        uint32_t spellfamily;                                       // 56
+        //uint32_t unk4;                                            // 57
+        uint32_t cinematic_id;                                      // 58 CinematicSequences.dbc
+        uint32_t expansion;                                         // 59
     };
 
     struct ChrRacesEntry
     {
-        uint32_t race_id;                 // 0
-        uint32_t flags;                   // 1
-        uint32_t faction_id;              // 2
-        //uint32_t unk1;                  // 3
-        uint32_t model_male;              // 4
-        uint32_t model_female;            // 5
-        // uint32_t unk2;                 // 6
-        uint32_t team_id;                 // 7
-        //uint32_t unk3[4];               // 8-11
-        uint32_t cinematic_id;            // 12 CinematicSequences.dbc
-        //uint32_t unk4                   // 13
-        char* name[16];                 // 14-29
-        //uint32_t name_flags             // 30
-        //char* name_female[16];        // 31-46
-        //uint32_t name_female_flags      // 47
-        //char* name_neutral[16];       // 48-63
-        //uint32_t name_neutral_flags     // 64 string flags, unused
-        //uint32_t unk5[3]                // 65-67 unused
-        uint32_t expansion;               // 68
+        uint32_t race_id;                                           // 0
+        uint32_t flags;                                             // 1
+        uint32_t faction_id;                                        // 2
+        //uint32_t unk1;                                            // 3
+        uint32_t model_male;                                        // 4
+        uint32_t model_female;                                      // 5
+        // uint32_t unk2;                                           // 6
+        uint32_t team_id;                                           // 7
+        //uint32_t unk3[4];                                         // 8-11
+        uint32_t cinematic_id;                                      // 12 CinematicSequences.dbc
+        //uint32_t unk4                                             // 13
+        char* name[16];                                             // 14-29
+        //uint32_t name_flags                                       // 30
+        //char* name_female[16];                                    // 31-46
+        //uint32_t name_female_flags                                // 47
+        //char* name_neutral[16];                                   // 48-63
+        //uint32_t name_neutral_flags                               // 64 string flags, unused
+        //uint32_t unk5[3]                                          // 65-67 unused
+        uint32_t expansion;                                         // 68
     };
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t display_id;            // 0
-        //uint32_t model;               // 1
-        //uint32_t unk0                 // 2
-        //uint32_t InfoExtra;           // 3
-        //float size;                   // 4
-                                        // 5 - 15 unk
+        uint32_t display_id;                                        // 0
+        //uint32_t model;                                           // 1
+        //uint32_t unk0                                             // 2
+        //uint32_t InfoExtra;                                       // 3
+        //float size;                                               // 4
+                                                                    // 5 - 15 unk
     };
 
     struct CreatureFamilyEntry
     {
-        uint32_t ID;                      // 0
-        float minsize;                  // 1
-        uint32_t minlevel;                // 2
-        float maxsize;                  // 3
-        uint32_t maxlevel;                // 4
-        uint32_t skilline;                // 5
-        uint32_t tameable;                // 6 second skill line - 270 Generic
-        uint32_t petdietflags;            // 7
-        uint32_t talenttree;              // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
-        //uint32_t unk;                   // 9 some index 0 - 63
-        char* name[16];                 // 10-25
-        //uint32_t nameflags;             // 26
-        //uint32_t iconFile;              // 27
+        uint32_t ID;                                                // 0
+        float minsize;                                              // 1
+        uint32_t minlevel;                                          // 2
+        float maxsize;                                              // 3
+        uint32_t maxlevel;                                          // 4
+        uint32_t skilline;                                          // 5
+        uint32_t tameable;                                          // 6 second skill line - 270 Generic
+        uint32_t petdietflags;                                      // 7
+        uint32_t talenttree;                                        // 8 (-1 = none, 0 = ferocity(410), 1 = tenacity(409), 2 = cunning(411))
+        //uint32_t unk;                                             // 9 some index 0 - 63
+        char* name[16];                                             // 10-25
+        //uint32_t nameflags;                                       // 26
+        //uint32_t iconFile;                                        // 27
     };
 
     struct CreatureSpellDataEntry
     {
-        uint32_t id;                      // 0
-        uint32_t Spells[3];               // 1-3
-        uint32_t PHSpell;                 // 4
-        uint32_t Cooldowns[3];            // 5-7
-        uint32_t PH;                      // 8
+        uint32_t id;                                                // 0
+        uint32_t Spells[3];                                         // 1-3
+        uint32_t PHSpell;                                           // 4
+        uint32_t Cooldowns[3];                                      // 5-7
+        uint32_t PH;                                                // 8
     };
 
     struct CurrencyTypesEntry
     {
-        //uint32_t ID;            // 0 not used
-        uint32_t item_id;         // 1 used as index
-        //uint32_t Category;      // 2 may be category
-        uint32_t bit_index;       // 3 bit index in PLAYER_FIELD_KNOWN_CURRENCIES (1 << (index-1))
+        //uint32_t ID;                                              // 0 not used
+        uint32_t item_id;                                           // 1 used as index
+        //uint32_t Category;                                        // 2 may be category
+        uint32_t bit_index;                                         // 3 bit index in PLAYER_FIELD_KNOWN_CURRENCIES (1 << (index-1))
     };
 
     struct DurabilityCostsEntry
     {
-        uint32_t itemlevel;       // 0
-        uint32_t modifier[29];    // 1-29
+        uint32_t itemlevel;                                         // 0
+        uint32_t modifier[29];                                      // 1-29
     };
 
     struct DurabilityQualityEntry
     {
-        uint32_t id;              // 0
-        float quality_modifier; // 1
+        uint32_t id;                                                // 0
+        float quality_modifier;                                     // 1
     };
 
     struct EmotesTextEntry
     {
-        uint32_t Id;              // 0
-        //uint32_t name;          // 1
-        uint32_t textid;          // 2
-        uint32_t textid2;         // 3
-        uint32_t textid3;         // 4
-        uint32_t textid4;         // 5
-        //uint32_t unk1;          // 6
-        uint32_t textid5;         // 7
-        //uint32_t unk2;          // 8
-        uint32_t textid6;         // 9
-        //uint32_t unk3;          // 10
-        //uint32_t unk4;          // 11
-        //uint32_t unk5;          // 12
-        //uint32_t unk6;          // 13
-        //uint32_t unk7;          // 14
-        //uint32_t unk8;          // 15
-        //uint32_t unk9;          // 16
-        //uint32_t unk10;         // 17
-        //uint32_t unk11;         // 18
+        uint32_t Id;                                                // 0
+        //uint32_t name;                                            // 1
+        uint32_t textid;                                            // 2
+        uint32_t textid2;                                           // 3
+        uint32_t textid3;                                           // 4
+        uint32_t textid4;                                           // 5
+        //uint32_t unk1;                                            // 6
+        uint32_t textid5;                                           // 7
+        //uint32_t unk2;                                            // 8
+        uint32_t textid6;                                           // 9
+        //uint32_t unk3;                                            // 10
+        //uint32_t unk4;                                            // 11
+        //uint32_t unk5;                                            // 12
+        //uint32_t unk6;                                            // 13
+        //uint32_t unk7;                                            // 14
+        //uint32_t unk8;                                            // 15
+        //uint32_t unk9;                                            // 16
+        //uint32_t unk10;                                           // 17
+        //uint32_t unk11;                                           // 18
     };
 
     struct FactionEntry
     {
-        uint32_t ID;                      // 0
-        int32_t RepListId;                // 1
-        uint32_t RaceMask[4];             // 2-5
-        uint32_t ClassMask[4];            // 6-9
-        int32_t baseRepValue[4];          // 10-13
-        uint32_t repFlags[4];             // 14-17
-        uint32_t parentFaction;           // 18
-        float spillover_rate_in;        // 19
-        float spillover_rate_out;       // 20
-        uint32_t spillover_max_in;        // 21
-        //uint32_t unk1;                  // 22
-        char* Name[16];                 // 23-38
-        //uint32_t name_flags;            // 39
-        //uint32_t Description[16];       // 40-55
-        //uint32_t description_flags;     // 56
+        uint32_t ID;                                                // 0
+        int32_t RepListId;                                          // 1
+        uint32_t RaceMask[4];                                       // 2-5
+        uint32_t ClassMask[4];                                      // 6-9
+        int32_t baseRepValue[4];                                    // 10-13
+        uint32_t repFlags[4];                                       // 14-17
+        uint32_t parentFaction;                                     // 18
+        float spillover_rate_in;                                    // 19
+        float spillover_rate_out;                                   // 20
+        uint32_t spillover_max_in;                                  // 21
+        //uint32_t unk1;                                            // 22
+        char* Name[16];                                             // 23-38
+        //uint32_t name_flags;                                      // 39
+        //uint32_t Description[16];                                 // 40-55
+        //uint32_t description_flags;                               // 56
     };
 
     struct FactionTemplateEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t Faction;                 // 1
-        uint32_t FactionGroup;            // 2
-        uint32_t Mask;                    // 3
-        uint32_t FriendlyMask;            // 4
-        uint32_t HostileMask;             // 5
-        uint32_t EnemyFactions[4];        // 6-9
-        uint32_t FriendlyFactions[4];     // 10-13
+        uint32_t ID;                                                // 0
+        uint32_t Faction;                                           // 1
+        uint32_t FactionGroup;                                      // 2
+        uint32_t Mask;                                              // 3
+        uint32_t FriendlyMask;                                      // 4
+        uint32_t HostileMask;                                       // 5
+        uint32_t EnemyFactions[4];                                  // 6-9
+        uint32_t FriendlyFactions[4];                               // 10-13
     };
 
     struct GameObjectDisplayInfoEntry
     {
-        uint32_t Displayid;               // 0
-        char* filename;                 // 1
-        //uint32_t  unk1[10];             // 2-11
-        float minX;                     // 12
-        float minY;                     // 13
-        float minZ;                     // 14
-        float maxX;                     // 15
-        float maxY;                     // 16
-        float maxZ;                     // 17
-        //uint32_t transport;             // 18
+        uint32_t Displayid;                                         // 0
+        char* filename;                                             // 1
+        //uint32_t unk1[10];                                        // 2-11
+        float minX;                                                 // 12
+        float minY;                                                 // 13
+        float minZ;                                                 // 14
+        float maxX;                                                 // 15
+        float maxY;                                                 // 16
+        float maxZ;                                                 // 17
+        //uint32_t transport;                                       // 18
     };
 
     struct GemPropertiesEntry
     {
-        uint32_t Entry;                   // 0
-        uint32_t EnchantmentID;           // 1
-        //uint32_t unk1;                  // 2 bool
-        //uint32_t unk2;                  // 3 bool
-        uint32_t SocketMask;              // 4
+        uint32_t Entry;                                             // 0
+        uint32_t EnchantmentID;                                     // 1
+        //uint32_t unk1;                                            // 2 bool
+        //uint32_t unk2;                                            // 3 bool
+        uint32_t SocketMask;                                        // 4
     };
 
     struct GlyphPropertiesEntry
     {
-        uint32_t Entry;                   // 0
-        uint32_t SpellID;                 // 1
-        uint32_t Type;                    // 2 (0 = Major, 1 = Minor)
-        uint32_t unk;                     // 3 glyph_icon spell.dbc
+        uint32_t Entry;                                             // 0
+        uint32_t SpellID;                                           // 1
+        uint32_t Type;                                              // 2 (0 = Major, 1 = Minor)
+        uint32_t unk;                                               // 3 glyph_icon spell.dbc
     };
 
     struct GlyphSlotEntry
     {
-        uint32_t Id;              // 0
-        uint32_t Type;            // 1
-        uint32_t Slot;            // 2
+        uint32_t Id;                                                // 0
+        uint32_t Type;                                              // 1
+        uint32_t Slot;                                              // 2
     };
 
     struct GtBarberShopCostBaseEntry
     {
-        float cost;             // 0 cost base
+        float cost;                                                 // 0 cost base
     };
 
     struct GtChanceToMeleeCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToMeleeCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtChanceToSpellCritBaseEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtCombatRatingsEntry
     {
-        float val;              // 0
+        float val;                                                  // 0
     };
 
     struct GtOCTRegenHPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtOCTRegenMPEntry
     {
-        float ratio;            // 0
+        float ratio;                                                // 0
     };
 
     struct GtRegenHPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
     struct GtRegenMPPerSptEntry
     {
-        float ratio;            // 0 regen base
+        float ratio;                                                // 0 regen base
     };
 
 #define MAX_HOLIDAY_DURATIONS 10
@@ -906,108 +906,108 @@ namespace DBC::Structures
 
     struct HolidaysEntry
     {
-        uint32_t Id;                                  // 0
-        uint32_t Duration[MAX_HOLIDAY_DURATIONS];     // 1-10
-        uint32_t Date[MAX_HOLIDAY_DATES];             // 11-36
-        uint32_t Region;                              // 37
-        uint32_t Looping;                             // 38
-        uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];    // 39-48
-        //uint32_t holidayNameId;                     // 49 HolidayNames.dbc
-        //uint32_t holidayDescriptionId;              // 50 HolidayDescriptions.dbc
-        char* TextureFilename;                      // 51
-        uint32_t Priority;                            // 52
-        uint32_t CalendarFilterType;                  // 53
-        //uint32_t flags;                             // 54
+        uint32_t Id;                                                // 0
+        uint32_t Duration[MAX_HOLIDAY_DURATIONS];                   // 1-10
+        uint32_t Date[MAX_HOLIDAY_DATES];                           // 11-36
+        uint32_t Region;                                            // 37
+        uint32_t Looping;                                           // 38
+        uint32_t CalendarFlags[MAX_HOLIDAY_FLAGS];                  // 39-48
+        //uint32_t holidayNameId;                                   // 49 HolidayNames.dbc
+        //uint32_t holidayDescriptionId;                            // 50 HolidayDescriptions.dbc
+        char* TextureFilename;                                      // 51
+        uint32_t Priority;                                          // 52
+        uint32_t CalendarFilterType;                                // 53
+        //uint32_t flags;                                           // 54
     };
 
     struct ItemEntry
     {
-        uint32_t ID;                      // 0
-        uint32_t Class;                   // 1
-        uint32_t SubClass;                // 2 some items have strange subclasses
-        int32_t SoundOverrideSubclass;    // 3
-        int32_t Material;                 // 4
-        uint32_t DisplayId;               // 5
-        uint32_t InventoryType;           // 6
-        uint32_t Sheath;                  // 7
+        uint32_t ID;                                                // 0
+        uint32_t Class;                                             // 1
+        uint32_t SubClass;                                          // 2 some items have strange subclasses
+        int32_t SoundOverrideSubclass;                              // 3
+        int32_t Material;                                           // 4
+        uint32_t DisplayId;                                         // 5
+        uint32_t InventoryType;                                     // 6
+        uint32_t Sheath;                                            // 7
     };
 
     struct ItemExtendedCostEntry
     {
-        uint32_t costid;                  // 0
-        uint32_t honor_points;            // 1
-        uint32_t arena_points;            // 2
-        uint32_t arena_slot;              // 3
-        uint32_t item[5];                 // 4-8
-        uint32_t count[5];                // 9-13
-        uint32_t personalrating;          // 14
-        //uint32_t unk;                   // 15
+        uint32_t costid;                                            // 0
+        uint32_t honor_points;                                      // 1
+        uint32_t arena_points;                                      // 2
+        uint32_t arena_slot;                                        // 3
+        uint32_t item[5];                                           // 4-8
+        uint32_t count[5];                                          // 9-13
+        uint32_t personalrating;                                    // 14
+        //uint32_t unk;                                             // 15
     };
 
     struct ItemLimitCategoryEntry
     {
-        uint32_t Id;                      // 0
-        //char* name[16];               // 1-16 name langs
-        //uint32_t name_flags             // 17
-        uint32_t maxAmount;               // 18
-        uint32_t equippedFlag;            // 19 - equipped (bool?)
+        uint32_t Id;                                                // 0
+        //char* name[16];                                           // 1-16 name langs
+        //uint32_t name_flags                                       // 17
+        uint32_t maxAmount;                                         // 18
+        uint32_t equippedFlag;                                      // 19 - equipped (bool?)
     };
 
     struct ItemRandomPropertiesEntry
     {
-        uint32_t ID;                      // 0
-        //uint32_t name1;                 // 1
-        uint32_t spells[3];               // 2-4
-        //uint32_t unk1;                  // 5
-        //uint32_t unk2;                  // 6
-        char* name_suffix[16];          // 7-22
-        //uint32_t name_suffix_flags;     // 23
+        uint32_t ID;                                                // 0
+        //uint32_t name1;                                           // 1
+        uint32_t spells[3];                                         // 2-4
+        //uint32_t unk1;                                            // 5
+        //uint32_t unk2;                                            // 6
+        char* name_suffix[16];                                      // 7-22
+        //uint32_t name_suffix_flags;                               // 23
     };
 
     struct ItemRandomSuffixEntry
     {
-        uint32_t id;                      // 0
-        char* name_suffix[16];          // 1-16
-        //uint32_t name_suffix_flags;     // 17
-        //uint32_t unk1;                  // 18
-        uint32_t enchantments[3];         // 19-21
-        //uint32_t unk2[2];               // 22-23
-        uint32_t prefixes[3];             // 24-26
-        //uint32_t[2];                    // 27-28
+        uint32_t id;                                                // 0
+        char* name_suffix[16];                                      // 1-16
+        //uint32_t name_suffix_flags;                               // 17
+        //uint32_t unk1;                                            // 18
+        uint32_t enchantments[3];                                   // 19-21
+        //uint32_t unk2[2];                                         // 22-23
+        uint32_t prefixes[3];                                       // 24-26
+        //uint32_t[2];                                              // 27-28
     };
 
     struct ItemSetEntry
     {
-        uint32_t id;                      // 1
-        char* name[16];                 // 1-16 name (lang)
-        //uint32_t localeflag;            // 17 constant
-        uint32_t itemid[10];              // 18-27 item set items
-        //uint32_t unk[7];                // 28-34 all 0
-        uint32_t SpellID[8];              // 35-42
-        uint32_t itemscount[8];           // 43-50
-        uint32_t RequiredSkillID;         // 51
-        uint32_t RequiredSkillAmt;        // 52
+        uint32_t id;                                                // 1
+        char* name[16];                                             // 1-16 name (lang)
+        //uint32_t localeflag;                                      // 17 constant
+        uint32_t itemid[10];                                        // 18-27 item set items
+        //uint32_t unk[7];                                          // 28-34 all 0
+        uint32_t SpellID[8];                                        // 35-42
+        uint32_t itemscount[8];                                     // 43-50
+        uint32_t RequiredSkillID;                                   // 51
+        uint32_t RequiredSkillAmt;                                  // 52
     };
 
     struct LFGDungeonEntry
     {
-        uint32_t ID;              // 0
-        char* name[16];         // 1-17 Name lang
-        uint32_t minlevel;        // 18
-        uint32_t maxlevel;        // 19
-        uint32_t reclevel;        // 20
-        uint32_t recminlevel;     // 21
-        uint32_t recmaxlevel;     // 22
-        int32_t map;              // 23
-        uint32_t difficulty;      // 24
-        uint32_t flags;           // 25
-        uint32_t type;            // 26
-        //uint32_t  unk;          // 27
-        //char* iconname;       // 28
-        uint32_t expansion;       // 29
-        //uint32_t unk4;          // 30
-        uint32_t grouptype;       // 31
-        //char* desc[16];       // 32-47 Description
+        uint32_t ID;                                                // 0
+        char* name[16];                                             // 1-17 Name lang
+        uint32_t minlevel;                                          // 18
+        uint32_t maxlevel;                                          // 19
+        uint32_t reclevel;                                          // 20
+        uint32_t recminlevel;                                       // 21
+        uint32_t recmaxlevel;                                       // 22
+        int32_t map;                                                // 23
+        uint32_t difficulty;                                        // 24
+        uint32_t flags;                                             // 25
+        uint32_t type;                                              // 26
+        //uint32_t  unk;                                            // 27
+        //char* iconname;                                           // 28
+        uint32_t expansion;                                         // 29
+        //uint32_t unk4;                                            // 30
+        uint32_t grouptype;                                         // 31
+        //char* desc[16];                                           // 32-47 Description
 
         // Helpers
         uint32_t Entry() const { return ID + (type << 24); }
@@ -1015,84 +1015,84 @@ namespace DBC::Structures
 
     struct DungeonEncounterEntry
     {
-        uint32 id;                                              // 0        unique id
-        uint32 mapId;                                           // 1        map id
-        uint32 difficulty;                                      // 2        instance mode
-        //uint32 unk0;                                          // 3
-        uint32 encounterIndex;                                  // 4        encounter index for creating completed mask
-        char* encounterName[16];                                // 5        encounter name
-        //uint32 nameFlags;                                     // 21
-        //uint32 unk1;                                          // 22
+        uint32_t id;                                                // 0 unique id
+        uint32_t mapId;                                             // 1 map id
+        uint32_t difficulty;                                        // 2 instance mode
+        //uint32_t unk0;                                            // 3
+        uint32_t encounterIndex;                                    // 4 encounter index for creating completed mask
+        char* encounterName[16];                                    // 5 encounter name
+        //uint32_t nameFlags;                                       // 21
+        //uint32_t unk1;                                            // 22
     };
 
     struct LiquidTypeEntry
     {
-        uint32_t Id;                  // 0
-        //char* Name;               // 1
-        //uint32_t Flags;             // 2
-        uint32_t Type;                // 3
-        //uint32_t SoundId;           // 4
-        uint32_t SpellId;             // 5
-        //float MaxDarkenDepth;     // 6
-        //float FogDarkenIntensity; // 7
-        //float AmbDarkenIntensity; // 8
-        //float DirDarkenIntensity; // 9
-        //uint32_t LightID;           // 10
-        //float ParticleScale;      // 11
-        //uint32_t ParticleMovement;  // 12
-        //uint32_t ParticleTexSlots;  // 13
-        //uint32_t LiquidMaterialID;  // 14
-        //char* Texture[6];         // 15-20
-        //uint32_t Color[2];          // 21-22
-        //float Unk1[18];           // 23-40
-        //uint32_t Unk2[4];           // 41-44
+        uint32_t Id;                                                // 0
+        //char* Name;                                               // 1
+        //uint32_t Flags;                                           // 2
+        uint32_t Type;                                              // 3
+        //uint32_t SoundId;                                         // 4
+        uint32_t SpellId;                                           // 5
+        //float MaxDarkenDepth;                                     // 6
+        //float FogDarkenIntensity;                                 // 7
+        //float AmbDarkenIntensity;                                 // 8
+        //float DirDarkenIntensity;                                 // 9
+        //uint32_t LightID;                                         // 10
+        //float ParticleScale;                                      // 11
+        //uint32_t ParticleMovement;                                // 12
+        //uint32_t ParticleTexSlots;                                // 13
+        //uint32_t LiquidMaterialID;                                // 14
+        //char* Texture[6];                                         // 15-20
+        //uint32_t Color[2];                                        // 21-22
+        //float Unk1[18];                                           // 23-40
+        //uint32_t Unk2[4];                                         // 41-44
     };
 
 #define LOCK_NUM_CASES 8
 
     struct LockEntry
     {
-        uint32_t Id;                              // 0
-        uint32_t locktype[LOCK_NUM_CASES];        // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
-        uint32_t lockmisc[LOCK_NUM_CASES];        // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
-        uint32_t minlockskill[LOCK_NUM_CASES];    // 17-24 Required skill needed for lockmisc (if locktype = 2).
-        //uint32_t action[LOCK_NUM_CASES];        // 25-32 Something to do with direction / opening / closing.
+        uint32_t Id;                                                // 0
+        uint32_t locktype[LOCK_NUM_CASES];                          // 1-8 If this is 1, then the next lockmisc is an item ID, if it's 2, then it's an iRef to LockTypes.dbc.
+        uint32_t lockmisc[LOCK_NUM_CASES];                          // 9-16 Item to unlock or iRef to LockTypes.dbc depending on the locktype.
+        uint32_t minlockskill[LOCK_NUM_CASES];                      // 17-24 Required skill needed for lockmisc (if locktype = 2).
+        //uint32_t action[LOCK_NUM_CASES];                          // 25-32 Something to do with direction / opening / closing.
     };
 
     struct MailTemplateEntry
     {
-        uint32_t ID;              // 0
-        char* subject;          // 1
-        //float unused1[15]     // 2-16
-        //uint32_t flags1         // 17 name flags, unused
-        char* content;          // 18
-        //float unused2[15]     // 19-34
-        //uint32_t flags2         // 35 name flags, unused
+        uint32_t ID;                                                // 0
+        char* subject;                                              // 1
+        //float unused1[15]                                         // 2-16
+        //uint32_t flags1                                           // 17 name flags, unused
+        char* content;                                              // 18
+        //float unused2[15]                                         // 19-34
+        //uint32_t flags2                                           // 35 name flags, unused
     };
 
     struct MapEntry
     {
-        uint32_t id;                      // 0
-        //char* name_internal;          // 1
-        uint32_t map_type;                // 2
-        uint32_t map_flags;               // 3
-        //uint32_t is_pvp_zone;           // 4 -0 false -1 true
-        char* map_name[16];             // 5-20
-        //uint32_t name_flags;            // 21
-        uint32_t linked_zone;             // 22 common zone for instance and continent map
-        //char* horde_intro[16];        // 23-38 horde text for PvP Zones
-        //uint32_t hordeIntro_flags;      // 39
-        //char* alliance_intro[16];     // 40-55 alliance text for PvP Zones
-        //uint32_t allianceIntro_flags;   // 56
-        uint32_t multimap_id;             // 57
-        //uint32_t battlefield_map_icon;  // 58
-        int32_t parent_map;               // 59 map_id of parent map
-        float start_x;                  // 60 enter x coordinate (if exist single entry)
-        float start_y;                  // 61 enter y coordinate (if exist single entry)
-        //uint32_t dayTime;               // 62 
-        uint32_t addon;                   // 63 0-original maps, 1-tbc addon, 2-wotlk addon
-        uint32_t unk_time;                // 64
-        uint32_t max_players;             // 65
+        uint32_t id;                                                // 0
+        //char* name_internal;                                      // 1
+        uint32_t map_type;                                          // 2
+        uint32_t map_flags;                                         // 3
+        //uint32_t is_pvp_zone;                                     // 4 -0 false -1 true
+        char* map_name[16];                                         // 5-20
+        //uint32_t name_flags;                                      // 21
+        uint32_t linked_zone;                                       // 22 common zone for instance and continent map
+        //char* horde_intro[16];                                    // 23-38 horde text for PvP Zones
+        //uint32_t hordeIntro_flags;                                // 39
+        //char* alliance_intro[16];                                 // 40-55 alliance text for PvP Zones
+        //uint32_t allianceIntro_flags;                             // 56
+        uint32_t multimap_id;                                       // 57
+        //uint32_t battlefield_map_icon;                            // 58
+        int32_t parent_map;                                         // 59 map_id of parent map
+        float start_x;                                              // 60 enter x coordinate (if exist single entry)
+        float start_y;                                              // 61 enter y coordinate (if exist single entry)
+        //uint32_t dayTime;                                         // 62 
+        uint32_t addon;                                             // 63 0-original maps, 1-tbc addon, 2-wotlk addon
+        uint32_t unk_time;                                          // 64
+        uint32_t max_players;                                       // 65
 
         bool isDungeon() const { return map_type == MAP_INSTANCE || map_type == MAP_RAID; }
         bool isNonRaidDungeon() const { return map_type == MAP_INSTANCE; }
@@ -1111,94 +1111,94 @@ namespace DBC::Structures
 
     struct NameGenEntry
     {
-        uint32_t ID;              // 0
-        char* Name;             // 1
-        uint32_t unk1;            // 2
-        uint32_t type;            // 3
+        uint32_t ID;                                                // 0
+        char* Name;                                                 // 1
+        uint32_t unk1;                                              // 2
+        uint32_t type;                                              // 3
     };
 
     struct QuestXP
     {
-        uint32_t questLevel;     // 0
-        uint32_t xpIndex[10];    // 1-10
+        uint32_t questLevel;                                        // 0
+        uint32_t xpIndex[10];                                       // 1-10
     };
 
     struct ScalingStatDistributionEntry
     {
-        uint32_t id;                  // 0
-        int32_t stat[10];             // 1-10
-        uint32_t statmodifier[10];    // 11-20
-        uint32_t maxlevel;            // 21
+        uint32_t id;                                                // 0
+        int32_t stat[10];                                           // 1-10
+        uint32_t statmodifier[10];                                  // 11-20
+        uint32_t maxlevel;                                          // 21
     };
 
     struct ScalingStatValuesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t level;               // 1
-        uint32_t multiplier[16];      // 2-17 ///\todo split this
-        uint32_t unk1;                // 18
-        uint32_t amor_mod[5];         // 19-23
+        uint32_t id;                                                // 0
+        uint32_t level;                                             // 1
+        uint32_t multiplier[16];                                    // 2-17 ///\todo split this
+        uint32_t unk1;                                              // 18
+        uint32_t amor_mod[5];                                       // 19-23
     };
 
     struct SkillLineEntry
     {
-        uint32_t id;                  // 0
-        uint32_t type;                // 1
-        //uint32_t skillCostsID;      // 2
-        char* Name[16];             // 3-18
-        //uint32_t NameFlags;         // 19
-        //char* Description[16];    // 20-35
-        //uint32_t DescriptionFlags;  // 36
-        uint32_t spell_icon;          // 37
-        //char* add_name[16];       // 38-53
-        //uint32_t add_name_flags;    // 54
-        uint32_t linkable;            // 55
+        uint32_t id;                                                // 0
+        uint32_t type;                                              // 1
+        //uint32_t skillCostsID;                                    // 2
+        char* Name[16];                                             // 3-18
+        //uint32_t NameFlags;                                       // 19
+        //char* Description[16];                                    // 20-35
+        //uint32_t DescriptionFlags;                                // 36
+        uint32_t spell_icon;                                        // 37
+        //char* add_name[16];                                       // 38-53
+        //uint32_t add_name_flags;                                  // 54
+        uint32_t linkable;                                          // 55
     };
 
     struct SkillLineAbilityEntry
     {
-        uint32_t Id;                      // 0
-        uint32_t skilline;                // 1 skill id
-        uint32_t spell;                   // 2
-        uint32_t race_mask;               // 3
-        uint32_t class_mask;              // 4
-        //uint32_t excludeRace;           // 5
-        //uint32_t excludeClass;          // 6
-        uint32_t minSkillLineRank;        // 7 req skill value
-        uint32_t next;                    // 8
-        uint32_t acquireMethod;           // 9 auto learn
-        uint32_t grey;                    // 10 max
-        uint32_t green;                   // 11 min
-        //uint32_t abandonable;           // 12
-        //uint32_t reqTP;                 // 13
+        uint32_t Id;                                                // 0
+        uint32_t skilline;                                          // 1 skill id
+        uint32_t spell;                                             // 2
+        uint32_t race_mask;                                         // 3
+        uint32_t class_mask;                                        // 4
+        //uint32_t excludeRace;                                     // 5
+        //uint32_t excludeClass;                                    // 6
+        uint32_t minSkillLineRank;                                  // 7 req skill value
+        uint32_t next;                                              // 8
+        uint32_t acquireMethod;                                     // 9 auto learn
+        uint32_t grey;                                              // 10 max
+        uint32_t green;                                             // 11 min
+        //uint32_t abandonable;                                     // 12
+        //uint32_t reqTP;                                           // 13
     };
 
     struct StableSlotPrices
     {
-        uint32_t Id;              // 0
-        uint32_t Price;           // 1
+        uint32_t Id;                                                // 0
+        uint32_t Price;                                             // 1
     };
 
     struct SpellCastTimesEntry
     {
-        uint32_t ID;              // 0
-        uint32_t CastTime;        // 1
-        //uint32_t unk1;          // 2
-        //uint32_t unk2;          // 3
+        uint32_t ID;                                                // 0
+        uint32_t CastTime;                                          // 1
+        //uint32_t unk1;                                            // 2
+        //uint32_t unk2;                                            // 3
     };
 
     struct SpellDifficultyEntry
     {
-        uint32_t ID;              // 0
-        int32_t SpellId[4];       // 1-4 (instance modes)
+        uint32_t ID;                                                // 0
+        int32_t SpellId[4];                                         // 1-4 (instance modes)
     };
 
     struct SpellDurationEntry
     {
-        uint32_t ID;              // 0
-        uint32_t Duration1;       // 1
-        uint32_t Duration2;       // 2
-        uint32_t Duration3;       // 3
+        uint32_t ID;                                                // 0
+        uint32_t Duration1;                                         // 1
+        uint32_t Duration2;                                         // 2
+        uint32_t Duration3;                                         // 3
     };
 
     #define MAX_SPELL_EFFECTS 3
@@ -1322,222 +1322,222 @@ namespace DBC::Structures
 
     struct SpellItemEnchantmentEntry
     {
-        uint32_t Id;                  // 0
-        //uint32_t charges;           // 1
-        uint32_t type[3];             // 2-4
-        int32_t min[3];               // 5-7 for combat, in practice min==max
-        int32_t max[3];               // 8-10
-        uint32_t spell[3];            // 11-13
-        char* Name[16];             // 14-29
-        //uint32_t NameFlags;         // 30
-        uint32_t visual;              // 31 aura
-        uint32_t EnchantGroups;       // 32 slot
-        uint32_t GemEntry;            // 33
-        uint32_t ench_condition;      // 34
-        uint32_t req_skill;           // 35
-        uint32_t req_skill_value;     // 36
-        uint32_t req_level;           // 37
+        uint32_t Id;                                                // 0
+        //uint32_t charges;                                         // 1
+        uint32_t type[3];                                           // 2-4
+        int32_t min[3];                                             // 5-7 for combat, in practice min==max
+        int32_t max[3];                                             // 8-10
+        uint32_t spell[3];                                          // 11-13
+        char* Name[16];                                             // 14-29
+        //uint32_t NameFlags;                                       // 30
+        uint32_t visual;                                            // 31 aura
+        uint32_t EnchantGroups;                                     // 32 slot
+        uint32_t GemEntry;                                          // 33
+        uint32_t ench_condition;                                    // 34
+        uint32_t req_skill;                                         // 35
+        uint32_t req_skill_value;                                   // 36
+        uint32_t req_level;                                         // 37
     };
 
     struct SpellRadiusEntry
     {
-        uint32_t ID;                  // 0
-        float radius_min;           // 1 Radius
-        float radius_per_level;     // 2
-        float radius_max;           // 3 Radius2
+        uint32_t ID;                                                // 0
+        float radius_min;                                           // 1 Radius
+        float radius_per_level;                                     // 2
+        float radius_max;                                           // 3 Radius2
     };
 
     struct SpellRangeEntry
     {
-        uint32_t ID;                  // 0
-        float minRange;             // 1
-        float minRangeFriendly;     // 2
-        float maxRange;             // 3
-        float maxRangeFriendly;     // 4
-        uint32_t range_type;          // 5
-        //char* name1[16]           // 6-21
-        //uint32_t name1_falgs;       // 22
-        //char* name2[16]           // 23-38
-        //uint32_t name2_falgs;       // 39
+        uint32_t ID;                                                // 0
+        float minRange;                                             // 1
+        float minRangeFriendly;                                     // 2
+        float maxRange;                                             // 3
+        float maxRangeFriendly;                                     // 4
+        uint32_t range_type;                                        // 5
+        //char* name1[16]                                           // 6-21
+        //uint32_t name1_falgs;                                     // 22
+        //char* name2[16]                                           // 23-38
+        //uint32_t name2_falgs;                                     // 39
     };
 
     struct SpellRuneCostEntry
     {
-        uint32_t ID;              // 0
-        uint32_t bloodRuneCost;   // 1
-        uint32_t frostRuneCost;   // 2
-        uint32_t unholyRuneCost;  // 3
-        uint32_t runePowerGain;   // 4
+        uint32_t ID;                                                // 0
+        uint32_t bloodRuneCost;                                     // 1
+        uint32_t frostRuneCost;                                     // 2
+        uint32_t unholyRuneCost;                                    // 3
+        uint32_t runePowerGain;                                     // 4
     };
 
     struct SpellShapeshiftFormEntry
     {
-        uint32_t id;                  // 0
-        //uint32_t button_pos;        // 1
-        //char* name[16];           // 2-17
-        //uint32_t name_flags;        // 18
-        uint32_t Flags;               // 19
-        uint32_t unit_type;           // 20
-        //uint32_t unk1               // 21
-        uint32_t AttackSpeed;         // 22
-        uint32_t modelId;             // 23 alliance?
-        uint32_t modelId2;            // 24 horde?
-        //uint32_t unk2               // 25
-        //uint32_t unk3               // 26
-        uint32_t spells[8];           // 27-34
+        uint32_t id;                                                // 0
+        //uint32_t button_pos;                                      // 1
+        //char* name[16];                                           // 2-17
+        //uint32_t name_flags;                                      // 18
+        uint32_t Flags;                                             // 19
+        uint32_t unit_type;                                         // 20
+        //uint32_t unk1                                             // 21
+        uint32_t AttackSpeed;                                       // 22
+        uint32_t modelId;                                           // 23 alliance?
+        uint32_t modelId2;                                          // 24 horde?
+        //uint32_t unk2                                             // 25
+        //uint32_t unk3                                             // 26
+        uint32_t spells[8];                                         // 27-34
     };
 
     struct SummonPropertiesEntry
     {
-        uint32_t ID;                  // 0
-        uint32_t ControlType;         // 1
-        uint32_t FactionID;           // 2
-        uint32_t Type;                // 3
-        uint32_t Slot;                // 4
-        uint32_t Flags;               // 5
+        uint32_t ID;                                                // 0
+        uint32_t ControlType;                                       // 1
+        uint32_t FactionID;                                         // 2
+        uint32_t Type;                                              // 3
+        uint32_t Slot;                                              // 4
+        uint32_t Flags;                                             // 5
     };
 
     struct TalentEntry
     {
-        uint32_t TalentID;            // 0
-        uint32_t TalentTree;          // 1
-        uint32_t Row;                 // 2
-        uint32_t Col;                 // 3
-        uint32_t RankID[5];           // 4-8
-        //uint32_t unk[4];            // 9-12
-        uint32_t DependsOn;           // 13
-        //uint32_t unk1[2];           // 14-15
-        uint32_t DependsOnRank;       // 16
-        //uint32_t unk2[2];           // 17-18
-        //uint32_t unk3;              // 19
-        //uint32_t unk4;              // 20
-        //uint32_t unk5;              // 21
+        uint32_t TalentID;                                          // 0
+        uint32_t TalentTree;                                        // 1
+        uint32_t Row;                                               // 2
+        uint32_t Col;                                               // 3
+        uint32_t RankID[5];                                         // 4-8
+        //uint32_t unk[4];                                          // 9-12
+        uint32_t DependsOn;                                         // 13
+        //uint32_t unk1[2];                                         // 14-15
+        uint32_t DependsOnRank;                                     // 16
+        //uint32_t unk2[2];                                         // 17-18
+        //uint32_t unk3;                                            // 19
+        //uint32_t unk4;                                            // 20
+        //uint32_t unk5;                                            // 21
     };
 
     struct TalentTabEntry
     {
-        uint32_t TalentTabID;         // 0
-        //char* Name[16];           // 1-16
-        //uint32_t name_flags;        // 17
-        //uint32_t unk4;              // 18
-        //uint32_t unk5;              // 19
-        uint32_t ClassMask;           // 20
-        uint32_t PetTalentMask;       // 21
-        uint32_t TabPage;             // 22
-        //char* InternalName;       // 23
+        uint32_t TalentTabID;                                       // 0
+        //char* Name[16];                                           // 1-16
+        //uint32_t name_flags;                                      // 17
+        //uint32_t unk4;                                            // 18
+        //uint32_t unk5;                                            // 19
+        uint32_t ClassMask;                                         // 20
+        uint32_t PetTalentMask;                                     // 21
+        uint32_t TabPage;                                           // 22
+        //char* InternalName;                                       // 23
     };
 
     struct TaxiNodesEntry
     {
-        uint32_t id;                  // 0
-        uint32_t mapid;               // 1
-        float x;                    // 2
-        float y;                    // 3
-        float z;                    // 4
-        char* name[16];             // 5-21
-        //uint32_t nameflags;         // 22
-        uint32_t horde_mount;         // 23
-        uint32_t alliance_mount;      // 24
+        uint32_t id;                                                // 0
+        uint32_t mapid;                                             // 1
+        float x;                                                    // 2
+        float y;                                                    // 3
+        float z;                                                    // 4
+        char* name[16];                                             // 5-21
+        //uint32_t nameflags;                                       // 22
+        uint32_t horde_mount;                                       // 23
+        uint32_t alliance_mount;                                    // 24
     };
 
     struct TaxiPathEntry
     {
-        uint32_t id;                  // 0
-        uint32_t from;                // 1
-        uint32_t to;                  // 2
-        uint32_t price;               // 3
+        uint32_t id;                                                // 0
+        uint32_t from;                                              // 1
+        uint32_t to;                                                // 2
+        uint32_t price;                                             // 3
     };
 
     struct TaxiPathNodeEntry
     {
-        uint32_t id;                  // 0
-        uint32_t path;                // 1
-        uint32_t seq;                 // 2 nodeIndex
-        uint32_t mapid;               // 3
-        float x;                    // 4
-        float y;                    // 5
-        float z;                    // 6
-        uint32_t flags;               // 7
-        uint32_t waittime;            // 8
-        uint32_t arivalEventID;       // 9
-        uint32_t departureEventID;    // 10
+        uint32_t id;                                                // 0
+        uint32_t path;                                              // 1
+        uint32_t seq;                                               // 2 nodeIndex
+        uint32_t mapid;                                             // 3
+        float x;                                                    // 4
+        float y;                                                    // 5
+        float z;                                                    // 6
+        uint32_t flags;                                             // 7
+        uint32_t waittime;                                          // 8
+        uint32_t arivalEventID;                                     // 9
+        uint32_t departureEventID;                                  // 10
     };
 
     struct TotemCategoryEntry
     {
-        uint32_t id;            // 0
-        //char* name[16];       // 1-16
-        //uint32_t unk;         // 17
-        uint32_t categoryType;  // 18
-        uint32_t categoryMask;  // 19
+        uint32_t id;                                                // 0
+        //char* name[16];                                           // 1-16
+        //uint32_t unk;                                             // 17
+        uint32_t categoryType;                                      // 18
+        uint32_t categoryMask;                                      // 19
     };
 
     struct TransportAnimationEntry
     {
-        //uint32_t ID;          // 0
-        uint32_t TransportID;   // 1
-        uint32_t TimeIndex;     // 2
-        DBCPosition3D Pos;      // 3
-        //uint32_t SequenceID;  // 4
+        //uint32_t ID;                                              // 0
+        uint32_t TransportID;                                       // 1
+        uint32_t TimeIndex;                                         // 2
+        DBCPosition3D Pos;                                          // 3
+        //uint32_t SequenceID;                                      // 4
     };
 
     struct TransportRotationEntry
     {
-        //uint32_t ID;          // 0
-        uint32_t GameObjectsID; // 1
-        uint32_t TimeIndex;     // 2
-        float X;                // 3
-        float Y;                // 4
-        float Z;                // 5
-        float W;                // 6
+        //uint32_t ID;                                              // 0
+        uint32_t GameObjectsID;                                     // 1
+        uint32_t TimeIndex;                                         // 2
+        float X;                                                    // 3
+        float Y;                                                    // 4
+        float Z;                                                    // 5
+        float W;                                                    // 6
     };
 
     #define MAX_VEHICLE_SEATS 8
 
     struct VehicleEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        float turnSpeed;                                    // 2
-        float pitchSpeed;                                   // 3
-        float pitchMin;                                     // 4
-        float pitchMax;                                     // 5
-        uint32_t seatID[MAX_VEHICLE_SEATS];                   // 6-13
-        float mouseLookOffsetPitch;                         // 14
-        float cameraFadeDistScalarMin;                      // 15
-        float cameraFadeDistScalarMax;                      // 16
-        float cameraPitchOffset;                            // 17
-        float facingLimitRight;                             // 18
-        float facingLimitLeft;                              // 19
-        float msslTrgtTurnLingering;                        // 20
-        float msslTrgtPitchLingering;                       // 21
-        float msslTrgtMouseLingering;                       // 22
-        float msslTrgtEndOpacity;                           // 23
-        float msslTrgtArcSpeed;                             // 24
-        float msslTrgtArcRepeat;                            // 25
-        float msslTrgtArcWidth;                             // 26
-        float msslTrgtImpactRadius[2];                      // 27-28
-        char* msslTrgtArcTexture;                           // 29
-        char* msslTrgtImpactTexture;                        // 30
-        char* msslTrgtImpactModel[2];                       // 31-32
-        float cameraYawOffset;                              // 33
-        uint32_t uiLocomotionType;                            // 34
-        float msslTrgtImpactTexRadius;                      // 35
-        uint32_t uiSeatIndicatorType;                         // 36
-        uint32_t powerType;                                   // 37, new in 3.1
-        //uint32_t unk1;                                      // 38
-        //uint32_t unk2;                                      // 39  
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        float turnSpeed;                                            // 2
+        float pitchSpeed;                                           // 3
+        float pitchMin;                                             // 4
+        float pitchMax;                                             // 5
+        uint32_t seatID[MAX_VEHICLE_SEATS];                         // 6-13
+        float mouseLookOffsetPitch;                                 // 14
+        float cameraFadeDistScalarMin;                              // 15
+        float cameraFadeDistScalarMax;                              // 16
+        float cameraPitchOffset;                                    // 17
+        float facingLimitRight;                                     // 18
+        float facingLimitLeft;                                      // 19
+        float msslTrgtTurnLingering;                                // 20
+        float msslTrgtPitchLingering;                               // 21
+        float msslTrgtMouseLingering;                               // 22
+        float msslTrgtEndOpacity;                                   // 23
+        float msslTrgtArcSpeed;                                     // 24
+        float msslTrgtArcRepeat;                                    // 25
+        float msslTrgtArcWidth;                                     // 26
+        float msslTrgtImpactRadius[2];                              // 27-28
+        char* msslTrgtArcTexture;                                   // 29
+        char* msslTrgtImpactTexture;                                // 30
+        char* msslTrgtImpactModel[2];                               // 31-32
+        float cameraYawOffset;                                      // 33
+        uint32_t uiLocomotionType;                                  // 34
+        float msslTrgtImpactTexRadius;                              // 35
+        uint32_t uiSeatIndicatorType;                               // 36
+        uint32_t powerType;                                         // 37, new in 3.1
+        //uint32_t unk1;                                            // 38
+        //uint32_t unk2;                                            // 39
     };
 
     enum VehicleSeatFlags
     {
-        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,           // Passenger is hidden
+        VEHICLE_SEAT_FLAG_HIDE_PASSENGER             = 0x00000200,  // Passenger is hidden
         VEHICLE_SEAT_FLAG_UNK11                      = 0x00000400,
-        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,           // Lua_UnitInVehicleControlSeat
-        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,           // Can attack, cast spells and use items from vehicle?
-        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,           // Lua_CanExitVehicle
-        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,           // Lua_CanSwitchVehicleSeats
-        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,           // Lua_UnitHasVehicleUI
+        VEHICLE_SEAT_FLAG_CAN_CONTROL                = 0x00000800,  // Lua_UnitInVehicleControlSeat
+        VEHICLE_SEAT_FLAG_CAN_ATTACK                 = 0x00004000,  // Can attack, cast spells and use items from vehicle?
+        VEHICLE_SEAT_FLAG_USABLE                     = 0x02000000,  // Lua_CanExitVehicle
+        VEHICLE_SEAT_FLAG_CAN_SWITCH                 = 0x04000000,  // Lua_CanSwitchVehicleSeats
+        VEHICLE_SEAT_FLAG_CAN_CAST                   = 0x20000000,  // Lua_UnitHasVehicleUI
     };
 
     enum VehicleSeatFlagsB
@@ -1550,52 +1550,52 @@ namespace DBC::Structures
 
     struct VehicleSeatEntry
     {
-        uint32_t ID;                                          // 0
-        uint32_t flags;                                       // 1
-        int32_t attachmentID;                                 // 2
-        float attachmentOffsetX;                            // 3
-        float attachmentOffsetY;                            // 4
-        float attachmentOffsetZ;                            // 5
-        float enterPreDelay;                                // 6
-        float enterSpeed;                                   // 7
-        float enterGravity;                                 // 8
-        float enterMinDuration;                             // 9
-        float enterMaxDuration;                             // 10
-        float enterMinArcHeight;                            // 11
-        float enterMaxArcHeight;                            // 12
-        int32_t enterAnimStart;                               // 13
-        int32_t enterAnimLoop;                                // 14
-        int32_t rideAnimStart;                                // 15
-        int32_t rideAnimLoop;                                 // 16
-        int32_t rideUpperAnimStart;                           // 17
-        int32_t rideUpperAnimLoop;                            // 18
-        float exitPreDelay;                                 // 19
-        float exitSpeed;                                    // 20
-        float exitGravity;                                  // 21
-        float exitMinDuration;                              // 22
-        float exitMaxDuration;                              // 23
-        float exitMinArcHeight;                             // 24
-        float exitMaxArcHeight;                             // 25
-        int32_t exitAnimStart;                                // 26
-        int32_t exitAnimLoop;                                 // 27
-        int32_t exitAnimEnd;                                  // 28
-        float passengerYaw;                                 // 29
-        float passengerPitch;                               // 30
-        float passengerRoll;                                // 31
-        int32_t passengerAttachmentID;                        // 32
-        int32_t vehicleEnterAnim;                             // 33
-        int32_t vehicleExitAnim;                              // 34
-        int32_t vehicleRideAnimLoop;                          // 35
-        int32_t vehicleEnterAnimBone;                         // 36
-        int32_t vehicleExitAnimBone;                          // 37
-        int32_t vehicleRideAnimLoopBone;                      // 38
-        float vehicleEnterAnimDelay;                        // 39
-        float vehicleExitAnimDelay;                         // 40
-        uint32_t vehicleAbilityDisplay;                       // 41
-        uint32_t enterUISoundID;                              // 42
-        uint32_t exitUISoundID;                               // 43
-        int32_t uiSkin;                                       // 44
-        uint32_t flagsB;                                      // 45
+        uint32_t ID;                                                // 0
+        uint32_t flags;                                             // 1
+        int32_t attachmentID;                                       // 2
+        float attachmentOffsetX;                                    // 3
+        float attachmentOffsetY;                                    // 4
+        float attachmentOffsetZ;                                    // 5
+        float enterPreDelay;                                        // 6
+        float enterSpeed;                                           // 7
+        float enterGravity;                                         // 8
+        float enterMinDuration;                                     // 9
+        float enterMaxDuration;                                     // 10
+        float enterMinArcHeight;                                    // 11
+        float enterMaxArcHeight;                                    // 12
+        int32_t enterAnimStart;                                     // 13
+        int32_t enterAnimLoop;                                      // 14
+        int32_t rideAnimStart;                                      // 15
+        int32_t rideAnimLoop;                                       // 16
+        int32_t rideUpperAnimStart;                                 // 17
+        int32_t rideUpperAnimLoop;                                  // 18
+        float exitPreDelay;                                         // 19
+        float exitSpeed;                                            // 20
+        float exitGravity;                                          // 21
+        float exitMinDuration;                                      // 22
+        float exitMaxDuration;                                      // 23
+        float exitMinArcHeight;                                     // 24
+        float exitMaxArcHeight;                                     // 25
+        int32_t exitAnimStart;                                      // 26
+        int32_t exitAnimLoop;                                       // 27
+        int32_t exitAnimEnd;                                        // 28
+        float passengerYaw;                                         // 29
+        float passengerPitch;                                       // 30
+        float passengerRoll;                                        // 31
+        int32_t passengerAttachmentID;                              // 32
+        int32_t vehicleEnterAnim;                                   // 33
+        int32_t vehicleExitAnim;                                    // 34
+        int32_t vehicleRideAnimLoop;                                // 35
+        int32_t vehicleEnterAnimBone;                               // 36
+        int32_t vehicleExitAnimBone;                                // 37
+        int32_t vehicleRideAnimLoopBone;                            // 38
+        float vehicleEnterAnimDelay;                                // 39
+        float vehicleExitAnimDelay;                                 // 40
+        uint32_t vehicleAbilityDisplay;                             // 41
+        uint32_t enterUISoundID;                                    // 42
+        uint32_t exitUISoundID;                                     // 43
+        int32_t uiSkin;                                             // 44
+        uint32_t flagsB;                                            // 45
 
         bool IsUsable() const
         {
@@ -1624,48 +1624,47 @@ namespace DBC::Structures
 
     struct WMOAreaTableEntry
     {
-        uint32_t id;              // 0
-        int32_t rootId;           // 1
-        int32_t adtId;            // 2
-        int32_t groupId;          // 3
-        //uint32_t field4;        // 4
-        //uint32_t field5;        // 5
-        //uint32_t field6;        // 6
-        //uint32_t field7;        // 7
-        //uint32_t field8;        // 8
-        uint32_t flags;           // 9
-        uint32_t areaId;          // 10  ref -> AreaTableEntry
-        //char Name[16];        // 11-26
-        //uint32_t nameflags;     // 27
+        uint32_t id;                                                // 0
+        int32_t rootId;                                             // 1
+        int32_t adtId;                                              // 2
+        int32_t groupId;                                            // 3
+        //uint32_t field4;                                          // 4
+        //uint32_t field5;                                          // 5
+        //uint32_t field6;                                          // 6
+        //uint32_t field7;                                          // 7
+        //uint32_t field8;                                          // 8
+        uint32_t flags;                                             // 9
+        uint32_t areaId;                                            // 10 ref -> AreaTableEntry
+        //char Name[16];                                            // 11-26
+        //uint32_t nameflags;                                       // 27
     };
 
     struct WorldMapAreaEntry
     {
-        //uint32_t id;              // 0
-        uint32_t mapId;             // 1
-        uint32_t zoneId;            // 2
-        //const char* name;         // 3
-        //float y1;                 // 4
-        //float y2;                 // 5
-        //float x1;                 // 6
-        //float x2;                 // 7
-        int32_t continentMapId;     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
-        //uint32_t unk1             // 9
-        //uint32_t parentId         // 10
+        //uint32_t id;                                              // 0
+        uint32_t mapId;                                             // 1
+        uint32_t zoneId;                                            // 2
+        //const char* name;                                         // 3
+        //float y1;                                                 // 4
+        //float y2;                                                 // 5
+        //float x1;                                                 // 6
+        //float x2;                                                 // 7
+        int32_t continentMapId;                                     // 8 Map id of the continent where the area actually exists (-1 value means that mapId already has the continent map id)
+        //uint32_t unk1                                             // 9
+        //uint32_t parentId                                         // 10
     };
 
     struct WorldMapOverlayEntry
     {
-        uint32_t ID;              // 0
-        //uint32_t worldMapID;    // 1
-        uint32_t areaID;          // 2 - index to AreaTable
-        uint32_t areaID_2;        // 3 - index to AreaTable
-        uint32_t areaID_3;        // 4 - index to AreaTable
-        uint32_t areaID_4;        // 5 - index to AreaTable
-        //uint32_t unk1[2];       // 6-7
-        //uint32_t unk2;          // 8
-        //uint32_t unk3[7];       // 9-16
+        uint32_t ID;                                                // 0
+        //uint32_t worldMapID;                                      // 1 WorldMapArea.dbc
+        uint32_t areaID;                                            // 2 - index to AreaTable
+        uint32_t areaID_2;                                          // 3 - index to AreaTable
+        uint32_t areaID_3;                                          // 4 - index to AreaTable
+        uint32_t areaID_4;                                          // 5 - index to AreaTable
+        //uint32_t unk1[2];                                         // 6-7
+        //uint32_t unk2;                                            // 8
+        //uint32_t unk3[7];                                         // 9-16
     };
-
     #pragma pack(pop)
 }

--- a/src/world/Storage/DB2/DB2Loader.h
+++ b/src/world/Storage/DB2/DB2Loader.h
@@ -29,83 +29,78 @@ namespace DB2
 
     class DB2FileLoader
     {
+    public:
+        DB2FileLoader();
+        ~DB2FileLoader();
+
+        bool Load(const char *filename, const char *fmt);
+
+        class Record
+        {
         public:
-
-            DB2FileLoader();
-            ~DB2FileLoader();
-
-            bool Load(const char *filename, const char *fmt);
-
-            class Record
+            float getFloat(size_t field) const
             {
-                public:
+                assert(field < file.fieldCount);
+                float val = *reinterpret_cast<float*>(offset + file.GetOffset(field));
+                convertEndian(val);
+                return val;
+            }
+            uint32_t getUInt(size_t field) const
+            {
+                assert(field < file.fieldCount);
+                uint32_t val = *reinterpret_cast<uint32_t*>(offset + file.GetOffset(field));
+                convertEndian(val);
+                return val;
+            }
+            uint8_t getUInt8(size_t field) const
+            {
+                assert(field < file.fieldCount);
+                return *reinterpret_cast<uint8_t*>(offset + file.GetOffset(field));
+            }
 
-                    float getFloat(size_t field) const
-                    {
-                        assert(field < file.fieldCount);
-                        float val = *reinterpret_cast<float*>(offset + file.GetOffset(field));
-                        convertEndian(val);
-                        return val;
-                    }
-                    uint32 getUInt(size_t field) const
-                    {
-                        assert(field < file.fieldCount);
-                        uint32 val = *reinterpret_cast<uint32*>(offset + file.GetOffset(field));
-                        convertEndian(val);
-                        return val;
-                    }
-                    uint8 getUInt8(size_t field) const
-                    {
-                        assert(field < file.fieldCount);
-                        return *reinterpret_cast<uint8*>(offset + file.GetOffset(field));
-                    }
-
-                    const char *getString(size_t field) const
-                    {
-                        assert(field < file.fieldCount);
-                        size_t stringOffset = getUInt(field);
-                        assert(stringOffset < file.stringSize);
-                        return reinterpret_cast<char*>(file.stringTable + stringOffset);
-                    }
-
-                private:
-
-                    Record(DB2FileLoader &file_, unsigned char *offset_) : offset(offset_), file(file_) {}
-                    unsigned char *offset;
-                    DB2FileLoader &file;
-
-                    friend class DB2FileLoader;
-
-            };
-
-            Record getRecord(size_t id);
-            uint32_t GetNumRows() const { return recordCount; }
-            uint32_t GetCols() const { return fieldCount; }
-            uint32_t GetOffset(size_t id) const { return (fieldsOffset != NULL && id < fieldCount) ? fieldsOffset[id] : 0; }
-            bool IsLoaded() const { return (data != NULL); }
-            char* AutoProduceData(const char* fmt, uint32_t& count, char**& indexTable);
-            char* AutoProduceStringsArrayHolders(const char* fmt, char* dataTable);
-            char* AutoProduceStrings(const char* fmt, char* dataTable, DBC::LocaleConstant loc);
-            static uint32_t GetFormatRecordSize(const char * format, int32_t* index_pos = NULL);
-            static uint32_t GetFormatStringsFields(const char * format);
+            const char *getString(size_t field) const
+            {
+                assert(field < file.fieldCount);
+                size_t stringOffset = getUInt(field);
+                assert(stringOffset < file.stringSize);
+                return reinterpret_cast<char*>(file.stringTable + stringOffset);
+            }
 
         private:
+            Record(DB2FileLoader &file_, unsigned char *offset_) : offset(offset_), file(file_) {}
+            unsigned char *offset;
+            DB2FileLoader &file;
 
-            uint32_t recordSize;
-            uint32_t recordCount;
-            uint32_t fieldCount;
-            uint32_t stringSize;
-            uint32_t *fieldsOffset;
-            unsigned char *data;
-            unsigned char *stringTable;
+            friend class DB2FileLoader;
+        };
 
-            uint32_t tableHash;
-            uint32_t build;
+        Record getRecord(size_t id);
+        uint32_t GetNumRows() const { return recordCount; }
+        uint32_t GetCols() const { return fieldCount; }
+        uint32_t GetOffset(size_t id) const { return (fieldsOffset != NULL && id < fieldCount) ? fieldsOffset[id] : 0; }
+        bool IsLoaded() const { return (data != NULL); }
+        char* AutoProduceData(const char* fmt, uint32_t& count, char**& indexTable);
+        char* AutoProduceStringsArrayHolders(const char* fmt, char* dataTable);
+        char* AutoProduceStrings(const char* fmt, char* dataTable, DBC::LocaleConstant loc);
+        static uint32_t GetFormatRecordSize(const char * format, int32_t* index_pos = NULL);
+        static uint32_t GetFormatStringsFields(const char * format);
 
-            int unk1;
-            int unk2;
-            int unk3;
-            int locale;
-            int unk5;
+    private:
+        uint32_t recordSize;
+        uint32_t recordCount;
+        uint32_t fieldCount;
+        uint32_t stringSize;
+        uint32_t *fieldsOffset;
+        unsigned char *data;
+        unsigned char *stringTable;
+
+        uint32_t tableHash;
+        uint32_t build;
+
+        int unk1;
+        int unk2;
+        int unk3;
+        int locale;
+        int unk5;
     };
 }

--- a/src/world/Storage/DB2/DB2Structures.h
+++ b/src/world/Storage/DB2/DB2Structures.h
@@ -11,7 +11,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include <set>
 #include <vector>
 
-
 namespace DB2::Structures
 {
     namespace

--- a/src/world/Storage/DBC/DBCGlobals.hpp
+++ b/src/world/Storage/DBC/DBCGlobals.hpp
@@ -59,7 +59,7 @@ namespace DBC
 
     namespace
     {
-        const uint8 C_TOTAL_LOCALES = 15;
+        const uint8_t C_TOTAL_LOCALES = 15;
         char const* C_LOCALE_NAMES[C_TOTAL_LOCALES] =
         {
             "enGB",
@@ -79,13 +79,13 @@ namespace DBC
             "itIT"
         };
 
-        uint32 g_dbc_file_count = 0;
+        uint32_t g_dbc_file_count = 0;
     }
 
     typedef std::list<std::string> StoreProblemList;
 
     template <class T>
-    void LoadDBC(uint32& /*available_dbc_locales*/, StoreProblemList& errors, DBC::DBCStorage<T>& storage, std::string const& dbc_path,
+    void LoadDBC(uint32_t& /*available_dbc_locales*/, StoreProblemList& errors, DBC::DBCStorage<T>& storage, std::string const& dbc_path,
       std::string const& dbc_filename,std::string const* custom_format = NULL, std::string const* /*custom_index_name*/ = NULL)
     {
         ASSERT(DBC::DBCLoader::GetFormatRecordSize(storage.GetFormat()) == sizeof(T));

--- a/src/world/Storage/DBC/DBCLoader.cpp
+++ b/src/world/Storage/DBC/DBCLoader.cpp
@@ -24,22 +24,22 @@ namespace DBC
         return DBC::DBCRecord(m_data + record_id * m_record_size);
     }
 
-    uint32 DBC::DBCLoader::GetNumRows() const
+    uint32_t DBC::DBCLoader::GetNumRows() const
     {
         return m_record_count;
     }
 
-    uint32 DBC::DBCLoader::GetRowSize() const
+    uint32_t DBC::DBCLoader::GetRowSize() const
     {
         return m_record_size;
     }
 
-    uint32 DBC::DBCLoader::GetNumColumns() const
+    uint32_t DBC::DBCLoader::GetNumColumns() const
     {
         return m_field_count;
     }
 
-    uint32 DBC::DBCLoader::GetOffset(size_t id) const
+    uint32_t DBC::DBCLoader::GetOffset(size_t id) const
     {
         if (m_fields_offset != NULL && id < m_field_count)
         {
@@ -49,12 +49,12 @@ namespace DBC
         return 0;
     }
 
-    uint32 DBCLoader::GetFormatRecordSize(const char* dbc_format, int32* index_pos /* = NULL */)
+    uint32_t DBCLoader::GetFormatRecordSize(const char* dbc_format, int32_t* index_pos /* = NULL */)
     {
-        uint32 record_size = 0;
-        int32 i = -1;
+        uint32_t record_size = 0;
+        int32_t i = -1;
 
-        for (uint32 x = 0; dbc_format[x]; ++x)
+        for (uint32_t x = 0; dbc_format[x]; ++x)
         {
             switch (dbc_format[x])
             {
@@ -62,7 +62,7 @@ namespace DBC
                 record_size += sizeof(float);
                 break;
             case DBC::DbcFieldFormat::FT_INT:
-                record_size += sizeof(uint32);
+                record_size += sizeof(uint32_t);
                 break;
             case DBC::DbcFieldFormat::FT_STRING:
                 record_size += sizeof(char*);
@@ -72,10 +72,10 @@ namespace DBC
                 break;
             case DBC::DbcFieldFormat::FT_IND:
                 i = x;
-                record_size += sizeof(uint32);
+                record_size += sizeof(uint32_t);
                 break;
             case DBC::DbcFieldFormat::FT_BYTE:
-                record_size += sizeof(uint8);
+                record_size += sizeof(uint8_t);
                 break;
             case DBC::DbcFieldFormat::FT_NA:
             case DBC::DbcFieldFormat::FT_NA_BYTE:
@@ -99,7 +99,7 @@ namespace DBC
 
     bool DBCLoader::Load(const char* dbc_filename, const char* dbc_format)
     {
-        uint32 header;
+        uint32_t header;
         if (m_data)
         {
             delete[] m_data;
@@ -154,21 +154,21 @@ namespace DBC
             return false;
         }
 
-        m_fields_offset = new uint32[m_field_count];
+        m_fields_offset = new uint32_t[m_field_count];
         m_fields_offset[0] = 0;
 
-        for (uint32 i = 1; i < m_field_count; ++i)
+        for (uint32_t i = 1; i < m_field_count; ++i)
         {
             m_fields_offset[i] = m_fields_offset[i - 1];
             /* Byte fields */
             if (dbc_format[i - 1] == 'b' || dbc_format[i - 1] == 'X')
             {
-                m_fields_offset[i] += sizeof(uint8);
+                m_fields_offset[i] += sizeof(uint8_t);
             }
-            /* 4 byte fields (int32, float, strings) */
+            /* 4 byte fields (int32_t, float, strings) */
             else
             {
-                m_fields_offset[i] += sizeof(uint32);
+                m_fields_offset[i] += sizeof(uint32_t);
             }
         }
 
@@ -185,20 +185,20 @@ namespace DBC
         return true;
     }
 
-    char* DBCLoader::AutoProduceData(const char* dbc_format, uint32& record_count, char**& index_table, uint32 sql_record_count, uint32 sql_highest_index, char *& sql_data_table)
+    char* DBCLoader::AutoProduceData(const char* dbc_format, uint32_t& record_count, char**& index_table, uint32_t sql_record_count, uint32_t sql_highest_index, char *& sql_data_table)
     {
         if (strlen(dbc_format) != m_field_count) return NULL;
 
         /* Get struct size and index position */
         int i;
-        uint32 record_size = this->GetFormatRecordSize(dbc_format, &i);
+        uint32_t record_size = this->GetFormatRecordSize(dbc_format, &i);
 
         if (i >= 0)
         {
-            uint32 max_index = 0;
-            for (uint32 y = 0; y < m_record_count; ++y)
+            uint32_t max_index = 0;
+            for (uint32_t y = 0; y < m_record_count; ++y)
             {
-                uint32 index = this->GetRecord(y).GetUInt32(i, m_field_count, this->GetOffset(i));
+                uint32_t index = this->GetRecord(y).GetUInt32(i, m_field_count, this->GetOffset(i));
                 if (index > max_index)
                 {
                     max_index = index;
@@ -222,9 +222,9 @@ namespace DBC
         }
 
         char* data_table = new char[(m_record_count + sql_record_count) * record_size];
-        uint32 offset = 0;
+        uint32_t offset = 0;
 
-        for (uint32 y = 0; y < m_record_count; ++y)
+        for (uint32_t y = 0; y < m_record_count; ++y)
         {
             if (i >= 0)
             {
@@ -235,7 +235,7 @@ namespace DBC
                 index_table[y] = &data_table[offset];
             }
 
-            for (uint32 x = 0; x < m_field_count; ++x)
+            for (uint32_t x = 0; x < m_field_count; ++x)
             {
                 switch (dbc_format[x])
                 {
@@ -245,12 +245,12 @@ namespace DBC
                     break;
                 case DBC::DbcFieldFormat::FT_IND:
                 case DBC::DbcFieldFormat::FT_INT:
-                    *((uint32*)(&data_table[offset])) = this->GetRecord(y).GetUInt32(x, m_field_count, this->GetOffset(x));
-                    offset += sizeof(uint32);
+                    *((uint32_t*)(&data_table[offset])) = this->GetRecord(y).GetUInt32(x, m_field_count, this->GetOffset(x));
+                    offset += sizeof(uint32_t);
                     break;
                 case DBC::DbcFieldFormat::FT_BYTE:
-                    *((uint8*)(&data_table[offset])) = this->GetRecord(y).GetUInt8(x, m_field_count, this->GetOffset(x));
-                    offset += sizeof(uint8);
+                    *((uint8_t*)(&data_table[offset])) = this->GetRecord(y).GetUInt8(x, m_field_count, this->GetOffset(x));
+                    offset += sizeof(uint8_t);
                     break;
                 case DBC::DbcFieldFormat::FT_STRING:
                     /* Non-empty or "" strings are replaced in DBC::DBCLoader::AutoProduceStrings */
@@ -282,11 +282,11 @@ namespace DBC
         char* string_pool = new char[m_string_size];
         memcpy(string_pool, m_string_table, m_string_size);
 
-        uint32 offset = 0;
+        uint32_t offset = 0;
 
-        for (uint32 y = 0; y < m_record_count; ++y)
+        for (uint32_t y = 0; y < m_record_count; ++y)
         {
-            for (uint32 x = 0; x < m_field_count; ++x)
+            for (uint32_t x = 0; x < m_field_count; ++x)
             {
                 switch (dbc_format[x])
                 {
@@ -295,10 +295,10 @@ namespace DBC
                     break;
                 case DBC::DbcFieldFormat::FT_IND:
                 case DBC::DbcFieldFormat::FT_INT:
-                    offset += sizeof(uint32);
+                    offset += sizeof(uint32_t);
                     break;
                 case DBC::DbcFieldFormat::FT_BYTE:
-                    offset += sizeof(uint8);
+                    offset += sizeof(uint8_t);
                     break;
                 case DBC::DbcFieldFormat::FT_STRING:
                 {

--- a/src/world/Storage/DBC/DBCLoader.hpp
+++ b/src/world/Storage/DBC/DBCLoader.hpp
@@ -11,50 +11,48 @@ namespace DBC
 {
     enum DbcFieldFormat
     {
-        FT_NA = 'x',                                              //not used or unknown, 4 byte size
-        FT_NA_BYTE = 'X',                                         //not used or unknown, byte
-        FT_STRING = 's',                                          //char*
-        FT_FLOAT = 'f',                                           //float
-        FT_INT = 'i',                                             //uint32
-        FT_BYTE = 'b',                                            //uint8
-        FT_SORT = 'd',                                            //sorted by this field, field is not included
-        FT_IND = 'n',                                             //the same, but parsed to data
-        FT_LOGIC = 'l',                                           //Logical (boolean)
-        FT_SQL_PRESENT = 'p',                                     //Used in sql format to mark column present in sql dbc
-        FT_SQL_ABSENT = 'a'                                       //Used in sql format to mark column absent in sql dbc
+        FT_NA = 'x',                                              // not used or unknown, 4 byte size
+        FT_NA_BYTE = 'X',                                         // not used or unknown, byte
+        FT_STRING = 's',                                          // char*
+        FT_FLOAT = 'f',                                           // float
+        FT_INT = 'i',                                             // uint32
+        FT_BYTE = 'b',                                            // uint8
+        FT_SORT = 'd',                                            // sorted by this field, field is not included
+        FT_IND = 'n',                                             // the same, but parsed to data
+        FT_LOGIC = 'l',                                           // Logical (boolean)
+        FT_SQL_PRESENT = 'p',                                     // Used in sql format to mark column present in sql dbc
+        FT_SQL_ABSENT = 'a'                                       // Used in sql format to mark column absent in sql dbc
     };
 
     class DBCLoader
     {
-        protected:
+    protected:
+        uint32_t m_record_size;
+        uint32_t m_record_count;
+        uint32_t m_field_count;
+        uint32_t m_string_size;
+        uint32_t* m_fields_offset;
+        unsigned char* m_data;
+        unsigned char* m_string_table;
 
-            uint32 m_record_size;
-            uint32 m_record_count;
-            uint32 m_field_count;
-            uint32 m_string_size;
-            uint32* m_fields_offset;
-            unsigned char* m_data;
-            unsigned char* m_string_table;
+    public:
+        DBC::DBCRecord GetRecord(size_t record_id) const;
+        uint32_t GetNumRows() const;
+        uint32_t GetRowSize() const;
+        uint32_t GetNumColumns() const;
+        uint32_t GetOffset(size_t id) const;
 
-        public:
+        bool IsLoaded();
 
-            DBC::DBCRecord GetRecord(size_t record_id) const;
-            uint32 GetNumRows() const;
-            uint32 GetRowSize() const;
-            uint32 GetNumColumns() const;
-            uint32 GetOffset(size_t id) const;
+        char* AutoProduceData(const char* dbc_format, uint32_t& record_count, char**& index_table, uint32_t sql_record_count, uint32_t sql_highest_index, char *& sql_data_table);
+        char* AutoProduceStrings(const char* dbc_format, char* data_table);
+        static uint32_t GetFormatRecordSize(const char* dbc_format, int32* index_pos = NULL);
+        bool Load(const char* dbc_filename, const char* dbc_format);
 
-            bool IsLoaded();
+        DBCLoader();
+        ~DBCLoader();
 
-            char* AutoProduceData(const char* dbc_format, uint32& record_count, char**& index_table, uint32 sql_record_count, uint32 sql_highest_index, char *& sql_data_table);
-            char* AutoProduceStrings(const char* dbc_format, char* data_table);
-            static uint32 GetFormatRecordSize(const char* dbc_format, int32* index_pos = NULL);
-            bool Load(const char* dbc_filename, const char* dbc_format);
-
-            DBCLoader();
-            ~DBCLoader();
-
-            DBCLoader(DBCLoader const& right) = delete;
-            DBCLoader& operator=(DBCLoader const& right) = delete;
+        DBCLoader(DBCLoader const& right) = delete;
+        DBCLoader& operator=(DBCLoader const& right) = delete;
     };
 }

--- a/src/world/Storage/DBC/DBCRecord.cpp
+++ b/src/world/Storage/DBC/DBCRecord.cpp
@@ -12,27 +12,27 @@ namespace DBC
         /* No Body */
     }
 
-    float DBCRecord::GetFloat(size_t field, uint32 field_count, const uint32 field_offset) const
+    float DBCRecord::GetFloat(size_t field, uint32_t field_count, const uint32_t field_offset) const
     {
         assert(field < field_count);
         float val = *reinterpret_cast<float*>(m_offset + field_offset);
         return val;
     }
 
-    uint32 DBCRecord::GetUInt32(size_t field, uint32 field_count, const uint32 field_offset) const
+    uint32_t DBCRecord::GetUInt32(size_t field, uint32_t field_count, const uint32_t field_offset) const
     {
         assert(field < field_count);
-        uint32 val = *reinterpret_cast<uint32*>(m_offset + field_offset);
+        uint32_t val = *reinterpret_cast<uint32_t*>(m_offset + field_offset);
         return val;
     }
 
-    uint8 DBCRecord::GetUInt8(size_t field, uint32 field_count, const uint32 field_offset) const
+    uint8 DBCRecord::GetUInt8(size_t field, uint32_t field_count, const uint32_t field_offset) const
     {
         assert(field < field_count);
         return *reinterpret_cast<uint8*>(m_offset + field_offset);
     }
 
-    char* DBCRecord::GetString(size_t field, uint32 field_count, const uint32 field_offset, uint32 string_size, unsigned char* string_table) const
+    char* DBCRecord::GetString(size_t field, uint32_t field_count, const uint32_t field_offset, uint32_t string_size, unsigned char* string_table) const
     {
         assert(field < field_count);
         const size_t string_offset = GetUInt32(field, field_count, field_offset);

--- a/src/world/Storage/DBC/DBCRecord.hpp
+++ b/src/world/Storage/DBC/DBCRecord.hpp
@@ -11,17 +11,15 @@ namespace DBC
 {
     class DBCRecord
     {
-        protected:
+    protected:
+        unsigned char* m_offset;
 
-            unsigned char* m_offset;
+    public:
+        DBCRecord(unsigned char* offset);
 
-        public:
-
-            DBCRecord(unsigned char* offset);
-
-            float GetFloat(size_t field, uint32 field_count, uint32 field_offset) const;
-            uint32 GetUInt32(size_t field, uint32 field_count, uint32 field_offset) const;
-            uint8 GetUInt8(size_t field, uint32 field_count, uint32 field_offset) const;
-            char* GetString(size_t field, uint32 field_count, uint32 field_offset, uint32 string_size, unsigned char* string_table) const;
+        float GetFloat(size_t field, uint32_t field_count, uint32_t field_offset) const;
+        uint32_t GetUInt32(size_t field, uint32_t field_count, uint32_t field_offset) const;
+        uint8_t GetUInt8(size_t field, uint32_t field_count, uint32_t field_offset) const;
+        char* GetString(size_t field, uint32_t field_count, uint32_t field_offset, uint32_t string_size, unsigned char* string_table) const;
     };
 }

--- a/src/world/Storage/DBC/DBCSQL.cpp
+++ b/src/world/Storage/DBC/DBCSQL.cpp
@@ -11,7 +11,7 @@ namespace DBC::SQL
     {
         /* Convert DBC file name to SQL table name */
         sql_table_name = *dbc_filename;
-        for (uint32 i = 0; i < sql_table_name.size(); ++i)
+        for (uint32_t i = 0; i < sql_table_name.size(); ++i)
         {
             if (isalpha(sql_table_name[i]))
             {
@@ -27,8 +27,8 @@ namespace DBC::SQL
         DBC::DBCLoader::GetFormatRecordSize(format, &index_pos);
         if (index_pos >= 0)
         {
-            uint32 unsigned_index_pos = uint32(index_pos);
-            for (uint32 x = 0; x < format_string->size(); ++x)
+            uint32_t unsigned_index_pos = uint32_t(index_pos);
+            for (uint32_t x = 0; x < format_string->size(); ++x)
             {
                 if ((*format_string)[x] == DBC::DbcFieldFormat::FT_SQL_PRESENT)
                 {

--- a/src/world/Storage/DBC/DBCSQL.hpp
+++ b/src/world/Storage/DBC/DBCSQL.hpp
@@ -18,13 +18,12 @@ namespace DBC::SQL
         string const* format_string;
         string const* index_name;
         string sql_table_name;
-        int32 index_pos;
-        int32 sql_index_pos;
+        int32_t index_pos;
+        int32_t sql_index_pos;
         SqlDbc(string const* dbc_filename, string const* dbc_format, string const* id_name, char const* format);
 
-        private:
-
-            SqlDbc(SqlDbc const& right) = delete;
-            SqlDbc& operator=(SqlDbc const& right) = delete;
+    private:
+        SqlDbc(SqlDbc const& right) = delete;
+        SqlDbc& operator=(SqlDbc const& right) = delete;
     };
 }

--- a/src/world/Storage/DBC/DBCStorage.hpp
+++ b/src/world/Storage/DBC/DBCStorage.hpp
@@ -17,131 +17,129 @@ namespace DBC
     {
         typedef std::list<char*> StringPoolList;
 
-        public:
+    public:
+        DBCStorage(char const* f) : m_format(f), m_row_count(0), m_field_count(0), m_data_table(NULL)
+        {
+            m_index_table.as_t = NULL;
+        }
 
-            DBCStorage(char const* f) : m_format(f), m_row_count(0), m_field_count(0), m_data_table(NULL)
+        ~DBCStorage()
+        {
+            this->Clear();
+        }
+
+        T const* LookupEntry(uint32 id) const
+        {
+            if (id >= m_row_count)
             {
-                m_index_table.as_t = NULL;
+                return NULL;
             }
 
-            ~DBCStorage()
+            return m_index_table.as_t[id];
+        }
+
+        T const* AssertEntry(uint32 id) const
+        {
+            T const* entry = LookupEntry(id);
+            ASSERT(entry);
+            return entry;
+        }
+
+        uint32 GetNumRows() const
+        {
+            return m_row_count;
+        }
+
+        char const* GetFormat() const
+        {
+            return m_format;
+        }
+
+        uint32 GetFieldCount() const
+        {
+            return m_field_count;
+        }
+
+        bool Load(char const* dbc_filename, DBC::SQL::SqlDbc* sql)
+        {
+            DBC::DBCLoader dbc_loader;
+            // Only continue if load is successful
+            if (!dbc_loader.Load(dbc_filename, m_format))
             {
-                this->Clear();
+                return false;
             }
 
-            T const* LookupEntry(uint32 id) const
+            uint32 sql_record_count = 0;
+            uint32 sql_highest_index = 0;
+            // SQL not yet implemented
+            //auto result = 0;
+            // Load data from SQL
+            if (sql)
             {
-                if (id >= m_row_count)
-                {
-                    return NULL;
-                }
-
-                return m_index_table.as_t[id];
+                assert(false && "SqlDbc not yet implemented");
             }
 
-            T const* AssertEntry(uint32 id) const
+            char* sql_data_table = NULL;
+            m_field_count = dbc_loader.GetNumColumns();
+
+            m_data_table = reinterpret_cast<T*>(dbc_loader.AutoProduceData(m_format, m_row_count, m_index_table.as_char, sql_record_count, sql_highest_index, sql_data_table));
+
+            m_string_pool_list.push_back(dbc_loader.AutoProduceStrings(m_format, reinterpret_cast<char*>(m_data_table)));
+
+            /*if (result)
             {
-                T const* entry = LookupEntry(id);
-                ASSERT(entry);
-                return entry;
+                assert(false && "SqlDbc not yet implemented");
+            }*/
+
+            return m_index_table.as_t != NULL;
+        }
+
+        bool LoadStringsFrom(char const* dbc_filename)
+        {
+            // DBCs must already be loaded using Load
+            if (!m_index_table.as_t) return false;
+
+            DBC::DBCLoader dbc_loader;
+            // Only continue if Load was successful
+            if (!dbc_loader.Load(dbc_filename, m_format)) return false;
+
+            m_string_pool_list.push_back(dbc_loader.AutoProduceStrings(m_format, reinterpret_cast<char*>(m_data_table)));
+            return true;
+        }
+
+        void Clear()
+        {
+            if (!m_index_table.as_t) return;
+
+            delete[] reinterpret_cast<char*>(m_index_table.as_t);
+            m_index_table.as_t = NULL;
+            delete[] reinterpret_cast<char*>(m_data_table);
+            m_data_table = NULL;
+
+            while (!m_string_pool_list.empty())
+            {
+                delete[] m_string_pool_list.front();
+                m_string_pool_list.pop_front();
             }
 
-            uint32 GetNumRows() const
-            {
-                return m_row_count;
-            }
+            m_row_count = 0;
+        }
 
-            char const* GetFormat() const
-            {
-                return m_format;
-            }
+    private:
+        char const* m_format;
+        uint32 m_row_count;
+        uint32 m_field_count;
 
-            uint32 GetFieldCount() const
-            {
-                return m_field_count;
-            }
+        union
+        {
+            T** as_t;
+            char** as_char;
+        } m_index_table;
 
-            bool Load(char const* dbc_filename, DBC::SQL::SqlDbc* sql)
-            {
-                DBC::DBCLoader dbc_loader;
-                // Only continue if load is successful
-                if (!dbc_loader.Load(dbc_filename, m_format))
-                {
-                    return false;
-                }
+        T* m_data_table;
+        StringPoolList m_string_pool_list;
 
-                uint32 sql_record_count = 0;
-                uint32 sql_highest_index = 0;
-                // SQL not yet implemented
-                //auto result = 0;
-                // Load data from SQL
-                if (sql)
-                {
-                    assert(false && "SqlDbc not yet implemented");
-                }
-
-                char* sql_data_table = NULL;
-                m_field_count = dbc_loader.GetNumColumns();
-
-                m_data_table = reinterpret_cast<T*>(dbc_loader.AutoProduceData(m_format, m_row_count, m_index_table.as_char, sql_record_count, sql_highest_index, sql_data_table));
-
-                m_string_pool_list.push_back(dbc_loader.AutoProduceStrings(m_format, reinterpret_cast<char*>(m_data_table)));
-
-                /*if (result)
-                {
-                    assert(false && "SqlDbc not yet implemented");
-                }*/
-
-                return m_index_table.as_t != NULL;
-            }
-
-            bool LoadStringsFrom(char const* dbc_filename)
-            {
-                // DBCs must already be loaded using Load
-                if (!m_index_table.as_t) return false;
-
-                DBC::DBCLoader dbc_loader;
-                // Only continue if Load was successful
-                if (!dbc_loader.Load(dbc_filename, m_format)) return false;
-
-                m_string_pool_list.push_back(dbc_loader.AutoProduceStrings(m_format, reinterpret_cast<char*>(m_data_table)));
-                return true;
-            }
-
-            void Clear()
-            {
-                if (!m_index_table.as_t) return;
-
-                delete[] reinterpret_cast<char*>(m_index_table.as_t);
-                m_index_table.as_t = NULL;
-                delete[] reinterpret_cast<char*>(m_data_table);
-                m_data_table = NULL;
-
-                while (!m_string_pool_list.empty())
-                {
-                    delete[] m_string_pool_list.front();
-                    m_string_pool_list.pop_front();
-                }
-
-                m_row_count = 0;
-            }
-
-        private:
-
-            char const* m_format;
-            uint32 m_row_count;
-            uint32 m_field_count;
-
-            union
-            {
-                T** as_t;
-                char** as_char;
-            } m_index_table;
-
-            T* m_data_table;
-            StringPoolList m_string_pool_list;
-
-            DBCStorage(DBCStorage const& right) = delete;
-            DBCStorage& operator=(DBCStorage const& right) = delete;
+        DBCStorage(DBCStorage const& right) = delete;
+        DBCStorage& operator=(DBCStorage const& right) = delete;
     };
 }


### PR DESCRIPTION
**Todo / Checklist**

MOP Updated structure for ChrClasses.dbc and ChrRaces.dbc
MOP Updated structure for CurrencyTypes.dbc
MOP Updated structure for SkillLine.dbc
MOP Updated structure for SpellRadius.dbc
MOP Updated structure for SpellRuneCost.dbc
MOP Updated structure for TaxiNodes.dbc WMOAreaTable.dbc Faction.dbc
MOP Updated structure for AreaTrigger.dbc and ScalingStatValues.dbc
MOP Updated structure for DungeonEncounter.dbc
MOP Updated structure for Vehicle.dbc

Drop typedefs for uint8, int32, uint32
Update : namespace C++17
Code style and equal tab/..

**Tests Performed:** 

Build

