### PR TITLE
Spells have been adjusted, to eliminate charging errors.

### DIFF
--- a/src/scripts/SpellHandlers/Scripts/Druid.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Druid.cpp
@@ -10,12 +10,16 @@ enum DruidSpells
     SPELL_FUROR_R1                          = 17056,
     SPELL_FUROR_R2                          = 17058,
     SPELL_FUROR_R3                          = 17059,
+#if VERSION_STRING < Cata
     SPELL_FUROR_R4                          = 17060,
     SPELL_FUROR_R5                          = 17061,
+#endif
     SPELL_FUROR_RAGE                        = 17057,
     SPELL_FUROR_ENERGY                      = 17099,
+#if VERSION_STRING < Cata
     SPELL_IMPROVED_LEADER_OF_THE_PACK_R1    = 34297,
     SPELL_IMPROVED_LEADER_OF_THE_PACK_R2    = 34300,
+#endif
     SPELL_LEADER_OF_THE_PACK_DUMMY          = 17007,
     SPELL_LEADER_OF_THE_PACK_AURA           = 24932,
     SPELL_LEADER_OF_THE_PACK_HEAL           = 34299,
@@ -190,8 +194,10 @@ void setupDruidSpells(ScriptMgr* mgr)
         SPELL_FUROR_R1,
         SPELL_FUROR_R2,
         SPELL_FUROR_R3,
+#if VERSION_STRING < Cata
         SPELL_FUROR_R4,
         SPELL_FUROR_R5,
+#endif
         0
     };
     mgr->register_spell_script(furorIds, new FurorDummy);
@@ -200,6 +206,7 @@ void setupDruidSpells(ScriptMgr* mgr)
     mgr->register_spell_script(SPELL_FUROR_ENERGY, new Furor);
 #endif
 
+#if VERSION_STRING < Cata
     uint32_t improvedLeaderOfThePackIds[] =
     {
         SPELL_IMPROVED_LEADER_OF_THE_PACK_R1,
@@ -207,6 +214,7 @@ void setupDruidSpells(ScriptMgr* mgr)
         0
     };
     mgr->register_spell_script(improvedLeaderOfThePackIds, new ImprovedLeaderOfThePackDummy);
+#endif
 
     mgr->register_spell_script(SPELL_LEADER_OF_THE_PACK_DUMMY, new LeaderOfThePackDummy);
     mgr->register_spell_script(SPELL_LEADER_OF_THE_PACK_AURA, new LeaderOfThePack);

--- a/src/scripts/SpellHandlers/Scripts/Mage.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Mage.cpp
@@ -17,9 +17,11 @@ enum MageSpells
     SPELL_MASTER_OF_ELEMENTS_R3 = 29076,
     SPELL_MASTER_OF_ELEMENTS    = 29077,
     SPELL_POLYMORPH_R1          = 118,
+#if VERSION_STRING < Cata
     SPELL_POLYMORPH_R2          = 12824,
     SPELL_POLYMORPH_R3          = 12825,
     SPELL_POLYMORPH_R4          = 12826,
+#endif
     SPELL_POLYMORPH_TURTLE      = 28271,
     SPELL_POLYMORPH_PIG         = 28272,
     SPELL_POLYMORPH_SERPENT     = 61025,
@@ -263,9 +265,11 @@ void setupMageSpells(ScriptMgr* mgr)
     uint32_t polymorphIds[] =
     {
         SPELL_POLYMORPH_R1,
+#if VERSION_STRING < Cata
         SPELL_POLYMORPH_R2,
         SPELL_POLYMORPH_R3,
         SPELL_POLYMORPH_R4,
+#endif
         SPELL_POLYMORPH_TURTLE,
         SPELL_POLYMORPH_PIG,
 #if VERSION_STRING >= WotLK

--- a/src/scripts/SpellHandlers/Scripts/Paladin.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Paladin.cpp
@@ -16,14 +16,18 @@ enum PaladinSpells
     SPELL_EYE_FOR_AN_EYE_DUMMY_R1       = 9799,
     SPELL_EYE_FOR_AN_EYE_DUMMY_R2       = 25988,
     SPELL_HOLY_VENGEANCE                = 31803,
+#if VERSION_STRING < Cata
     SPELL_JUDGEMENT_OF_LIGHT_DEBUFF     = 20185,
     SPELL_JUDGEMENT_OF_LIGHT_HEAL       = 20267,
     SPELL_JUDGEMENT_OF_WISDOM_DEBUFF    = 20186,
     SPELL_JUDGEMENT_OF_WISDOM_MANA      = 20268,
+#endif
     SPELL_SEAL_OF_CORRUPTION_DIRECT     = 53739,
     SPELL_SEAL_OF_CORRUPTION_DUMMY      = 53736,
     SPELL_SEAL_OF_RIGHTEOUSNESS         = 25742,
+#if VERSION_STRING < Cata
     SPELL_SEAL_OF_RIGHTOUESNESS_DUMMY   = 21084,
+#endif
     SPELL_SEAL_OF_VENGEANCE_DIRECT      = 42463,
     SPELL_SEAL_OF_VENGEANCE_DUMMY       = 31801,
     SPELL_VENGEANCE_PROC_R1             = 20050,
@@ -394,10 +398,12 @@ void setupPaladinSpells(ScriptMgr* mgr)
     mgr->register_spell_script(eyeForEyeIds, new EyeForAnEyeDummy);
     mgr->register_spell_script(SPELL_EYE_FOR_AN_EYE_DAMAGE, new EyeForAnEye);
 
+#if VERSION_STRING < Cata
     mgr->register_spell_script(SPELL_JUDGEMENT_OF_LIGHT_DEBUFF, new JudgementOfLightDummy);
     mgr->register_spell_script(SPELL_JUDGEMENT_OF_LIGHT_HEAL, new JudgementOfLight);
     mgr->register_spell_script(SPELL_JUDGEMENT_OF_WISDOM_DEBUFF, new JudgementOfWisdomDummy);
     mgr->register_spell_script(SPELL_JUDGEMENT_OF_WISDOM_MANA, new JudgementOfWisdom);
+#endif
 
 #if VERSION_STRING == WotLK
     mgr->register_spell_script(SPELL_SEAL_OF_CORRUPTION_DIRECT, new SealOfVengeanceAndCorruptionDirect);
@@ -405,7 +411,9 @@ void setupPaladinSpells(ScriptMgr* mgr)
     mgr->register_spell_script(SPELL_BLOOD_CORRUPTION, new SealOfVengeanceAndCorruptionDot);
 #endif
 
+#if VERSION_STRING < Cata
     mgr->register_spell_script(SPELL_SEAL_OF_RIGHTOUESNESS_DUMMY, new SealOfRighteousnessDummy);
+#endif
 
 #if VERSION_STRING >= TBC
     mgr->register_spell_script(SPELL_SEAL_OF_VENGEANCE_DIRECT, new SealOfVengeanceAndCorruptionDirect);

--- a/src/scripts/SpellHandlers/Scripts/Priest.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Priest.cpp
@@ -29,25 +29,39 @@ enum PriestSpells
     SPELL_HOLY_CONCENTRATION_R3             = 63725,
     SPELL_IMPROVED_DEVOURING_PLAGUE_R1      = 63625,
     SPELL_IMPROVED_DEVOURING_PLAGUE_R2      = 63626,
+#if VERSION_STRING == WotLK
     SPELL_IMPROVED_DEVOURING_PLAGUE_R3      = 63627,
+#endif
     SPELL_IMPROVED_DEVOURING_PLAGUE_DMG     = 63675,
     SPELL_IMPROVED_DEVOURING_PLAGUE_HEAL    = 75999,
     SPELL_IMPROVED_MIND_BLAST_R1            = 15273,
     SPELL_IMPROVED_MIND_BLAST_R2            = 15312,
     SPELL_IMPROVED_MIND_BLAST_R3            = 15313,
+#if VERSION_STRING < Cata
     SPELL_IMPROVED_MIND_BLAST_R4            = 15314,
     SPELL_IMPROVED_MIND_BLAST_R5            = 15316,
+#endif
     SPELL_IMPROVED_SPIRIT_TAP_R1            = 49694,
     SPELL_IMPROVED_SPIRIT_TAP_R2            = 59000,
     SPELL_MIND_TRAUMA                       = 48301,
+#if VERSION_STRING < Cata
+#if VERSION_STRING >= TBC
     SPELL_SURGE_OF_LIGHT_PROC               = 33151,
+#endif
+#endif
     SPELL_VAMPIRIC_EMBRACE_DUMMY            = 15286,
     SPELL_VAMPIRIC_EMBRACE_HEAL             = 15290,
     SPELL_VAMPIRIC_TOUCH_R1                 = 34914,
+#if VERSION_STRING < Cata
+#if VERSION_STRING >= TBC
     SPELL_VAMPIRIC_TOUCH_R2                 = 34916,
     SPELL_VAMPIRIC_TOUCH_R3                 = 34917,
+#endif
+#endif
+#if VERSION_STRING == WotLK
     SPELL_VAMPIRIC_TOUCH_R4                 = 48159,
     SPELL_VAMPIRIC_TOUCH_R5                 = 48160,
+#endif
     SPELL_VAMPIRIC_TOUCH_DISPEL             = 64085,
     SPELL_VAMPIRIC_TOUCH_MANA               = 34919,
     SPELL_REPLENISHMENT                     = 57669,
@@ -656,7 +670,9 @@ void setupPriestSpells(ScriptMgr* mgr)
     {
         SPELL_IMPROVED_DEVOURING_PLAGUE_R1,
         SPELL_IMPROVED_DEVOURING_PLAGUE_R2,
+#if VERSION_STRING == WotLK
         SPELL_IMPROVED_DEVOURING_PLAGUE_R3,
+#endif
         0
     };
     mgr->register_spell_script(improvedDevouringPlagueIds, new ImprovedDevouringPlagueDummy);
@@ -670,8 +686,10 @@ void setupPriestSpells(ScriptMgr* mgr)
         SPELL_IMPROVED_MIND_BLAST_R1,
         SPELL_IMPROVED_MIND_BLAST_R2,
         SPELL_IMPROVED_MIND_BLAST_R3,
+#if VERSION_STRING < Cata
         SPELL_IMPROVED_MIND_BLAST_R4,
         SPELL_IMPROVED_MIND_BLAST_R5,
+#endif
         0
     };
     mgr->register_spell_script(improvedMindBlastIds, new ImprovedMindBlastDummy);
@@ -689,7 +707,7 @@ void setupPriestSpells(ScriptMgr* mgr)
     mgr->register_spell_script(improvedSpiritTapIds, new ImprovedSpiritTap);
 #endif
 
-#if VERSION_STRING < Mop
+#if VERSION_STRING < Cata
 #if VERSION_STRING >= TBC
     mgr->register_spell_script(SPELL_SURGE_OF_LIGHT_PROC, new SurgeOfLight);
 #endif
@@ -702,10 +720,16 @@ void setupPriestSpells(ScriptMgr* mgr)
     uint32_t vampiricTouchIds[] =
     {
         SPELL_VAMPIRIC_TOUCH_R1,
+#if VERSION_STRING < Cata
+#if VERSION_STRING >= TBC
         SPELL_VAMPIRIC_TOUCH_R2,
         SPELL_VAMPIRIC_TOUCH_R3,
+#endif
+#endif
+#if VERSION_STRING == WotLK
         SPELL_VAMPIRIC_TOUCH_R4,
         SPELL_VAMPIRIC_TOUCH_R5,
+#endif
         0
     };
     mgr->register_spell_script(vampiricTouchIds, new VampiricTouchDummy);

--- a/src/scripts/SpellHandlers/Scripts/Rogue.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Rogue.cpp
@@ -12,8 +12,10 @@ enum RogueSpells
     SPELL_CUT_TO_THE_CHASE_R1       = 51664,
     SPELL_CUT_TO_THE_CHASE_R2       = 51665,
     SPELL_CUT_TO_THE_CHASE_R3       = 51667,
+#if VERSION_STRING == WotLK
     SPELL_CUT_TO_THE_CHASE_R4       = 51668,
     SPELL_CUT_TO_THE_CHASE_R5       = 51669,
+#endif
     SPELL_CRIPPLING_POISON          = 3409,
     SPELL_DEADLY_BREW_R1            = 51625,
     SPELL_DEADLY_BREW_R2            = 51626,
@@ -133,8 +135,10 @@ void setupRogueSpells(ScriptMgr* mgr)
         SPELL_CUT_TO_THE_CHASE_R1,
         SPELL_CUT_TO_THE_CHASE_R2,
         SPELL_CUT_TO_THE_CHASE_R3,
+#if VERSION_STRING == WotLK
         SPELL_CUT_TO_THE_CHASE_R4,
         SPELL_CUT_TO_THE_CHASE_R5,
+#endif
         0
     };
     mgr->register_spell_script(cutChaseIds, new CutToTheChase);

--- a/src/scripts/SpellHandlers/Scripts/Shaman.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Shaman.cpp
@@ -8,33 +8,51 @@ This file is released under the MIT license. See README-MIT for more information
 enum ShamanSpells
 {
     SPELL_EARTH_SHIELD_R1               = 974,
+#if VERSION_STRING < Cata
+#if VERSION_STRING >= TBC
     SPELL_EARTH_SHIELD_R2               = 32593,
     SPELL_EARTH_SHIELD_R3               = 32594,
+#endif
+#endif
+#if VERSION_STRING == WotLK
     SPELL_EARTH_SHIELD_R4               = 49283,
     SPELL_EARTH_SHIELD_R5               = 49284,
+#endif
     SPELL_EARTH_SHIELD_HEAL             = 379,
     SPELL_LIGHTNING_SHIELD_DUMMY_R1     = 324,
+#if VERSION_STRING < Cata
     SPELL_LIGHTNING_SHIELD_DUMMY_R2     = 325,
     SPELL_LIGHTNING_SHIELD_DUMMY_R3     = 905,
     SPELL_LIGHTNING_SHIELD_DUMMY_R4     = 945,
     SPELL_LIGHTNING_SHIELD_DUMMY_R5     = 8134,
     SPELL_LIGHTNING_SHIELD_DUMMY_R6     = 10431,
     SPELL_LIGHTNING_SHIELD_DUMMY_R7     = 10432,
+#if VERSION_STRIBG >= TBC
     SPELL_LIGHTNING_SHIELD_DUMMY_R8     = 25469,
     SPELL_LIGHTNING_SHIELD_DUMMY_R9     = 25472,
+#if VERSION_STRING == WotLK
     SPELL_LIGHTNING_SHIELD_DUMMY_R10    = 49280,
     SPELL_LIGHTNING_SHIELD_DUMMY_R11    = 49281,
+#endif
+#endif
+#endif
     SPELL_LIGHTNING_SHIELD_DMG_R1       = 26364,
+#if VERSION_STRING < Cata
     SPELL_LIGHTNING_SHIELD_DMG_R2       = 26365,
     SPELL_LIGHTNING_SHIELD_DMG_R3       = 26366,
     SPELL_LIGHTNING_SHIELD_DMG_R4       = 26367,
     SPELL_LIGHTNING_SHIELD_DMG_R5       = 26369,
     SPELL_LIGHTNING_SHIELD_DMG_R6       = 26370,
     SPELL_LIGHTNING_SHIELD_DMG_R7       = 26363,
+#if VERSION_STRIBG >= TBC
     SPELL_LIGHTNING_SHIELD_DMG_R8       = 26371,
     SPELL_LIGHTNING_SHIELD_DMG_R9       = 26372,
+#if VERSION_STRING == WotLK
     SPELL_LIGHTNING_SHIELD_DMG_R10      = 49278,
     SPELL_LIGHTNING_SHIELD_DMG_R11      = 49279,
+#endif
+#endif
+#endif
 };
 
 // This is a common script to setup proc cooldown for Earth Shield, Water Shield and Lightning Shield
@@ -118,6 +136,7 @@ public:
         {
             case SPELL_LIGHTNING_SHIELD_DUMMY_R1:
                 return SPELL_LIGHTNING_SHIELD_DMG_R1;
+#if VERSION_STRING < Cata
             case SPELL_LIGHTNING_SHIELD_DUMMY_R2:
                 return SPELL_LIGHTNING_SHIELD_DMG_R2;
             case SPELL_LIGHTNING_SHIELD_DUMMY_R3:
@@ -130,14 +149,19 @@ public:
                 return SPELL_LIGHTNING_SHIELD_DMG_R6;
             case SPELL_LIGHTNING_SHIELD_DUMMY_R7:
                 return SPELL_LIGHTNING_SHIELD_DMG_R7;
+#if VERSION_STRIBG >= TBC
             case SPELL_LIGHTNING_SHIELD_DUMMY_R8:
                 return SPELL_LIGHTNING_SHIELD_DMG_R8;
             case SPELL_LIGHTNING_SHIELD_DUMMY_R9:
                 return SPELL_LIGHTNING_SHIELD_DMG_R9;
+#if VERSION_STRING == WotLK
             case SPELL_LIGHTNING_SHIELD_DUMMY_R10:
                 return SPELL_LIGHTNING_SHIELD_DMG_R10;
             case SPELL_LIGHTNING_SHIELD_DUMMY_R11:
                 return SPELL_LIGHTNING_SHIELD_DMG_R11;
+#endif
+#endif
+#endif
         }
 
         return 0;
@@ -199,10 +223,16 @@ void setupShamanSpells(ScriptMgr* mgr)
     uint32_t earthShieldIds[] =
     {
         SPELL_EARTH_SHIELD_R1,
+#if VERSION_STRING < Cata
+#if VERSION_STRING >= TBC
         SPELL_EARTH_SHIELD_R2,
         SPELL_EARTH_SHIELD_R3,
+#endif
+#endif
+#if VERSION_STRING == WotLK
         SPELL_EARTH_SHIELD_R4,
         SPELL_EARTH_SHIELD_R5,
+#endif
         0
     };
     mgr->register_spell_script(earthShieldIds, new EarthShieldDummy);
@@ -211,32 +241,44 @@ void setupShamanSpells(ScriptMgr* mgr)
     uint32_t lightningShieldDummyIds[] =
     {
         SPELL_LIGHTNING_SHIELD_DUMMY_R1,
+#if VERSION_STRING < Cata
         SPELL_LIGHTNING_SHIELD_DUMMY_R2,
         SPELL_LIGHTNING_SHIELD_DUMMY_R3,
         SPELL_LIGHTNING_SHIELD_DUMMY_R4,
         SPELL_LIGHTNING_SHIELD_DUMMY_R5,
         SPELL_LIGHTNING_SHIELD_DUMMY_R6,
         SPELL_LIGHTNING_SHIELD_DUMMY_R7,
+#if VERSION_STRIBG >= TBC
         SPELL_LIGHTNING_SHIELD_DUMMY_R8,
         SPELL_LIGHTNING_SHIELD_DUMMY_R9,
+#if VERSION_STRING == WotLK
         SPELL_LIGHTNING_SHIELD_DUMMY_R10,
         SPELL_LIGHTNING_SHIELD_DUMMY_R11,
+#endif
+#endif
+#endif
         0
     };
     mgr->register_spell_script(lightningShieldDummyIds, new LightningShieldDummy);
     uint32_t lightningShieldDmgIds[] =
     {
         SPELL_LIGHTNING_SHIELD_DMG_R1,
+#if VERSION_STRING < Cata
         SPELL_LIGHTNING_SHIELD_DMG_R2,
         SPELL_LIGHTNING_SHIELD_DMG_R3,
         SPELL_LIGHTNING_SHIELD_DMG_R4,
         SPELL_LIGHTNING_SHIELD_DMG_R5,
         SPELL_LIGHTNING_SHIELD_DMG_R6,
         SPELL_LIGHTNING_SHIELD_DMG_R7,
+#if VERSION_STRIBG >= TBC
         SPELL_LIGHTNING_SHIELD_DMG_R8,
         SPELL_LIGHTNING_SHIELD_DMG_R9,
+#if VERSION_STRING == WotLK
         SPELL_LIGHTNING_SHIELD_DMG_R10,
         SPELL_LIGHTNING_SHIELD_DMG_R11,
+#endif
+#endif
+#endif
         0
     };
     mgr->register_spell_script(lightningShieldDmgIds, new LightningShield);

--- a/src/world/Spell/Spell_ClassScripts.cpp
+++ b/src/world/Spell/Spell_ClassScripts.cpp
@@ -570,16 +570,22 @@ void SpellMgr::setupSpellClassScripts()
     //////////////////////////////////////////////////////////////////////////////////////////
     // Mage
     addSpellById(2120, FirestarterTalent::Create);   //Rank 1
+#if VERSION_STRING < Cata
     addSpellById(2121, FirestarterTalent::Create);   //Rank 2
     addSpellById(8422, FirestarterTalent::Create);   //Rank 3
     addSpellById(8423, FirestarterTalent::Create);   //Rank 4
     addSpellById(10215, FirestarterTalent::Create);   //Rank 5
     addSpellById(10216, FirestarterTalent::Create);   //Rank 6
+#if VERSION_STRING >= TBC
     addSpellById(27086, FirestarterTalent::Create);   //Rank 7
+#if VERSION_STRING == WotLK
     addSpellById(42925, FirestarterTalent::Create);   //Rank 8
     addSpellById(42926, FirestarterTalent::Create);   //Rank 9
-
+#endif
+#endif
+#endif
     addSpellById(5143, MissileBarrage::Create);   //Rank 1
+#if VERSION_STRING < Cata
     addSpellById(5144, MissileBarrage::Create);   //Rank 2
     addSpellById(5145, MissileBarrage::Create);   //Rank 3
     addSpellById(8416, MissileBarrage::Create);   //Rank 4
@@ -588,10 +594,15 @@ void SpellMgr::setupSpellClassScripts()
     addSpellById(10212, MissileBarrage::Create);   //Rank 7
     addSpellById(25345, MissileBarrage::Create);   //Rank 8
     addSpellById(27075, MissileBarrage::Create);   //Rank 9
+#if VERSION_STRING >= TBC
     addSpellById(38699, MissileBarrage::Create);   //Rank 10
     addSpellById(38704, MissileBarrage::Create);   //Rank 11
+#if VERSION_STRING == WotLK
     addSpellById(42843, MissileBarrage::Create);   //Rank 12
     addSpellById(42846, MissileBarrage::Create);   //Rank 13
+#endif
+#endif
+#endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Warrior
@@ -602,14 +613,20 @@ void SpellMgr::setupSpellClassScripts()
     //////////////////////////////////////////////////////////////////////////////////////////
     // Shaman
     addSpellById(1535, FireNova::Create);   //Rank 1
+#if VERSION_STRING < Cata
     addSpellById(8498, FireNova::Create);   //Rank 2
     addSpellById(8499, FireNova::Create);   //Rank 3
     addSpellById(11314, FireNova::Create);  //Rank 4
     addSpellById(11315, FireNova::Create);  //Rank 5
+#if VERSION_STRING >= TBC
     addSpellById(25546, FireNova::Create);  //Rank 6
     addSpellById(25547, FireNova::Create);  //Rank 7
+#if VERSION_STRING == WotLK
     addSpellById(61649, FireNova::Create);  //Rank 8
     addSpellById(61657, FireNova::Create);  //Rank 9
+#endif
+#endif
+#endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Rogue
@@ -632,43 +649,51 @@ void SpellMgr::setupSpellClassScripts()
     addSpellById(55095, &FrostFeverSpell::Create);
 
     addSpellById(48721, &BloodBoilSpell::Create);   // Rank 1
+#if VERSION_STRING == WotLK
     addSpellById(49939, &BloodBoilSpell::Create);   // Rank 2
     addSpellById(49940, &BloodBoilSpell::Create);   // Rank 3
     addSpellById(49941, &BloodBoilSpell::Create);   // Rank 4
-
+#endif
     addSpellById(45902, &BloodStrikeSpell::Create);   // Rank 1
+#if VERSION_STRING == WotLK
     addSpellById(49926, &BloodStrikeSpell::Create);   // Rank 2
     addSpellById(49927, &BloodStrikeSpell::Create);   // Rank 3
     addSpellById(49928, &BloodStrikeSpell::Create);   // Rank 4
     addSpellById(49929, &BloodStrikeSpell::Create);   // Rank 5
     addSpellById(49930, &BloodStrikeSpell::Create);   // Rank 6
-
+#endif
     addSpellById(47541, &DeathCoilSpell::Create);   // Rank 1
+#if VERSION_STRING == WotLK
     addSpellById(49892, &DeathCoilSpell::Create);   // Rank 2
     addSpellById(49893, &DeathCoilSpell::Create);   // Rank 3
     addSpellById(49894, &DeathCoilSpell::Create);   // Rank 4
     addSpellById(49895, &DeathCoilSpell::Create);   // Rank 5
-
+#endif
     addSpellById(56815, &RuneStrileSpell::Create);
 
     addAuraById(48707, &AntiMagicShellAura::Create);
 
+#if VERSION_STRING == WotLK
     addAuraById(49145, &SpellDeflectionAura::Create);   // Rank 1
     addAuraById(49495, &SpellDeflectionAura::Create);   // Rank 2
     addAuraById(49497, &SpellDeflectionAura::Create);   // Rank 3
+#endif
 
     addSpellById(50452, &BloodwormSpell::Create);
 
     addAuraById(52284, &WillOfTheNecropolisAura::Create);   // Rank 1
+#if VERSION_STRING == WotLK
     addAuraById(52285, &WillOfTheNecropolisAura::Create);   // Rank 1
     addAuraById(52286, &WillOfTheNecropolisAura::Create);   // Rank 1
-
+#endif
     addSpellById(55233, &VampiricBloodSpell::Create);
 
     addSpellById(55050, &HeartStrikeSpell::Create);   // Rank 1
+#if VERSION_STRING == WotLK
     addSpellById(55258, &HeartStrikeSpell::Create);   // Rank 2
     addSpellById(55259, &HeartStrikeSpell::Create);   // Rank 3
     addSpellById(55260, &HeartStrikeSpell::Create);   // Rank 4
     addSpellById(55261, &HeartStrikeSpell::Create);   // Rank 5
     addSpellById(55262, &HeartStrikeSpell::Create);   // Rank 6
+ #endif
 }


### PR DESCRIPTION
**Todo / Checklist:**
   
    - Spells adjusted for versions, Classic, TBC, WolTK & Cata
      src/scripts/SpellHandlers/Scripts/Druid.cpp
      src/scripts/SpellHandlers/Scripts/Mage.cpp
      src/scripts/SpellHandlers/Scripts/Paladin.cpp
      src/scripts/SpellHandlers/Scripts/Priest.cpp 
      src/scripts/SpellHandlers/Scripts/Rogue.cpp
      src/scripts/SpellHandlers/Scripts/Shaman.cpp
      src/world/Spell/Spell_ClassScripts.cpp

**Tests Performed:** 

    - Build
      Classic, TBC, WolTK & Cata
    - Tested in-gam
      Classic, TBC, WolTK & Cata



