### PR TITLE
Some chat fixes

### DIFF
--- a/src/world/Server/Packets/CmsgMessageChat.h
+++ b/src/world/Server/Packets/CmsgMessageChat.h
@@ -85,13 +85,16 @@ namespace AscEmu::Packets
             {
                 case CHAT_MSG_EMOTE:
                 case CHAT_MSG_SAY:
+                case CHAT_MSG_YELL:
                 case CHAT_MSG_PARTY:
+                case CHAT_MSG_PARTY_LEADER:
                 case CHAT_MSG_RAID:
                 case CHAT_MSG_RAID_LEADER:
                 case CHAT_MSG_RAID_WARNING:
                 case CHAT_MSG_GUILD:
                 case CHAT_MSG_OFFICER:
-                case CHAT_MSG_YELL:
+                case CHAT_MSG_BATTLEGROUND:
+                case CHAT_MSG_BATTLEGROUND_LEADER:
                 case CHAT_MSG_AFK:
                 case CHAT_MSG_DND:
                     packet >> message;
@@ -133,16 +136,18 @@ namespace AscEmu::Packets
 
             switch (type)
             {
+                case CHAT_MSG_EMOTE:
                 case CHAT_MSG_SAY:
+                case CHAT_MSG_YELL:
                 case CHAT_MSG_PARTY:
                 case CHAT_MSG_PARTY_LEADER:
-                case CHAT_MSG_BATTLEGROUND_LEADER:
-                case CHAT_MSG_GUILD:
-                case CHAT_MSG_OFFICER:
                 case CHAT_MSG_RAID:
                 case CHAT_MSG_RAID_LEADER:
                 case CHAT_MSG_RAID_WARNING:
+                case CHAT_MSG_GUILD:
+                case CHAT_MSG_OFFICER:
                 case CHAT_MSG_BATTLEGROUND:
+                case CHAT_MSG_BATTLEGROUND_LEADER:
                 case CHAT_MSG_AFK:
                 case CHAT_MSG_DND:
                     textLength = packet.readBits(9);

--- a/src/world/Server/Packets/Handlers/LootHandler.cpp
+++ b/src/world/Server/Packets/Handlers/LootHandler.cpp
@@ -367,6 +367,7 @@ void WorldSession::handleLootMoneyOpcode(WorldPacket& /*recvPacket*/)
             else
             {
                 _player->modCoinage(money);
+                _player->GetSession()->SendPacket(SmsgLootMoneyNotify(money, 1).serialise().get());
 #if VERSION_STRING > TBC
                 _player->GetAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY, money, 0, 0);
 #endif
@@ -403,6 +404,7 @@ void WorldSession::handleLootMoneyOpcode(WorldPacket& /*recvPacket*/)
 
             const uint32_t sharedMoney = money / uint32_t(groupMembers.size());
 
+            // TODO: money is given to group members even if they are not near the looter
             for (auto& player : groupMembers)
             {
                 if (worldConfig.player.isGoldCapEnabled && (player->getCoinage() + sharedMoney) > worldConfig.player.limitGoldAmount)
@@ -412,7 +414,7 @@ void WorldSession::handleLootMoneyOpcode(WorldPacket& /*recvPacket*/)
                 else
                 {
                     player->modCoinage(sharedMoney);
-                    player->GetSession()->SendPacket(SmsgLootMoneyNotify(sharedMoney).serialise().get());
+                    player->GetSession()->SendPacket(SmsgLootMoneyNotify(sharedMoney, groupMembers.size() <= 1).serialise().get());
 
 #if VERSION_STRING > TBC
                     player->GetAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY, sharedMoney, 0, 0);

--- a/src/world/Server/Packets/SmsgLootMoneyNotify.h
+++ b/src/world/Server/Packets/SmsgLootMoneyNotify.h
@@ -15,14 +15,15 @@ namespace AscEmu::Packets
     {
     public:
         uint32_t money;
+        uint8_t playersNear; // 0 = "Your share of the loot is...", 1 = "You loot..."
 
-        SmsgLootMoneyNotify() : SmsgLootMoneyNotify(0)
+        SmsgLootMoneyNotify() : SmsgLootMoneyNotify(0, 1)
         {
         }
 
-        SmsgLootMoneyNotify(uint32_t money) :
+        SmsgLootMoneyNotify(uint32_t money, uint8_t playersNear) :
             ManagedPacket(SMSG_LOOT_MONEY_NOTIFY, 0),
-            money(money)
+            money(money), playersNear(playersNear)
         {
         }
 
@@ -31,7 +32,7 @@ namespace AscEmu::Packets
 
         bool internalSerialise(WorldPacket& packet) override
         {
-            packet << money;
+            packet << money << playersNear;
             return true;
         }
 

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -565,7 +565,7 @@ void World::removeQueuedSocket(WorldSocket* socket)
 // Send Messages
 void World::sendMessageToOnlineGms(const std::string& message, WorldSession* sendToSelf /*nullptr*/)
 {
-    const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, message).serialise().get();
+    const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, message).serialise();
 
     std::lock_guard<std::mutex> guard(mSessionLock);
 
@@ -574,16 +574,16 @@ void World::sendMessageToOnlineGms(const std::string& message, WorldSession* sen
         if (activeSessions->second->GetPlayer() && activeSessions->second->GetPlayer()->IsInWorld() && activeSessions->second != sendToSelf)
         {
             if (activeSessions->second->CanUseCommand('u'))
-                activeSessions->second->SendPacket(data);
+                activeSessions->second->SendPacket(data.get());
         }
     }
 }
 
 void World::sendMessageToAll(const std::string& message, WorldSession* sendToSelf /*nullptr*/)
 {
-    const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, message).serialise().get();
+    const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, message).serialise();
 
-    sendGlobalMessage(data, sendToSelf);
+    sendGlobalMessage(data.get(), sendToSelf);
 
     if (settings.announce.showAnnounceInConsoleOutput)
     {
@@ -661,9 +661,9 @@ void World::sendBroadcastMessageById(uint32_t broadcastId)
         {
             const char* text = activeSessions->second->LocalizedBroadCast(broadcastId);
 
-            const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, text).serialise().get();
+            const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_SYSTEM, LANG_UNIVERSAL, 0, text).serialise();
 
-            activeSessions->second->SendPacket(data);
+            activeSessions->second->SendPacket(data.get());
         }
     }
 }

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -1976,8 +1976,8 @@ void AIInterface::_UpdateCombat(uint32 /*p_time*/)
 
                 std::string msg = "%s attempts to run away in fear!";
 
-                const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_CHANNEL, LANG_UNIVERSAL, 0, msg, 0, "", 0, static_cast<Creature*>(m_Unit)->GetCreatureProperties()->Name).serialise().get();
-                m_Unit->SendMessageToSet(data, false);
+                const auto data = AscEmu::Packets::SmsgMessageChat(CHAT_MSG_CHANNEL, LANG_UNIVERSAL, 0, msg, 0, "", 0, static_cast<Creature*>(m_Unit)->GetCreatureProperties()->Name).serialise();
+                m_Unit->SendMessageToSet(data.get(), false);
 
                 m_hasFleed = true;
             }

--- a/src/world/Units/Creatures/Creature.cpp
+++ b/src/world/Units/Creatures/Creature.cpp
@@ -2416,9 +2416,9 @@ void Creature::SendTimedScriptTextChatMessage(uint32 textid, uint32 delay)
 
     auto name = GetCreatureProperties()->Name;
 
-    const auto data = AscEmu::Packets::SmsgMessageChat(ct->type, ct->language, 0, ct->text, getGuid(), name).serialise().get();
+    const auto data = AscEmu::Packets::SmsgMessageChat(ct->type, ct->language, 0, ct->text, getGuid(), name).serialise();
 
-    SendMessageToSet(data, true);      // sending this
+    SendMessageToSet(data.get(), true);      // sending this
 }
 
 void Creature::SendChatMessageToPlayer(uint8 type, uint32 lang, const char* msg, Player* plr)
@@ -2426,9 +2426,9 @@ void Creature::SendChatMessageToPlayer(uint8 type, uint32 lang, const char* msg,
     if (plr == NULL)
         return;
 
-    const auto data = AscEmu::Packets::SmsgMessageChat(type, lang, 0, msg, getGuid(), GetCreatureProperties()->Name).serialise().get();
+    const auto data = AscEmu::Packets::SmsgMessageChat(type, lang, 0, msg, getGuid(), GetCreatureProperties()->Name).serialise();
 
-    plr->GetSession()->SendPacket(data);
+    plr->GetSession()->SendPacket(data.get());
 }
 
 void Creature::HandleMonsterSayEvent(MONSTER_SAY_EVENTS Event)

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -8362,9 +8362,9 @@ void Unit::SendChatMessageAlternateEntry(uint32 entry, uint8 type, uint32 lang, 
     if (ci == nullptr)
         return;
 
-    const auto data = SmsgMessageChat(type, lang, 0, msg, getGuid(), ci->Name).serialise().get();
+    const auto data = SmsgMessageChat(type, lang, 0, msg, getGuid(), ci->Name).serialise();
 
-    SendMessageToSet(data, true);
+    SendMessageToSet(data.get(), true);
 }
 
 void Unit::WipeHateList()


### PR DESCRIPTION
**Todo / Checklist**
Fix SMSG_MESSAGECHAT in several places where the packet is sent (slightly related to https://github.com/AscEmu/AscEmu/issues/854)
Fix party leader and battleground chat in <= WotLK
Fix text emotes and yelling in >= Cata
Correct SMSG_LOOT_MONEY_NOTIFY packet structure

**Tests Performed:** 
Built and tested ingame in wotlk and cata


