### PR TITLE
Encapsulate string utils in class Util

### DIFF
--- a/src/logonserver/Console/LogonConsole.cpp
+++ b/src/logonserver/Console/LogonConsole.cpp
@@ -410,7 +410,7 @@ void LogonConsole::checkAccountName(std::string name, uint8 type)
 {
     std::string aname(name);
 
-    Util::StringToUpperCase(aname);
+    AscEmu::Util::Strings::toUpperCase(aname);
 
     switch (type)
     {

--- a/src/logonserver/LogonCommServer/LogonCommServer.cpp
+++ b/src/logonserver/LogonCommServer/LogonCommServer.cpp
@@ -472,7 +472,7 @@ void LogonCommServerSocket::HandleDatabaseModify(WorldPacket & recvData)
             recvData >> banreason;
 
             // remember we expect this in uppercase
-            Util::StringToUpperCase(account);
+            AscEmu::Util::Strings::toUpperCase(account);
 
             std::shared_ptr<Account> pAccount = sAccountMgr.getAccountByName(account);
             if (pAccount == NULL)
@@ -494,7 +494,7 @@ void LogonCommServerSocket::HandleDatabaseModify(WorldPacket & recvData)
             //recvData >> gm;
 
             //// remember we expect this in uppercase
-            //Util::StringToUpperCase(account);
+            //AscEmu::Util::Strings::toUpperCase(account);
 
             //Account* pAccount = sAccountMgr.getAccountByName(account);
             //if (pAccount == NULL)
@@ -516,7 +516,7 @@ void LogonCommServerSocket::HandleDatabaseModify(WorldPacket & recvData)
             recvData >> duration;
 
             // remember we expect this in uppercase
-            Util::StringToUpperCase(account);
+            AscEmu::Util::Strings::toUpperCase(account);
 
             std::shared_ptr<Account> pAccount = sAccountMgr.getAccountByName(account);
             if (pAccount == NULL)
@@ -623,7 +623,7 @@ void LogonCommServerSocket::HandleDatabaseModify(WorldPacket & recvData)
             std::string name_save = name;  // save original name to check
 
             // remember we expect this in uppercase
-            Util::StringToUpperCase(name);
+            AscEmu::Util::Strings::toUpperCase(name);
 
             auto account_check = sAccountMgr.getAccountByName(name);
 
@@ -687,7 +687,7 @@ void LogonCommServerSocket::HandleRequestCheckAccount(WorldPacket & recvData)
             std::string account_name_save = account_name;  // save original account_name to check
 
             // remember we expect this in uppercase
-            Util::StringToUpperCase(account_name);
+            AscEmu::Util::Strings::toUpperCase(account_name);
 
             std::shared_ptr<Account> account_check = sAccountMgr.getAccountByName(account_name);
             if (account_check == nullptr)
@@ -722,7 +722,7 @@ void LogonCommServerSocket::HandleRequestCheckAccount(WorldPacket & recvData)
             std::string account_name_save = account_name;  // save original account_name to check
 
             // remember we expect this in uppercase
-            Util::StringToUpperCase(account_name);
+            AscEmu::Util::Strings::toUpperCase(account_name);
 
             std::shared_ptr<Account> account_check = sAccountMgr.getAccountByName(account_name);
             if (account_check == nullptr)

--- a/src/logonserver/LogonStdAfx.h
+++ b/src/logonserver/LogonStdAfx.h
@@ -31,6 +31,7 @@
 
 #include "../shared/Log.hpp"
 #include "../shared/Logging/Logger.hpp" 
+#include "../shared/Util/Strings.hpp"
 #include "../shared/Util.hpp"
 #include "../shared/ByteBuffer.h"
 #include "../shared/Config/Config.h"

--- a/src/logonserver/Server/AccountMgr.cpp
+++ b/src/logonserver/Server/AccountMgr.cpp
@@ -89,7 +89,7 @@ void AccountMgr::addAccount(Field* field)
         memset(account->SrpHash, 0, 20);
     }
 
-    Util::StringToUpperCase(accountName);
+    AscEmu::Util::Strings::toUpperCase(accountName);
 
     _accountMap[accountName] = account;
 }
@@ -183,7 +183,7 @@ void AccountMgr::reloadAccounts(bool silent)
             Field* field = result->Fetch();
             std::string accountName = field[1].GetString();
 
-            Util::StringToUpperCase(accountName);
+            AscEmu::Util::Strings::toUpperCase(accountName);
 
             const auto account = _getAccountByNameLockFree(accountName);
             if (account == nullptr)

--- a/src/logonserver/Server/Master.cpp
+++ b/src/logonserver/Server/Master.cpp
@@ -385,8 +385,8 @@ bool MasterLogon::SetLogonConfiguration()
 {
     logonConfig.loadConfigValues();
 
-    std::vector<std::string> allowedIPs = Util::SplitStringBySeperator(logonConfig.logonServer.allowedIps, " ");
-    std::vector<std::string> allowedModIPs = Util::SplitStringBySeperator(logonConfig.logonServer.allowedModIps, " ");
+    std::vector<std::string> allowedIPs = AscEmu::Util::Strings::split(logonConfig.logonServer.allowedIps, " ");
+    std::vector<std::string> allowedModIPs = AscEmu::Util::Strings::split(logonConfig.logonServer.allowedModIps, " ");
 
     m_allowedIpLock.Acquire();
     m_allowedIps.clear();

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -26,6 +26,8 @@ set(sources
 
     Threading/AEThread.cpp
     Threading/AEThreadPool.cpp
+	
+    Util/Strings.cpp
 
     CrashHandler.cpp
     crc32.cpp
@@ -104,6 +106,8 @@ set(headers
     Threading/AEThread.h
     Threading/AEThreadPool.h
     Threading/ThreadState.h
+	
+    Util/Strings.hpp
     
     Common.hpp
     Log.hpp

--- a/src/shared/Util.cpp
+++ b/src/shared/Util.cpp
@@ -4,6 +4,7 @@ This file is released under the MIT license. See README-MIT for more information
 */
 
 #include "Util.hpp"
+#include "Util/Strings.hpp"
 #include <iostream>
 #include <vector>
 #include <string>
@@ -16,63 +17,7 @@ This file is released under the MIT license. See README-MIT for more information
 namespace Util
 {
     //////////////////////////////////////////////////////////////////////////////////////////
-    // String functions
-
-    void StringToLowerCase(std::string& str)
-    {
-        // C4244
-        //std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        for (std::size_t i = 0; i < str.length(); ++i)
-            str[i] = static_cast<char>(::tolower(str[i]));
-    }
-
-    void StringToUpperCase(std::string& str)
-    {
-        // C4244
-        //std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-        for (std::size_t i = 0; i < str.length(); ++i)
-            str[i] = static_cast<char>(::toupper(str[i]));
-    }
-
-    void CapitalizeString(std::string& str)
-    {
-        if (!str.empty())
-        {
-            str[0] = static_cast<char>(::toupper(str[0]));
-
-            for (std::size_t i = 1; i < str.length(); ++i)
-                str[i] = static_cast<char>(::tolower(str[i]));
-        }
-    }
-
-    std::vector<std::string> SplitStringBySeperator(const std::string& str_src, const std::string& str_sep)
-    {
-        std::vector<std::string> string_vector {};
-
-        //\NOTE: somehow people think it is a good idea to use a separator as last char in a string
-        //       just remove it from the string before processing single strings (shitty db saving and loading)
-        std::string source = str_src;
-        if (source[source.size()] == str_sep[0])
-            source = source.substr(0, source.size() -1);
-
-        std::stringstream string_stream(source);
-        std::string isolated_string;
-
-        std::vector<char> seperator(str_sep.c_str(), str_sep.c_str() + str_sep.size() + 1);
-
-        while (std::getline(string_stream, isolated_string, seperator[0]))
-        {
-            if (isolated_string.size() != 0)
-                string_vector.push_back(isolated_string);
-        }
-
-        return string_vector;
-    }
-
-    bool findXinYString(std::string& x, std::string& y)
-    {
-        return y.find(x) != std::string::npos;
-    }
+    // WoW String functions
 
     uint32_t getLanguagesIdFromString(std::string langstr)
     {
@@ -286,7 +231,7 @@ namespace Util
         read_time_var >> time_period;
         read_time_var >> time_var;
 
-        Util::StringToLowerCase(time_var);
+        AscEmu::Util::Strings::toLowerCase(time_var);
 
         if (time_var.compare("y") == 0)
             multiplier = TimeVars::Year;

--- a/src/shared/Util.hpp
+++ b/src/shared/Util.hpp
@@ -15,22 +15,7 @@ This file is released under the MIT license. See README-MIT for more information
 namespace Util
 {
     //////////////////////////////////////////////////////////////////////////////////////////
-    // String functions
-
-    /*! \brief Manipulates the string to lowercase */
-    void StringToLowerCase(std::string& str);
-
-    /*! \brief Manipulates the string to uppercase */
-    void StringToUpperCase(std::string& str);
-
-    /*! \brief Capitalize word (uppercase first char, lowercase rest) */
-    void CapitalizeString(std::string& str);
-
-    /*! \brief Seperates string by seperator (one char) returns string vecotr */
-    std::vector<std::string> SplitStringBySeperator(const std::string& str_src, const std::string& str_sep);
-
-    /*! \brief Returns true if string x is in sttrin y */
-    bool findXinYString(std::string& x, std::string& y);
+    // WoW String functions
 
     /*! \brief Returns wow specific language string to id*/
     uint32_t getLanguagesIdFromString(std::string langstr);

--- a/src/shared/Util/Strings.cpp
+++ b/src/shared/Util/Strings.cpp
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2014-2021 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#include "Strings.hpp"
+
+namespace AscEmu::Util::Strings
+{
+    void toLowerCase(std::string& source)
+    {
+        // C4244
+        //std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        for (std::size_t i = 0; i < source.length(); ++i)
+            source[i] = static_cast<char>(::tolower(source[i]));
+    }
+
+    void toUpperCase(std::string& source)
+    {
+        // C4244
+        //std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+        for (std::size_t i = 0; i < source.length(); ++i)
+            source[i] = static_cast<char>(::toupper(source[i]));
+    }
+
+    void capitalize(std::string& str)
+    {
+        if (!str.empty())
+        {
+            str[0] = static_cast<char>(::toupper(str[0]));
+
+            for (std::size_t i = 1; i < str.length(); ++i)
+                str[i] = static_cast<char>(::tolower(str[i]));
+        }
+    }
+
+    std::vector<std::string> split(const std::string& source, const std::string& seperator)
+    {
+        std::vector<std::string> string_vector{};
+
+        //\NOTE: somehow people think it is a good idea to use a separator as last char in a string
+        //       just remove it from the string before processing single strings (shitty db saving and loading)
+        std::string result = source;
+        if (result[result.size()] == seperator[0])
+            result = result.substr(0, result.size() - 1);
+
+        std::stringstream string_stream(result);
+        std::string isolated_string;
+
+        std::vector<char> seperatorCharacter(seperator.c_str(), seperator.c_str() + seperator.size() + 1);
+
+        while (std::getline(string_stream, isolated_string, seperatorCharacter[0]))
+        {
+            if (isolated_string.size() != 0)
+                string_vector.push_back(isolated_string);
+        }
+
+        return string_vector;
+    }
+
+    bool contains(std::string& string, std::string& source)
+    {
+        return source.find(string) != std::string::npos;
+    }
+}

--- a/src/shared/Util/Strings.hpp
+++ b/src/shared/Util/Strings.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2014-2021 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "Common.hpp"
+
+namespace AscEmu::Util::Strings
+{
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // String functions
+
+    /*! \brief Manipulates the string to lowercase */
+    void toLowerCase(std::string& source);
+
+    /*! \brief Manipulates the string to uppercase */
+    void toUpperCase(std::string& source);
+
+    /*! \brief Capitalize word (uppercase first char, lowercase rest) */
+    void capitalize(std::string& source);
+
+    /*! \brief Seperates string by seperator (one char) returns string vecotr */
+    std::vector<std::string> split(const std::string& source, const std::string& seperator);
+
+    /*! \brief Returns true if string is in source */
+    bool contains(std::string& string, std::string& source);
+}

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -1445,7 +1445,7 @@ bool ChatHandler::HandleCharSetNameCommand(const char* args, WorldSession* m_ses
     }
 
     std::string new_name = new_name_cmd;
-    Util::CapitalizeString(new_name);
+    AscEmu::Util::Strings::capitalize(new_name);
 
     PlayerInfo* pi = sObjectMgr.GetPlayerInfoByName(current_name);
     if (pi == nullptr)

--- a/src/world/Chat/Commands/LookupCommands.cpp
+++ b/src/world/Chat/Commands/LookupCommands.cpp
@@ -66,7 +66,7 @@ bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* arg
         return true;
     }
 
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     GreenSystemMessage(m_session, "Starting search of achievement `%s`...", x.c_str());
     auto startTime = Util::TimeNow();
     uint32 i, j, numFound = 0;
@@ -96,8 +96,8 @@ bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* arg
 #else
                     y = std::string(achievement->name);
 #endif
-                    Util::StringToLowerCase(y);
-                    foundmatch = Util::findXinYString(x, y);
+                    AscEmu::Util::Strings::toLowerCase(y);
+                    foundmatch = AscEmu::Util::Strings::contains(x, y);
                 }
                 if (!foundmatch && lookupdesc)
                 {
@@ -106,8 +106,8 @@ bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* arg
 #else
                     y = std::string(achievement->description);
 #endif
-                    Util::StringToLowerCase(y);
-                    foundmatch = Util::findXinYString(x, y);
+                    AscEmu::Util::Strings::toLowerCase(y);
+                    foundmatch = AscEmu::Util::Strings::contains(x, y);
                 }
                 if (!foundmatch && lookupreward)
                 {
@@ -116,8 +116,8 @@ bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* arg
 #else
                     y = std::string(achievement->rewardName);
 #endif
-                    Util::StringToLowerCase(y);
-                    foundmatch = Util::findXinYString(x, y);
+                    AscEmu::Util::Strings::toLowerCase(y);
+                    foundmatch = AscEmu::Util::Strings::contains(x, y);
                 }
                 if (!foundmatch)
                 {
@@ -188,8 +188,8 @@ bool ChatHandler::HandleLookupAchievementCommand([[maybe_unused]]const char* arg
 #else
                 y = std::string(criteria->name);
 #endif
-                Util::StringToLowerCase(y);
-                if (Util::findXinYString(x, y) == false)
+                AscEmu::Util::Strings::toLowerCase(y);
+                if (AscEmu::Util::Strings::contains(x, y) == false)
                 {
                     continue;
                 }
@@ -267,7 +267,7 @@ bool ChatHandler::HandleLookupCreatureCommand(const char* args, WorldSession* m_
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     if (x.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -289,14 +289,14 @@ bool ChatHandler::HandleLookupCreatureCommand(const char* args, WorldSession* m_
 
             std::string litName = std::string( lit ? lit->name : "");
 
-            Util::StringToLowerCase(litName);
+            AscEmu::Util::Strings::toLowerCase(litName);
 
             bool localizedFound = false;
-            if (Util::findXinYString(x, litName))
+            if (AscEmu::Util::Strings::contains(x, litName))
                 localizedFound = true;
 
             std::string names_lower = it->lowercase_name;
-            if (Util::findXinYString(x, names_lower) || localizedFound)
+            if (AscEmu::Util::Strings::contains(x, names_lower) || localizedFound)
             {
                 SystemMessage(m_session, "ID: %u |cfffff000%s", it->Id, it->Name.c_str());
                 ++count;
@@ -324,7 +324,7 @@ bool ChatHandler::HandleLookupFactionCommand(const char* args, WorldSession* m_s
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     if (x.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -344,8 +344,8 @@ bool ChatHandler::HandleLookupFactionCommand(const char* args, WorldSession* m_s
 #else
             std::string y = std::string(faction->Name);
 #endif
-            Util::StringToLowerCase(y);
-            if (Util::findXinYString(x, y))
+            AscEmu::Util::Strings::toLowerCase(y);
+            if (AscEmu::Util::Strings::contains(x, y))
             {
 #if VERSION_STRING < Cata
                 SendHighlightedName(m_session, "Faction", faction->Name[0], y, x, faction->ID);
@@ -373,7 +373,7 @@ bool ChatHandler::HandleLookupItemCommand(const char* args, WorldSession* m_sess
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     if (x.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -396,14 +396,14 @@ bool ChatHandler::HandleLookupItemCommand(const char* args, WorldSession* m_sess
 
         std::string litName = std::string(lit ? lit->name : "");
 
-        Util::StringToLowerCase(litName);
+        AscEmu::Util::Strings::toLowerCase(litName);
 
         bool localizedFound = false;
-        if (Util::findXinYString(x, litName))
+        if (AscEmu::Util::Strings::contains(x, litName))
             localizedFound = true;
 
         std::string proto_lower = it->lowercase_name;
-        if (Util::findXinYString(x, proto_lower) || localizedFound)
+        if (AscEmu::Util::Strings::contains(x, proto_lower) || localizedFound)
         {
             SendItemLinkToPlayer(it, m_session, false, 0, localizedFound ? m_session->language : 0);
             ++count;
@@ -429,7 +429,7 @@ bool ChatHandler::HandleLookupObjectCommand(const char* args, WorldSession* m_se
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
 
     GreenSystemMessage(m_session, "Starting search of object `%s`...", x.c_str());
     auto startTime = Util::TimeNow();
@@ -443,8 +443,8 @@ bool ChatHandler::HandleLookupObjectCommand(const char* args, WorldSession* m_se
     {
         gameobject_info = sMySQLStore.getGameObjectProperties(itr->second.entry);
         y = std::string(gameobject_info->name);
-        Util::StringToLowerCase(y);
-        if (Util::findXinYString(x, y))
+        AscEmu::Util::Strings::toLowerCase(y);
+        if (AscEmu::Util::Strings::contains(x, y))
         {
             std::string Name;
             std::stringstream strm;
@@ -485,7 +485,7 @@ bool ChatHandler::HandleLookupQuestCommand(const char* args, WorldSession* m_ses
         return false;
 
     std::string search_string = std::string(args);
-    Util::StringToLowerCase(search_string);
+    AscEmu::Util::Strings::toLowerCase(search_string);
     if (search_string.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -510,14 +510,14 @@ bool ChatHandler::HandleLookupQuestCommand(const char* args, WorldSession* m_ses
 
         std::string liName = std::string(li ? li->title : "");
 
-        Util::StringToLowerCase(liName);
-        Util::StringToLowerCase(lower_quest_title);
+        AscEmu::Util::Strings::toLowerCase(liName);
+        AscEmu::Util::Strings::toLowerCase(lower_quest_title);
 
         bool localizedFound = false;
-        if (Util::findXinYString(search_string, liName))
+        if (AscEmu::Util::Strings::contains(search_string, liName))
             localizedFound = true;
 
-        if (Util::findXinYString(search_string, lower_quest_title) || localizedFound)
+        if (AscEmu::Util::Strings::contains(search_string, lower_quest_title) || localizedFound)
         {
             std::string questid = MyConvertIntToString(quest->id);
             std::string questtitle = localizedFound ? (li ? li->title : "") : quest->title;
@@ -559,7 +559,7 @@ bool ChatHandler::HandleLookupSpellCommand(const char* args, WorldSession* m_ses
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     if (x.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -575,8 +575,8 @@ bool ChatHandler::HandleLookupSpellCommand(const char* args, WorldSession* m_ses
     {
         SpellInfo const* spell = sSpellMgr.getSpellInfo(it->first);
         std::string y = std::string(spell->getName());
-        Util::StringToLowerCase(y);
-        if (Util::findXinYString(x, y))
+        AscEmu::Util::Strings::toLowerCase(y);
+        if (AscEmu::Util::Strings::contains(x, y))
         {
             sprintf((char*)itoabuf, "%u", spell->getId());
             recout = (const char*)itoabuf;
@@ -614,7 +614,7 @@ bool ChatHandler::HandleLookupSkillCommand(const char* args, WorldSession* m_ses
         return false;
 
     std::string x = std::string(args);
-    Util::StringToLowerCase(x);
+    AscEmu::Util::Strings::toLowerCase(x);
     if (x.length() < 4)
     {
         RedSystemMessage(m_session, "Your search string must be at least 4 characters long.");
@@ -635,8 +635,8 @@ bool ChatHandler::HandleLookupSkillCommand(const char* args, WorldSession* m_ses
 #else
         std::string y = std::string(skill_line->Name);
 #endif
-        Util::StringToLowerCase(y);
-        if (Util::findXinYString(x, y))
+        AscEmu::Util::Strings::toLowerCase(y);
+        if (AscEmu::Util::Strings::contains(x, y))
         {
 #if VERSION_STRING < Cata
             SendHighlightedName(m_session, "Skill", skill_line->Name[0], y, x, skill_line->id);

--- a/src/world/Chat/Commands/RecallCommands.cpp
+++ b/src/world/Chat/Commands/RecallCommands.cpp
@@ -118,12 +118,12 @@ bool ChatHandler::HandleRecallListCommand(const char* args, WorldSession* m_sess
     recout += "Recall locations|r:\n\n";
 
     std::string search(args);
-    Util::StringToLowerCase(search);
+    AscEmu::Util::Strings::toLowerCase(search);
 
     for (auto* recall : sMySQLStore.getRecallStore())
     {
         std::string recallName(recall->name);
-        Util::StringToLowerCase(recallName);
+        AscEmu::Util::Strings::toLowerCase(recallName);
         if (recallName.find(search) == 0)
         {
             recout += MSG_COLOR_LIGHTBLUE;

--- a/src/world/Management/AuctionHouse.cpp
+++ b/src/world/Management/AuctionHouse.cpp
@@ -459,7 +459,7 @@ void AuctionHouse::sendAuctionList(Player* player, AscEmu::Packets::CmsgAuctionL
 
         // this is going to hurt. - name
         std::string proto_lower = proto->lowercase_name;
-        if (srlPacket.searchedName.length() > 0 && !Util::findXinYString(srlPacket.searchedName, proto_lower))
+        if (srlPacket.searchedName.length() > 0 && !AscEmu::Util::Strings::contains(srlPacket.searchedName, proto_lower))
             continue;
 
         // rarity

--- a/src/world/Management/ChannelMgr.cpp
+++ b/src/world/Management/ChannelMgr.cpp
@@ -43,8 +43,8 @@ void ChannelMgr::loadConfigSettings()
 
     m_confSettingLock.Acquire();
 
-    m_bannedChannels = Util::SplitStringBySeperator(bannedChannels, ";");
-    m_minimumChannel = Util::SplitStringBySeperator(minimumLevel, ";");
+    m_bannedChannels = AscEmu::Util::Strings::split(bannedChannels, ";");
+    m_minimumChannel = AscEmu::Util::Strings::split(minimumLevel, ";");
 
     m_confSettingLock.Release();
 }

--- a/src/world/Management/Guild/GuildMgr.cpp
+++ b/src/world/Management/Guild/GuildMgr.cpp
@@ -77,11 +77,11 @@ Guild* GuildMgr::getGuildByLeader(uint64_t guid) const
 Guild* GuildMgr::getGuildByName(const std::string& guildName) const
 {
     std::string search = guildName;
-    Util::StringToUpperCase(search);
+    AscEmu::Util::Strings::toUpperCase(search);
     for (GuildContainer::const_iterator itr = GuildStore.begin(); itr != GuildStore.end(); ++itr)
     {
         std::string gname = itr->second->getName();
-        Util::StringToUpperCase(gname);
+        AscEmu::Util::Strings::toUpperCase(gname);
         if (search == gname)
             return itr->second;
     }

--- a/src/world/Management/Item.Legacy.cpp
+++ b/src/world/Management/Item.Legacy.cpp
@@ -165,7 +165,7 @@ void Item::LoadFromDB(Field* fields, Player* plr, bool light)
     std::string enchant_field = fields[15].GetString();
     if (!enchant_field.empty())
     {
-        std::vector<std::string> enchants = Util::SplitStringBySeperator(enchant_field, ";");
+        std::vector<std::string> enchants = AscEmu::Util::Strings::split(enchant_field, ";");
         uint32 enchant_id;
 
         uint32 time_left;

--- a/src/world/Management/QuestMgr.cpp
+++ b/src/world/Management/QuestMgr.cpp
@@ -2347,7 +2347,7 @@ void QuestMgr::LoadExtraQuestStuff()
         {
             const_cast<QuestProperties*>(qst)->quest_list.clear();
             std::string quests = std::string(qst->x_or_y_quest_string);
-            std::vector<std::string> qsts = Util::SplitStringBySeperator(quests, " ");
+            std::vector<std::string> qsts = AscEmu::Util::Strings::split(quests, " ");
             for (std::vector<std::string>::iterator iter = qsts.begin(); iter != qsts.end(); ++iter)
             {
                 uint32 id = atol((*iter).c_str());
@@ -2359,7 +2359,7 @@ void QuestMgr::LoadExtraQuestStuff()
         if (qst->remove_quests.size())
         {
             std::string quests = std::string(qst->remove_quests);
-            std::vector<std::string> qsts = Util::SplitStringBySeperator(quests, " ");
+            std::vector<std::string> qsts = AscEmu::Util::Strings::split(quests, " ");
             for (std::vector<std::string>::iterator iter = qsts.begin(); iter != qsts.end(); ++iter)
             {
                 uint32 id = atol((*iter).c_str());

--- a/src/world/Map/InstanceMgr.cpp
+++ b/src/world/Map/InstanceMgr.cpp
@@ -119,7 +119,7 @@ void InstanceMgr::loadAndApplySavedInstanceValues()
             instance->m_expiration = result->Fetch()[3].GetUInt32();
 
             const std::string npcString = result->Fetch()[4].GetString();
-            auto npcStrings = Util::SplitStringBySeperator(npcString, " ");
+            auto npcStrings = AscEmu::Util::Strings::split(npcString, " ");
             for (const auto str : npcStrings)
             {
                 if (uint32_t val = atol(str.c_str()))

--- a/src/world/Objects/ObjectMgr.cpp
+++ b/src/world/Objects/ObjectMgr.cpp
@@ -273,7 +273,7 @@ void ObjectMgr::DeletePlayerInfo(uint32 guid)
         pl->m_Group->RemovePlayer(pl);
 
     std::string pnam = std::string(pl->name);
-    Util::StringToLowerCase(pnam);
+    AscEmu::Util::Strings::toLowerCase(pnam);
     PlayerNameStringIndexMap::iterator i2 = m_playersInfoByName.find(pnam);
     if (i2 != m_playersInfoByName.end() && i2->second == pl)
     {
@@ -303,7 +303,7 @@ void ObjectMgr::AddPlayerInfo(PlayerInfo* pn)
     m_playersinfo[pn->guid] = pn;
 
     std::string pnam = std::string(pn->name);
-    Util::StringToLowerCase(pnam);
+    AscEmu::Util::Strings::toLowerCase(pnam);
     m_playersInfoByName[pnam] = pn;
 }
 
@@ -312,13 +312,13 @@ void ObjectMgr::RenamePlayerInfo(PlayerInfo* pn, const char* oldname, const char
     std::lock_guard<std::mutex> guard(playernamelock);
 
     std::string oldn = std::string(oldname);
-    Util::StringToLowerCase(oldn);
+    AscEmu::Util::Strings::toLowerCase(oldn);
 
     PlayerNameStringIndexMap::iterator itr = m_playersInfoByName.find(oldn);
     if (itr != m_playersInfoByName.end() && itr->second == pn)
     {
         std::string newn = std::string(newname);
-        Util::StringToLowerCase(newn);
+        AscEmu::Util::Strings::toLowerCase(newn);
         m_playersInfoByName.erase(itr);
         m_playersInfoByName[newn] = pn;
     }
@@ -442,7 +442,7 @@ void ObjectMgr::LoadPlayersInfo()
             }
 
             std::string lpn = std::string(pn->name);
-            Util::StringToLowerCase(lpn);
+            AscEmu::Util::Strings::toLowerCase(lpn);
             m_playersInfoByName[lpn] = pn;
 
             //this is startup -> no need in lock -> don't use addplayerinfo
@@ -458,7 +458,7 @@ void ObjectMgr::LoadPlayersInfo()
 PlayerInfo* ObjectMgr::GetPlayerInfoByName(const char* name)
 {
     std::string lpn = std::string(name);
-    Util::StringToLowerCase(lpn);
+    AscEmu::Util::Strings::toLowerCase(lpn);
 
     std::lock_guard<std::mutex> guard(playernamelock);
 
@@ -808,7 +808,7 @@ Player* ObjectMgr::GetPlayer(const char* name, bool caseSensitive)
     if (!caseSensitive)
     {
         std::string strName = name;
-        Util::StringToLowerCase(strName);
+        AscEmu::Util::Strings::toLowerCase(strName);
         for (PlayerStorageMap::const_iterator itr = _players.begin(); itr != _players.end(); ++itr)
         {
             if (!stricmp(itr->second->getName().c_str(), strName.c_str()))

--- a/src/world/Server/LogonCommClient/LogonCommHandler.cpp
+++ b/src/world/Server/LogonCommClient/LogonCommHandler.cpp
@@ -463,7 +463,7 @@ void LogonCommHandler::loadRealmsConfiguration()
 
             std::string realmType = "Normal";
             ARCEMU_ASSERT(Config.MainConfig.tryGetString(realmString.str(), "Icon", &realmType));
-            Util::StringToLowerCase(realmType);
+            AscEmu::Util::Strings::toLowerCase(realmType);
 
             // process realm type
             if (realmType.compare("pvp") == 0)
@@ -504,8 +504,8 @@ void LogonCommHandler::testConsoleLogon(std::string & username, std::string & pa
     std::string newpass = password;
     std::string srpstr;
 
-    Util::StringToUpperCase(newuser);
-    Util::StringToUpperCase(newpass);
+    AscEmu::Util::Strings::toUpperCase(newuser);
+    AscEmu::Util::Strings::toUpperCase(newpass);
 
     srpstr = newuser + ":" + newpass;
 

--- a/src/world/Server/Packets/Handlers/CharacterHandler.cpp
+++ b/src/world/Server/Packets/Handlers/CharacterHandler.cpp
@@ -166,7 +166,7 @@ void WorldSession::handleCharFactionOrRaceChange(WorldPacket& recvPacket)
         srlPacket.charCreate.face, srlPacket.charCreate.hairStyle, srlPacket.charCreate.hairColor, srlPacket.charCreate.facialHair);
 
     std::string newname = srlPacket.charCreate.name;
-    Util::CapitalizeString(newname);
+    AscEmu::Util::Strings::capitalize(newname);
 
     sObjectMgr.RenamePlayerInfo(playerInfoPacket, playerInfoPacket->name, newname.c_str());
 
@@ -237,7 +237,7 @@ void WorldSession::handleCharRenameOpcode(WorldPacket& recvPacket)
     }
 
     std::string newName = srlPacket.name;
-    Util::CapitalizeString(newName);
+    AscEmu::Util::Strings::capitalize(newName);
     sObjectMgr.RenamePlayerInfo(playerInfo, playerInfo->name, newName.c_str());
 
     sPlrLog.writefromsession(this, "renamed character %s, %u (guid), to %s.", playerInfo->name, playerInfo->guid, newName.c_str());
@@ -576,7 +576,7 @@ void WorldSession::handleCharCustomizeLooksOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    Util::CapitalizeString(srlPacket.createStruct.name);
+    AscEmu::Util::Strings::capitalize(srlPacket.createStruct.name);
 
     CharacterDatabase.WaitExecute("UPDATE `characters` set name = '%s' WHERE guid = %u",
         srlPacket.createStruct.name.c_str(), srlPacket.guid.getGuidLow());

--- a/src/world/Server/Packets/SmsgMonsterMoveTransport.h
+++ b/src/world/Server/Packets/SmsgMonsterMoveTransport.h
@@ -45,7 +45,7 @@ namespace AscEmu::Packets
             packet << uint8_t(unitGuid.isPlayer());
 
             packet << currentPosition.x << currentPosition.y << currentPosition.z;
-            packet << Util::getMSTime();
+            packet << ::Util::getMSTime();
             packet << uint8_t(4);           // splinetype facing_angle
             packet << currentPosition.o;    // facing angle
             packet << uint32_t(0x00800000); // splineflag transport

--- a/src/world/StdAfx.h
+++ b/src/world/StdAfx.h
@@ -38,6 +38,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "AuthCodes.h"
 #include "CallBack.h"
 #include "CThreads.h"
+#include "Util/Strings.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -74,7 +74,7 @@ void MySQLDataStore::loadAdditionalTableConfig()
     if (strData.empty())
         return;
 
-    std::vector<std::string> strs = Util::SplitStringBySeperator(strData, ",");
+    std::vector<std::string> strs = AscEmu::Util::Strings::split(strData, ",");
     if (strs.empty())
         return;
 
@@ -374,7 +374,7 @@ void MySQLDataStore::loadItemPropertiesTable()
 
             //lowercase
             std::string lower_case_name = itemProperties.Name;
-            Util::StringToLowerCase(lower_case_name);
+            AscEmu::Util::Strings::toLowerCase(lower_case_name);
             itemProperties.lowercase_name = lower_case_name;
 
             //forced pet entries (hacky stuff ->spells)
@@ -670,7 +670,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
 
             //lowercase
             std::string lower_case_name = creatureProperties.Name;
-            Util::StringToLowerCase(lower_case_name);
+            AscEmu::Util::Strings::toLowerCase(lower_case_name);
             creatureProperties.lowercase_name = lower_case_name;
 
             creatureProperties.SubName = fields[8].GetString();
@@ -810,7 +810,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             if (creatureProperties.aura_string.size() != 0)
             {
                 std::string auras = creatureProperties.aura_string;
-                std::vector<std::string> split_auras = Util::SplitStringBySeperator(auras, " ");
+                std::vector<std::string> split_auras = AscEmu::Util::Strings::split(auras, " ");
                 for (std::vector<std::string>::iterator it = split_auras.begin(); it != split_auras.end(); ++it)
                 {
                     uint32_t id = atol((*it).c_str());
@@ -2318,7 +2318,7 @@ void MySQLDataStore::loadPlayerCreateInfoTable()
         playerCreateInfo.maxdmg = fields[21].GetFloat();
 
         std::string taxiMaskStr = fields[22].GetString();
-        std::vector<std::string> tokens = Util::SplitStringBySeperator(taxiMaskStr, " ");
+        std::vector<std::string> tokens = AscEmu::Util::Strings::split(taxiMaskStr, " ");
 
         memset(playerCreateInfo.taximask, 0, sizeof(playerCreateInfo.taximask));
         int index;
@@ -3241,12 +3241,12 @@ MySQLStructure::LocalesItem const* MySQLDataStore::getLocalizedItem(uint32_t ent
 MySQLStructure::RecallStruct const* MySQLDataStore::getRecallByName(const std::string name)
 {
     std::string searchName(name);
-    Util::StringToLowerCase(searchName);
+    AscEmu::Util::Strings::toLowerCase(searchName);
 
     for (auto itr : _recallStore)
     {
         std::string recallName(itr->name);
-        Util::StringToLowerCase(recallName);
+        AscEmu::Util::Strings::toLowerCase(recallName);
         if (recallName == searchName)
             return itr;
     }

--- a/src/world/Units/Creatures/Corpse.cpp
+++ b/src/world/Units/Creatures/Corpse.cpp
@@ -85,7 +85,7 @@ void Corpse::setDynamicFlags(uint32_t flags) { write(corpseData()->dynamic_flags
 void Corpse::setCorpseDataFromDbString(std::string dbString)
 {
     std::string seperator = " ";
-    auto dataVector = Util::SplitStringBySeperator(dbString, seperator);
+    auto dataVector = AscEmu::Util::Strings::split(dbString, seperator);
 
     char const achievement_format[] = "luif";
     uint8_t countPosition = 0;

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -661,7 +661,7 @@ void Player::CharChange_Language(uint64 GUID, uint8 race)
 bool Player::Create(CharCreate& charCreateContent)
 {
     m_name = charCreateContent.name;
-    Util::CapitalizeString(m_name);
+    AscEmu::Util::Strings::capitalize(m_name);
 
     info = sMySQLStore.getPlayerCreateInfo(charCreateContent._race, charCreateContent._class);
     if (info == nullptr)
@@ -3113,7 +3113,7 @@ void Player::LoadFromDBProc(QueryResultVector & results)
         {
             uint32_t tps[2] = {0,0};
 
-            auto talentPointsVector = Util::SplitStringBySeperator(talentPoints, " ");
+            auto talentPointsVector = AscEmu::Util::Strings::split(talentPoints, " ");
             for (uint8_t i = 0; i < 2; ++i)
                 tps[i] = std::stoi(talentPointsVector[i]);
 
@@ -3130,7 +3130,7 @@ void Player::LoadFromDBProc(QueryResultVector & results)
         {
             uint32_t tps[2] = {0,0};
 
-            auto talentPointsVector = Util::SplitStringBySeperator(talentPoints, " ");
+            auto talentPointsVector = AscEmu::Util::Strings::split(talentPoints, " ");
             for (uint8_t i = 0; i < 2; ++i)
                 tps[i] = std::stoi(talentPointsVector[i]);
 
@@ -5372,7 +5372,7 @@ void Player::SetDrunkValue(uint16 newDrunkenValue, uint32 itemId)
 
 void Player::LoadTaxiMask(const char* data)
 {
-    std::vector<std::string> tokens = Util::SplitStringBySeperator(data, " ");
+    std::vector<std::string> tokens = AscEmu::Util::Strings::split(data, " ");
 
     int index;
     std::vector<std::string>::iterator iter;


### PR DESCRIPTION
**Description**
Created Strings.hpp/cpp to encapsulate string utils from class Util. So we dont need any pre-/infix in methods name, because of the new namespace.

**Todo / Checklist**
- [X] Target is branch develop.
- [X] Detailed description about this pull request.
- [X] Checked AE-Coding standards.

**Tests Performed:** 
- [X] Build AE.
- [X] Server startup.
- [] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


