### PR TITLE
Bugfix: Logger::setMinimumMessageType no Crash with MessageType Trace.

### DIFF
--- a/src/shared/Logging/Logger.cpp
+++ b/src/shared/Logging/Logger.cpp
@@ -67,7 +67,6 @@ namespace AscEmu::Logging
 
     void Logger::setMinimumMessageType(MessageType minimumMessageType)
     {
-        assert(minimumMessageType);
         this->minimumMessageType = minimumMessageType;
     }
 


### PR DESCRIPTION
**Description**
Logger::setMinimumMessageType no Crash with MessageType Trace anymore.

**Todo / Checklist**
- [X] Target is branch develop.
- [X] Detailed description about this pull request.
- [X] Checked AE-Coding standards.

**Tests Performed:** 
- [X] Build AE.
- [X] Server startup.
- [] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


