### PR TITLE
Encapsulate RealmFlags from LogonServerDefines to RealmFlag.

### DIFF
--- a/src/logonserver/CMakeLists.txt
+++ b/src/logonserver/CMakeLists.txt
@@ -6,6 +6,7 @@ project(logon CXX)
 include(Auth/CMakeLists.txt)
 include(Console/CMakeLists.txt)
 include(LogonCommServer/CMakeLists.txt)
+include(Realm/CMakeLists.txt)
 include(Server/CMakeLists.txt)
 
 set(SRC_LOGON_PROJECT
@@ -23,6 +24,7 @@ set(sources
    ${SRC_AUTH_FILES}
    ${SRC_CONSOLE_FILES}
    ${SRC_LOGON_COMM_SERVER_FILES}
+   ${SRC_REALM_FILES}
    ${SRC_SERVER_FILES}
    ${SRC_LOGON_PROJECT}
 )

--- a/src/logonserver/Realm/CMakeLists.txt
+++ b/src/logonserver/Realm/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2021 AscEmu Team <http://www.ascemu.org>
+
+set(PATH_PREFIX Realm)
+
+set(SRC_REALM_FILES
+   ${PATH_PREFIX}/RealmFlag.hpp
+)
+
+source_group(Realm FILES ${SRC_REALM_FILES})
+unset(PATH_PREFIX)

--- a/src/logonserver/Realm/RealmFlag.hpp
+++ b/src/logonserver/Realm/RealmFlag.hpp
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2014-2021 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+namespace AscEmu::Realm
+{
+    enum RealmFlag
+    {
+        NONE = 0x00,
+        ///\todo Other emulators have VERSION_MISMATCH instead of INVALID
+        INVALID = 0x01,
+        OFFLINE = 0x02,
+        SPECIFIC_BUILD = 0x04,     // client will show realm version in RealmList screen in form "RealmName (major.minor.revision.build)"
+        UNKNOWN_1 = 0x08,
+        UNKOWN_2 = 0x10,
+        ///\todo Other emulators have REALM_FLAG_NEW_PLAYERS and REALM_FLAG_RECOMMENDED swaped.
+        NEW_PLAYERS = 0x20,
+        RECOMMENDED = 0x40,
+        FULL = 0x80
+    };
+}

--- a/src/logonserver/Realm/RealmFlag.hpp
+++ b/src/logonserver/Realm/RealmFlag.hpp
@@ -15,7 +15,7 @@ namespace AscEmu::Realm
         OFFLINE = 0x02,
         SPECIFIC_BUILD = 0x04,     // client will show realm version in RealmList screen in form "RealmName (major.minor.revision.build)"
         UNKNOWN_1 = 0x08,
-        UNKOWN_2 = 0x10,
+        UNKNOWN_2 = 0x10,
         ///\todo Other emulators have REALM_FLAG_NEW_PLAYERS and REALM_FLAG_RECOMMENDED swaped.
         NEW_PLAYERS = 0x20,
         RECOMMENDED = 0x40,

--- a/src/logonserver/Server/LogonServerDefines.hpp
+++ b/src/logonserver/Server/LogonServerDefines.hpp
@@ -7,19 +7,6 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Config/Config.h"
 
-enum RealmFlags
-{
-    REALM_FLAG_NONE         = 0x00,
-    REALM_FLAG_INVALID      = 0x01,
-    REALM_FLAG_OFFLINE      = 0x02,
-    REALM_FLAG_SPECIFYBUILD = 0x04,     // client will show realm version in RealmList screen in form "RealmName (major.minor.revision.build)"
-    REALM_FLAG_UNK1         = 0x08,
-    REALM_FLAG_UNK2         = 0x10,
-    REALM_FLAG_NEW_PLAYERS  = 0x20,
-    REALM_FLAG_RECOMMENDED  = 0x40,
-    REALM_FLAG_FULL         = 0x80
-};
-
 struct AllowedIP
 {
     unsigned int IP;

--- a/src/logonserver/Server/RealmsMgr.cpp
+++ b/src/logonserver/Server/RealmsMgr.cpp
@@ -8,6 +8,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "RealmsMgr.h"
 #include "Util.hpp"
 #include <Threading/AEThreadPool.h>
+#include "Realm/RealmFlag.hpp"
 
 RealmsMgr& RealmsMgr::getInstance()
 {
@@ -170,7 +171,7 @@ void RealmsMgr::sendRealms(AuthSocket* Socket)
                 data << uint8_t(realms->timeZone);
                 data << uint8_t(realms->id);
 
-                if (realms->flags & REALM_FLAG_SPECIFYBUILD)
+                if (realms->flags & AscEmu::Realm::RealmFlag::SPECIFIC_BUILD)
                 {
                     data << Socket->GetChallenge()->version1;
                     data << Socket->GetChallenge()->version2;
@@ -278,7 +279,7 @@ void RealmsMgr::setRealmOffline(uint32_t realm_id)
     auto realm = getRealmById(realm_id);
     if (realm != nullptr)
     {
-        realm->flags = REALM_FLAG_OFFLINE | REALM_FLAG_INVALID;
+        realm->flags = AscEmu::Realm::RealmFlag::OFFLINE | AscEmu::Realm::RealmFlag::INVALID;
         realm->_characterMap.clear();
         sLogger.info("RealmsMgr : Realm %u is now offline (socket close).", realm_id);
         sLogonSQL->Query("UPDATE realms SET status = 0 WHERE id = %u", uint32_t(realm->id));
@@ -296,15 +297,15 @@ void RealmsMgr::updateRealmPop(uint32_t realm_id, float pop)
     {
         uint8_t flags;
         if (pop >= 3)
-            flags = REALM_FLAG_FULL | REALM_FLAG_INVALID;
+            flags = AscEmu::Realm::RealmFlag::FULL | AscEmu::Realm::RealmFlag::INVALID;
         else if (pop >= 2)
-            flags = REALM_FLAG_INVALID;
+            flags = AscEmu::Realm::RealmFlag::INVALID;
         else if (pop >= 1.25)
             flags = 0;
         else if (pop >= 0.5)
-            flags = REALM_FLAG_RECOMMENDED;
+            flags = AscEmu::Realm::RealmFlag::RECOMMENDED;
         else
-            flags = REALM_FLAG_NEW_PLAYERS;
+            flags = AscEmu::Realm::RealmFlag::NEW_PLAYERS;
 
         realm->population = (pop > 0) ? (pop >= 1) ? (pop >= 2) ? 2.0f : 1.0f : 0.0f : 0.0f;
         realm->flags = flags;


### PR DESCRIPTION
**Description**
The RealmFlags are now a custom file named RealmFlag.hpp. The Prefix REALM_FLAG was removed and the enum is now in the namespave AscEmu::Realm. The RealmFlag REALM_FLAG_SPCIFYBUILD was renamed to SPECIFIC_BUILD.

**Todo / Checklist**
- [X] Target is branch develop.
- [X] Detailed description about this pull request.
- [X] Checked AE-Coding standards.

**Tests Performed:** 
- [X] Build AE.
- [X] Server startup.
- [] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


