### PR TITLE
Fix database automatic update in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,5 +41,7 @@ add_subdirectory(src/scripts)
 # install libraries for windows build (libmysql.dll, libey32.dll)
 if(WIN32)
     install(FILES ${INSTALLED_DEPENDENCIES} DESTINATION .)
-    install(DIRECTORY ${INSTALL_DB_FILES} DESTINATION sql FILES_MATCHING PATTERN "*.sql")
 endif()
+
+# install db updates
+install(DIRECTORY ${INSTALL_DB_FILES} DESTINATION sql FILES_MATCHING PATTERN "*.sql")

--- a/cmake/Systems/Apple.cmake
+++ b/cmake/Systems/Apple.cmake
@@ -21,3 +21,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()
+
+# Check for database update files
+set(PATH_DB_FILES ${CMAKE_SOURCE_DIR}/sql/)
+set(INSTALL_DB_FILES ${PATH_DB_FILES})

--- a/cmake/Systems/FreeBSD.cmake
+++ b/cmake/Systems/FreeBSD.cmake
@@ -19,3 +19,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()
+
+# Check for database update files
+set(PATH_DB_FILES ${CMAKE_SOURCE_DIR}/sql/)
+set(INSTALL_DB_FILES ${PATH_DB_FILES})

--- a/cmake/Systems/Linux.cmake
+++ b/cmake/Systems/Linux.cmake
@@ -22,3 +22,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 else()
     message(FATAL_ERROR "Compiler is not supported")
 endif()
+
+# Check for database update files
+set(PATH_DB_FILES ${CMAKE_SOURCE_DIR}/sql/)
+set(INSTALL_DB_FILES ${PATH_DB_FILES})

--- a/src/shared/Database/DatabaseUpdater.cpp
+++ b/src/shared/Database/DatabaseUpdater.cpp
@@ -136,10 +136,20 @@ void DatabaseUpdater::applyUpdatesForDatabase(std::string database, Database& db
     std::map<uint32_t, DatabaseUpdateFile> updateSqlStore;
 
     uint32_t count = 0;
+    std::vector<std::string> updateFiles;
+
     for (auto& p : fs::recursive_directory_iterator(sqlUpdateDir))
     {
         const std::string filePathName = p.path().string();
+        updateFiles.push_back(filePathName);
+    }
 
+    // In Windows, recursive_directory_iterator seems to get files sorted but
+    // in Linux they are in random order -Appled
+    std::sort(updateFiles.begin(), updateFiles.end());
+
+    for (const auto& filePathName : updateFiles)
+    {
         std::string fileName = filePathName;
         fileName.erase(0, sqlUpdateDir.size() + 1);
 
@@ -157,6 +167,8 @@ void DatabaseUpdater::applyUpdatesForDatabase(std::string database, Database& db
         updateSqlStore.emplace(std::pair<uint32_t, DatabaseUpdateFile>(count, dbUpdateFile));
         ++count;
     }
+
+    updateFiles.clear();
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 3. save filenames into vector, when newer than current db version


### PR DESCRIPTION
**Description**
Automatic database update feature applies SQL updates in random order and messes up entire database in Linux.

std::filesystem::recursive_directory_iterator doesn't get files in sorted order in Linux while in Windows they seem to be always sorted.

Cppreference says "The iteration order is unspecified, except that each directory entry is visited only once."

Before:
![Before](https://i.ibb.co/bXYcRNy/before.jpg)

After:
![After](https://i.ibb.co/0sXGbrL/after.jpg)

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


