### PR TITLE
Fix BUILD_TOOLS on Linux systems

### DIFF
--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -29,6 +29,7 @@
 #ifdef _WIN32
 #include "direct.h"
 #else
+#include <algorithm>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -89,7 +90,7 @@ uint32_t getBuildNumber()
                                             // tested for the required text we are searching for: 1, 5, 6, or 8
     unsigned char jumpBytesBuffer[128];     // used for skipping past the bytes from the file's start
                                             // to the base # area, before we start searching for the base #, for faster processing
-                                        
+
     unsigned char preWOTLKbuildNumber[3];   // will hold the last 3 digits of the build number
     unsigned char postTBCbuildNumber[4];    // will hold the last 4 digits of the build number
 


### PR DESCRIPTION
**Description**

Building the tools on Linux systems fails with:

```
/home/eric/projects/ascemu/server/src/tools/map_extractor/System.cpp: In function ‘std::string getWowExeName()’:
/home/eric/projects/ascemu/server/src/tools/map_extractor/System.cpp:75:18: error: ‘transform’ is not a member of ‘std’
   75 |             std::transform(name.begin(), name.end(), name.begin(), [](unsigned char chars) { return std::tolower(chars); });
      |                  ^~~~~~~~~
make[2]: *** [src/tools/map_extractor/CMakeFiles/map_extractor.dir/build.make:76: src/tools/map_extractor/CMakeFiles/map_extractor.dir/System.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1057: src/tools/map_extractor/CMakeFiles/map_extractor.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

This PR adds the required `#include <algorithm>` to `map_extractor/System.cpp`.

**Todo / Checklist**
- [X] Target is branch develop.
- [X] Detailed description about this pull request.
- [X] Checked AE-Coding standards.

**Tests Performed:** 
- [X] Build AE.
- [] Server startup.
- [] Log into world.