### PR TITLE
correct binary names inside vmaps.sh script

### DIFF
--- a/src/tools/vmap_tools/vmaps.sh
+++ b/src/tools/vmap_tools/vmaps.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 mkdir -p vmaps
-./vmap_extractor
-./vmap_assembler Buildings vmaps
+./vmap4_extractor
+./vmap4_assembler Buildings vmaps
 


### PR DESCRIPTION
**Description**
The vmaps.sh script is refering to binary names that don't exist.
Binaries produced by the build are called: `vmap4_extractor` and `vmap4_assembler`.

**Todo / Checklist**
- [X] Target is branch develop.
- [X] Detailed description about this pull request.
- [X] Checked AE-Coding standards.

**Tests Performed:** 
- [X] Build AE.
- [] Server startup.
- [] Log into world.