### PR TITLE
Fix spell modifier packets in Cata

### DIFF
--- a/src/world/Management/QuestDefines.hpp
+++ b/src/world/Management/QuestDefines.hpp
@@ -13,25 +13,41 @@ namespace QuestStatus
 {
     enum
     {
-        NotAvailable = 0x00,                // There aren't any quests available.              | "No Mark"
-        AvailableButLevelTooLow = 0x01,     // Quest available, and your level isn't enough.   | "Gray Quotation Mark !"
-        AvailableChat = 0x02,               // Quest available it shows a talk balloon.        | "No Mark"
+#if VERSION_STRING < Cata
+        NotAvailable = 0x00,                 // There aren't any quests available.              | "No Mark"
+        AvailableButLevelTooLow = 0x01,      // Quest available, and your level isn't enough.   | "Gray Quotation Mark !"
+        AvailableChat = 0x02,                // Quest available it shows a talk balloon.        | "No Mark"
 
 #if VERSION_STRING < WotLK
-        NotFinished = 0x03,                 // Quest isn't finished yet.                       | "Gray Question ? Mark"
+        NotFinished = 0x03,                  // Quest isn't finished yet.                       | "Gray Question ? Mark"
         RepeatableFinished = 0x04,
-        Repeatable = 0x05,                  // Quest repeatable                                | "Blue Question ? Mark"
-        Available = 0x06,                   // Quest available, and your level is enough       | "Yellow Quotation ! Mark"
-        Finished = 0x07,                    // Quest has been finished.                        | "Yellow Question  ? Mark" (7 has no minimap icon)
+        Repeatable = 0x05,                   // Quest repeatable                                | "Blue Question ? Mark"
+        Available = 0x06,                    // Quest available, and your level is enough       | "Yellow Quotation ! Mark"
+        Finished2 = 0x07,                    // Quest has been finished.                        | "Yellow Question  ? Mark" no minimap dot
+        Finished = 0x08,                     // Quest has been finished.                        | "Yellow Question  ? Mark" with minimap dot
 #else
         // On 3.1.2 0x03 and 0x04 is some new status, so the old ones are now shifted by 2 (0x03->0x05 and so on).
         RepeatableFinishedLowLevel = 0x03,
         RepeatableLowLevel = 0x04,
-        NotFinished = 0x05,                 // Quest isn't finished yet.                       | "Gray Question ? Mark"
+        NotFinished = 0x05,                  // Quest isn't finished yet.                       | "Gray Question ? Mark"
         RepeatableFinished = 0x06,
-        Repeatable = 0x07,                  // Quest repeatable                                | "Blue Question ? Mark"
-        Available = 0x08,                   // Quest available, and your level is enough       | "Yellow Quotation ! Mark"
-        Finished = 0x0A,                    // Quest has been finished.                        | "Yellow Question  ? Mark" (7 has no minimap icon)
+        Repeatable = 0x07,                   // Quest repeatable                                | "Blue Question ? Mark"
+        Available = 0x08,                    // Quest available, and your level is enough       | "Yellow Quotation ! Mark"
+        Finished2 = 0x09,                    // Quest has been finished.                        | "Yellow Question  ? Mark" no minimap dot
+        Finished = 0x0A,                     // Quest has been finished.                        | "Yellow Question  ? Mark" with minimap dot
+#endif
+#else
+        NotAvailable = 0x000,                // There aren't any quests available.              | "No Mark"
+        AvailableButLevelTooLow = 0x002,     // Quest available, and your level isn't enough.   | "Gray Quotation Mark !"
+        AvailableChat = 0x004,               // Quest available it shows a talk balloon.        | "No Mark"
+        RepeatableFinishedLowLevel = 0x008,
+        RepeatableLowLevel = 0x010,
+        NotFinished = 0x020,                 // Quest isn't finished yet.                       | "Gray Question ? Mark"
+        RepeatableFinished = 0x040,
+        Repeatable = 0x080,                  // Quest repeatable                                | "Blue Question ? Mark"
+        Available = 0x100,                   // Quest available, and your level is enough       | "Yellow Quotation ! Mark"
+        Finished2 = 0x200,                   // Quest has been finished.                        | "Yellow Question  ? Mark" no minimap dot
+        Finished = 0x400,                    // Quest has been finished.                        | "Yellow Question  ? Mark" with minimap dot
 #endif
     };
 }

--- a/src/world/Management/TransporterHandler.cpp
+++ b/src/world/Management/TransporterHandler.cpp
@@ -157,7 +157,7 @@ void TransportHandler::loadTransportForPlayers(Player* player)
 void TransportHandler::removeInstancedTransport(Transporter* transport, uint32_t instanceID)
 {
     auto itr = _TransportersByInstanceIdMap[instanceID].find(transport);
-    if (itr != _TransportersByInstanceIdMap[instanceID].end());
+    if (itr != _TransportersByInstanceIdMap[instanceID].end())
         _TransportersByInstanceIdMap[instanceID].erase(transport);
 }
 

--- a/src/world/Objects/MovementDefines.h
+++ b/src/world/Objects/MovementDefines.h
@@ -220,7 +220,7 @@ enum MovementFlags
     MOVEFLAG_FULL_FALLING_MASK      = 0xE000
 };
 
-enum MovementFlags2
+enum MovementFlags2 : uint16_t
 {
     MOVEFLAG2_NONE                  = 0x0000,
     MOVEFLAG2_NO_STRAFING           = 0x0001,
@@ -4256,7 +4256,7 @@ static MovementStatusElements MoveUpdateTeleport[] =
     MSEEnd,
 };
 
-static MovementStatusElements* GetMovementStatusElementsSequence(uint16_t opcode)
+static inline MovementStatusElements* GetMovementStatusElementsSequence(uint16_t opcode)
 {
     switch (opcode)
     {

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -2233,7 +2233,7 @@ void Object::buildMovementUpdate(ByteBuffer* data, uint16_t updateFlags, Player*
 #endif
 
 #if VERSION_STRING == Cata
-void Object::buildMovementUpdate(ByteBuffer* data, uint16_t updateFlags, Player* target)
+void Object::buildMovementUpdate(ByteBuffer* data, uint16_t updateFlags, Player* /*target*/)
 {
     ObjectGuid Guid = getGuid();
     uint32_t movementFlags = 0;

--- a/src/world/Objects/Transporter.cpp
+++ b/src/world/Objects/Transporter.cpp
@@ -407,7 +407,7 @@ void Transporter::UpdatePlayerPositions(PassengerSet& passengers)
     }
 }
 
-void Transporter::EnableMovement(bool enabled, MapMgr* instance)
+void Transporter::EnableMovement(bool enabled, MapMgr* /*instance*/)
 {
     if (!GetGameObjectProperties()->mo_transport.can_be_stopped)
         return;

--- a/src/world/Server/Packets/Handlers/QueryHandler.cpp
+++ b/src/world/Server/Packets/Handlers/QueryHandler.cpp
@@ -118,7 +118,11 @@ void WorldSession::handleInrangeQuestgiverQuery(WorldPacket& /*recvPacket*/)
             if (creature->isQuestGiver())
             {
                 temp.rawGuid = creature->getGuid();
-                temp.status = uint8_t(sQuestMgr.CalcStatus(creature, _player));
+#if VERSION_STRING < Cata
+                temp.status = static_cast<uint8_t>(sQuestMgr.CalcStatus(creature, _player));
+#else
+                temp.status = sQuestMgr.CalcStatus(creature, _player);
+#endif
                 questgiverSet.push_back(temp);
             }
         }

--- a/src/world/Server/Packets/Handlers/QuestHandler.cpp
+++ b/src/world/Server/Packets/Handlers/QuestHandler.cpp
@@ -482,7 +482,11 @@ void WorldSession::handleQuestgiverStatusQueryOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    const uint32_t questStatus = sQuestMgr.CalcStatus(qst_giver, _player);
+#if VERSION_STRING < Cata
+    const auto questStatus = static_cast<uint8_t>(sQuestMgr.CalcStatus(qst_giver, _player));
+#else
+    const auto questStatus = sQuestMgr.CalcStatus(qst_giver, _player);
+#endif
     SendPacket(SmsgQuestgiverStatus(srlPacket.questGiverGuid.getRawGuid(), questStatus).serialise().get());
 }
 

--- a/src/world/Server/Packets/Handlers/VehicleHandler.cpp
+++ b/src/world/Server/Packets/Handlers/VehicleHandler.cpp
@@ -77,7 +77,7 @@ void WorldSession::handleRequestVehicleSwitchSeat(WorldPacket& recvPacket)
     }
 }
 
-void WorldSession::handleChangeSeatsOnControlledVehicle(WorldPacket& recvPacket)
+void WorldSession::handleChangeSeatsOnControlledVehicle([[maybe_unused]]WorldPacket& recvPacket)
 {
     if (_player->getCurrentVehicle() == nullptr)
         return;

--- a/src/world/Server/Packets/SmsgCharEnum.h
+++ b/src/world/Server/Packets/SmsgCharEnum.h
@@ -85,7 +85,7 @@ namespace AscEmu::Packets
             {
                 for (auto const& data : enum_data)
                 {
-                    WoWGuid guid(data.guid, 0, HIGHGUID_TYPE_PLAYER);
+                    WoWGuid guid(data.guid);
                     WoWGuid guildGuid(data.guildId, 0, HIGHGUID_TYPE_GUILD);
 
                     packet.writeBit(guid[3]);

--- a/src/world/Server/Packets/SmsgFeatureSystemStatus.h
+++ b/src/world/Server/Packets/SmsgFeatureSystemStatus.h
@@ -31,11 +31,12 @@ namespace AscEmu::Packets
     protected:
         size_t expectedSize() const override
         {
-#if VERSION_STRING > WotLK
-            return 1 + 4 + 4 + 4 + 4 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4;
-#endif
-#if VERSION_STRING > CATA
+#if VERSION_STRING > Cata
             return 4 + 4 + 4 + 1 + 4 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4;
+#elif VERSION_STRING > WotLK
+            return 1 + 4 + 4 + 4 + 4 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4;
+#else
+            return 1 + 1;
 #endif
         }
 

--- a/src/world/Server/Packets/SmsgQuestgiverStatus.h
+++ b/src/world/Server/Packets/SmsgQuestgiverStatus.h
@@ -14,7 +14,11 @@ namespace AscEmu::Packets
     {
     public:
         uint64_t questgiverGuid;
+#if VERSION_STRING < Cata
+        uint8_t status;
+#else
         uint32_t status;
+#endif
 
         SmsgQuestgiverStatus() : SmsgQuestgiverStatus(0, 0)
         {
@@ -29,7 +33,14 @@ namespace AscEmu::Packets
 
     protected:
 
-        size_t expectedSize() const override { return 12; }
+        size_t expectedSize() const override
+        {
+#if VERSION_STRING < Cata
+            return 8 + 1;
+#else
+            return 8 + 4;
+#endif
+        }
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/SmsgQuestgiverStatus.h
+++ b/src/world/Server/Packets/SmsgQuestgiverStatus.h
@@ -24,7 +24,11 @@ namespace AscEmu::Packets
         {
         }
 
+#if VERSION_STRING < Cata
+        SmsgQuestgiverStatus(uint64_t questgiverGuid, uint8_t status) :
+#else
         SmsgQuestgiverStatus(uint64_t questgiverGuid, uint32_t status) :
+#endif
             ManagedPacket(SMSG_QUESTGIVER_STATUS, 0),
             questgiverGuid(questgiverGuid),
             status(status)

--- a/src/world/Server/Packets/SmsgQuestgiverStatusMultiple.h
+++ b/src/world/Server/Packets/SmsgQuestgiverStatusMultiple.h
@@ -13,7 +13,11 @@ This file is released under the MIT license. See README-MIT for more information
 struct QuestgiverInrangeStatus
 {
     uint64_t rawGuid;
+#if VERSION_STRING < Cata
     uint8_t status;
+#else
+    int32_t status;
+#endif
 };
 
 namespace AscEmu::Packets
@@ -29,14 +33,14 @@ namespace AscEmu::Packets
         }
 
         SmsgQuestgiverStatusMultiple(uint32_t inrangeCount, std::vector<QuestgiverInrangeStatus> questgiverSet) :
-            ManagedPacket(SMSG_QUESTGIVER_STATUS_MULTIPLE, 1000),
+            ManagedPacket(SMSG_QUESTGIVER_STATUS_MULTIPLE, 0),
             inrangeCount(inrangeCount),
             questgiverSet(questgiverSet)
         {
         }
 
     protected:
-        size_t expectedSize() const override { return m_minimum_size; }
+        size_t expectedSize() const override { return 4 + (sizeof(QuestgiverInrangeStatus) * inrangeCount); }
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/SmsgSetPctSpellModifier.h
+++ b/src/world/Server/Packets/SmsgSetPctSpellModifier.h
@@ -13,6 +13,7 @@ namespace AscEmu::Packets
     class SmsgSetPctSpellModifier : public ManagedPacket
     {
     public:
+#if VERSION_STRING < Cata
         uint8_t spellGroup;
         uint8_t spellType;
         uint32_t modifier;
@@ -28,16 +29,48 @@ namespace AscEmu::Packets
             modifier(modifier)
         {
         }
+#else
+        uint32_t unk; // probably count for different modifier types in packet
+        uint32_t modCount;
+        uint8_t spellType;
+        std::vector<std::pair<uint8_t, float>> modValues;
+
+        SmsgSetPctSpellModifier() : SmsgSetPctSpellModifier(0, {})
+        {
+        }
+
+        SmsgSetPctSpellModifier(uint8_t spellType, std::vector<std::pair<uint8_t, float>> modValues) :
+            ManagedPacket(SMSG_SET_PCT_SPELL_MODIFIER, 0),
+            spellType(spellType),
+            modValues(modValues),
+            unk(1),
+            modCount(static_cast<uint32_t>(modValues.size()))
+        {
+        }
+#endif
 
     protected:
         size_t expectedSize() const override
         {
+#if VERSION_STRING < Cata
             return 1 + 1 + 4;
+#else
+            return 4 + 4 + 1 + ((1 + 4) * modValues.size());
+#endif
         }
 
         bool internalSerialise(WorldPacket& packet) override
         {
+#if VERSION_STRING < Cata
             packet << spellGroup << spellType << modifier;
+#else
+            packet << unk << modCount << spellType;
+
+            for (const auto& mod : modValues)
+            {
+                packet << mod.first << mod.second;
+            }
+#endif
             return true;
         }
 

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -3830,6 +3830,9 @@ void Aura::SendDummyModifierLog(std::map< SpellInfo*, uint32 >* m, SpellInfo* sp
             m->erase(itr);
     }
 
+#if VERSION_STRING >= Cata
+    std::vector<std::pair<uint8_t, float>> modValues;
+#endif
     uint32 intbit = 0, groupnum = 0;
     for (uint8 bit = 0; bit < SPELL_GROUPS; ++bit, ++intbit)
     {
@@ -3843,9 +3846,20 @@ void Aura::SendDummyModifierLog(std::map< SpellInfo*, uint32 >* m, SpellInfo* sp
             if (p_target == nullptr)
                 continue;
 
+#if VERSION_STRING < Cata
             p_target->sendSpellModifierPacket(bit, type, v, pct);
+#else
+            modValues.push_back(std::make_pair(bit, static_cast<float>(v)));
+#endif
         }
     }
+
+#if VERSION_STRING >= Cata
+    if (p_target != nullptr)
+        p_target->sendSpellModifierPacket(type, modValues, pct);
+
+    modValues.clear();
+#endif
 }
 
 void Aura::SpellAuraAddClassTargetTrigger(AuraEffectModifier* aurEff, bool apply)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -3788,6 +3788,7 @@ void Player::sendSpellCooldownEventPacket(uint32_t spellId)
     m_session->SendPacket(SmsgCooldownEvent(spellId, getGuid()).serialise().get());
 }
 
+#if VERSION_STRING < Cata
 void Player::sendSpellModifierPacket(uint8_t spellGroup, uint8_t spellType, int32_t modifier, bool isPct)
 {
     if (isPct)
@@ -3795,6 +3796,15 @@ void Player::sendSpellModifierPacket(uint8_t spellGroup, uint8_t spellType, int3
     else
         m_session->SendPacket(SmsgSetFlatSpellModifier(spellGroup, spellType, modifier).serialise().get());
 }
+#else
+void Player::sendSpellModifierPacket(uint8_t spellType, std::vector<std::pair<uint8_t, float>> modValues, bool isPct)
+{
+    if (isPct)
+        m_session->SendPacket(SmsgSetPctSpellModifier(spellType, modValues).serialise().get());
+    else
+        m_session->SendPacket(SmsgSetFlatSpellModifier(spellType, modValues).serialise().get());
+}
+#endif
 
 void Player::sendLoginVerifyWorldPacket(uint32_t mapId, float posX, float posY, float posZ, float orientation)
 {

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -1318,7 +1318,11 @@ public:
     void sendPlaySoundPacket(uint32_t soundId);
     void sendExploreExperiencePacket(uint32_t areaId, uint32_t experience);
     void sendSpellCooldownEventPacket(uint32_t spellId);
+#if VERSION_STRING < Cata
     void sendSpellModifierPacket(uint8_t spellGroup, uint8_t spellType, int32_t modifier, bool isPct);
+#else
+    void sendSpellModifierPacket(uint8_t spellType, std::vector<std::pair<uint8_t, float>> modValues, bool isPct);
+#endif
     void sendLoginVerifyWorldPacket(uint32_t mapId, float posX, float posY, float posZ, float orientation);
     void sendMountResultPacket(uint32_t result);
     void sendDismountResultPacket(uint32_t result);


### PR DESCRIPTION
**Description**
Spells: Correct spell modifier packets in Cata
Quests: Correct quest packets and quest status in Cata
Misc: Fix level 4 warnings in Cata

Closes https://github.com/AscEmu/AscEmu/issues/896

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

***Multiversion Ingame Tests Performed:***
- [ ] BC
- [x] WotLK
- [x] Cata


