### PR TITLE
fix crash 🐐

### DIFF
--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -2710,8 +2710,6 @@ void MySQLDataStore::loadPlayerCreateInfoClassLevelstats()
 #endif
     }
 
-    delete player_classlevelstats_result;
-
 #if VERSION_STRING > WotLK
     //Zyres: load missing and rewuired data from dbc!
     int32_t player_classlevelstats_count = 0;


### PR DESCRIPTION
**Description**

> 23:53:01 [INFO]: MySQLDataLoads : Loaded 800 rows from player_classlevelstats table in 12 ms!
> 23:53:01 [ERROR][MAJOR]: Server has crashed. Creating crash dump file CrashDumps\dump-world.exe.dmp
> 23:53:01 [ERROR][MAJOR]: Crash Handler : Advanced crash handler initialized.
> 23:53:06 [INFO]: sql : Waiting for all database queries to finish...
> 23:53:07 [INFO]: sql : All pending database operations cleared.
> 23:53:07 [INFO]: Saving all players to database...
> 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [x] WotLK



