### PR TITLE
Instance cell loading for TBC dungeons/raids

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/Instance_Arcatraz.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_Arcatraz.cpp
@@ -13,6 +13,12 @@ class ArcatrazInstanceScript : public InstanceScript
 public:
     explicit ArcatrazInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new ArcatrazInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // VOID_ZONE 36119 // DBC: 36119; it's not fully functionl without additional core support (for dmg and random place targeting).

--- a/src/scripts/InstanceScripts/Tbc/Instance_AuchenaiCrypts.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_AuchenaiCrypts.cpp
@@ -12,6 +12,12 @@ class AuchenaiCryptsInstanceScript : public InstanceScript
 public:
     explicit AuchenaiCryptsInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new AuchenaiCryptsInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // Shirrak the Dead WatcherAI

--- a/src/scripts/InstanceScripts/Tbc/Instance_BlackMorass.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_BlackMorass.cpp
@@ -13,6 +13,12 @@ class TheBlackMorassInstanceScript : public InstanceScript
 public:
     explicit TheBlackMorassInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheBlackMorassInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // ChronoLordAI

--- a/src/scripts/InstanceScripts/Tbc/Instance_BloodFurnace.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_BloodFurnace.cpp
@@ -13,6 +13,12 @@ class BloodFurnaceInstanceScript : public InstanceScript
 public:
     explicit BloodFurnaceInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new BloodFurnaceInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class KelidanTheBreakerAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_Botanica.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_Botanica.cpp
@@ -13,6 +13,12 @@ class BotanicaInstanceScript : public InstanceScript
 public:
     explicit BotanicaInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new BotanicaInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class BloodProtectorAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_HellfireRamparts.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_HellfireRamparts.cpp
@@ -13,6 +13,12 @@ class HellfireRampartsInstanceScript : public InstanceScript
 public:
     explicit HellfireRampartsInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new HellfireRampartsInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // \todo "Do you smell that? Fresh meat has somehow breached our citadel. Be wary of any intruders." should be on some areatrigger

--- a/src/scripts/InstanceScripts/Tbc/Instance_MagistersTerrace.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_MagistersTerrace.cpp
@@ -16,6 +16,12 @@ class InstanceMagistersTerraceScript : public InstanceScript
 public:
     explicit InstanceMagistersTerraceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new InstanceMagistersTerraceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // Fel Crystal Spawn Locations

--- a/src/scripts/InstanceScripts/Tbc/Instance_ManaTombs.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_ManaTombs.cpp
@@ -12,6 +12,12 @@ class ManaTombsInstanceScript : public InstanceScript
 public:
     explicit ManaTombsInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new ManaTombsInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class EtherealDarkcasterAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_OldHillsbradFoothills.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_OldHillsbradFoothills.cpp
@@ -33,6 +33,12 @@ public:
 
     static InstanceScript* Create(MapMgr* pMapMgr) { return new OldHilsbradInstance(pMapMgr); }
 
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
+
     void OnPlayerEnter(Player* pPlayer)
     {
         if (pPlayer->getGender() == 0)

--- a/src/scripts/InstanceScripts/Tbc/Instance_SethekkHalls.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_SethekkHalls.cpp
@@ -13,6 +13,12 @@ class SethekkHallsInstanceScript : public InstanceScript
 public:
     explicit SethekkHallsInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new SethekkHallsInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class AvianDarkhawkAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_ShadowLabyrinth.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_ShadowLabyrinth.cpp
@@ -14,6 +14,12 @@ class ShadowLabyrinthInstanceScript : public InstanceScript
 public:
     explicit ShadowLabyrinthInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new ShadowLabyrinthInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class CabalAcolyteAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_TheMechanar.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_TheMechanar.cpp
@@ -12,6 +12,12 @@ class TheMechanarInstanceScript : public InstanceScript
 public:
     explicit TheMechanarInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheMechanarInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class ArcaneServantAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_TheShatteredHalls.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_TheShatteredHalls.cpp
@@ -14,6 +14,12 @@ class InstanceTheShatteredHallsScript : public InstanceScript
 public:
     explicit InstanceTheShatteredHallsScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new InstanceTheShatteredHallsScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 class FelOrcConvertAI : public CreatureAIScript

--- a/src/scripts/InstanceScripts/Tbc/Instance_TheSlavePens.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_TheSlavePens.cpp
@@ -13,6 +13,12 @@ class TheSlavePensInstanceScript : public InstanceScript
 public:
     explicit TheSlavePensInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheSlavePensInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Tbc/Instance_TheSteamvault.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_TheSteamvault.cpp
@@ -13,6 +13,12 @@ class TheSteamvaultInstanceScript : public InstanceScript
 public:
     explicit TheSteamvaultInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheSteamvaultInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Tbc/Instance_TheUnderbog.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Instance_TheUnderbog.cpp
@@ -13,6 +13,12 @@ class TheUnderbogInstanceScript : public InstanceScript
 public:
     explicit TheUnderbogInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheUnderbogInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Tbc/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_BlackTemple.cpp
@@ -299,6 +299,12 @@ public:
 
     static InstanceScript* Create(MapMgr* pMapMgr) { return new BlackTempleScript(pMapMgr); }
 
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
+
     void OnCreatureDeath(Creature* pVictim, Unit* /*pKiller*/) override
     {
         // You don't have to use additional scripts to open any gates / doors

--- a/src/scripts/InstanceScripts/Tbc/Raid_CoT_BattleOfMountHyjal.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_CoT_BattleOfMountHyjal.cpp
@@ -18,6 +18,12 @@ public:
 
     static InstanceScript* Create(MapMgr* pMapMgr) { return new MountHyjalScript(pMapMgr); }
 
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
+
     void SetLocaleInstanceData(uint32_t pType, uint32_t pIndex, uint32_t pData)
     {
         if (pType >= HYJAL_TYPE_END || pIndex >= 10)

--- a/src/scripts/InstanceScripts/Tbc/Raid_Karazhan.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_Karazhan.cpp
@@ -14,6 +14,12 @@ class KarazhanInstanceScript : public InstanceScript
 public:
     explicit KarazhanInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new KarazhanInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 // Partially by Plexor (I used a spell before, but changed to his method)

--- a/src/scripts/InstanceScripts/Tbc/Raid_SunwellPlateau.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_SunwellPlateau.cpp
@@ -13,6 +13,12 @@ class SunwellPlateauInstanceScript : public InstanceScript
 public:
     explicit SunwellPlateauInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new SunwellPlateauInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 /*

--- a/src/scripts/InstanceScripts/Tbc/Raid_TheEye.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_TheEye.cpp
@@ -14,6 +14,12 @@ class TheEyeInstanceScript : public InstanceScript
 public:
     explicit TheEyeInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new TheEyeInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Tbc/Raid_ZulAman.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_ZulAman.cpp
@@ -13,6 +13,12 @@ class ZulAmanInstanceScript : public InstanceScript
 public:
     explicit ZulAmanInstanceScript(MapMgr* pMapMgr) : InstanceScript(pMapMgr){}
     static InstanceScript* Create(MapMgr* pMapMgr) { return new ZulAmanInstanceScript(pMapMgr); }
+
+    void OnLoad() override
+    {
+        // Load All Cells in Our Instance
+        GetInstance()->updateAllCells(true);
+    }
 };
 
 //\todo move AddEmote to database


### PR DESCRIPTION
**Description**
<!-- Short description about this PR. NOTE: Never mix style changes, refactorings and new implementations in one PR. Keep it as simple as possible -->

This adds cell loading to all tbc dungeons and raids except for Gruuls Lair,  Magtheridon's lair and Serpentshrine Caverns as @aaron02 has did this already or is planning to.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


