### PR TITLE
Spell explicit target

### DIFF
--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -661,8 +661,11 @@ bool ChatHandler::HandleNpcRespawnCommand(const char* /*args*/, WorldSession* m_
         sGMLog.writefromsession(m_session, "respawned Creature: `%s` with entry: %u on map: %u sqlid: %u", creature_target->GetCreatureProperties()->Name.c_str(),
             creature_target->getEntry(), creature_target->GetMapMgr()->GetMapId(), creature_target->spawnid);
 
-        creature_target->GetMapMgr()->pInstance->m_killedNpcs.erase(creature_target->getSpawnId());
-        creature_target->GetMapMgr()->pInstance->m_killedNpcs.erase(creature_target->getEntry());
+        if (creature_target->GetMapMgr()->pInstance != nullptr)
+        {
+            creature_target->GetMapMgr()->pInstance->m_killedNpcs.erase(creature_target->getSpawnId());
+            creature_target->GetMapMgr()->pInstance->m_killedNpcs.erase(creature_target->getEntry());
+        }
 
         creature_target->Despawn(0, 1000);
     }

--- a/src/world/Spell/Spell.Legacy.h
+++ b/src/world/Spell/Spell.Legacy.h
@@ -179,6 +179,7 @@ class SERVER_DECL Spell
         // Stores hitted targets for each spell effect
         std::vector<uint64_t> m_effectTargets[MAX_SPELL_EFFECTS];
 
+        SpellCastResult checkExplicitTarget(Object* target, uint32_t requiredTargetMask) const;
         void safeAddMissedTarget(uint64_t targetGuid, SpellDidHitResult hitResult, SpellDidHitResult extendedHitResult);
 
         Unit* unitTarget = nullptr;

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -60,7 +60,8 @@ public:
 
     bool hasTargetType(uint32_t type) const;
     uint32_t getRequiredTargetMaskForEffectTarget(uint32_t implicitTarget, uint8_t effectIndex) const;
-    uint32_t getRequiredTargetMaskForEffect(uint8_t effectIndex) const;
+    uint32_t getRequiredTargetMaskForEffect(uint8_t effectIndex, bool getExplicitMask = false) const;
+    uint32_t getRequiredTargetMask(bool getExplicitMask) const;
     int aiTargetType() const;
     bool isTargetingStealthed() const;
 
@@ -81,6 +82,8 @@ public:
 
     bool appliesAreaAura(uint32_t auraType) const;
     uint32_t getAreaAuraEffect() const;
+
+    bool isTriggerSpellCastedByCaster(SpellInfo const* triggeringSpell) const;
 
     // Getters for spell data
     uint32_t getId() const { return Id; }


### PR DESCRIPTION
**Description**
Chat: Fix crash in npc respawn command
Spells: Fix some caster/target issues when spell is triggered by an aura
Spells: Check for explicit targets in ::canCast()

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


