### PR TITLE
Fix player health issue, absorbs in melee attack packet and couple warnings

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/Raid_GruulsLair.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_GruulsLair.cpp
@@ -362,7 +362,7 @@ public:
         getLinkedCreatureAIScript()->DoAction(ACTION_ADD_DEATH);
     }
 
-    void AIUpdate(unsigned long time_passed) override
+    void AIUpdate(unsigned long /*time_passed*/) override
     {
         Unit* pTarget = getCreature()->GetAIInterface()->getCurrentTarget();
         if (pTarget != NULL)
@@ -598,7 +598,7 @@ protected:
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Spell Effect: Ground Slam
-bool GroundSlamEffect(uint8_t effectIndex, Spell* pSpell)
+bool GroundSlamEffect(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
 
@@ -612,7 +612,7 @@ bool GroundSlamEffect(uint8_t effectIndex, Spell* pSpell)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Spell Effect: Shatter
-bool ShatterEffect(uint8_t effectIndex, Spell* pSpell)
+bool ShatterEffect(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     Unit* target = pSpell->GetUnitTarget();
 

--- a/src/scripts/InstanceScripts/Tbc/Raid_Magtheridons_Lair.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Raid_Magtheridons_Lair.cpp
@@ -336,7 +336,7 @@ public:
         }
     }
 
-    void OnDied(Unit* killer) override
+    void OnDied(Unit* /*killer*/) override
     {
          _castAISpell(soulTransfer);
     }
@@ -401,7 +401,7 @@ public:
         Reset();
     }
 
-    void OnDied(Unit* killer) override
+    void OnDied(Unit* /*killer*/) override
     {
         sendDBChatMessage(SAY_DEATH);
         getInstanceScript()->setLocalData(DATA_MANTICRON_CUBE, ACTION_DISABLE);
@@ -484,7 +484,7 @@ public:
 
                     if (target)
                     {
-                        Creature* debris = spawnCreature(NPC_MAGTHERIDON_ROOM, target->GetPosition());
+                        /*Creature* debris = */spawnCreature(NPC_MAGTHERIDON_ROOM, target->GetPosition());
                         target->castSpell(target, SPELL_DEBRIS_VISUAL, true); // hackfix invis creatures cant have visual spells atm -_-
                         scriptEvents.addEvent(EVENT_DEBRIS, 20000);
                     }
@@ -590,7 +590,7 @@ protected:
 class SoulTransfer : public SpellScript
 {
 public:
-    void filterEffectTargets(Spell* spell, uint8_t effectIndex, std::vector<uint64_t>* effectTargets) override
+    void filterEffectTargets(Spell* spell, uint8_t /*effectIndex*/, std::vector<uint64_t>* effectTargets) override
     {
         // Hackfix shouldnt only cast on Channelers
         effectTargets->clear();

--- a/src/scripts/InstanceScripts/Wotlk/Instance_TheVioletHold.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/Instance_TheVioletHold.cpp
@@ -272,12 +272,6 @@ public:
         TheVioletHoldScript* pInstance = (TheVioletHoldScript*)getCreature()->GetMapMgr()->GetScript();
         if (!pInstance)
             return;
-
-        auto guardSet = pInstance->getCreatureSetForEntry(30659);
-        for (auto guard : guardSet)
-        {
-
-        }
     }
 };
 
@@ -316,7 +310,6 @@ public:
         if (!pObject->isCreature())
             return;
 
-        Creature* sinclari = static_cast<Creature*>(pObject);
         switch (Id)
         {
             case 1:

--- a/src/world/Management/ArenaTeam.cpp
+++ b/src/world/Management/ArenaTeam.cpp
@@ -213,7 +213,7 @@ std::vector<ArenaTeamPacketList> ArenaTeam::getRoosterMembers() const
             arenaTeamListMember.isLoggedIn = playerInfo->m_loggedInPlayer ? 1 : 0;
             arenaTeamListMember.name = playerInfo->name;
             arenaTeamListMember.isLeader = m_members[i].Info->guid == m_leader ? 0 : 1;
-            arenaTeamListMember.lastLevel = playerInfo->lastLevel;
+            arenaTeamListMember.lastLevel = static_cast<uint8_t>(playerInfo->lastLevel);
             arenaTeamListMember.cl = playerInfo->cl;
             arenaTeamListMember.playedWeek = m_members[i].Played_ThisWeek;
             arenaTeamListMember.wonWeek = m_members[i].Won_ThisWeek;

--- a/src/world/Management/Item.Legacy.cpp
+++ b/src/world/Management/Item.Legacy.cpp
@@ -651,7 +651,7 @@ void Item::ApplyEnchantmentBonus(uint32 Slot, bool Apply)
         //This in some cases will try to write for example 3 visuals into one place, but now every item has only one 
         //field for this, and as we can't choose which visual to have, we'll accept the last one.
 
-        m_owner->setVisibleItemEnchantment(ItemSlot, Slot, Apply ? Entry->Id : 0);
+        m_owner->setVisibleItemEnchantment(ItemSlot, static_cast<uint8_t>(Slot), Apply ? Entry->Id : 0);
     }
     else
     {

--- a/src/world/Map/MapMgr.cpp
+++ b/src/world/Map/MapMgr.cpp
@@ -2298,7 +2298,6 @@ bool MapMgr::cellHasAreaID(uint32_t CellX, uint32_t CellY, uint16_t &AreaID)
     int32_t OffsetTileX = TileX - _terrain->TileStartX;
     int32_t OffsetTileY = TileY - _terrain->TileStartY;
 
-    uint32_t areaid = 0;
     bool Required = false;
     bool Result = false;
 
@@ -2316,7 +2315,7 @@ bool MapMgr::cellHasAreaID(uint32_t CellX, uint32_t CellY, uint16_t &AreaID)
     {
         for (uint32_t yc = (CellY%CellsPerTile) * 16 / CellsPerTile; yc < (CellY%CellsPerTile) * 16 / CellsPerTile + 16 / CellsPerTile; yc++)
         {
-            areaid = _terrain->GetTile(OffsetTileX, OffsetTileY)->m_map.m_areaMap[yc * 16 + xc];
+            const auto areaid = _terrain->GetTile(OffsetTileX, OffsetTileY)->m_map.m_areaMap[yc * 16 + xc];
             if (areaid)
             {
                 AreaID = areaid;

--- a/src/world/Server/Packets/SmsgMessageChat.h
+++ b/src/world/Server/Packets/SmsgMessageChat.h
@@ -234,7 +234,6 @@ namespace AscEmu::Packets
             uint64_t unpacked_guid;
             uint32_t unk;
             uint32_t message_length;
-            uint8_t flag;
             packet >> type >> language >> unpacked_guid >> unk >> unpacked_guid >> message_length >> message >> flag;
             senderGuid = WoWGuid(unpacked_guid);
             return false;

--- a/src/world/Server/Script/CreatureAIScript.h
+++ b/src/world/Server/Script/CreatureAIScript.h
@@ -50,7 +50,7 @@ public:
     virtual void OnReachWP(uint32_t /*type*/, uint32_t /*id*/) {}
     virtual void OnLootTaken(Player* /*player*/, ItemProperties const* /*_itemProperties*/) {}
     virtual void AIUpdate() {}
-    virtual void AIUpdate(unsigned long time_passed) {}
+    virtual void AIUpdate(unsigned long /*time_passed*/) {}
     virtual void OnEmote(Player* /*_player*/, EmoteType /*_emote*/) {}
     virtual void StringFunctionCall(int) {}
     virtual void OnSummon(Unit* /*summoner*/) {}

--- a/src/world/Server/Script/ScriptMgr.h
+++ b/src/world/Server/Script/ScriptMgr.h
@@ -577,7 +577,7 @@ class SERVER_DECL InstanceScript
         virtual void OnPlayerDeath(Player* /*pVictim*/, Unit* /*pKiller*/) {}
 
         // Spawn Groups
-        virtual void OnSpawnGroupKilled(uint32_t groupId) {}
+        virtual void OnSpawnGroupKilled(uint32_t /*groupId*/) {}
 
         // Area and AreaTrigger
         virtual void OnPlayerEnter(Player* /*pPlayer*/) {}

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -733,7 +733,7 @@ void AIInterface::UpdateAgent(unsigned long time_passed)
             {
                 if (float(getUnit()->getHealthPct()) <= itr->maxHealth && itr->maxCount)
                 {
-                    internalPhase = itr->misc1;
+                    internalPhase = static_cast<uint8_t>(itr->misc1);
 
                     itr->maxCount = itr->maxCount - 1;
 
@@ -2653,7 +2653,7 @@ void AIInterface::eventOnLoad()
     }
 }
 
-void AIInterface::eventOnTargetDied(Object* pKiller)
+void AIInterface::eventOnTargetDied(Object* /*pKiller*/)
 {
     // Killed Scripts
     for (auto onKilledScript : onKilledScripts)
@@ -2666,7 +2666,7 @@ void AIInterface::eventOnTargetDied(Object* pKiller)
                 {
                     if (float(getUnit()->getHealthPct()) <= onKilledScript.maxHealth && onKilledScript.maxCount)
                     {
-                        internalPhase = onKilledScript.misc1;
+                        internalPhase = static_cast<uint8_t>(onKilledScript.misc1);
 
                         onKilledScript.maxCount = onKilledScript.maxCount - 1;
 
@@ -2958,7 +2958,7 @@ void AIInterface::setWayPointToMove(uint32_t waypointId)
     init.Launch();
 }
 
-bool AIInterface::activateShowWayPoints(Player* player, bool showBackwards)
+bool AIInterface::activateShowWayPoints(Player* player, bool /*showBackwards*/)
 {
     if (sWaypointMgr->getPath(getUnit()->ToCreature()->getWaypointPath()) == nullptr)
         return false;

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -1301,26 +1301,19 @@ void Player::setInitialPlayerData()
 {
     if (lvlinfo != nullptr)
     {
-        //\ TODO: LevelInfo base health and mana stats already have stamina and intellect calculated into them
-        const auto levelone = sObjectMgr.GetLevelInfo(getRace(), getClass(), 1);
-        if (levelone != nullptr)
-        {
-            setBaseHealth(lvlinfo->HP - ((lvlinfo->Stat[STAT_STAMINA] - levelone->Stat[STAT_STAMINA]) * 10));
-            setBaseMana(lvlinfo->Mana - ((lvlinfo->Stat[STAT_INTELLECT] - levelone->Stat[STAT_INTELLECT]) * 15));
-        }
-        else
-        {
-            setBaseHealth(lvlinfo->HP);
-            setBaseMana(lvlinfo->Mana);
-        }
-
-        // Set max health and powers
-        setMaxHealth(lvlinfo->HP);
+        setBaseHealth(lvlinfo->HP);
+        setBaseMana(lvlinfo->Mana);
     }
     else
     {
-        sLogger.failure("No Levelinfo for Player!");
+        sLogger.failure("Major error in Player::setInitialPlayerData : No LevelInfo for player (level %u, race %u, class %u)!", getLevel(), getRace(), getClass());
+
+        setBaseHealth(1);
+        setBaseMana(1);
     }
+
+    // Set max health and powers
+    setMaxHealth(getBaseHealth());
 
     // First initialize all power fields to 0
     for (uint8_t power = POWER_TYPE_MANA; power < TOTAL_PLAYER_POWER_TYPES; ++power)

--- a/src/world/Units/UnitDefines.hpp
+++ b/src/world/Units/UnitDefines.hpp
@@ -108,7 +108,8 @@ enum TotemSlots : uint8_t
 
 enum class VisualState : uint8_t
 {
-    ATTACK              = 1,
+    MISS                = 0,
+    ATTACK,
     DODGE,
     PARRY,
     INTERRUPT,


### PR DESCRIPTION
**Description**
Players: Fix issue where health or mana sometimes ends up being uint32_t(-1)
Units: Small refactoring to melee attack packets, should now show absorbs correctly
Misc: Fix bunch of level 4 warnings (the rest are for you @Zyres 😉 )

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.


