### PR TITLE
Fix missed warnings when compiling

### DIFF
--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -3525,7 +3525,7 @@ void AIInterface::UpdateAISpells()
         // Shuffle Around our Spells to randomize the cast
         if (mCreatureAISpells.size())
         {
-            for (int i = 0; i < mCreatureAISpells.size() - 1; ++i)
+            for (size_t i = 0; i < mCreatureAISpells.size() - 1; ++i)
             {
                 int j = i + rand() % (mCreatureAISpells.size() - i);
                 std::swap(mCreatureAISpells[i], mCreatureAISpells[j]);
@@ -3848,7 +3848,7 @@ void AIInterface::sendStoredText(definedEmoteVector store, Unit* target)
     // Shuffle Around our textIds to randomize it
     if (store.size())
     {
-        for (int i = 0; i < store.size() - 1; ++i)
+        for (size_t i = 0; i < store.size() - 1; ++i)
         {
             int j = i + rand() % (store.size() - i);
             std::swap(store[i], store[j]);


### PR DESCRIPTION
This fixes 2 warnings during compiling AIInterface.cpp(3528): warning C4018: '<': signed/unsigned mismatch)

**Description**
<!-- Short description about this PR. NOTE: Never mix style changes, refactorings and new implementations in one PR. Keep it as simple as possible -->

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [x] BC
- [x] WotLK
- [x] Cata
-->


