### PR TITLE
Initialize profession points properly

### DIFF
--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -1360,7 +1360,13 @@ void WorldSession::handleItemQuerySingleOpcode(WorldPacket& recvPacket)
     data << itemProto->RandomPropId;
     data << itemProto->RandomSuffixId;
     data << itemProto->Block;
-    data << sMySQLStore.getItemSetLinkedBonus(itemProto->ItemSet);
+
+    const auto setBonus = sMySQLStore.getItemSetLinkedBonus(itemProto->ItemSet);
+    if (setBonus == 0)
+        data << itemProto->ItemSet;
+    else
+        data << setBonus;
+
     data << itemProto->MaxDurability;
     data << itemProto->ZoneNameID;
     data << itemProto->MapID;
@@ -1488,7 +1494,13 @@ void WorldSession::handleItemQuerySingleOpcode(WorldPacket& recvPacket)
     data << itemProperties->RandomPropId;
     data << itemProperties->RandomSuffixId;
     data << itemProperties->Block;
-    data << itemProperties->ItemSet;
+
+    const auto setBonus = sMySQLStore.getItemSetLinkedBonus(itemProperties->ItemSet);
+    if (setBonus == 0)
+        data << itemProperties->ItemSet;
+    else
+        data << setBonus;
+
     data << itemProperties->MaxDurability;
     data << itemProperties->ZoneNameID;
     data << itemProperties->MapID;

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -473,8 +473,6 @@ void WorldSession::sendTrainerList(Creature* creature)
 
 uint8_t WorldSession::trainerGetSpellStatus(TrainerSpell* trainerSpell)
 {
-    bool can_learn_primary_prof = _player->getFreePrimaryProfessionPoints() < 2;
-
     if (!trainerSpell->pCastSpell && !trainerSpell->pLearnSpell)
         return TRAINER_STATUS_NOT_LEARNABLE;
 
@@ -491,7 +489,7 @@ uint8_t WorldSession::trainerGetSpellStatus(TrainerSpell* trainerSpell)
         || (trainerSpell->RequiredSpell && !_player->HasSpell(trainerSpell->RequiredSpell))
         || (trainerSpell->Cost && !_player->hasEnoughCoinage(trainerSpell->Cost))
         || (trainerSpell->RequiredSkillLine && _player->_GetSkillLineCurrent(trainerSpell->RequiredSkillLine, true) < trainerSpell->RequiredSkillLineValue)
-        || (trainerSpell->IsProfession && !can_learn_primary_prof)
+        || (trainerSpell->IsProfession && _player->getFreePrimaryProfessionPoints() == 0)
         )
         return TRAINER_STATUS_NOT_LEARNABLE;
     return TRAINER_STATUS_LEARNABLE;
@@ -519,7 +517,7 @@ void WorldSession::sendTrainerList(Creature* creature)
         size_t count_pos = data.wpos();
         data << uint32_t(trainer->Spells.size());
 
-        bool can_learn_primary_prof = _player->getFreePrimaryProfessionPoints() < 2;
+        bool can_learn_primary_prof = _player->getFreePrimaryProfessionPoints() != 0;
 
         uint32_t count = 0;
         for (auto itr : trainer->Spells)

--- a/src/world/Server/Packets/Handlers/SkillHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SkillHandler.cpp
@@ -3,7 +3,7 @@ Copyright (c) 2014-2021 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
-
+#include "Server/World.h"
 #include "Server/WorldSession.h"
 #include "Server/Packets/ManagedPacket.h"
 #include "Server/Packets/CmsgUnlearnSkill.h"
@@ -12,7 +12,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Units/Players/Player.h"
 
 using namespace AscEmu::Packets;
-
 
 void WorldSession::handleUnlearnSkillOpcode(WorldPacket& recvPacket)
 {
@@ -23,16 +22,13 @@ void WorldSession::handleUnlearnSkillOpcode(WorldPacket& recvPacket)
     _player->RemoveSpellsFromLine(srlPacket.skillLineId);
     _player->_RemoveSkillLine(srlPacket.skillLineId);
 
-    uint32_t remainingPoints = _player->getFreePrimaryProfessionPoints();
-    if (remainingPoints == _player->getFreePrimaryProfessionPoints())
-    {
-        const auto skillLineEntry = sSkillLineStore.LookupEntry(srlPacket.skillLineId);
-        if (!skillLineEntry)
-            return;
+    const auto skillLineEntry = sSkillLineStore.LookupEntry(srlPacket.skillLineId);
+    if (!skillLineEntry)
+        return;
 
-        if (skillLineEntry->type == SKILL_TYPE_PROFESSION && remainingPoints < 2)
-            _player->setFreePrimaryProfessionPoints(remainingPoints + 1);
-    }
+    const auto remainingPoints = _player->getFreePrimaryProfessionPoints();
+    if (skillLineEntry->type == SKILL_TYPE_PROFESSION && remainingPoints < worldConfig.player.maxProfessions)
+        _player->modFreePrimaryProfessionPoints(1);
 }
 
 void WorldSession::handleLearnTalentOpcode(WorldPacket& recvPacket)

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -1476,9 +1476,13 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
     if (target != nullptr)
     {
         // Check explicit unit target
-        const auto targetCheck = checkExplicitTarget(target, getSpellInfo()->getRequiredTargetMask(true));
-        if (targetCheck != SPELL_CAST_SUCCESS)
-            return targetCheck;
+        // but skip spells with pet target here
+        if (!getSpellInfo()->hasTargetType(EFF_TARGET_PET))
+        {
+            const auto targetCheck = checkExplicitTarget(target, getSpellInfo()->getRequiredTargetMask(true));
+            if (targetCheck != SPELL_CAST_SUCCESS)
+                return targetCheck;
+        }
 
         // Target's aura state requirements
         if (!m_triggeredSpell && getSpellInfo()->getTargetAuraState() > 0 && !target->hasAuraState(static_cast<AuraState>(getSpellInfo()->getTargetAuraState()), getSpellInfo(), u_caster))

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -4138,20 +4138,6 @@ void Spell::SpellEffectSkillStep(uint8_t effectIndex) // Skill Step
     {
         target->_ModifySkillMaximum(skill, max);
     }
-    else
-    {
-        // Don't add skills to players logging in.
-        /*if ((GetProto()->Attributes & 64) && playerTarget->m_TeleportState == 1)
-        return;*/
-
-        if (skill_line->type == SKILL_TYPE_PROFESSION)
-            target->ModPrimaryProfessionPoints(-1);
-
-        if (skill == SKILL_RIDING)
-            target->_AddSkillLine(skill, max, max);
-        else
-            target->_AddSkillLine(skill, 1, max);
-    }
 }
 
 void Spell::SpellEffectAddHonor(uint8_t effectIndex)

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -546,6 +546,9 @@ bool SpellInfo::hasTargetType(uint32_t type) const
 {
     for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
+        if (Effect[i] == SPELL_EFFECT_NULL)
+            continue;
+
         if (EffectImplicitTargetA[i] == type ||
             EffectImplicitTargetB[i] == type)
             return true;

--- a/src/world/Units/Creatures/AIInterface.cpp
+++ b/src/world/Units/Creatures/AIInterface.cpp
@@ -3555,9 +3555,9 @@ void AIInterface::UpdateAISpells()
         // Shuffle Around our Spells to randomize the cast
         if (mCreatureAISpells.size())
         {
-            for (size_t i = 0; i < mCreatureAISpells.size() - 1; ++i)
+            for (uint16_t i = 0; i < mCreatureAISpells.size() - 1; ++i)
             {
-                int j = i + rand() % (mCreatureAISpells.size() - i);
+                const auto j = i + rand() % (mCreatureAISpells.size() - i);
                 std::swap(mCreatureAISpells[i], mCreatureAISpells[j]);
             }
         }
@@ -3878,9 +3878,9 @@ void AIInterface::sendStoredText(definedEmoteVector store, Unit* target)
     // Shuffle Around our textIds to randomize it
     if (store.size())
     {
-        for (size_t i = 0; i < store.size() - 1; ++i)
+        for (uint16_t i = 0; i < store.size() - 1; ++i)
         {
-            int j = i + rand() % (store.size() - i);
+            const auto j = i + rand() % (store.size() - i);
             std::swap(store[i], store[j]);
         }
 

--- a/src/world/Units/Creatures/Pet.cpp
+++ b/src/world/Units/Creatures/Pet.cpp
@@ -1390,7 +1390,14 @@ void Pet::UpdateSpellList(bool showLearnSpells)
                     bool addThisSpell = true;
                     for (PetSpellMap::iterator itr = mSpells.begin(); itr != mSpells.end(); ++itr)
                     {
-                        if ((itr->first->custom_NameHash == sp->custom_NameHash) && (itr->first->custom_RankNumber >= sp->custom_RankNumber))
+                        // Very hacky way to check if spell is same but different rank
+                        // It's better than nothing until better solution is implemented -Appled
+                        const bool sameSpell = itr->first->custom_NameHash == sp->custom_NameHash &&
+                            itr->first->getSpellVisual(0) == sp->getSpellVisual(0) &&
+                            itr->first->getSpellIconID() == sp->getSpellIconID() &&
+                            itr->first->getName() == sp->getName();
+
+                        if (sameSpell && (itr->first->custom_RankNumber >= sp->custom_RankNumber))
                         {
                             // Pet already has this spell, or a higher rank. Don't add it.
                             addThisSpell = false;
@@ -1430,7 +1437,14 @@ void Pet::AddSpell(SpellInfo const* sp, bool learning, bool showLearnSpell)
         {
             for (PetSpellMap::iterator itr = mSpells.begin(); itr != mSpells.end(); ++itr)
             {
-                if (sp->custom_NameHash == itr->first->custom_NameHash)
+                // Very hacky way to check if spell is same but different rank
+                // It's better than nothing until better solution is implemented -Appled
+                const bool sameSpell = itr->first->custom_NameHash == sp->custom_NameHash &&
+                    itr->first->getSpellVisual(0) == sp->getSpellVisual(0) &&
+                    itr->first->getSpellIconID() == sp->getSpellIconID() &&
+                    itr->first->getName() == sp->getName();
+
+                if (sameSpell)
                 {
                     // replace the action bar
                     for (uint8 i = 0; i < 10; ++i)

--- a/src/world/Units/Players/Player.cpp
+++ b/src/world/Units/Players/Player.cpp
@@ -344,11 +344,25 @@ uint32_t Player::getFreePrimaryProfessionPoints() const
 
 void Player::setFreePrimaryProfessionPoints(uint32_t points)
 {
+    if (points > worldConfig.player.maxProfessions)
+        points = worldConfig.player.maxProfessions;
+
 #if VERSION_STRING < Cata
     write(playerData()->character_points_2, points);
 #else
     write(playerData()->character_points_1, points);
 #endif
+}
+
+void Player::modFreePrimaryProfessionPoints(int32_t amount)
+{
+    int32_t value = getFreePrimaryProfessionPoints();
+    value += amount;
+
+    if (value < 0)
+        value = 0;
+
+    setFreePrimaryProfessionPoints(value);
 }
 
 uint32_t Player::getTrackCreature() const { return playerData()->track_creatures; }
@@ -1447,8 +1461,6 @@ void Player::setInitialPlayerData()
 #if VERSION_STRING >= TBC
     addUnitFlags2(UNIT_FLAG2_ENABLE_POWER_REGEN);
 #endif
-
-    setFreePrimaryProfessionPoints(worldConfig.player.maxProfessions);
 
     // Set current health and power after stats are loaded
     setHealth(getMaxHealth());

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -575,6 +575,7 @@ public:
 
     uint32_t getFreePrimaryProfessionPoints() const;
     void setFreePrimaryProfessionPoints(uint32_t points);
+    void modFreePrimaryProfessionPoints(int32_t amount);
 
     uint32_t getTrackCreature() const;
     void setTrackCreature(uint32_t id);
@@ -1917,23 +1918,6 @@ public:
         //  PVP Stuff
         /////////////////////////////////////////////////////////////////////////////////////////
         uint32 m_pvpTimer;
-
-        //\todo fix this
-        void ModPrimaryProfessionPoints(int32 amt)
-        {
-    #if VERSION_STRING < Cata
-            int32_t value = getFreePrimaryProfessionPoints();
-            value += amt;
-
-            if (value < 0)
-                value = 0;
-
-            setFreePrimaryProfessionPoints(value);
-
-    #else
-            if (amt == 0) { return; }
-    #endif
-        }
 
         void AddHonor(uint32 honorPoints, bool sendUpdate);
         void UpdateHonor();

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -8768,15 +8768,24 @@ AuraCheckResponse Unit::AuraCheck(SpellInfo const* proto, Object* /*caster*/)
     resp.Error = AURA_CHECK_RESULT_NONE;
     resp.Misc = 0;
 
-    uint32 name_hash = proto->custom_NameHash;
     uint32 rank = proto->custom_RankNumber;
 
     // look for spells with same namehash
     for (uint32 x = MAX_TOTAL_AURAS_START; x < MAX_TOTAL_AURAS_END; x++)
     {
         Aura* aura = m_auras[x];
-        if (aura != NULL && aura->getSpellInfo()->custom_NameHash == name_hash)
+        if (aura != NULL)
         {
+            // Very hacky way to check if spell is same but different rank
+            // It's better than nothing until better solution is implemented -Appled
+            const bool sameSpell = aura->getSpellInfo()->custom_NameHash == proto->custom_NameHash &&
+                aura->getSpellInfo()->getSpellVisual(0) == proto->getSpellVisual(0) &&
+                aura->getSpellInfo()->getSpellIconID() == proto->getSpellIconID() &&
+                aura->getSpellInfo()->getName() == proto->getName();
+
+            if (!sameSpell)
+                continue;
+
             // we've got an aura with the same name as the one we're trying to apply
             // but first we check if it has the same effects
             SpellInfo const* aura_sp = aura->getSpellInfo();
@@ -8824,8 +8833,14 @@ AuraCheckResponse Unit::AuraCheck(SpellInfo const* proto, Aura* aur, Object* /*c
     resp.Error = AURA_CHECK_RESULT_NONE;
     resp.Misc = 0;
 
-    // look for spells with same namehash
-    if (aur->getSpellInfo()->custom_NameHash == proto->custom_NameHash)
+    // Very hacky way to check if spell is same but different rank
+    // It's better than nothing until better solution is implemented -Appled
+    const bool sameSpell = aur->getSpellInfo()->custom_NameHash == proto->custom_NameHash &&
+        aur->getSpellInfo()->getSpellVisual(0) == proto->getSpellVisual(0) &&
+        aur->getSpellInfo()->getSpellIconID() == proto->getSpellIconID() &&
+        aur->getSpellInfo()->getName() == proto->getName();
+
+    if (sameSpell)
     {
         // we've got an aura with the same name as the one we're trying to apply
         // but first we check if it has the same effects


### PR DESCRIPTION
**Description**
Players: Initialize profession points properly
Spells: Do not check for explicit target when spell is targeting pet
Items: Show correct itemset when querying items

Closes https://github.com/AscEmu/AscEmu/issues/908

NOTE: this will NOT fix existing characters. If you want your existing character to be able to learn professions please run following SQL query to characters database:

`
UPDATE characters SET available_prof_points='2' WHERE available_prof_points='0';
`

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

***Multiversion Ingame Tests Performed:***
- [ ] BC
- [x] WotLK
- [x] Cata


