### PR TITLE
Improve profession and class trainers

### DIFF
--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -117,7 +117,6 @@ bool ChatHandler::HandleNpcAddTrainerSpellCommand(const char* args, WorldSession
     uint32_t spellid;
     uint32_t cost;
     uint32_t reqlevel;
-#if VERSION_STRING < Cata
     uint32_t reqspell;
     uint32_t delspell;
 
@@ -126,14 +125,6 @@ bool ChatHandler::HandleNpcAddTrainerSpellCommand(const char* args, WorldSession
         RedSystemMessage(m_session, "Command must be in format: .npc add trainerspell <spell_id> <cost> <required_spell> <required_player_level> <delete_spell_id>.");
         return true;
     }
-#else
-
-    if (sscanf(args, "%u %u %u", &spellid, &cost, &reqlevel) != 3)
-    {
-        RedSystemMessage(m_session, "Command must be in format: .npc add trainerspell <spell_id> <cost> <required_player_level>.");
-        return true;
-    }
-#endif
 
     auto creature_trainer = creature_target->GetTrainer();
     if (creature_trainer == nullptr)
@@ -156,15 +147,11 @@ bool ChatHandler::HandleNpcAddTrainerSpellCommand(const char* args, WorldSession
     }
 
     TrainerSpell sp;
-#if VERSION_STRING < Cata
-    sp.Cost = cost;
-    sp.IsProfession = false;
-    sp.pLearnSpell = learn_spell;
-    sp.pCastRealSpell = nullptr;
-    sp.pCastSpell = nullptr;
-    sp.RequiredLevel = reqlevel;
-    sp.RequiredSpell = reqspell;
-    sp.DeleteSpell = delspell;
+    sp.cost = cost;
+    sp.learnSpell = learn_spell;
+    sp.requiredLevel = reqlevel;
+    sp.requiredSpell[0] = reqspell;
+    sp.deleteSpell = delspell;
 
     creature_trainer->Spells.push_back(sp);
     creature_trainer->SpellCount++;
@@ -173,19 +160,6 @@ bool ChatHandler::HandleNpcAddTrainerSpellCommand(const char* args, WorldSession
     sGMLog.writefromsession(m_session, "added spell  %s (%u) to trainer %s (%u)", learn_spell->getName().c_str(), learn_spell->getId(), creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
     WorldDatabase.Execute("REPLACE INTO trainer_spells VALUES(%u, %u, %u, %u, %u, %u, %u, %u, %u, %u)",
         creature_target->getEntry(), 0, learn_spell->getId(), cost, reqspell, 0, 0, reqlevel, delspell, 0);
-#else
-    sp.spellCost = cost;
-    sp.spell = learn_spell->getId();
-    sp.reqLevel = reqlevel;
-
-    creature_trainer->Spells.push_back(sp);
-    creature_trainer->SpellCount++;
-
-    SystemMessage(m_session, "Added spell %s (%u) to trainer %s (%u).", learn_spell->getName().c_str(), learn_spell->getId(), creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
-    sGMLog.writefromsession(m_session, "added spell  %s (%u) to trainer %s (%u)", learn_spell->getName().c_str(), learn_spell->getId(), creature_target->GetCreatureProperties()->Name.c_str(), creature_target->getEntry());
-    WorldDatabase.Execute("REPLACE INTO trainer_spells VALUES(%u, %u, %u, %u, %u, %u)",
-                          creature_target->getEntry(), learn_spell->getId(), cost, (int)0, (int)0, reqlevel);
-#endif
 
     return true;
 }

--- a/src/world/Data/Flags.hpp
+++ b/src/world/Data/Flags.hpp
@@ -8,6 +8,14 @@ This file is released under the MIT license. See README-MIT for more information
 #include "WorldConf.h"
 
 #if VERSION_STRING == Classic
+enum TrainerSpellState
+{
+    TRAINER_SPELL_GREEN                 = 0,
+    TRAINER_SPELL_RED                   = 1,
+    TRAINER_SPELL_GRAY                  = 2,
+    TRAINER_SPELL_GREEN_DISABLED        = 10
+};
+
 enum ObjectUpdateFlags
 {
     UPDATEFLAG_NONE                     = 0x0000,
@@ -23,6 +31,14 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == TBC
+enum TrainerSpellState
+{
+    TRAINER_SPELL_GREEN                 = 0,
+    TRAINER_SPELL_RED                   = 1,
+    TRAINER_SPELL_GRAY                  = 2,
+    TRAINER_SPELL_GREEN_DISABLED        = 10
+};
+
 enum ObjectUpdateFlags
 {
     UPDATEFLAG_NONE                     = 0x0000,
@@ -38,6 +54,14 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == WotLK
+enum TrainerSpellState
+{
+    TRAINER_SPELL_GREEN                 = 0,
+    TRAINER_SPELL_RED                   = 1,
+    TRAINER_SPELL_GRAY                  = 2,
+    TRAINER_SPELL_GREEN_DISABLED        = 10
+};
+
 enum ObjectUpdateFlags
 {
     UPDATEFLAG_NONE                     = 0x0000,

--- a/src/world/Macros/CreatureMacros.hpp
+++ b/src/world/Macros/CreatureMacros.hpp
@@ -15,15 +15,6 @@ This file is released under the MIT license. See README-MIT for more information
 #define TRAINER_TYPE_MAX 16
 
 /// -
-#define TRAINER_STATUS_LEARNABLE 0
-
-/// -
-#define TRAINER_STATUS_NOT_LEARNABLE 1
-
-/// -
-#define TRAINER_STATUS_ALREADY_HAVE 2
-
-/// -
 #define CREATURE_AI_TEXT_COUNT 5
 
 /// -

--- a/src/world/Management/Skill.hpp
+++ b/src/world/Management/Skill.hpp
@@ -9,7 +9,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
-enum PlayerSkills
+enum PlayerSkills : uint16_t
 {
 #if VERSION_STRING <= Cata
     SKILL_FROST                         = 6,
@@ -283,4 +283,13 @@ enum SkillTypes : uint8_t
     SKILL_TYPE_LANGUAGE                 = 10, // Language skills
     SKILL_TYPE_PROFESSION               = 11, // Profession skills
     SKILL_TYPE_NA                       = 12
+};
+
+enum SkillRangeType : uint8_t
+{
+    SKILL_RANGE_LANGUAGE,                     // 300..300
+    SKILL_RANGE_LEVEL,                        // 1..max skill for level
+    SKILL_RANGE_MONO,                         // 1..1, grey monolite bar
+    SKILL_RANGE_RANK,                         // 1..skill for known rank
+    SKILL_RANGE_NONE                          // 0..0 always
 };

--- a/src/world/Objects/ObjectMgr.h
+++ b/src/world/Objects/ObjectMgr.h
@@ -93,43 +93,39 @@ class Group;
 class SpellInfo;
 
 //it seems trainerspells should be part of trainer files ;)
-#if VERSION_STRING >= Cata
 struct TrainerSpell
 {
-    TrainerSpell() : spell(0), spellCost(0), reqSkill(0), reqSkillValue(0), reqLevel(0)
+    TrainerSpell() : castSpell(nullptr), castRealSpell(nullptr), learnSpell(nullptr), deleteSpell(0),
+        requiredLevel(0), requiredSkillLine(0), requiredSkillLineValue(0), isPrimaryProfession(false),
+        cost(0)
     {
-        for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-            learnedSpell[i] = 0;
+        for (uint8_t i = 0; i < 3; ++i)
+            requiredSpell[i] = 0;
     }
 
-    uint32_t spell;
-    uint32_t spellCost;
-    uint32_t reqSkill;
-    uint32_t reqSkillValue;
-    uint32_t reqLevel;
-    uint32_t learnedSpell[3];
+    // This spell is casted on player
+    SpellInfo const* castSpell;
+    // The taught spell from castSpell
+    SpellInfo const* castRealSpell;
+    // This spell is added to player
+    SpellInfo const* learnSpell;
+    uint32_t deleteSpell;
+    uint32_t requiredLevel;
+    uint32_t requiredSpell[3];
+    uint32_t requiredSkillLine;
+    uint32_t requiredSkillLineValue;
+    bool isPrimaryProfession;
+    uint32_t cost;
 
-    // helpers
-    bool IsCastable() const
+    static uint8_t getMaxRequiredSpellCount()
     {
-        return learnedSpell[0] != spell;
-    }
-};
+#if VERSION_STRING < Cata
+        return 3;
 #else
-struct TrainerSpell
-{
-    SpellInfo const* pCastSpell;
-    SpellInfo const* pLearnSpell;
-    SpellInfo const* pCastRealSpell;
-    uint32 DeleteSpell;
-    uint32 RequiredSpell;
-    uint32 RequiredSkillLine;
-    uint32 RequiredSkillLineValue;
-    bool IsProfession;
-    uint32 Cost;
-    uint32 RequiredLevel;
-};
+        return 2;
 #endif
+    }
+};
 
 // oh a trainer look it is here and not in Unit/Creature/whatever file ;)
 struct Trainer
@@ -207,7 +203,6 @@ typedef std::map<std::string, PlayerInfo*> PlayerNameStringIndexMap;
 typedef std::unordered_map<std::string, PlayerInfo*> PlayerNameStringIndexMap;
 #endif
 
-#if VERSION_STRING >= Cata
 // spell_id  req_spell
 typedef std::multimap<uint32_t, uint32_t> SpellRequiredMap;
 typedef std::pair<SpellRequiredMap::const_iterator, SpellRequiredMap::const_iterator> SpellRequiredMapBounds;
@@ -219,7 +214,6 @@ typedef std::pair<SpellsRequiringSpellMap::const_iterator, SpellsRequiringSpellM
 // skill line ability
 typedef std::multimap<uint32_t, DBC::Structures::SkillLineAbilityEntry const*> SkillLineAbilityMap;
 typedef std::pair<SkillLineAbilityMap::const_iterator, SkillLineAbilityMap::const_iterator> SkillLineAbilityMapBounds;
-#endif
 
 // finally we are here, the base class of this file ;)
 class SERVER_DECL ObjectMgr : public EventableObject
@@ -241,6 +235,8 @@ class SERVER_DECL ObjectMgr : public EventableObject
 
         void generateDatabaseGossipMenu(Object* object, uint32_t gossipMenuId, Player* player, uint32_t forcedTextId = 0);
         void generateDatabaseGossipOptionAndSubMenu(Object* object, Player* player, uint32_t gossipItemId, uint32_t gossipMenuId);
+
+        void loadTrainers();
         //MIT END
 
         void LoadCreatureTimedEmotes();
@@ -366,7 +362,6 @@ class SERVER_DECL ObjectMgr : public EventableObject
         uint32 GenerateReportID();
         uint32 GenerateEquipmentSetID();
 
-#if VERSION_STRING >= Cata
         // Spell Required table
         SpellRequiredMapBounds GetSpellsRequiredForSpellBounds(uint32_t spell_id) const;
         SpellsRequiringSpellMapBounds GetSpellsRequiringSpellBounds(uint32_t spell_id) const;
@@ -377,9 +372,7 @@ class SERVER_DECL ObjectMgr : public EventableObject
 
         void LoadSkillLineAbilityMap();
         SkillLineAbilityMapBounds GetSkillLineAbilityMapBounds(uint32_t spell_id) const;
-#endif
 
-        void LoadTrainers();
         Trainer* GetTrainer(uint32 Entry);
 
         LevelInfo* GetLevelInfo(uint32 Race, uint32 Class, uint32 Level);
@@ -491,11 +484,9 @@ class SERVER_DECL ObjectMgr : public EventableObject
         DungeonEncounterContainer _dungeonEncounterStore;
         std::unordered_map<uint32_t, CreatureMovementData> _creatureMovementOverrides;
 
-#if VERSION_STRING >= Cata
         SpellsRequiringSpellMap mSpellsReqSpell;
         SpellRequiredMap mSpellReq;
         SkillLineAbilityMap mSkillLineAbilityMap;
-#endif
 
     protected:
 

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -895,14 +895,12 @@ void World::loadMySQLTablesByTask()
 
     sObjectMgr.LoadInstanceEncounters();
     sObjectMgr.LoadCreatureTimedEmotes();
-    sObjectMgr.LoadTrainers();
+    sObjectMgr.loadTrainers();
     sObjectMgr.LoadSpellSkills();
     sObjectMgr.LoadVendors();
     sObjectMgr.LoadSpellTargetConstraints();
-#if VERSION_STRING >= Cata
     sObjectMgr.LoadSpellRequired();
     sObjectMgr.LoadSkillLineAbilityMap();
-#endif
     sObjectMgr.LoadPetSpellCooldowns();
     sObjectMgr.LoadGuildCharters();
     sTicketMgr.loadGMTickets();

--- a/src/world/Server/WorldSession.h
+++ b/src/world/Server/WorldSession.h
@@ -794,11 +794,8 @@ class SERVER_DECL WorldSession
         void sendInnkeeperBind(Creature* creature);
         void sendTrainerList(Creature* creature);
         void sendStabledPetList(uint64_t npcguid);
-#if VERSION_STRING < Cata
-        uint8_t trainerGetSpellStatus(TrainerSpell* trainerSpell);
-#else
-        TrainerSpellState trainerGetSpellStatus(TrainerSpell* trainerSpell);
-#endif
+
+        TrainerSpellState trainerGetSpellStatus(TrainerSpell const* trainerSpell) const;
 
     protected:
         void handleTabardVendorActivateOpcode(WorldPacket& recvPacket);

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -289,6 +289,58 @@ SpellInfo const* SpellMgr::getSpellInfoByDifficulty([[maybe_unused]]const uint32
 #endif
 }
 
+SkillRangeType SpellMgr::getSkillRangeType(DBC::Structures::SkillLineEntry const* skill, bool racial) const
+{
+    if (skill == nullptr)
+        return SKILL_RANGE_NONE;
+
+    // Helper lambda
+    const auto isProfessionSkill = [](uint32_t skillId) -> bool
+    {
+        auto* const skillLine = sSkillLineStore.LookupEntry(skillId);
+        const auto isPrimaryProfessionSkill = skillLine != nullptr && skillLine->type == SKILL_TYPE_PROFESSION;
+
+        return isPrimaryProfessionSkill || skillId == SKILL_FISHING || skillId == SKILL_COOKING || skillId == SKILL_FIRST_AID;
+    };
+
+    switch (skill->type)
+    {
+        case SKILL_TYPE_LANGUAGE:
+        {
+            return SKILL_RANGE_LANGUAGE;
+        }
+        case SKILL_TYPE_WEAPON:
+        {
+            return SKILL_RANGE_LEVEL;
+        }
+        case SKILL_TYPE_ARMOR:
+        case SKILL_TYPE_CLASS:
+        {
+#if VERSION_STRING <= WotLK
+            if (skill->id != SKILL_LOCKPICKING)
+                return SKILL_RANGE_MONO;
+            else
+#endif
+                return SKILL_RANGE_LEVEL;
+        }
+        case SKILL_TYPE_SECONDARY:
+        case SKILL_TYPE_PROFESSION:
+        {
+            // not set skills for professions and racial abilities
+            if (isProfessionSkill(skill->id))
+                return SKILL_RANGE_RANK;
+            else if (racial)
+                return SKILL_RANGE_NONE;
+            else
+                return SKILL_RANGE_MONO;
+        }
+        default:
+            break;
+    }
+
+    return SKILL_RANGE_NONE;
+}
+
 // Private methods
 
 void SpellMgr::loadSpellInfoData()

--- a/src/world/Spell/SpellMgr.hpp
+++ b/src/world/Spell/SpellMgr.hpp
@@ -9,6 +9,8 @@ This file is released under the MIT license. See README-MIT for more information
 #include "SpellAuras.h"
 #include "SpellInfo.hpp"
 
+#include "Management/Skill.hpp"
+#include "Storage/DBC/DBCStructures.hpp"
 #include "Units/Players/PlayerDefines.hpp"
 
 struct SpellArea
@@ -84,6 +86,8 @@ public:
     SpellInfo const* getSpellInfo(const uint32_t spellId) const;
     SpellInfo const* getSpellInfoByDifficulty(const uint32_t spellId, const uint8_t difficulty) const;
     SpellInfoMap const* getSpellInfoMap() const { return &mSpellInfoMapStore; }
+
+    SkillRangeType getSkillRangeType(DBC::Structures::SkillLineEntry const* skill, bool racial) const;
 
 private:
     // DBC files

--- a/src/world/Units/Players/Player.Legacy.cpp
+++ b/src/world/Units/Players/Player.Legacy.cpp
@@ -8211,23 +8211,15 @@ void Player::_UpdateSkillFields()
         }
 
         const uint16_t id = itr->first;
+        uint8_t skillStep = 0;
 
-        if (itr->second.Skill->type == SKILL_TYPE_PROFESSION)
-        {
-            //field 0
-            setSkillInfoId(f, id | 0x10000);
-#if VERSION_STRING > TBC
-            m_achievementMgr.UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL, itr->second.Skill->id, itr->second.CurrentValue, 0);
-#endif
-        }
-        else
-        {
-            //field 0
-            setSkillInfoId(f, id);
-#if VERSION_STRING > TBC
-            m_achievementMgr.UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL, itr->second.Skill->id, itr->second.MaximumValue / 75, 0);
-#endif
-        }
+        // Get skill step
+        if (itr->second.Skill->type == SKILL_TYPE_SECONDARY || itr->second.Skill->type == SKILL_TYPE_PROFESSION)
+            skillStep = static_cast<uint8_t>(itr->second.MaximumValue / 75);
+
+        //field 0
+        setSkillInfoId(f, id);
+        setSkillInfoStep(f, skillStep);
 
         //field 1
         setSkillInfoCurrentValue(f, itr->second.CurrentValue);
@@ -8235,6 +8227,14 @@ void Player::_UpdateSkillFields()
 
         //field 2
         setSkillInfoBonusTemporary(f, itr->second.BonusValue);
+
+#ifdef FT_ACHIEVEMENTS
+        if (itr->second.Skill->type == SKILL_TYPE_PROFESSION)
+            m_achievementMgr.UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL, itr->second.Skill->id, itr->second.CurrentValue, 0);
+        else
+            m_achievementMgr.UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL, itr->second.Skill->id, itr->second.MaximumValue / 75, 0);
+#endif
+
         ++itr;
         ++f;
     }

--- a/src/world/Units/Players/Player.h
+++ b/src/world/Units/Players/Player.h
@@ -562,10 +562,12 @@ public:
     uint16_t getSkillStep(uint32_t index, uint8_t offset) const;
     uint16_t getSkillCurrentValue(uint32_t index, uint8_t offset) const;
     uint16_t getSkillMaximumValue(uint32_t index, uint8_t offset) const;
+    uint32_t getProfessionSkillLine(uint32_t index) const;
     void setSkillLineId(uint32_t index, uint32_t value);
     void setSkillStep(uint32_t index, uint32_t value);
     void setSkillCurrentValue(uint32_t index, uint32_t value);
     void setSkillMaximumValue(uint32_t index, uint32_t value);
+    void setProfessionSkillLine(uint32_t index, uint32_t value);
 #endif
 
     uint32_t getFreeTalentPoints() const;
@@ -918,12 +920,15 @@ public:
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Spells and skills
-    bool isSpellFitByClassAndRace(uint32_t spell_id);
+    void setInitialPlayerSkills();
+
     void updateAutoRepeatSpell();
     bool canUseFlyingMountHere();
 
     bool canDualWield2H() const;
     void setDualWield2H(bool enable);
+
+    bool isSpellFitByClassAndRace(uint32_t spell_id) const;
 
     // Cooldowns
     bool hasSpellOnCooldown(SpellInfo const* spellInfo);

--- a/src/world/Units/Unit.h
+++ b/src/world/Units/Unit.h
@@ -312,11 +312,11 @@ public:
 
     uint8_t getRace() const;
     void setRace(uint8_t race);
-    uint32_t getRaceMask() { return 1 << (getRace() - 1); }
+    uint32_t getRaceMask() const { return 1 << (getRace() - 1); }
 
     uint8_t getClass() const;
     void setClass(uint8_t class_);
-    uint32_t getClassMask() { return 1 << (getClass() - 1); }
+    uint32_t getClassMask() const { return 1 << (getClass() - 1); }
 
     uint8_t getGender() const;
     void setGender(uint8_t gender);


### PR DESCRIPTION
**Description**
NPCs: Improve class and profession trainers, now cata uses same code for trainer spells as wotlk
NPCs: Trainers can teach you multiple spells now (Cata)
Skills: Profession skill levels should show correctly on trainers now (Cata)
Skills: Fix missing unlearn button in professions under skill tab (Classic - wotlk)
Skills: Fix already learnt profession ranks appearing in trainer list (Classic - wotlk)

Closes https://github.com/AscEmu/AscEmu/issues/752 and https://github.com/AscEmu/AscEmu/issues/28

TODO: when a skill is changed, added or removed we loop through all skills and update each and every skill. This generates some weird skill gain messages to chat. In the future, if we need to update, add or remove a skill we should only update that WoWData field instead of looping through all skills. We could save the field position for each skill in PlayerSkill or smth.
In Cata the generated skill gain messages are even worse because there we must have all profession initialized to null. 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

***Multiversion Ingame Tests Performed:***
- [ ] BC
- [x] WotLK
- [x] Cata


