### PR TITLE
Couple spell fixes and fixing npc loot issue

### DIFF
--- a/sql/world/updates/20211112-00_playercreateinfo_spell_learn.sql
+++ b/sql/world/updates/20211112-00_playercreateinfo_spell_learn.sql
@@ -1,0 +1,8 @@
+-- Frost Armor is no longer a mage starting spell in cata, it is learnt at level 56
+UPDATE `playercreateinfo_spell_learn` SET `max_build`='12340' WHERE `spellid`='168';
+-- Seal of Righteousness is no longer a paladin starting spell in cata, it is learnt at level 3
+UPDATE `playercreateinfo_spell_learn` SET `max_build`='12340' WHERE `spellid`='21084';
+-- Rogues no longer have passive threat reduction in cata
+UPDATE `playercreateinfo_spell_learn` SET `max_build`='12340' WHERE `spellid`='21184';
+
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('97', '20211112-00_playercreateinfo_spell_learn');

--- a/src/scripts/SpellHandlers/Scripts/Mage.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Mage.cpp
@@ -8,6 +8,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 enum MageSpells
 {
+    SPELL_ARCANE_MISSILES_PROC  = 79683,
+    SPELL_DEEP_FREEZE_DAMAGE    = 71757,
     SPELL_GLYPH_OF_THE_PENGUIN  = 52648,
     SPELL_HOT_STREAK_BUFF       = 48108,
     SPELL_HOT_STREAK_R1         = 44445,
@@ -31,6 +33,30 @@ enum MageSpells
     ICON_POLYMORPH_SHEEP        = 82,
     CREATURE_CHILLY             = 29726, // Penguin NPC for Glyph of the Penguin
 };
+
+#if VERSION_STRING >= Cata
+class ArcaneMissilesProc : public SpellScript
+{
+public:
+    uint32_t calcProcChance(SpellProc* /*proc*/, Unit* /*victim*/, SpellInfo const* /*castingSpell*/) override
+    {
+        // DBC data says 100% but ingame tooltip says 40%
+        return 40;
+    }
+};
+#endif
+
+#if VERSION_STRING >= WotLK
+class DeepFreezeDamage : public SpellScript
+{
+public:
+    bool canProc(SpellProc* /*spellProc*/, Unit* victim, SpellInfo const* /*castingSpell*/, DamageInfo /*damageInfo*/) override
+    {
+        // TODO: prevent proc for now, fix this later
+        return false;
+    }
+};
+#endif
 
 #if VERSION_STRING >= WotLK
 class HotStreakDummy : public SpellScript
@@ -236,6 +262,14 @@ void setupMageSpells(ScriptMgr* mgr)
 {
     // Call legacy script setup
     SetupLegacyMageSpells(mgr);
+
+#if VERSION_STRING >= Cata
+    mgr->register_spell_script(SPELL_ARCANE_MISSILES_PROC, new ArcaneMissilesProc);
+#endif
+
+#if VERSION_STRING >= WotLK
+    mgr->register_spell_script(SPELL_DEEP_FREEZE_DAMAGE, new DeepFreezeDamage);
+#endif
 
 #if VERSION_STRING >= WotLK
     uint32_t hotStreakIds[] =

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -940,6 +940,14 @@ DamageInfo Object::doSpellDamage(Unit* victim, uint32_t spellId, float_t dmg, ui
 
     victim->addHealthBatchEvent(healthBatch);
 
+    // Tagging should happen when damage packets are sent
+    const auto plrOwner = getPlayerOwner();
+    if (plrOwner != nullptr && victim->isCreature() && victim->IsTaggable())
+    {
+        victim->Tag(getGuid());
+        plrOwner->TagUnit(victim);
+    }
+
     // Handle procs
     if (isCreatureOrPlayer())
     {

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -58,7 +58,7 @@ ConfigMgr Config;
 
 // DB version
 static const char* REQUIRED_CHAR_DB_VERSION = "20201216-00_rename_event_properties";
-static const char* REQUIRED_WORLD_DB_VERSION = "20211108-00_playercreateinfo";
+static const char* REQUIRED_WORLD_DB_VERSION = "20211112-00_playercreateinfo_spell_learn";
 
 void Master::_OnSignal(int s)
 {

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -1040,7 +1040,10 @@ int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = n
         else
             diff += unitCaster->getLevel();
 
-        basePoints += float2int32(diff * basePointsPerLevel);
+        diff = float2int32(diff * basePointsPerLevel);
+        // Should not happen but just in case do not make total value negative
+        if (diff > 0)
+            basePoints += diff;
     }
 
     if (randomPoints > 1)

--- a/src/world/Units/Unit.Legacy.cpp
+++ b/src/world/Units/Unit.Legacy.cpp
@@ -8037,6 +8037,15 @@ DamageInfo Unit::Strike(Unit* pVictim, WeaponDamageType weaponType, SpellInfo co
             this->CombatStatus.OnDamageDealt(pVictim);
         }
     }
+
+    // Tagging should happen when damage packets are sent
+    const auto plrOwner = getPlayerOwner();
+    if (plrOwner != nullptr && pVictim->isCreature() && pVictim->IsTaggable())
+    {
+        pVictim->Tag(getGuid());
+        plrOwner->TagUnit(pVictim);
+    }
+
     //////////////////////////////////////////////////////////////////////////////////////////
     //Post Damage Dealing Processing
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/world/Units/Unit.cpp
+++ b/src/world/Units/Unit.cpp
@@ -5182,9 +5182,16 @@ void Unit::dealDamage(Unit* victim, uint32_t damage, uint32_t spellId, bool remo
 
     victim->setStandState(STANDSTATE_STAND);
 
+    // Tagging should happen when damage packets are sent
+    const auto plrOwner = getPlayerOwner();
+    if (plrOwner != nullptr && victim->isCreature() && victim->IsTaggable())
+    {
+        victim->Tag(getGuid());
+        plrOwner->TagUnit(victim);
+    }
+
     if (victim->isPvpFlagSet())
     {
-        const auto plrOwner = getPlayerOwner();
         if (isPet())
         {
             if (!isPvpFlagSet())
@@ -5749,12 +5756,6 @@ uint32_t Unit::_handleBatchDamage(HealthBatchEvent const* batch, uint32_t* rageG
         const auto plrOwner = attacker->getPlayerOwner();
         if (plrOwner != nullptr)
         {
-            if (isCreature() && IsTaggable())
-            {
-                Tag(plrOwner->getGuid());
-                plrOwner->TagUnit(this);
-            }
-
             // Battleground damage score
             if (plrOwner->m_bg != nullptr && GetMapMgr() == attacker->GetMapMgr())
             {


### PR DESCRIPTION
**Description**
Units: Fix issue where mobs sometimes are not lootable
Spells: Prevent negative spell damage when spell damage is scaling with level
Spells: Correct some player starting spells
Spells: Correct two mage passive spells in Cata

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

***Multiversion Ingame Tests Performed:***
- [] BC
- [x] WotLK
- [x] Cata


