### PR TITLE
Rewrite unit combat

### DIFF
--- a/src/scripts/LuaEngine/FunctionTables.h
+++ b/src/scripts/LuaEngine/FunctionTables.h
@@ -340,7 +340,6 @@ RegType<Unit> UnitMethods[] =
     { "PhaseDelete", &LuaUnit::PhaseDelete},
     { "GetPhase", &LuaUnit::GetPhase},
     { "AggroWithInRangeFriends", &LuaUnit::AggroWithInRangeFriends},
-    { "GetPrimaryCombatTarget", &LuaUnit::GetPrimaryCombatTarget},
     { "MoveRandomArea", &LuaUnit::MoveRandomArea},
     { "SendLootWindow", &LuaUnit::SendLootWindow},
     { "AddLoot", &LuaUnit::AddLoot},

--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -401,7 +401,7 @@ public:
     {
         TEST_UNIT()
         // If Pointer isn't in combat skip everything
-        if (!ptr->m_combatStatusHandler.IsInCombat())
+        if (!ptr->getCombatHandler().isInCombat())
             return 0;
 
         Unit* pTarget = ptr->getAIInterface()->getCurrentTarget();
@@ -756,7 +756,7 @@ public:
     {
         if (ptr == nullptr || !ptr->IsInWorld())
             RET_NIL()
-            if (ptr->m_combatStatusHandler.IsInCombat())
+            if (ptr->getCombatHandler().isInCombat())
                 lua_pushboolean(L, 1);
             else
                 lua_pushboolean(L, 0);
@@ -1251,21 +1251,6 @@ public:
         TEST_PLAYER()
         uint32_t itemid = static_cast<uint32_t>(luaL_checkinteger(L, 1));
         lua_pushinteger(L, static_cast<Player*>(ptr)->getItemInterface()->GetItemCount(itemid, false));
-        return 1;
-    }
-
-    static int GetPrimaryCombatTarget(lua_State* L, Unit* ptr)
-    {
-        TEST_PLAYER()
-
-        if (!ptr->m_combatStatusHandler.IsInCombat())
-        {
-            lua_pushinteger(L, 0);
-            return 1;
-        }
-
-        PUSH_UNIT(L, ptr->GetMapMgr()->GetUnit(dynamic_cast<Player*>(ptr)->m_combatStatusHandler.GetPrimaryAttackTarget()));
-
         return 1;
     }
 

--- a/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
@@ -1521,7 +1521,7 @@ bool CenarionMoondust(uint8_t /*effectIndex*/, Spell* pSpell) // Body And Heart 
     }
 
     // Make sure that creature will attack player
-    if (!lunaclaw->m_combatStatusHandler.IsInCombat())
+    if (!lunaclaw->getCombatHandler().isInCombat())
     {
         lunaclaw->getAIInterface()->setCurrentTarget(p_caster);
     }
@@ -1564,7 +1564,7 @@ bool CenarionLunardust(uint8_t /*effectIndex*/, Spell* pSpell)  // Body And Hear
     }
 
     // Make sure that creature will attack player
-    if (!lunaclaw->m_combatStatusHandler.IsInCombat())
+    if (!lunaclaw->getCombatHandler().isInCombat())
     {
         lunaclaw->getAIInterface()->setCurrentTarget(p_caster);
     }

--- a/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
@@ -192,8 +192,7 @@ bool PreyOnTheWeakPeriodicDummy(uint8_t /*effectIndex*/, Aura* a, bool apply)
 
     if (p_target != NULL && p_target->getClass() == ROGUE)
     {
-
-        Unit* target = p_target->GetMapMgr()->GetUnit(p_target->m_combatStatusHandler.GetPrimaryAttackTarget());
+        Unit* target = p_target->GetMapMgrUnit(p_target->getTargetGuid());
         if (target == NULL)
             return true;
 

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -334,7 +334,7 @@ bool ChatHandler::HandleNpcInfoCommand(const char* /*args*/, WorldSession* m_ses
     if (creature_target->m_factionTemplate)
         SystemMessage(m_session, "Combat Support: 0x%.3X", creature_target->m_factionTemplate->FriendlyMask);
 
-    if (creature_target->m_combatStatusHandler.IsInCombat())
+    if (creature_target->getCombatHandler().isInCombat())
         SystemMessage(m_session, "Is in combat!");
     else
         SystemMessage(m_session, "Not in combat!");

--- a/src/world/Macros/AIInterfaceMacros.hpp
+++ b/src/world/Macros/AIInterfaceMacros.hpp
@@ -33,7 +33,7 @@ typedef std::vector<AreaBoundary const*> CreatureBoundary;
 #define TARGET_UPDATE_INTERVAL_ON_PLAYER 1000
 
 /// this is a multiple of PLAYER_TARGET_UPDATE_INTERVAL
-#define TARGET_UPDATE_INTERVAL 5000
+#define TARGET_UPDATE_INTERVAL 4500
 
 /// -
 // #define PLAYER_SIZE 1.5f

--- a/src/world/Management/HonorHandler.cpp
+++ b/src/world/Management/HonorHandler.cpp
@@ -136,7 +136,7 @@ void HonorHandler::OnPlayerKilled(Player* pPlayer, Player* pVictim)
 
                 bool added = false;
                 Player* plr = static_cast<Player*>(itr);
-                if (pVictim->m_combatStatusHandler.m_attackers.find(plr->getGuid()) != pVictim->m_combatStatusHandler.m_attackers.end())
+                if (pVictim->getCombatHandler().isInCombatWithPlayer(plr))
                 {
                     added = true;
                     contributors.insert(plr);

--- a/src/world/Management/ItemInterface.cpp
+++ b/src/world/Management/ItemInterface.cpp
@@ -2088,7 +2088,7 @@ int8 ItemInterface::CanEquipItemInSlot(int8 DstInvSlot, int8 slot, ItemPropertie
 
     if ((slot < INVENTORY_SLOT_BAG_END && DstInvSlot == INVENTORY_SLOT_NOT_SET) || (slot >= BANK_SLOT_BAG_START && slot < BANK_SLOT_BAG_END && DstInvSlot == INVENTORY_SLOT_NOT_SET))
     {
-        if (!ignore_combat && m_pOwner->m_combatStatusHandler.IsInCombat() && (slot < EQUIPMENT_SLOT_MAINHAND || slot > EQUIPMENT_SLOT_RANGED))
+        if (!ignore_combat && m_pOwner->getCombatHandler().isInCombat() && (slot < EQUIPMENT_SLOT_MAINHAND || slot > EQUIPMENT_SLOT_RANGED))
             return INV_ERR_CANT_DO_IN_COMBAT;
 
         if (IsEquipped(proto->ItemId) && (proto->Unique || proto->Flags & ITEM_FLAG_UNIQUE_EQUIP))

--- a/src/world/Management/LootMgr.h
+++ b/src/world/Management/LootMgr.h
@@ -5,6 +5,9 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "Map/InstanceDefines.hpp"
+#include "Objects/Units/Creatures/CreatureDefines.hpp"
+
 #define MAX_NR_LOOT_ITEMS 16
 #define MAX_NR_LOOT_QUESTITEMS 32
 #define MAX_NR_LOOT_EQUIPABLE 2

--- a/src/world/Map/MapCell.h
+++ b/src/world/Map/MapCell.h
@@ -44,6 +44,10 @@ public:
     void LoadObjects(CellSpawns* sp);
     inline uint32_t GetPlayerCount() { return _playerCount; }
 
+    bool isIdlePending() const;
+    void scheduleCellIdleState();
+    void cancelPendingIdle();
+
     inline bool IsUnloadPending() { return _unloadpending; }
     inline void SetUnloadPending(bool up) { _unloadpending = up; }
     void QueueUnloadPending();
@@ -66,6 +70,7 @@ private:
     bool _active;
     bool _loaded;
     bool _unloadpending;
+    bool _idlepending = false;
 
     uint16_t _playerCount;
 

--- a/src/world/Map/MapMgr.h
+++ b/src/world/Map/MapMgr.h
@@ -221,6 +221,7 @@ public:
     uint8 iInstanceMode;
 
     void UnloadCell(uint32 x, uint32 y);
+    void setCellIdle(uint16_t x, uint16_t y, MapCell* cell);
     void EventRespawnCreature(Creature* c, uint16 x, uint16 y);
     void EventRespawnGameObject(GameObject* o, uint16 x, uint16 y);
     void SendChatMessageToCellPlayers(Object* obj, WorldPacket* packet, uint32 cell_radius, uint32 langpos, int32 lang, WorldSession* originator);

--- a/src/world/Objects/Units/CMakeLists.txt
+++ b/src/world/Objects/Units/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(PATH_PREFIX Objects/Units)
 
 set(SRC_UNITS_FILES
+    ${PATH_PREFIX}/CombatHandler.cpp
+    ${PATH_PREFIX}/CombatHandler.hpp
     ${PATH_PREFIX}/Stats.cpp
     ${PATH_PREFIX}/Stats.h
     ${PATH_PREFIX}/Unit.cpp

--- a/src/world/Objects/Units/CombatHandler.cpp
+++ b/src/world/Objects/Units/CombatHandler.cpp
@@ -1,0 +1,408 @@
+/*
+Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#include "CombatHandler.hpp"
+#include "UnitDefines.hpp"
+
+CombatHandler::CombatHandler(Unit* owner) : m_owner(owner)
+{}
+
+void CombatHandler::onHostileAction(Unit* victim, bool skipInitialDelay/* = false*/)
+{
+    if (victim == nullptr || !victim->IsInWorld())
+        return;
+
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+    _initiateCombatWith(victim);
+
+    if (skipInitialDelay)
+    {
+        const auto msTime = Util::getMSTime();
+        _checkPvpFlags(victim, false);
+        _combatAction(victim, msTime, false, true);
+        return;
+    }
+
+    m_combatBatchAttackingTargets.insert(std::make_pair(victim->getGuid(), BatchTargetInfo(victim, false)));
+}
+
+void CombatHandler::onFriendlyAction(Unit* target, bool skipInitialDelay/* = false*/)
+{
+    if (target == nullptr || !target->IsInWorld())
+        return;
+
+    // If target is not in combat, unit should not get in combat either
+    if (!target->getCombatHandler().isInCombat())
+        return;
+
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+    _initiateCombatWith(target);
+
+    if (skipInitialDelay)
+    {
+        const auto msTime = Util::getMSTime();
+        _checkPvpFlags(target, true);
+        _combatAction(target, msTime, true, true);
+        return;
+    }
+
+    m_combatBatchAttackingTargets.insert(std::make_pair(target->getGuid(), BatchTargetInfo(target, true)));
+}
+
+void CombatHandler::takeCombatAction(Unit* initiater, bool friendlyCombat/* = false*/, bool skipInitialDelay/* = false*/)
+{
+    if (initiater == nullptr || !initiater->IsInWorld())
+        return;
+
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+    initiater->getCombatHandler()._notifyOnCombatInitiated(getOwner());
+
+    if (!friendlyCombat)
+    {
+        if (skipInitialDelay)
+        {
+            const auto msTime = Util::getMSTime();
+            _combatAction(initiater, msTime, false, false);
+            return;
+        }
+
+        m_combatBatchAttackedByTargets.insert(std::make_pair(initiater->getGuid(), BatchTargetInfo(initiater, false)));
+    }
+}
+
+void CombatHandler::clearCombat()
+{
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+
+    _leaveCombat();
+    m_combatBatchAttackingTargets.clear();
+    m_combatBatchAttackedByTargets.clear();
+    m_combatInitiatedWith.clear();
+}
+
+void CombatHandler::onRemoveFromWorld()
+{
+    // Clear this unit from all in range units combat map to avoid crashes when removed from world
+    for (const auto& obj : getOwner()->getInRangeObjectsSet())
+    {
+        if (obj == nullptr || !obj->isCreatureOrPlayer())
+            continue;
+
+        dynamic_cast<Unit*>(obj)->getCombatHandler().onUnitRemovedFromWorld(getOwner()->getGuid());
+    }
+
+    clearCombat();
+}
+
+void CombatHandler::onUnitRemovedFromWorld(uint64_t guid)
+{
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+
+    // No need to remove from player combat map
+    m_combatBatchAttackingTargets.erase(guid);
+    m_combatBatchAttackedByTargets.erase(guid);
+    m_combatInitiatedWith.erase(guid);
+}
+
+bool CombatHandler::isInCombat() const
+{
+    return m_inCombat;
+}
+
+bool CombatHandler::isInCombatWithPlayer(Player const* player) const
+{
+    if (!isInCombat())
+        return false;
+
+    std::lock_guard<std::mutex> guard(m_mutexPlayerCombat);
+    return m_combatPlayerTargets.find(player->getGuid()) != m_combatPlayerTargets.end();
+}
+
+bool CombatHandler::isInPreCombatWithUnit(Unit const* player) const
+{
+    std::lock_guard<std::mutex> guard(m_mutexCombat);
+    return m_combatBatchAttackingTargets.find(player->getGuid()) != m_combatBatchAttackingTargets.end();
+}
+
+void CombatHandler::updateCombat(uint32_t msTime)
+{
+    auto diff = msTime - m_lastCombatUpdateTime;
+    if (diff >= COMBAT_BATCH_INTERVAL)
+    {
+        std::lock_guard<std::mutex> guard(m_mutexCombat);
+        m_lastCombatUpdateTime = msTime;
+
+        // Make sure unit cannot leave combat in the same update tick he got it
+        auto hadCombatAction = false;
+
+        // Unit is attacking or healing these targets
+        if (!m_combatBatchAttackingTargets.empty())
+        {
+            for (auto itr = m_combatBatchAttackingTargets.cbegin(); itr != m_combatBatchAttackingTargets.cend();)
+            {
+                // Make sure target still exists
+                auto* const target = itr->second.unit;
+                if (target == nullptr || !target->IsInWorld())
+                {
+                    itr = m_combatBatchAttackingTargets.erase(itr);
+                    continue;
+                }
+
+                _checkPvpFlags(target, itr->second.isFriendly);
+                _combatAction(target, msTime, itr->second.isFriendly, true);
+                hadCombatAction = true;
+
+                itr = m_combatBatchAttackingTargets.erase(itr);
+            }
+        }
+
+        // Unit is being attacked or healed by these targets
+        if (!m_combatBatchAttackedByTargets.empty())
+        {
+            for (auto itr = m_combatBatchAttackedByTargets.cbegin(); itr != m_combatBatchAttackedByTargets.cend();)
+            {
+                // Make sure attacker still exists
+                auto* const attacker = itr->second.unit;
+                if (attacker == nullptr || !attacker->IsInWorld())
+                {
+                    itr = m_combatBatchAttackedByTargets.erase(itr);
+                    continue;
+                }
+
+                if (getOwner()->isPlayer() && attacker->isPlayer())
+                {
+                    // Special pvp case - neither attacker or victim should enter in combat
+                    // if attacker managed to clear combat right after attack
+                    // i.e. if rogue casts vanish right after ambush but before combat batch,
+                    // neither rogue or victim should enter in combat and rogue should be able to sap target
+                    if (!attacker->getCombatHandler().isInPreCombatWithUnit(getOwner()) &&
+                        !attacker->getCombatHandler().isInCombatWithPlayer(dynamic_cast<Player*>(getOwner())))
+                    {
+                        itr = m_combatBatchAttackedByTargets.erase(itr);
+                        continue;
+                    }
+                }
+
+                _combatAction(attacker, msTime, false, false);
+                hadCombatAction = true;
+
+                itr = m_combatBatchAttackedByTargets.erase(itr);
+            }
+        }
+
+        if (!isInCombat() || hadCombatAction)
+            return;
+
+        if (!m_combatInitiatedWith.empty())
+        {
+            for (auto itr = m_combatInitiatedWith.begin(); itr != m_combatInitiatedWith.end();)
+            {
+                // First check, set time
+                if (itr->second == 0)
+                {
+                    itr->second = msTime;
+                    ++itr;
+                    continue;
+                }
+
+                // If creature is in this container for over 4.5 seconds it can be assumed that the combat is bugged
+                // Remove creature from map and try clear combat in next update
+                diff = msTime - itr->second;
+                if (diff >= PVP_COMBAT_LEAVE_MIN_TIME)
+                {
+                    itr = m_combatInitiatedWith.erase(itr);
+                    continue;
+                }
+                else
+                {
+                    ++itr;
+                }
+            }
+
+            return;
+        }
+
+        // Creatures are simple; if threat list is empty then leave combat, else stay in combat
+        if (getOwner()->isCreature() && getOwner()->getPlayerOwner() == nullptr)
+        {
+            if (getOwner()->getThreatManager().isThreatListEmpty())
+                _leaveCombat();
+
+            return;
+        }
+
+        // At this point owner is either player or player controlled creature (pet, summon etc)
+        // If player or pet has threat with something => stay in combat
+        if (!getOwner()->getThreatManager().getThreatenedByMeList().empty())
+            return;
+
+        // Owner is not in combat with creatures
+        // Check if owner is still in combat with other players or pets
+        if (!m_combatPlayerTargets.empty())
+            return;
+
+        // Owner can leave combat
+        _leaveCombat();
+    }
+
+    // Update pvp combat
+    diff = msTime - m_lastPvPCombatUpdateTime;
+    if (diff >= PVP_COMBAT_TIMER_PULSE)
+    {
+        std::lock_guard<std::mutex> guard(m_mutexCombat);
+
+        // Timer must keep going even if unit is not in combat
+        _updatePvpCombat(msTime);
+        m_lastPvPCombatUpdateTime = msTime;
+    }
+}
+
+Unit* CombatHandler::getOwner() const
+{
+    return m_owner;
+}
+
+void CombatHandler::_enterCombat(bool initiatingCombat, Unit* enteringCombatWith, bool friendlyTarget)
+{
+    if (m_inCombat)
+        return;
+
+    getOwner()->addUnitFlags(UNIT_FLAG_COMBAT);
+    m_inCombat = true;
+
+    if (getOwner()->isPlayer())
+        sHookInterface.OnEnterCombat(dynamic_cast<Player*>(getOwner()), enteringCombatWith);
+
+    // If summons get in combat master will also get in combat
+    // However if master gets in combat summons won't get in combat if kept on passive
+    _notifyOwner(friendlyTarget, enteringCombatWith, initiatingCombat);
+}
+
+void CombatHandler::_leaveCombat()
+{
+    if (!m_inCombat)
+        return;
+
+    getOwner()->removeUnitFlags(UNIT_FLAG_COMBAT);
+    m_inCombat = false;
+
+    std::lock_guard<std::mutex> guard(m_mutexPlayerCombat);
+    m_combatPlayerTargets.clear();
+}
+
+void CombatHandler::_combatAction(Unit* target, uint32_t msTime, bool friendlyAction, bool initiatingCombat)
+{
+    _resetPvpCombatTimer(msTime, target);
+
+    // Set owner in combat
+    // Victim is set in combat when spell lands on target or damage is done
+    if (!isInCombat())
+        _enterCombat(initiatingCombat, target, friendlyAction);
+    else
+        _notifyOwner(friendlyAction, target, initiatingCombat);
+}
+
+void CombatHandler::_initiateCombatWith(Unit* enteringCombatWith)
+{
+    if (enteringCombatWith->isPlayer() || enteringCombatWith->getPlayerOwner() != nullptr)
+        return;
+
+    m_combatInitiatedWith.insert(std::make_pair(enteringCombatWith->getGuid(), 0U));
+}
+
+void CombatHandler::_notifyOnCombatInitiated(Unit* initiatedCombatWith)
+{
+    if (initiatedCombatWith->isPlayer() || initiatedCombatWith->getPlayerOwner() != nullptr)
+        return;
+
+    m_combatInitiatedWith.erase(initiatedCombatWith->getGuid());
+}
+
+void CombatHandler::_notifyOwner(bool friendlyAction, Unit* enteringCombatWith, bool initiatingCombat)
+{
+    // If unit has an owner, the owner should also get in combat
+    // TODO: owner can be creature too
+    auto* const owner = getOwner()->getPlayerOwner();
+    if (owner == nullptr || owner == getOwner())
+        return;
+
+    // Skip combat delay for owner as it was already delayed for this unit
+    if (initiatingCombat)
+    {
+        if (friendlyAction)
+            owner->getCombatHandler().onFriendlyAction(enteringCombatWith, true);
+        else
+            owner->getCombatHandler().onHostileAction(enteringCombatWith, true);
+    }
+    else
+    {
+        owner->getCombatHandler().takeCombatAction(enteringCombatWith, false, true);
+    }
+}
+
+void CombatHandler::_checkPvpFlags(Unit* target, bool friendlyAction)
+{
+    const auto playerOwner = getOwner()->getPlayerOwner();
+    if (playerOwner == nullptr)
+        return;
+
+    if (target->isPvpFlagSet())
+    {
+        if (getOwner()->isPet())
+        {
+            if (!getOwner()->isPvpFlagSet())
+                playerOwner->PvPToggle();
+
+            if (!friendlyAction)
+                playerOwner->AggroPvPGuards();
+        }
+        else
+        {
+            if (!playerOwner->isPvpFlagSet())
+                playerOwner->PvPToggle();
+
+            if (!friendlyAction)
+                playerOwner->AggroPvPGuards();
+        }
+    }
+}
+
+void CombatHandler::_updatePvpCombat(uint32_t msTime)
+{
+    if (!isInCombat())
+        return;
+
+    std::lock_guard<std::mutex> guard(m_mutexPlayerCombat);
+    for (auto itr = m_combatPlayerTargets.cbegin(); itr != m_combatPlayerTargets.cend();)
+    {
+        const auto combatDiff = msTime - itr->second;
+        if (combatDiff >= PVP_COMBAT_LEAVE_MIN_TIME)
+        {
+            // Last hostile action with this target was over 4.5 seconds ago
+            itr = m_combatPlayerTargets.erase(itr);
+        }
+        else
+        {
+            ++itr;
+        }
+    }
+}
+
+void CombatHandler::_resetPvpCombatTimer(uint32_t msTime, Unit* victim)
+{
+    // No need to check if unit is also creature
+    if (!victim->isPlayer() && victim->getPlayerOwner() == nullptr)
+        return;
+
+    std::lock_guard<std::mutex> guard(m_mutexPlayerCombat);
+    auto itr = m_combatPlayerTargets.find(victim->getGuid());
+    if (itr != m_combatPlayerTargets.end())
+    {
+        itr->second = msTime;
+        return;
+    }
+
+    m_combatPlayerTargets.insert(std::make_pair(victim->getGuid(), msTime));
+}

--- a/src/world/Objects/Units/CombatHandler.hpp
+++ b/src/world/Objects/Units/CombatHandler.hpp
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "CommonTypes.hpp"
+
+#include <map>
+#include <mutex>
+#include <utility>
+
+class Unit;
+class Player;
+
+class SERVER_DECL CombatHandler
+{
+public:
+    CombatHandler(Unit* owner);
+    ~CombatHandler() = default;
+
+    // Damage dealt, applied aura or casted spell on hostile target
+    void onHostileAction(Unit* victim, bool skipInitialDelay = false);
+    // Healed, applied aura or casted spell on friendly target
+    void onFriendlyAction(Unit* target, bool skipInitialDelay = false);
+    // Damage taken, healed, applied aura or casted spell by attacker or healer
+    void takeCombatAction(Unit* initiater, bool friendlyCombat = false, bool skipInitialDelay = false);
+
+    void clearCombat();
+
+    // If removed from world, clear this unit from nearby units combat map to avoid crashes
+    void onRemoveFromWorld();
+    void onUnitRemovedFromWorld(uint64_t guid);
+
+    bool isInCombat() const;
+    bool isInCombatWithPlayer(Player const* player) const;
+    // Needed to check in special pvp case
+    bool isInPreCombatWithUnit(Unit const* unit) const;
+    void updateCombat(uint32_t msTime);
+
+    Unit* getOwner() const;
+
+private:
+    struct BatchTargetInfo
+    {
+        BatchTargetInfo(Unit* unit, bool isFriendly) : unit(unit), isFriendly(isFriendly) {}
+
+        Unit* unit = nullptr;
+        bool isFriendly = false;
+    };
+
+    // <Guid, BatchTargetInfo>
+    typedef std::map<uint64_t, BatchTargetInfo> BatchTargetMap;
+    // <Guid, last hostile action>
+    typedef std::map<uint64_t, uint32_t> PlayerCombatMap;
+    // <Guid, time since combat was inititated>
+    typedef std::map<uint64_t, uint32_t> CombatInitiatedMap;
+
+    void _enterCombat(bool initiatingCombat, Unit* enteringCombatWith, bool friendlyTarget);
+    void _leaveCombat();
+
+    void _combatAction(Unit* target, uint32_t msTime, bool friendlyAction, bool initiatingCombat);
+
+    // Only pure creatures are handled with these to avoid leave combat before threat is applied
+    void _initiateCombatWith(Unit* enteringCombatWith);
+    void _notifyOnCombatInitiated(Unit* initiatedCombatWith);
+
+    void _notifyOwner(bool friendlyAction, Unit* enteringCombatWith, bool initiatingCombat);
+    void _checkPvpFlags(Unit* target, bool friendlyAction);
+    void _updatePvpCombat(uint32_t msTime);
+    void _resetPvpCombatTimer(uint32_t msTime, Unit* victim);
+
+    uint32_t m_lastCombatUpdateTime = 0;
+    uint32_t m_lastPvPCombatUpdateTime = 0;
+    bool m_inCombat = false;
+
+    // Unit is attacking these targets
+    BatchTargetMap m_combatBatchAttackingTargets;
+    // Unit is being attacked by these targets
+    BatchTargetMap m_combatBatchAttackedByTargets;
+    // Contains players and player owned creatures
+    PlayerCombatMap m_combatPlayerTargets;
+    // Containts all creature targets owner has initiated combat with
+    // Target will be cleared from map when target has got in combat with owner
+    CombatInitiatedMap m_combatInitiatedWith;
+
+    Unit* m_owner = nullptr;
+
+    mutable std::mutex m_mutexCombat;
+    mutable std::mutex m_mutexPlayerCombat;
+};

--- a/src/world/Objects/Units/Creatures/AIInterface.h
+++ b/src/world/Objects/Units/Creatures/AIInterface.h
@@ -696,5 +696,6 @@ protected:
     bool m_cannotReachTarget;
     SmallTimeTracker m_noTargetTimer;
     SmallTimeTracker m_cannotReachTimer;
-    SmallTimeTracker m_updateTargetsTimer;
+    SmallTimeTracker m_updateTargetTimer;
+    SmallTimeTracker m_updateCreatureTargetTimer;
 };

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -1197,7 +1197,7 @@ void Creature::RegenerateHealth()
     {
         amt = getMaxHealth() * 0.10f;
     }
-    else if (!m_combatStatusHandler.IsInCombat())
+    else if (!getCombatHandler().isInCombat())
     {
         // 25% of max health per tick
         amt = getMaxHealth() * 0.25f;
@@ -2243,9 +2243,6 @@ void Creature::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
     smsg_AttackStop(this);
     setHealth(0);
 
-    // Wipe our attacker set on death
-    m_combatStatusHandler.Vanished();
-
     RemoveAllNonPersistentAuras();
 
     CALL_SCRIPT_EVENT(pAttacker, _internalOnTargetDied)(this);
@@ -2259,6 +2256,8 @@ void Creature::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
     // Clear Threat
     getThreatManager().clearAllThreat();
     getThreatManager().removeMeFromThreatLists();
+
+    getCombatHandler().clearCombat();
 
     // Add Kills if Player is in Vehicle
     if (pAttacker->isVehicle())

--- a/src/world/Objects/Units/Creatures/Pet.cpp
+++ b/src/world/Objects/Units/Creatures/Pet.cpp
@@ -605,7 +605,7 @@ void Pet::Update(unsigned long time_passed)
         if (m_HappinessTimer == 0)
         {
             int32 burn = 1042;          //Based on WoWWiki pet looses 50 happiness over 6 min => 1042 every 7.5 s
-            if (m_combatStatusHandler.IsInCombat())
+            if (getCombatHandler().isInCombat())
                 burn >>= 1;             //in combat reduce burn by half (guessed)
 
             modPower(POWER_TYPE_HAPPINESS, -burn);
@@ -2191,9 +2191,6 @@ void Pet::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
     smsg_AttackStop(this);
     setHealth(0);
 
-    // Wipe our attacker set on death
-    m_combatStatusHandler.Vanished();
-
     CALL_SCRIPT_EVENT(pAttacker, OnTargetDied)(this);
     pAttacker->getAIInterface()->eventOnTargetDied(this);
     pAttacker->smsg_AttackStop(this);
@@ -2201,6 +2198,8 @@ void Pet::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
     // Clear Threat
     getThreatManager().clearAllThreat();
     getThreatManager().removeMeFromThreatLists();
+
+    getCombatHandler().clearCombat();
 
     {
         //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/world/Objects/Units/Players/Player.Legacy.cpp
+++ b/src/world/Objects/Units/Players/Player.Legacy.cpp
@@ -6090,7 +6090,7 @@ void Player::EndDuel(uint8 WinCondition)
     std::list<Pet*> summons = GetSummons();
     for (std::list<Pet*>::iterator itr = summons.begin(); itr != summons.end(); ++itr)
     {
-        (*itr)->m_combatStatusHandler.Vanished();
+        (*itr)->getCombatHandler().clearCombat();
         (*itr)->getAIInterface()->setPetOwner(this);
         (*itr)->getAIInterface()->handleEvent(EVENT_FOLLOWOWNER, *itr, 0);
         (*itr)->getThreatManager().clearAllThreat();
@@ -6100,7 +6100,7 @@ void Player::EndDuel(uint8 WinCondition)
     std::list<Pet*> duelingWithSummons = DuelingWith->GetSummons();
     for (std::list<Pet*>::iterator itr = duelingWithSummons.begin(); itr != duelingWithSummons.end(); ++itr)
     {
-        (*itr)->m_combatStatusHandler.Vanished();
+        (*itr)->getCombatHandler().clearCombat();
         (*itr)->getAIInterface()->setPetOwner(this);
         (*itr)->getAIInterface()->handleEvent(EVENT_FOLLOWOWNER, *itr, 0);
         (*itr)->getThreatManager().clearAllThreat();
@@ -6839,7 +6839,6 @@ void Player::CompleteLoading()
     }
 
     sInstanceMgr.BuildSavedInstancesForPlayer(this);
-    m_combatStatusHandler.UpdateFlag();
 
 #if VERSION_STRING > TBC
     // add glyphs
@@ -7706,7 +7705,7 @@ void Player::RemoveShapeShiftSpell(uint32 id)
 // COOLDOWNS
 void Player::UpdatePotionCooldown()
 {
-    if (m_lastPotionId == 0 || m_combatStatusHandler.IsInCombat())
+    if (m_lastPotionId == 0 || getCombatHandler().isInCombat())
         return;
 
     if (ItemProperties const* proto = sMySQLStore.getItemProperties(m_lastPotionId))
@@ -8536,12 +8535,11 @@ void Player::Die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
         setMountDisplayId(0);
     }
 
-    // Wipe our attacker set on death
-    m_combatStatusHandler.Vanished();
-
     CALL_SCRIPT_EVENT(pAttacker, OnTargetDied)(this);
     pAttacker->getAIInterface()->eventOnTargetDied(this);
     pAttacker->smsg_AttackStop(this);
+
+    getCombatHandler().clearCombat();
 
     m_underwaterTime = 0;
     m_underwaterState = 0;

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -1566,7 +1566,7 @@ void Player::setInitialPlayerData()
 void Player::regeneratePlayerPowers(uint16_t diff)
 {
     // Rage and Runic Power (neither decays while in combat)
-    if ((isClassDeathKnight() || isClassDruid() || isClassWarrior()) && !m_combatStatusHandler.IsInCombat())
+    if ((isClassDeathKnight() || isClassDruid() || isClassWarrior()) && !getCombatHandler().isInCombat())
     {
         m_rageRunicPowerRegenerateTimer += diff;
         if (m_rageRunicPowerRegenerateTimer >= REGENERATION_INTERVAL_RAGE_RUNIC_POWER)
@@ -1583,7 +1583,7 @@ void Player::regeneratePlayerPowers(uint16_t diff)
 
 #if VERSION_STRING >= Cata
     // Holy Power (does not decay while in combat)
-    if (isClassPaladin() && !m_combatStatusHandler.IsInCombat())
+    if (isClassPaladin() && !getCombatHandler().isInCombat())
     {
         m_holyPowerRegenerateTimer += diff;
         if (m_holyPowerRegenerateTimer >= REGENERATION_INTERVAL_HOLY_POWER)
@@ -4837,7 +4837,7 @@ void Player::setPvpFlag()
     for (auto& summon : GetSummons())
         summon->setPvpFlag();
 
-    if (m_combatStatusHandler.IsInCombat())
+    if (getCombatHandler().isInCombat())
         addPlayerFlags(PLAYER_FLAG_PVP_GUARD_ATTACKABLE);
 }
 

--- a/src/world/Objects/Units/ThreatHandler.cpp
+++ b/src/world/Objects/Units/ThreatHandler.cpp
@@ -407,7 +407,7 @@ void ThreatManager::removeMeFromThreatLists()
     }
 }
 
-/*static*/ float ThreatManager::calculateModifiedThreat(float threat, Unit* victim, SpellInfo const* spell)
+/*static*/ float ThreatManager::calculateModifiedThreat(Unit* owner, float threat, Unit* victim, SpellInfo const* spell, Spell* castingSpell/* = nullptr*/)
 {
     // modifiers by spell
     if (spell)
@@ -416,6 +416,9 @@ void ThreatManager::removeMeFromThreatLists()
             if (spell->custom_ThreatForSpellCoef != 1.0f)
                 threat *= spell->custom_ThreatForSpellCoef;
     }
+
+    if (castingSpell != nullptr)
+        owner->applySpellModifiers(SPELLMOD_THREAT_REDUCED, &threat, castingSpell->getSpellInfo(), castingSpell);
 
     // modifiers by effect school
     ThreatManager const& victimMgr = victim->getThreatManager();
@@ -497,7 +500,7 @@ void ThreatManager::evaluateSuppressed(bool canExpire)
     }
 }
 
-void ThreatManager::addThreat(Unit* target, float amount, SpellInfo const* spell, bool ignoreModifiers, bool ignoreRedirects)
+void ThreatManager::addThreat(Unit* target, float amount, SpellInfo const* spell, bool ignoreModifiers, bool ignoreRedirects, Spell* castingSpell/* = nullptr*/)
 {
     // Can we even have a Threat List if not return
     if (!canHaveThreatList())
@@ -526,7 +529,7 @@ void ThreatManager::addThreat(Unit* target, float amount, SpellInfo const* spell
 
     // apply threat modifiers to the amount
     if (!ignoreModifiers)
-        amount = calculateModifiedThreat(amount, target, spell);
+        amount = calculateModifiedThreat(getOwner(), amount, target, spell, castingSpell);
 
     // if we're increasing threat, send some/all of it to redirection targets instead if applicable
     if (!ignoreRedirects && amount > 0.0f)

--- a/src/world/Objects/Units/ThreatHandler.h
+++ b/src/world/Objects/Units/ThreatHandler.h
@@ -47,6 +47,7 @@ public:
     bool isThreatenedBy(uint64_t const& who, bool includeOffline = false) const;
     // is there a threat list entry on owner's threat list with victim == who?
     bool isThreatenedBy(Unit const* who, bool includeOffline = false) const;
+    inline auto const& getThreatenedByMeList() const { return _threatenedByMe; }
 
     // returns ThreatReference amount if a ref exists, 0.0f otherwise
     float getThreat(Unit const* who, bool includeOffline = false) const;
@@ -57,7 +58,7 @@ public:
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Affect my threat list
-    void addThreat(Unit* target, float amount, SpellInfo const* spell = nullptr, bool ignoreModifiers = false, bool ignoreRedirects = false);
+    void addThreat(Unit* target, float amount, SpellInfo const* spell = nullptr, bool ignoreModifiers = false, bool ignoreRedirects = false, Spell* castingSpell = nullptr);
 
     void scaleThreat(Unit* target, float factor);
 
@@ -109,7 +110,7 @@ private:
     bool _ownerCanHaveThreatList;
 
     static bool compareReferencesLT(ThreatReference const* a, ThreatReference const* b, float aWeight);
-    static float calculateModifiedThreat(float threat, Unit* victim, SpellInfo const* spell);
+    static float calculateModifiedThreat(Unit* owner, float threat, Unit* victim, SpellInfo const* spell, Spell* castingSpell = nullptr);
 
     // Attacking me
     void putThreatListRef(uint64_t const& guid, ThreatReference* ref);

--- a/src/world/Objects/Units/Unit.Legacy.cpp
+++ b/src/world/Objects/Units/Unit.Legacy.cpp
@@ -578,10 +578,14 @@ void Unit::Update(unsigned long time_passed)
         }
 #endif
 
-        if (m_aiInterface != NULL)
+        if (m_aiInterface != NULL && m_useAI)
         {
-            if (m_useAI)
-                m_aiInterface->Update(time_passed);
+            diff = msTime - m_lastAiInterfaceUpdateTime;
+            if (diff >= 100)
+            {
+                m_aiInterface->Update(diff);
+                m_lastAiInterfaceUpdateTime = msTime;
+            }
         }
         getThreatManager().update(time_passed);
         getCombatHandler().updateCombat(msTime);

--- a/src/world/Objects/Units/Unit.h
+++ b/src/world/Objects/Units/Unit.h
@@ -320,7 +320,7 @@ public:
     bool hasUnitFlags(uint32_t unitFlags) const;
 
     // helper
-    bool isInCombat() const { return hasUnitFlags(UNIT_FLAG_COMBAT); }
+    bool isInCombat() const { return getCombatHandler().isInCombat(); }
     virtual bool canSwim();
 
 #if VERSION_STRING > Classic
@@ -693,6 +693,7 @@ public:
 protected:
     AIInterface* m_aiInterface;
     bool m_useAI = false;
+    uint32_t m_lastAiInterfaceUpdateTime = 0;
 
 public:
     AIInterface* getAIInterface() const { return m_aiInterface; }

--- a/src/world/Objects/Units/Unit.h
+++ b/src/world/Objects/Units/Unit.h
@@ -5,10 +5,11 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
-#include "Objects/Object.h"
-#include "UnitDefines.hpp"
+#include "CombatHandler.hpp"
 #include "Management/LootMgr.h"
 #include "Macros/UnitMacros.hpp"
+#include "Movement/AbstractFollower.h"
+#include "Objects/Object.h"
 #include "Objects/Units/Creatures/Summons/SummonHandler.h"
 #include "Spell/Definitions/AuraEffects.hpp"
 #include "Spell/Definitions/AuraStates.hpp"
@@ -21,7 +22,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Spell/SpellProc.hpp"
 #include "Storage/MySQLStructures.h"
 #include "ThreatHandler.h"
-#include "Movement/AbstractFollower.h"
+#include "UnitDefines.hpp"
 #include <optional>
 
 struct DamageSplitTarget;
@@ -160,12 +161,6 @@ struct OnHitSpell
     uint32_t maxdmg;
 };
 
-struct AreaAura
-{
-    uint32_t auraid;
-    Unit* caster;
-};
-
 typedef struct
 {
     SpellInfo const* spell_info;
@@ -179,62 +174,6 @@ struct AuraCheckResponse
 };
 
 typedef std::list<struct ProcTriggerSpellOnSpell> ProcTriggerSpellOnSpellList;
-
-class Unit;
-class SERVER_DECL CombatStatusHandler
-{
-    typedef std::set<uint64_t> AttackerMap;
-    typedef std::set<uint32_t> HealedSet; // Must Be Players!
-
-    HealedSet m_healers;
-    HealedSet m_healed;
-
-    Unit* m_Unit;
-
-    bool m_lastStatus = false;
-
-    AttackerMap m_attackTargets;
-
-    uint64_t m_primaryAttackTarget = 0;
-
-public:
-    CombatStatusHandler(Unit* _unit) : m_Unit(_unit) {}
-
-    AttackerMap m_attackers;
-
-    void AddAttackTarget(const uint64_t& guid);                      // this means we clicked attack, not actually striked yet, so they shouldn't be in combat.
-    void ClearPrimaryAttackTarget();                                // means we deselected the unit, stopped attacking it.
-
-    void OnDamageDealt(Unit* pTarget);                              // this is what puts the other person in combat.
-    void WeHealed(Unit* pHealTarget);                               // called when a player heals another player, regardless of combat state.
-
-    void RemoveAttacker(Unit* pAttacker, const uint64_t& guid);      // this means we stopped attacking them totally. could be because of deaggro, etc.
-    void RemoveAttackTarget(Unit* pTarget);                         // means our DoT expired.
-
-    void UpdateFlag();                                              // detects if we have changed combat state (in/out), and applies the flag.
-    bool IsInCombat() const;                                        // checks if we are in combat or not.
-    void OnRemoveFromWorld();                                       // called when we are removed from world, kills all references to us.
-
-    void Vanished()
-    {
-        ClearAttackers();
-        ClearHealers();
-    }
-
-    const uint64_t& GetPrimaryAttackTarget() { return m_primaryAttackTarget; }
-    void SetUnit(Unit* p) { m_Unit = p; }
-    void TryToClearAttackTargets();                                 // for pvp timeout
-    void AttackersForgetHate();                                     // used right now for Feign Death so attackers go home
-
-protected:
-    bool InternalIsInCombat();                                      // called by UpdateFlag, do not call from anything else!
-    bool IsAttacking(Unit* pTarget);                                // internal function used to determine if we are still attacking target x.
-    void AddAttacker(const uint64_t& guid);                          // internal function to add an attacker
-    void RemoveHealed(Unit* pHealTarget);                           // usually called only by updateflag
-    void ClearHealers();                                            // this is called on instance change.
-    void ClearAttackers();                                          // means we vanished, or died.
-    void ClearMyHealers();
-};
 
 struct WoWUnit;
 
@@ -605,21 +544,15 @@ public:
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Combat
-private:
-
 public:
-    CombatStatusHandler m_combatStatusHandler;
-
     int32_t m_CombatResult_Dodge = 0;
     int32_t m_CombatResult_Parry = 0;
-    uint32_t m_CombatUpdateTimer = 0;
 
-    const CombatStatusHandler* getCombatHandler() const { return &m_combatStatusHandler; }
+    CombatHandler& getCombatHandler();
+    CombatHandler const& getCombatHandler() const;
 
-    void combatUpdatePvPTimeout();
-    void combatResetPvPTimeout();
-
-    void eventUpdateCombatFlag();
+private:
+    CombatHandler m_combatHandler;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // MovementInfo (from class Object)
@@ -1023,6 +956,7 @@ public:
     void emoteExpire();
     uint32_t getOldEmote() const;
 
+    // Note; calling this method will not cause combat or any threat to victim
     void dealDamage(Unit* victim, uint32_t damage, uint32_t spellId, bool removeAuras = true);
     void takeDamage(Unit* attacker, uint32_t damage, uint32_t spellId);
     // Quick method to create a simple damaging health batch event
@@ -1488,8 +1422,6 @@ public:
         int32 amt = 0;
         int32 max = 0;
     } m_soulSiphon;
-
-    uint32 m_cTimer = 0;
 
     void DispelAll(bool positive);
 

--- a/src/world/Objects/Units/UnitDefines.hpp
+++ b/src/world/Objects/Units/UnitDefines.hpp
@@ -80,6 +80,13 @@ enum HealthAndPowerIntervals : uint16_t
     CREATURE_REGENERATION_INTERVAL_MANA_ENERGY  = 2000
 };
 
+enum UnitBatchTimers : uint16_t
+{
+    COMBAT_BATCH_INTERVAL                       = 500,  // Combat batch timer
+    PVP_COMBAT_TIMER_PULSE                      = 2000, // How often pvp combat is updated
+    PVP_COMBAT_LEAVE_MIN_TIME                   = 4500, // Minimum timer player can leave pvp combat
+};
+
 enum PowerFieldIndexes : uint8_t
 {
     POWER_FIELD_INDEX_1 = 1,

--- a/src/world/Server/EventMgr.h
+++ b/src/world/Server/EventMgr.h
@@ -141,7 +141,6 @@ enum EventTypes : uint16_t
     EVENT_AURA_REGEN,
     EVENT_AURA_PERIODIC_REGEN,
     EVENT_AURA_PERIODIC_HEALPERC,
-    EVENT_ATTACK_TIMEOUT,                       /// Zack 2007 05 05: if no action is taken then combat should be exited after 5 seconds.
     EVENT_SUMMON_EXPIRE,                        /// Zack 2007 05 28: similar to pet expire but we can have multiple guardians
     EVENT_MUTE_PLAYER,                          /// Zack 2007 06 05: player gains his voice back
     EVENT_PLAYER_FORCED_RESURRECT,              /// Zack 2007 06 08: After player not pushing release spirit for 6 minutes while dead
@@ -197,7 +196,6 @@ enum EventTypes : uint16_t
     EVENT_EOTS_CHECK_CAPTURE_POINT_STATUS,
     EVENT_EOTS_RESET_FLAG,
     EVENT_PLAYER_RESET_HEARTBEAT,
-    EVENT_COMBAT_TIMER,
     EVENT_CREATURE_AISPELL_UNUSED,
     EVENT_UNIT_DELAYED_SPELL_CANCEL,
     EVENT_AURA_PERIODIC_ENERGIZE_VARIABLE,      /// Aspect of the Viper

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -179,7 +179,7 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
     }
 
     // Combat check
-    if (_player->m_combatStatusHandler.IsInCombat())
+    if (_player->getCombatHandler().isInCombat())
     {
         for (uint8_t i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
         {
@@ -1021,7 +1021,7 @@ void WorldSession::handleSwapInvItemOpcode(WorldPacket& recvPacket)
     // We're doing an equip swap.
     if (srlPacket.srcSlot < EQUIPMENT_SLOT_END || srlPacket.destSlot < EQUIPMENT_SLOT_END)
     {
-        if (_player->m_combatStatusHandler.IsInCombat())
+        if (_player->getCombatHandler().isInCombat())
         {
             // These can't be swapped
             if (srlPacket.srcSlot < EQUIPMENT_SLOT_MAINHAND || srlPacket.destSlot < EQUIPMENT_SLOT_MAINHAND)

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -213,12 +213,6 @@ void WorldSession::handleSetSelectionOpcode(WorldPacket& recvPacket)
 
     if (_player->m_comboPoints)
         _player->updateComboPoints();
-
-    if (srlPacket.guid == 0)
-    {
-        if (_player->IsInWorld())
-            _player->combatResetPvPTimeout();
-    }
 }
 
 void WorldSession::handleTogglePVPOpcode(WorldPacket& /*recvPacket*/)
@@ -274,7 +268,7 @@ void WorldSession::handleLogoutRequestOpcode(WorldPacket& /*recvPacket*/)
 
     if (GetPermissionCount() == 0)
     {
-        if (_player->m_combatStatusHandler.IsInCombat() || _player->DuelingWith != nullptr)
+        if (_player->getCombatHandler().isInCombat() || _player->DuelingWith != nullptr)
         {
             SendPacket(SmsgLogoutResponse(true).serialise().get());
             return;
@@ -1040,7 +1034,7 @@ void WorldSession::handleSummonResponseOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    if (_player->m_combatStatusHandler.IsInCombat())
+    if (_player->getCombatHandler().isInCombat())
         return;
 
     _player->SafeTeleport(_player->m_summonMapId, _player->m_summonInstanceId, _player->m_summonPos);

--- a/src/world/Server/Packets/Handlers/PetHandler.cpp
+++ b/src/world/Server/Packets/Handlers/PetHandler.cpp
@@ -105,12 +105,12 @@ void WorldSession::handlePetAction(WorldPacket& recvPacket)
                             summonedPet->SendActionFeedback(PET_FEEDBACK_CANT_ATTACK_TARGET);
                             return;
                         }
-                        summonedPet->getThreatManager().clearAllThreat();
-                        summonedPet->getThreatManager().removeMeFromThreatLists();
 
                         summonedPet->getAIInterface()->setPetOwner(_player);
 
+                        summonedPet->getMovementManager()->remove(FOLLOW_MOTION_TYPE);
                         summonedPet->getAIInterface()->onHostileAction(unitTarget, nullptr, true);
+                        summonedPet->getAIInterface()->updateVictim(unitTarget);
                     }
                     break;
                     case PET_ACTION_FOLLOW:
@@ -118,17 +118,13 @@ void WorldSession::handlePetAction(WorldPacket& recvPacket)
                         if (summonedPet->hasUnitStateFlag(UNIT_STATE_CHASING))
                             summonedPet->getMovementManager()->remove(CHASE_MOTION_TYPE);
 
-                        summonedPet->getThreatManager().clearAllThreat();
-                        summonedPet->getThreatManager().removeMeFromThreatLists();
-
                         summonedPet->getAIInterface()->setPetOwner(_player);
+                        summonedPet->getAIInterface()->setCurrentTarget(nullptr);
                         summonedPet->getAIInterface()->handleEvent(EVENT_FOLLOWOWNER, summonedPet, 0);
                     }
                     break;
                     case PET_ACTION_STAY:
                     {
-                        summonedPet->getThreatManager().clearAllThreat();
-                        summonedPet->getThreatManager().removeMeFromThreatLists();
                         summonedPet->getMovementManager()->remove(FOLLOW_MOTION_TYPE);
                     }
                     break;

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -549,7 +549,7 @@ void CreatureAIScript::setCanEnterCombat(bool enterCombat)
 
 bool CreatureAIScript::_isInCombat()
 {
-    return _creature->m_combatStatusHandler.IsInCombat();
+    return _creature->getCombatHandler().isInCombat();
 }
 
 void CreatureAIScript::_delayNextAttack(uint32_t milliseconds)
@@ -1355,7 +1355,7 @@ bool CreatureAIScript::isValidUnitTarget(Object* pObject, TargetFilter pFilter, 
         // hostile/friendly
         if ((~pFilter & TargetFilter_Corpse) && (pFilter & TargetFilter_Friendly))
         {
-            if (!UnitTarget->m_combatStatusHandler.IsInCombat())
+            if (!UnitTarget->getCombatHandler().isInCombat())
                 return false; // not-in-combat targets if friendly
 
             if (isHostile(getCreature(), UnitTarget) || getCreature()->getThreatManager().getThreat(UnitTarget) > 0)

--- a/src/world/Spell/Spell.Legacy.h
+++ b/src/world/Spell/Spell.Legacy.h
@@ -68,7 +68,7 @@ class SERVER_DECL Spell
         void handleHittedEffect(const uint64_t targetGuid, uint8_t effIndex, int32_t effDamage, bool reCheckTarget = false);
         // Handles missed targets and effects
         void handleMissedTarget(SpellTargetMod const missedTarget);
-        void handleMissedEffect(const uint64_t targetGuid);
+        void handleMissedEffect(SpellTargetMod const missedTarget, bool reCheckTarget = false);
         // Finishes the casted spell
         void finish(bool successful = true);
 
@@ -229,6 +229,12 @@ class SERVER_DECL Spell
             Aura* aur = nullptr;
         };
 
+        struct MissSpellEffect
+        {
+            uint32_t travelTime = 0;
+            SpellTargetMod missInfo = SpellTargetMod(0, SPELL_DID_HIT_SUCCESS, SPELL_DID_HIT_SUCCESS);
+        };
+
         bool canAttackCreatureType(Creature* target) const;
 
         // Removes used item and/or item charges
@@ -266,8 +272,7 @@ class SERVER_DECL Spell
 
         std::map<uint64_t, HitAuraEffect> m_pendingAuras;
         std::map<uint64_t, HitSpellEffect> m_hitEffects;
-        // <targetGuid, travelTime>
-        std::map<uint64_t, uint32_t> m_missEffects;
+        std::map<uint64_t, MissSpellEffect> m_missEffects;
         std::vector<uint64_t> m_critTargets;
 
         bool isForcedCrit = false;

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -889,9 +889,6 @@ void Aura::SpellAuraModConfuse(AuraEffectModifier* aurEff, bool apply)
             p_target->sendClientControlPacket(m_target, 1);
 
             m_target->setAItoUse(false);
-
-            if (u_caster != nullptr)
-                sHookInterface.OnEnterCombat(p_target, u_caster);
         }
         else
         {
@@ -1024,9 +1021,6 @@ void Aura::SpellAuraModFear(AuraEffectModifier* aurEff, bool apply)
                 p_target->sendClientControlPacket(m_target, 1);
 
                 m_target->setAItoUse(false);
-
-                if (u_caster != nullptr)
-                    sHookInterface.OnEnterCombat(p_target, u_caster);
                 p_target->SpeedCheatReset();
             }
             else
@@ -1490,6 +1484,8 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
                             _unit->getThreatManager().clearThreat(m_target);
 
                     }
+
+                    m_target->getCombatHandler().clearCombat();
 
                     for (uint32 x = MAX_POSITIVE_AURAS_EXTEDED_START; x < MAX_POSITIVE_AURAS_EXTEDED_END; x++)
                     {

--- a/src/world/Spell/SpellAuras.cpp
+++ b/src/world/Spell/SpellAuras.cpp
@@ -179,13 +179,6 @@ void Aura::removeAura(AuraRemoveMode mode/* = AURA_REMOVE_BY_SERVER*/)
     const auto caster = GetUnitCaster();
     if (caster != nullptr)
     {
-        // Remove attacker
-        if (caster != getOwner())
-        {
-            caster->m_combatStatusHandler.RemoveAttackTarget(getOwner());
-            getOwner()->m_combatStatusHandler.RemoveAttacker(caster, caster->getGuid());
-        }
-
         /**********************Cooldown**************************
         * this is only needed for some spells
         * for now only spells that have:
@@ -229,11 +222,6 @@ void Aura::removeAura(AuraRemoveMode mode/* = AURA_REMOVE_BY_SERVER*/)
             if (charm != nullptr && charm->getCreatedBySpellId() == getSpellInfo()->getId())
                 caster->UnPossess();
         }
-    }
-    else
-    {
-        // Remove attacker
-        getOwner()->m_combatStatusHandler.RemoveAttacker(nullptr, m_casterGuid);
     }
 
     // Remove aura from unit before removing modifiers

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -6250,7 +6250,7 @@ void Spell::SpellEffectActivateSpec(uint8_t /*effectIndex*/)
     if (p_caster == nullptr)
         return;
 
-    if (p_caster->m_combatStatusHandler.IsInCombat())
+    if (p_caster->getCombatHandler().isInCombat())
     {
         sendCastResult(SPELL_FAILED_AFFECTING_COMBAT);
         return;


### PR DESCRIPTION
**Description**
**Units: Rewrite combat system**
Combat is now processed in batches. Each time combat update is called the combat handler determines if unit can enter combat or leave combat. 

**MapMgr: Map cells will now wait for 30 seconds before going to idle (splitted into own commit)**
This allows units to reset properly in idle map cell. Let's say you are in dungeon and you pull couple mobs. If you run to instance portal and go through it back to normal world the cell in instance is now idle. If you wait for let's say 1 minute and you'll go back into the dungeon the map cell is reactivated and the mobs are still at the instance portal waiting for you.
Since cell now waits for 30 seconds to before going idle it allows mobs properly reset themselves and return to spawn points. 

This also applies to normal world. If you are fighting a mob anywhere and you teleport to another cell by any means, you are stuck in combat because the mob you were fighting with didn't reset properly. With cell waiting 30 seconds the mob will reset itself and evade properly.


**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


