### PR TITLE
Passive auras with effect 262 must be sent to client

### DIFF
--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -4104,9 +4104,7 @@ void Unit::addAura(Aura* aur)
     }
 
     // Find a visual slot for aura
-    uint8_t visualSlot = 0xFF;
-    if (!aur->IsPassive() || aur->getSpellInfo()->getAttributesEx() & ATTRIBUTESEX_NO_INITIAL_AGGRO)
-        visualSlot = findVisualSlotForAura(!aur->isNegative());
+    const auto visualSlot = findVisualSlotForAura(aur);
 
     aur->m_visualSlot = visualSlot;
     aur->m_auraSlot = auraSlot;
@@ -4209,10 +4207,20 @@ void Unit::addAura(Aura* aur)
 
 }
 
-uint8_t Unit::findVisualSlotForAura(bool isPositive) const
+uint8_t Unit::findVisualSlotForAura(Aura const* aur) const
 {
+    uint8_t visualSlot = 0xFF;
+#if VERSION_STRING < WotLK
+    // Pre wotlk do not send self casted passive area auras
+    if (aur->IsPassive())
+#else
+    // Since wotlk send all passive area auras
+    if (aur->IsPassive() && !aur->IsAreaAura() && !aur->hasAuraEffect(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
+#endif
+        return visualSlot;
+
     uint8_t start, end;
-    if (isPositive)
+    if (!aur->isNegative())
     {
         start = 0;
         end = MAX_POSITIVE_VISUAL_AURAS_END;
@@ -4222,8 +4230,6 @@ uint8_t Unit::findVisualSlotForAura(bool isPositive) const
         start = MAX_NEGATIVE_VISUAL_AURAS_START;
         end = MAX_NEGATIVE_VISUAL_AURAS_END;
     }
-
-    uint8_t visualSlot = 0xFF;
 
     // Find an empty slot
     for (auto i = start; i < end; ++i)
@@ -4590,14 +4596,6 @@ void Unit::setTransformAura(uint32_t auraId)
 void Unit::sendAuraUpdate(Aura* aur, bool remove)
 {
     if (aur->m_visualSlot >= MAX_NEGATIVE_VISUAL_AURAS_END)
-        return;
-
-    // Check if aura is hidden on self cast
-    if (aur->getCasterGuid() == getGuid() && aur->getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_HIDE_AURA_ON_SELF_CAST)
-        return;
-
-    // Check if aura is hidden when not self cast
-    if (aur->getCasterGuid() != getGuid() && aur->getSpellInfo()->getAttributesExE() & ATTRIBUTESEXE_HIDE_AURA_ON_NON_SELF_CAST)
         return;
 
 #if VERSION_STRING < WotLK

--- a/src/world/Objects/Units/Unit.h
+++ b/src/world/Objects/Units/Unit.h
@@ -785,7 +785,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Aura
     void addAura(Aura* aur);
-    uint8_t findVisualSlotForAura(bool isPositive) const;
+    uint8_t findVisualSlotForAura(Aura const* aur) const;
 
     Aura* getAuraWithId(uint32_t spell_id);
     Aura* getAuraWithId(uint32_t* auraId);

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -6114,7 +6114,7 @@ bool Aura::IsCombatStateAffecting()
     return false;
 }
 
-bool Aura::IsAreaAura()
+bool Aura::IsAreaAura() const
 {
     auto sp = m_spellInfo;
 

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -495,7 +495,7 @@ class SERVER_DECL Aura : public EventableObject
         Aura(SpellInfo const* proto, int32 duration, Object* caster, Unit* target, bool temporary = false, Item* i_caster = NULL);
         ~Aura();
 
-        inline bool IsPassive() { if (!m_spellInfo) return false; return (m_spellInfo->isPassive() && !m_areaAura); }
+        inline bool IsPassive() const { if (!m_spellInfo) return false; return (m_spellInfo->isPassive() && !m_areaAura); }
 
         inline uint16 GetAuraSlot() const { return m_auraSlot; }
         void SetAuraSlot(uint16 slot) { m_auraSlot = slot; }
@@ -526,7 +526,7 @@ class SERVER_DECL Aura : public EventableObject
         /// Tells if the Aura is an area Aura.
         /// \param none    \return true if it is false otherwise.
         //////////////////////////////////////////////////////////////////////////////////////////
-        bool IsAreaAura();
+        bool IsAreaAura() const;
 
         //////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/world/Spell/SpellDefines.hpp
+++ b/src/world/Spell/SpellDefines.hpp
@@ -40,7 +40,7 @@ enum SpellAttributes
     ATTRIBUTES_ABILITY                              = 0x00000010,
     ATTRIBUTES_TRADESPELL                           = 0x00000020,   // Tradeskill recipies
     ATTRIBUTES_PASSIVE                              = 0x00000040,
-    ATTRIBUTES_NO_VISUAL_AURA                       = 0x00000080,   // not visible in spellbook or aura bar
+    ATTRIBUTES_NO_VISUAL_AURA                       = 0x00000080,   // Not visible in spellbook or aura bar. Client handles this by itself.
     ATTRIBUTES_NO_CAST                              = 0x00000100,   //seems to be afflicts pet
     ATTRIBUTES_TARGET_MAINHAND                      = 0x00000200,   // automatically select item from mainhand
     ATTRIBUTES_ON_NEXT_SWING_2                      = 0x00000400,   //completely the same as ATTRIBUTE_ON_NEXT_ATTACK for class spells. So difference somewhere in mob abilities.
@@ -245,8 +245,8 @@ enum SpellAttributesExE
     ATTRIBUTESEXE_UNK26                             = 0x01000000,
     ATTRIBUTESEXE_UNK27                             = 0x02000000,
     ATTRIBUTESEXE_SKIP_LINE_OF_SIGHT_CHECK          = 0x04000000,   // Used for spells which explode around target
-    ATTRIBUTESEXE_HIDE_AURA_ON_SELF_CAST            = 0x08000000,
-    ATTRIBUTESEXE_HIDE_AURA_ON_NON_SELF_CAST        = 0x10000000,
+    ATTRIBUTESEXE_HIDE_AURA_ON_SELF_CAST            = 0x08000000,   // Client handles this by itself
+    ATTRIBUTESEXE_HIDE_AURA_ON_NON_SELF_CAST        = 0x10000000,   // Client handles this by itself
     ATTRIBUTESEXE_UNK31                             = 0x20000000,
     ATTRIBUTESEXE_UNK32                             = 0x40000000,
     ATTRIBUTESEXE_UNK33                             = 0x80000000


### PR DESCRIPTION
**Description**
Auras: Passive auras with effect 262 must be sent to client
This fixes spells like warrior talent Juggernaut which makes Charge useable in combat

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


