### PR TITLE
Correct reapply mechanism on stackable auras

### DIFF
--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -4078,8 +4078,11 @@ void Unit::addAura(Aura* aur)
                     if (aur->getAuraEffect(i)->getAuraEffectType() == SPELL_AURA_NONE)
                         continue;
 
-                    _aura->addAuraEffect(aur->getAuraEffect(i));
+                    _aura->addAuraEffect(aur->getAuraEffect(i), true);
                 }
+
+                // On reapply get duration from new aura
+                _aura->setOriginalDuration(aur->getOriginalDuration());
 
                 // Refresh duration and apply new stack if stackable
                 _aura->refreshOrModifyStack(false, 1);

--- a/src/world/Spell/SpellAuras.cpp
+++ b/src/world/Spell/SpellAuras.cpp
@@ -82,7 +82,7 @@ bool Aura::hasAuraEffect(AuraEffect auraEffect) const
     return false;
 }
 
-void Aura::addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValue, float_t effectPctModifier, bool isStaticDamage, uint8_t effIndex)
+void Aura::addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValue, float_t effectPctModifier, bool isStaticDamage, uint8_t effIndex, bool reapplying/* = false*/)
 {
     if (effIndex >= MAX_SPELL_EFFECTS)
         return;
@@ -94,7 +94,7 @@ void Aura::addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValu
     }
 
     m_auraEffects[effIndex].setAuraEffectType(auraEffect);
-    m_auraEffects[effIndex].setEffectDamage(damage);
+    m_auraEffects[effIndex].setEffectDamage(reapplying ? damage * getStackCount() : damage);
     m_auraEffects[effIndex].setEffectBaseDamage(damage);
     m_auraEffects[effIndex].setEffectMiscValue(miscValue);
     m_auraEffects[effIndex].setEffectPercentModifier(effectPctModifier);
@@ -103,17 +103,20 @@ void Aura::addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValu
     m_auraEffects[effIndex].setAura(this);
     ++m_auraEffectCount;
 
-    // Calculate effect amplitude
-    _calculateEffectAmplitude(effIndex);
+    if (!reapplying)
+    {
+        // Calculate effect amplitude
+        _calculateEffectAmplitude(effIndex);
+    }
 }
 
-void Aura::addAuraEffect(AuraEffectModifier const* auraEffect)
+void Aura::addAuraEffect(AuraEffectModifier const* auraEffect, bool reapplying/* = false*/)
 {
     if (auraEffect == nullptr)
         return;
 
     addAuraEffect(auraEffect->getAuraEffectType(), auraEffect->getEffectBaseDamage(), auraEffect->getEffectMiscValue(),
-        auraEffect->getEffectPercentModifier(), auraEffect->isEffectDamageStatic(), auraEffect->getEffectIndex());
+        auraEffect->getEffectPercentModifier(), auraEffect->isEffectDamageStatic(), auraEffect->getEffectIndex(), reapplying);
 }
 
 void Aura::removeAuraEffect(uint8_t effIndex, bool reapplying/* = false*/)

--- a/src/world/Spell/SpellAuras.h
+++ b/src/world/Spell/SpellAuras.h
@@ -159,8 +159,8 @@ class SERVER_DECL Aura : public EventableObject
         AuraEffectModifier const* getAuraEffect(uint8_t effIndex) const;
         AuraEffectModifier* getModifiableAuraEffect(uint8_t effIndex);
         bool hasAuraEffect(AuraEffect auraEffect) const;
-        void addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValue, float_t effectPctModifier, bool isStaticDamage, uint8_t effIndex);
-        void addAuraEffect(AuraEffectModifier const* auraEffect);
+        void addAuraEffect(AuraEffect auraEffect, int32_t damage, int32_t miscValue, float_t effectPctModifier, bool isStaticDamage, uint8_t effIndex, bool reapplying = false);
+        void addAuraEffect(AuraEffectModifier const* auraEffect, bool reapplying = false);
         void removeAuraEffect(uint8_t effIndex, bool reapplying = false);
         // Returns how many active aura effects the aura has
         uint8_t getAppliedEffectCount() const;


### PR DESCRIPTION
**Description**
Auras: Correct reapply mechanism on stackable auras
Atm there is a bug with stackable auras on aura reapply (which I introduced :P). When old effect is removed it only removed base amount and ignored possible aura stacks.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
***Multiversion Ingame Tests Performed:***
- [] BC
- [] WotLK
- [] Cata
-->


