### PR TITLE
Using the types and functions in <filesystem> does not require linking with -lstdc++fs now.

### DIFF
--- a/cmake/Compilers/gcc.cmake
+++ b/cmake/Compilers/gcc.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
 
-# GCC >= 8.0.0
-set(GCC_SUPPORTS_VERSION 8.0.0)
+# GCC >= 9.0.0
+set(GCC_SUPPORTS_VERSION 9.0.0)
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_SUPPORTS_VERSION)
     message(FATAL_ERROR "AscEmu requires version ${GCC_SUPPORTS_VERSION} to build but found ${CMAKE_CXX_COMPILER_VERSION}")

--- a/src/logonserver/CMakeLists.txt
+++ b/src/logonserver/CMakeLists.txt
@@ -42,8 +42,6 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} c++)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD")
     target_link_libraries(${PROJECT_NAME} c++experimental)
-elseif (NOT WIN32)
-    target_link_libraries(${PROJECT_NAME} stdc++fs)
 endif ()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.h.in ${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.h)

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -84,8 +84,6 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} c++)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD")
     target_link_libraries(${PROJECT_NAME} c++experimental)
-elseif (NOT WIN32)
-    target_link_libraries(${PROJECT_NAME} stdc++fs)
 endif ()
 
 if (USE_PCH)

--- a/src/shared/Common.hpp.in
+++ b/src/shared/Common.hpp.in
@@ -5,7 +5,10 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include <filesystem>
 #include "Common.Legacy.h"
+
+namespace fs = std::filesystem;
 
 #ifdef WIN32
     #define LIBMASK ".dll";
@@ -67,16 +70,3 @@ namespace TimeShiftmask
         Year = 24
     };
 }
-
-//\ brief: C++17 filesystem. It is currently experimental.
-//         On MSVC it is included with <filesystem> (Since VS 2019 16.3.5)
-//         On GCC and Clang you have to include <experimental/filesystem> and set the
-//         compilerflag =stdc++17 and link stdc++fs.
-//         We use the namespace fs to simplify it. On GCC it is v1.
-#if (WIN32 || _WIN64)
-    #include <filesystem>
-    namespace fs = std::filesystem;
-#else
-    #include <experimental/filesystem>
-    namespace fs = std::experimental::filesystem::v1;
-#endif

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -163,8 +163,6 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} c++)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD")
     target_link_libraries(${PROJECT_NAME} c++experimental)
-elseif (NOT WIN32)
-    target_link_libraries(${PROJECT_NAME} stdc++fs)
 endif ()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES ENABLE_EXPORTS TRUE)


### PR DESCRIPTION
Using the types and functions in <filesystem> does not require linking with -lstdc++fs now.

**Description**
<!-- Short description about this PR. NOTE: Never mix style changes, refactorings and new implementations in one PR. Keep it as simple as possible -->

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE. (Test GCC)
- [x] Server startup.
- [x] Log into world.
