### PR TITLE
Refactor building object updates

### DIFF
--- a/sql/world/updates/20220513-00_creature_properties.sql
+++ b/sql/world/updates/20220513-00_creature_properties.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_properties` SET `invisibility_type`='1' WHERE `invisibility_type` > '0';
+ALTER TABLE `creature_properties` CHANGE COLUMN `invisibility_type` `isTriggerNpc` SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0' AFTER `money`;
+
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('105', '20220513-00_creature_properties');

--- a/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
+++ b/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
@@ -579,7 +579,7 @@ void AlteracValley::AVNode::Spawn()
             m_flag = m_bg->SpawnGameObject(g->id[m_state], m_bg->getWorldMap()->getBaseMap()->getMapId(), g->x, g->y, g->z, g->o, 0, 0, 1.0f);
             m_flag->SetFaction(g_gameObjectFactions[m_state]);
             m_flag->setAnimationProgress(100);
-            m_flag->setDynamic(1);
+            m_flag->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
             m_flag->PushToWorld(m_bg->getWorldMap());
         }
         else
@@ -596,7 +596,7 @@ void AlteracValley::AVNode::Spawn()
                 m_flag->setGoType(static_cast<uint8_t>(gameobject_info->type));
                 m_flag->SetFaction(g_gameObjectFactions[m_state]);
                 m_flag->setAnimationProgress(100);
-                m_flag->setDynamic(1);
+                m_flag->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
                 m_flag->PushToWorld(m_bg->getWorldMap());
             }
         }
@@ -842,7 +842,7 @@ void AlteracValley::AVNode::Capture()
             if (m_flag != nullptr)
             {
                 m_flag->setFlags(GO_FLAG_NONSELECTABLE);
-                m_flag->setDynamic(0);
+                m_flag->setDynamicFlags(GO_DYN_FLAG_NONE);
                 m_flag->setState(GO_STATE_CLOSED);
             }
 

--- a/src/scripts/Battlegrounds/ArathiBasin/ArathiBasin.cpp
+++ b/src/scripts/Battlegrounds/ArathiBasin/ArathiBasin.cpp
@@ -203,7 +203,7 @@ void ArathiBasin::SpawnControlPoint(uint32_t Id, uint32_t Type)
         m_controlPoints[Id]->setState(GO_STATE_CLOSED);
         m_controlPoints[Id]->setGoType(static_cast<uint8_t>(gameobject_info->type));
         m_controlPoints[Id]->setAnimationProgress(100);
-        m_controlPoints[Id]->setDynamic(1);
+        m_controlPoints[Id]->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
         m_controlPoints[Id]->setDisplayId(gameobject_info->display_id);
 
         switch (Type)

--- a/src/scripts/Battlegrounds/IsleOfConquest/IsleOfConquest.cpp
+++ b/src/scripts/Battlegrounds/IsleOfConquest/IsleOfConquest.cpp
@@ -520,7 +520,7 @@ void IsleOfConquest::SpawnControlPoint(uint32_t Id, uint32_t Type)
         controlpoint[Id].banner->setState(GO_STATE_CLOSED);
         controlpoint[Id].banner->setGoType(static_cast<uint8_t>(gameobject_info->type));
         controlpoint[Id].banner->setAnimationProgress(100);
-        controlpoint[Id].banner->setDynamic(1);
+        controlpoint[Id].banner->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
         controlpoint[Id].banner->setDisplayId(gameobject_info->display_id);
 
         switch (Type)

--- a/src/scripts/Battlegrounds/WarsongGulch/WarsongGulch.cpp
+++ b/src/scripts/Battlegrounds/WarsongGulch/WarsongGulch.cpp
@@ -75,7 +75,7 @@ WarsongGulch::WarsongGulch(BattlegroundMap* mgr, uint32_t id, uint32_t lgroup, u
 
     for (uint8_t i = 0; i < 2; ++i)
     {
-        m_dropFlags[i]->setDynamic(1);
+        m_dropFlags[i]->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
         m_dropFlags[i]->setScale(2.5f);
     }
 

--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -1354,6 +1354,7 @@ public:
 
                 questLog->finishAndRemove();
                 plr->addQuestToFinished(quest_id);
+                plr->updateNearbyQuestGameObjects();
                 lua_pushnumber(L, 1);
                 return 1;
             }

--- a/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/QIspells.cpp
@@ -1468,7 +1468,7 @@ bool ToLegionHold(uint8_t /*effectIndex*/, Aura* pAura, bool apply)
         if (pGameObject != nullptr)
         {
             pGameObject->Despawn(60000, 0);
-            pPlayer->UpdateNearbyGameObjects();
+            pPlayer->updateNearbyQuestGameObjects();
         }
     }
     else
@@ -2263,7 +2263,7 @@ bool WarIsHell(uint8_t /*effectIndex*/, Spell* pSpell)
         obj->Despawn(1 * 60 * 1000, 0);
 
     target->Despawn(2000, 60 * 1000);
-    plr->UpdateNearbyGameObjects();
+    plr->updateNearbyQuestGameObjects();
 
     return true;
 }
@@ -2582,7 +2582,7 @@ bool StoppingTheSpread(uint8_t /*effectIndex*/, Spell* pSpell)
         }
 
         target->Despawn(2000, 60 * 1000);
-        plr->UpdateNearbyGameObjects();
+        plr->updateNearbyQuestGameObjects();
         questLog->updatePlayerFields();
     }
 
@@ -2651,7 +2651,7 @@ bool TheFleshLies(uint8_t /*effectIndex*/, Spell* pSpell)
                 obj->Despawn(1 * 30 * 1000, 0);
         }
         target->Despawn(2000, 60 * 1000);
-        plr->UpdateNearbyGameObjects();
+        plr->updateNearbyQuestGameObjects();
     }
 
     return true;
@@ -2854,7 +2854,7 @@ bool ShatariTorch(uint8_t /*effectIndex*/, Spell* pSpell)
 
     target->Despawn(0, 1 * 60 * 1000);
 
-    plr->UpdateNearbyGameObjects();
+    plr->updateNearbyQuestGameObjects();
 
     return true;
 }

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -59,7 +59,7 @@ bool ChatHandler::HandleMoveHardcodedScriptsToDBCommand(const char* args, WorldS
         }
 
         auto creature_spawn = new MySQLStructure::CreatureSpawn;
-        uint8 gender = creature_properties->GetGenderAndCreateRandomDisplayID(&creature_spawn->displayid);
+        uint8 gender = creature_properties->generateRandomDisplayIdAndReturnGender(&creature_spawn->displayid);
         creature_spawn->entry = entry;
         creature_spawn->id = sObjectMgr.GenerateCreatureSpawnID();
         creature_spawn->movetype = 0;

--- a/src/world/Chat/Commands/GameObjectCommands.cpp
+++ b/src/world/Chat/Commands/GameObjectCommands.cpp
@@ -121,13 +121,13 @@ bool ChatHandler::HandleGOEnableCommand(const char* /*args*/, WorldSession* m_se
     if (gameobject->IsActive())
     {
         // Deactivate
-        gameobject->setDynamic(0);
+        gameobject->setDynamicFlags(GO_DYN_FLAG_NONE);
         BlueSystemMessage(m_session, "Gameobject deactivated.");
     }
     else
     {
         // /Activate
-        gameobject->setDynamic(1);
+        gameobject->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
         BlueSystemMessage(m_session, "Gameobject activated.");
     }
 
@@ -181,7 +181,7 @@ bool ChatHandler::HandleGOInfoCommand(const char* /*args*/, WorldSession* m_sess
     SystemMessage(m_session, "%s Model:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getDisplayId());
     SystemMessage(m_session, "%s State:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getState());
     SystemMessage(m_session, "%s flags:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getFlags());
-    SystemMessage(m_session, "%s dynflags:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getDynamic());
+    SystemMessage(m_session, "%s dynflags:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getDynamicFlags());
     SystemMessage(m_session, "%s faction:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->getFactionTemplate());
     SystemMessage(m_session, "%s phase:%s%u", MSG_COLOR_GREEN, MSG_COLOR_LIGHTBLUE, gameobject->GetPhase());
 

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -730,7 +730,7 @@ bool ChatHandler::HandleNpcSpawnCommand(const char* args, WorldSession* m_sessio
     }
 
     auto creature_spawn = new MySQLStructure::CreatureSpawn;
-    uint8 gender = creature_properties->GetGenderAndCreateRandomDisplayID(&creature_spawn->displayid);
+    uint8 gender = creature_properties->generateRandomDisplayIdAndReturnGender(&creature_spawn->displayid);
     creature_spawn->entry = entry;
     creature_spawn->id = sObjectMgr.GenerateCreatureSpawnID();
     creature_spawn->movetype = 0;

--- a/src/world/Chat/Commands/QuestCommands.cpp
+++ b/src/world/Chat/Commands/QuestCommands.cpp
@@ -68,7 +68,7 @@ std::string RemoveQuestFromPlayer(Player* plr, QuestProperties const* qst)
                         plr->getItemInterface()->RemoveItemAmt(itemId, 1);
                 }
 
-                plr->UpdateNearbyGameObjects();
+                plr->updateNearbyQuestGameObjects();
             }
             else
             {
@@ -206,6 +206,7 @@ bool ChatHandler::HandleQuestStartCommand(const char* args, WorldSession* m_sess
                         }
                     }
 
+                    player->updateNearbyQuestGameObjects();
                     sHookInterface.OnQuestAccept(player, questProperties, nullptr);
 
                     recout += "Quest has been added to the player's quest log.";
@@ -462,6 +463,9 @@ bool ChatHandler::HandleQuestFinishCommand(const char* args, WorldSession* m_ses
                 plr->getAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_QUEST_REWARD_GOLD, qst->reward_money, 0, 0);
 #endif
             }
+
+            plr->updateNearbyQuestGameObjects();
+
 #if VERSION_STRING > TBC
             plr->getAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUESTS_IN_ZONE, qst->zone_id, 0, 0);
             plr->getAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST, qst->id, 0, 0);

--- a/src/world/Data/WoWObject.hpp
+++ b/src/world/Data/WoWObject.hpp
@@ -110,7 +110,15 @@ struct WoWObject
     };
 
     uint32_t entry;
-    uint32_t dynamic_flags;
+    union
+    {
+        struct
+        {
+            uint16_t dynamic_flags;
+            int16_t path_progress;
+        } dynamic_field_parts;
+        uint32_t dynamic_field;
+    };
     float scale_x;
 
     void setLowGuid(uint32_t val)

--- a/src/world/GameClassic/Storage/DBCStructures.h
+++ b/src/world/GameClassic/Storage/DBCStructures.h
@@ -233,7 +233,7 @@ namespace DBC::Structures
 
     struct CreatureDisplayInfoEntry
     {
-        uint32_t display_id;                                        // 0
+        uint32_t ID;                                                // 0
         uint32_t ModelID;                                           // 1
         //uint32_t SoundID                                          // 2
         uint32_t ExtendedDisplayInfoID;                             // 3

--- a/src/world/Management/Group.cpp
+++ b/src/world/Management/Group.cpp
@@ -1395,7 +1395,11 @@ void Group::SendLootUpdates(Object* o)
         Flags |= U_DYN_FLAG_LOOTABLE;
         Flags |= U_DYN_FLAG_TAPPED_BY_PLAYER;
 
+#if VERSION_STRING < Mop
         o->BuildFieldUpdatePacket(&buf, getOffsetForStructuredField(WoWUnit, dynamic_flags), Flags);
+#else
+        o->BuildFieldUpdatePacket(&buf, getOffsetForStructuredField(WoWObject, dynamic_field), Flags);
+#endif
 
         Lock();
 

--- a/src/world/Management/ItemInterface.cpp
+++ b/src/world/Management/ItemInterface.cpp
@@ -644,6 +644,8 @@ Item* ItemInterface::SafeRemoveAndRetreiveItemFromSlot(int8 ContainerSlot, int16
             else if (slot < INVENTORY_SLOT_BAG_END)
                 m_pOwner->applyItemMods(pItem, slot, false);
 
+            sQuestMgr.onPlayerItemRemove(GetOwner(), pItem);
+
             if (destroy)
             {
                 if (pItem->IsInWorld())
@@ -821,6 +823,8 @@ bool ItemInterface::SafeFullRemoveItemFromSlot(int8 ContainerSlot, int16 slot)
             }
 
             pItem->DeleteFromDB();
+
+            sQuestMgr.onPlayerItemRemove(GetOwner(), pItem);
 
             //delete pItem;
             // We make it a garbage item, so when it's used for a spell, it gets deleted in the next Player update
@@ -1199,6 +1203,7 @@ uint32 ItemInterface::RemoveItemAmt(uint32 id, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1238,6 +1243,7 @@ uint32 ItemInterface::RemoveItemAmt(uint32 id, uint32 amt)
                         {
                             item2->setStackCount(item2->getStackCount() - amt);
                             item2->m_isDirty = true;
+                            sQuestMgr.onPlayerItemRemove(GetOwner(), item2);
                             return amt;
                         }
                         else if (item2->getStackCount() == amt)
@@ -1275,6 +1281,7 @@ uint32 ItemInterface::RemoveItemAmt(uint32 id, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1309,6 +1316,7 @@ uint32 ItemInterface::RemoveItemAmt(uint32 id, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1361,6 +1369,7 @@ uint32 ItemInterface::RemoveItemAmt_ProtectPointer(uint32 id, uint32 amt, Item**
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1409,6 +1418,7 @@ uint32 ItemInterface::RemoveItemAmt_ProtectPointer(uint32 id, uint32 amt, Item**
                         {
                             item2->setStackCount(item2->getStackCount() - amt);
                             item2->m_isDirty = true;
+                            sQuestMgr.onPlayerItemRemove(GetOwner(), item2);
                             return amt;
                         }
                         else if (item2->getStackCount() == amt)
@@ -1451,6 +1461,7 @@ uint32 ItemInterface::RemoveItemAmt_ProtectPointer(uint32 id, uint32 amt, Item**
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1491,6 +1502,7 @@ uint32 ItemInterface::RemoveItemAmt_ProtectPointer(uint32 id, uint32 amt, Item**
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1545,6 +1557,7 @@ uint32 ItemInterface::RemoveItemAmtByGuid(uint64 guid, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1585,6 +1598,7 @@ uint32 ItemInterface::RemoveItemAmtByGuid(uint64 guid, uint32 amt)
                         {
                             item2->setStackCount(item2->getStackCount() - amt);
                             item2->m_isDirty = true;
+                            sQuestMgr.onPlayerItemRemove(GetOwner(), item2);
                             return amt;
                         }
                         else if (item2->getStackCount() == amt)
@@ -1622,6 +1636,7 @@ uint32 ItemInterface::RemoveItemAmtByGuid(uint64 guid, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)
@@ -1657,6 +1672,7 @@ uint32 ItemInterface::RemoveItemAmtByGuid(uint64 guid, uint32 amt)
                 {
                     item->setStackCount(item->getStackCount() - amt);
                     item->m_isDirty = true;
+                    sQuestMgr.onPlayerItemRemove(GetOwner(), item);
                     return amt;
                 }
                 else if (item->getStackCount() == amt)

--- a/src/world/Management/ObjectMgr.h
+++ b/src/world/Management/ObjectMgr.h
@@ -191,6 +191,7 @@ typedef std::list<DBC::Structures::AchievementCriteriaEntry const*> AchievementC
 typedef std::unordered_map<std::string, CachedCharacterInfo*> PlayerNameStringIndexMap;
 
 // finally we are here, the base class of this file ;)
+//MIT
 class SERVER_DECL ObjectMgr : public EventableObject
 {
 private:
@@ -198,7 +199,6 @@ private:
     ~ObjectMgr() = default;
 
 public:
-    //MIT
     static ObjectMgr& getInstance();
     void initialize();
     void finalize();
@@ -212,6 +212,10 @@ public:
     void generateDatabaseGossipOptionAndSubMenu(Object* object, Player* player, uint32_t gossipItemId, uint32_t gossipMenuId);
 
     void loadTrainers();
+
+    // Preload CreatureDisplayInfoStore and CreatureModelDataStore to avoid DBC lookup calls
+    void loadCreatureDisplayInfo();
+    CreatureDisplayInfoData const* getCreatureDisplayInfoData(uint32_t displayId) const;
 
     Player* createPlayerByGuid(uint8_t _class, uint32_t guid);
 
@@ -441,6 +445,7 @@ public:
         SpellEffectMaps mSpellEffectMaps;
         DungeonEncounterContainer _dungeonEncounterStore;
         std::unordered_map<uint32_t, CreatureMovementData> _creatureMovementOverrides;
+        std::unordered_map<uint32_t, CreatureDisplayInfoData> _creatureDisplayInfoData;
 
     protected:
 

--- a/src/world/Management/QuestLogEntry.cpp
+++ b/src/world/Management/QuestLogEntry.cpp
@@ -267,7 +267,6 @@ void QuestLogEntry::finishAndRemove()
 
     m_player->setQuestLogInSlot(nullptr, m_slot);
     m_player->addQuestToRemove(m_questProperties->id);
-    m_player->UpdateNearbyGameObjects();
 
     delete this;
 }
@@ -398,7 +397,7 @@ void QuestLogEntry::sendQuestComplete()
     data << m_questProperties->id;
     m_player->getSession()->SendPacket(&data);
 
-    m_player->UpdateNearbyGameObjects();
+    m_player->updateNearbyQuestGameObjects();
 
     CALL_QUESTSCRIPT_EVENT(this, OnQuestComplete)(m_player, this);
 }

--- a/src/world/Management/QuestMgr.h
+++ b/src/world/Management/QuestMgr.h
@@ -86,23 +86,27 @@ class Item;
 typedef std::list<QuestRelation*> QuestRelationList;
 typedef std::list<QuestAssociation*> QuestAssociationList;
 
-
+// APGL End
+// MIT Start
 class SERVER_DECL QuestMgr
 {
-    private:
+private:
+    QuestMgr() = default;
+    ~QuestMgr() = default;
 
-        QuestMgr() = default;
-        ~QuestMgr() = default;
+public:
+    static QuestMgr& getInstance();
+    void finalize();
 
-    public:
+    QuestMgr(QuestMgr&&) = delete;
+    QuestMgr(QuestMgr const&) = delete;
+    QuestMgr& operator=(QuestMgr&&) = delete;
+    QuestMgr& operator=(QuestMgr const&) = delete;
 
-        static QuestMgr& getInstance();
-        void finalize();
+    void onPlayerItemRemove(Player* plr, Item const* item);
 
-        QuestMgr(QuestMgr&&) = delete;
-        QuestMgr(QuestMgr const&) = delete;
-        QuestMgr& operator=(QuestMgr&&) = delete;
-        QuestMgr& operator=(QuestMgr const&) = delete;
+    // MIT End
+    // APGL Start
 
         uint32 PlayerMeetsReqs(Player* plr, QuestProperties const* qst, bool skiplevelcheck);
 

--- a/src/world/Map/Maps/MapScriptInterface.cpp
+++ b/src/world/Map/Maps/MapScriptInterface.cpp
@@ -99,7 +99,7 @@ Creature* MapScriptInterface::spawnCreature(uint32_t Entry, LocationVector pos, 
     MySQLStructure::CreatureSpawn* spawn = new MySQLStructure::CreatureSpawn;
     spawn->entry = Entry;
     uint32_t DisplayID = 0;
-    uint8_t Gender = creature_properties->GetGenderAndCreateRandomDisplayID(&DisplayID);
+    uint8_t Gender = creature_properties->generateRandomDisplayIdAndReturnGender(&DisplayID);
     spawn->displayid = DisplayID;
     spawn->id = 0;
     spawn->movetype = 0;
@@ -162,7 +162,7 @@ Creature* MapScriptInterface::spawnCreature(MySQLStructure::CreatureSpawn* sp, b
         return nullptr;
     }
 
-    uint8_t Gender = creature_properties->GetGenderAndCreateRandomDisplayID(&sp->displayid);
+    uint8_t Gender = creature_properties->generateRandomDisplayIdAndReturnGender(&sp->displayid);
     Creature* p = this->m_worldMap.createCreature(sp->entry);
     if (p)
     {

--- a/src/world/Map/Maps/WorldMap.cpp
+++ b/src/world/Map/Maps/WorldMap.cpp
@@ -2299,6 +2299,7 @@ void WorldMap::updateObjects()
 
                     // build the update
                     count = pObj->BuildValuesUpdateBlockForPlayer(&update, static_cast<Player*>(nullptr));
+                    update.clear();
 
                     if (count)
                     {
@@ -2308,9 +2309,14 @@ void WorldMap::updateObjects()
 
                             // Make sure that the target player can see us.
                             if (lplr && lplr->isVisibleObject(pObj->getGuid()))
+                            {
+                                // Build correct update to each player
+                                // Data may differ from player to player
+                                pObj->BuildValuesUpdateBlockForPlayer(&update, lplr);
                                 lplr->getUpdateMgr().pushUpdateData(&update, count);
+                                update.clear();
+                            }
                         }
-                        update.clear();
                     }
                 }
             }

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -138,12 +138,17 @@ bool GameObject::hasFlags(uint32_t flags) const { return (getFlags() & flags) !=
 float GameObject::getParentRotation(uint8_t type) const { return gameObjectData()->rotation[type]; }
 void GameObject::setParentRotation(uint8_t type, float rotation) { write(gameObjectData()->rotation[type], rotation); }
 
-#if VERSION_STRING < Mop
-uint32_t GameObject::getDynamic() const { return gameObjectData()->dynamic; }
-void GameObject::setDynamic(uint32_t dynamic) { write(gameObjectData()->dynamic, dynamic); }
-#else
-uint32_t GameObject::getDynamic() const { return 0; }
-void GameObject::setDynamic(uint32_t dynamic) { return; }
+#if VERSION_STRING < WotLK
+uint32_t GameObject::getDynamicFlags() const { return gameObjectData()->dynamic; }
+void GameObject::setDynamicFlags(uint32_t dynamicFlags) { write(gameObjectData()->dynamic, dynamicFlags); }
+#elif VERSION_STRING < Mop
+uint32_t GameObject::getDynamicField() const { return gameObjectData()->dynamic; }
+uint16_t GameObject::getDynamicFlags() const { return gameObjectData()->dynamic_field_parts.dyn_flag; }
+int16_t GameObject::getDynamicPathProgress() const { return gameObjectData()->dynamic_field_parts.path_progress; }
+void GameObject::setDynamicField(uint32_t dynamic) { write(gameObjectData()->dynamic, dynamic); }
+void GameObject::setDynamicField(uint16_t dynamicFlags, int16_t pathProgress) { setDynamicField(static_cast<uint32_t>(pathProgress) << 16 | dynamicFlags); }
+void GameObject::setDynamicFlags(uint16_t dynamicFlags) { setDynamicField(dynamicFlags, getDynamicPathProgress()); }
+void GameObject::setDynamicPathProgress(int16_t pathProgress) { setDynamicField(getDynamicFlags(), pathProgress); }
 #endif
 
 uint32_t GameObject::getFactionTemplate() const { return gameObjectData()->faction_template; }

--- a/src/world/Objects/GameObject.h
+++ b/src/world/Objects/GameObject.h
@@ -25,6 +25,7 @@
 #include "Management/TransporterHandler.h"
 #include "Data/WoWGameObject.hpp"
 #include "Map/Maps/BaseMap.hpp"
+#include "WorldConf.h"
 
 enum GameObject_State : uint8_t
 {
@@ -422,8 +423,18 @@ public:
     float getParentRotation(uint8_t type) const;
     void setParentRotation(uint8_t type, float rotation);
 
-    uint32_t getDynamic() const;
-    void setDynamic(uint32_t dynamic);
+#if VERSION_STRING < WotLK
+    uint32_t getDynamicFlags() const;
+    void setDynamicFlags(uint32_t dynamicFlags);
+#elif VERSION_STRING < Mop
+    uint32_t getDynamicField() const;
+    uint16_t getDynamicFlags() const;
+    int16_t getDynamicPathProgress() const;
+    void setDynamicField(uint32_t dynamic);
+    void setDynamicField(uint16_t dynamicFlags, int16_t pathProgress);
+    void setDynamicFlags(uint16_t dynamicFlags);
+    void setDynamicPathProgress(int16_t pathProgress);
+#endif
 
     uint32_t getFactionTemplate() const;
     void setFactionTemplate(uint32_t id);

--- a/src/world/Objects/Object.h
+++ b/src/world/Objects/Object.h
@@ -192,6 +192,19 @@ public:
     void setEntry(uint32_t entry);
     uint32_t getEntry() const;
 
+#if VERSION_STRING >= Mop
+    uint32_t getDynamicField() const;
+    uint16_t getDynamicFlags() const;
+    int16_t getDynamicPathProgress() const;
+    void setDynamicField(uint32_t dynamic);
+    void setDynamicField(uint16_t dynamicFlags, int16_t pathProgress);
+    void setDynamicFlags(uint16_t dynamicFlags);
+    void addDynamicFlags(uint16_t dynamicFlags);
+    void removeDynamicFlags(uint16_t dynamicFlags);
+    bool hasDynamicFlags(uint16_t dynamicFlags) const;
+    void setDynamicPathProgress(int16_t pathProgress);
+#endif
+
     float getScale() const;
     void setScale(float scaleX);
 
@@ -201,6 +214,11 @@ public:
 
     //! This includes any nested objects we have, inventory for example.
     virtual uint32_t buildCreateUpdateBlockForPlayer(ByteBuffer* data, Player* target);
+
+    // Forces update for WoWData field
+    void forceBuildUpdateValueForField(uint32_t field, Player* target);
+    // Forces update for multiple WoWData fields
+    void forceBuildUpdateValueForFields(uint32_t const* fields, Player* target);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Object Type Id
@@ -289,31 +307,31 @@ public:
     void removeSelfFromInrangeSets();
 
     // Objects
-    std::vector<Object*> getInRangeObjectsSet();
+    std::vector<Object*> getInRangeObjectsSet() const;
 
-    bool hasInRangeObjects();
-    size_t getInRangeObjectsCount();
+    bool hasInRangeObjects() const;
+    size_t getInRangeObjectsCount() const;
 
     bool isObjectInInRangeObjectsSet(Object* pObj) const;
     void removeObjectFromInRangeObjectsSet(Object* pObj);
 
     // Players
-    std::vector<Object*> getInRangePlayersSet();
-    size_t getInRangePlayersCount();
+    std::vector<Object*> getInRangePlayersSet() const;
+    size_t getInRangePlayersCount() const;
 
     // Opposite Faction
-    std::vector<Object*> getInRangeOppositeFactionSet();
+    std::vector<Object*> getInRangeOppositeFactionSet() const;
 
-    bool isObjectInInRangeOppositeFactionSet(Object* pObj);
+    bool isObjectInInRangeOppositeFactionSet(Object* pObj) const;
     void updateInRangeOppositeFactionSet();
 
     void addInRangeOppositeFaction(Object* obj);
     void removeObjectFromInRangeOppositeFactionSet(Object* obj);
 
     // same faction
-    std::vector<Object*> getInRangeSameFactionSet();
+    std::vector<Object*> getInRangeSameFactionSet() const;
 
-    bool isObjectInInRangeSameFactionSet(Object* pObj);
+    bool isObjectInInRangeSameFactionSet(Object* pObj) const;
     void updateInRangeSameFactionSet();
 
     void addInRangeSameFaction(Object* obj);
@@ -686,7 +704,7 @@ public:
         void buildMovementUpdate(ByteBuffer* data, uint16_t updateFlags, Player* target);
 #endif
 
-        void buildValuesUpdate(ByteBuffer* data, UpdateMask* updateMask, Player* target);
+        void buildValuesUpdate(uint8_t updateType, ByteBuffer* data, UpdateMask* updateMask, Player* target);
 
         // WoWGuid class
         WoWGuid m_wowGuid;

--- a/src/world/Objects/ObjectDefines.h
+++ b/src/world/Objects/ObjectDefines.h
@@ -5,6 +5,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include <cstdint>
 
 //\brief: TypeFlags, mostly used to define updatePackets.
 //\note: check out class inheritance. it is not true that every unit is "just" a creature.
@@ -29,57 +30,67 @@ This file is released under the MIT license. See README-MIT for more information
 
 enum TYPE
 {
-    TYPE_OBJECT = 1,
-    TYPE_ITEM = 2,
-    TYPE_CONTAINER = 4,
-    TYPE_UNIT = 8,
-    TYPE_PLAYER = 16,
-    TYPE_GAMEOBJECT = 32,
-    TYPE_DYNAMICOBJECT = 64,
-    TYPE_CORPSE = 128,
-    //TYPE_AIGROUP = 256,       not used
-    //TYPE_AREATRIGGER = 512,   not used
-    //TYPE_IN_GUILD = 1024      not used
+    TYPE_OBJECT                     = 1,
+    TYPE_ITEM                       = 2,
+    TYPE_CONTAINER                  = 4,
+    TYPE_UNIT                       = 8,
+    TYPE_PLAYER                     = 16,
+    TYPE_GAMEOBJECT                 = 32,
+    TYPE_DYNAMICOBJECT              = 64,
+    TYPE_CORPSE                     = 128,
+    //TYPE_AIGROUP                  = 256,      not used
+    //TYPE_AREATRIGGER              = 512,      not used
+    //TYPE_IN_GUILD                 = 1024      not used
 };
 
 //\todo: remove these typeIds and use flags instead. No reason to use two different enums to define a object type.
-enum TYPEID
+enum TYPEID : uint8_t
 {
-    TYPEID_OBJECT = 0,
-    TYPEID_ITEM = 1,
-    TYPEID_CONTAINER = 2,
-    TYPEID_UNIT = 3,
-    TYPEID_PLAYER = 4,
-    TYPEID_GAMEOBJECT = 5,
-    TYPEID_DYNAMICOBJECT = 6,
-    TYPEID_CORPSE = 7,
-    // TYPEID_AIGROUP = 8,      // Not used
-    TYPEID_AREATRIGGER = 9      // WoWTrigger is a thing on Cata
+    TYPEID_OBJECT                   = 0,
+    TYPEID_ITEM                     = 1,
+    TYPEID_CONTAINER                = 2,
+    TYPEID_UNIT                     = 3,
+    TYPEID_PLAYER                   = 4,
+    TYPEID_GAMEOBJECT               = 5,
+    TYPEID_DYNAMICOBJECT            = 6,
+    TYPEID_CORPSE                   = 7,
+    // TYPEID_AIGROUP               = 8,      // Not used
+    TYPEID_AREATRIGGER              = 9       // WoWTrigger is a thing on Cata
 };
 
 #if VERSION_STRING <= WotLK
-enum OBJECT_UPDATE_TYPE
+enum OBJECT_UPDATE_TYPE : uint8_t
 {
-    UPDATETYPE_VALUES = 0,
-    UPDATETYPE_MOVEMENT = 1,
-    UPDATETYPE_CREATE_OBJECT = 2,
-    UPDATETYPE_CREATE_OBJECT2 = 3,
+    UPDATETYPE_VALUES               = 0,
+    UPDATETYPE_MOVEMENT             = 1,
+    UPDATETYPE_CREATE_OBJECT        = 2,
+    UPDATETYPE_CREATE_OBJECT2       = 3,
     UPDATETYPE_OUT_OF_RANGE_OBJECTS = 4
 };
 #elif VERSION_STRING >= Cata
-enum OBJECT_UPDATE_TYPE
+enum OBJECT_UPDATE_TYPE : uint8_t
 {
-    UPDATETYPE_VALUES = 0,
-    UPDATETYPE_CREATE_OBJECT = 1,
-    UPDATETYPE_CREATE_OBJECT2 = 2,
+    UPDATETYPE_VALUES               = 0,
+    UPDATETYPE_CREATE_OBJECT        = 1,
+    UPDATETYPE_CREATE_OBJECT2       = 2,
     UPDATETYPE_OUT_OF_RANGE_OBJECTS = 3
 };
 #endif
 
-enum PHASECOMMANDS
+enum PHASECOMMANDS : uint8_t
 {
-    PHASE_SET = 0,      /// overwrites the phase value with the supplied one
-    PHASE_ADD = 1,      /// adds the new bits to the current phase value
-    PHASE_DEL = 2,      /// removes the given bits from the current phase value
-    PHASE_RESET = 3     /// sets the default phase of 1, same as PHASE_SET with 1 as the new value
+    PHASE_SET                       = 0,    /// overwrites the phase value with the supplied one
+    PHASE_ADD                       = 1,    /// adds the new bits to the current phase value
+    PHASE_DEL                       = 2,    /// removes the given bits from the current phase value
+    PHASE_RESET                     = 3     /// sets the default phase of 1, same as PHASE_SET with 1 as the new value
+};
+
+enum GameObjectDynamicFlags : uint8_t
+{
+    GO_DYN_FLAG_NONE                = 0x00,
+    GO_DYN_FLAG_INTERACTABLE        = 0x01,
+    GO_DYN_FLAG_UNK_2               = 0x02,
+    GO_DYN_FLAG_UNK_3               = 0x04,
+    GO_DYN_FLAG_SPARKLE             = 0x08,
+    GO_DYN_FLAG_TRANSPORT_STOPPED   = 0x10,
 };

--- a/src/world/Objects/Transporter.h
+++ b/src/world/Objects/Transporter.h
@@ -137,7 +137,7 @@ private:
 
     void DoEventIfAny(KeyFrame const& node, bool departure);
 
-    void setDynamicPathProgress();
+    void updatePathProgress();
 
     // Helpers to know if stop frame was reached
     bool IsMoving() const { return _isMoving; }

--- a/src/world/Objects/Units/Creatures/AIInterface.cpp
+++ b/src/world/Objects/Units/Creatures/AIInterface.cpp
@@ -2284,12 +2284,6 @@ void AIInterface::setCreatureProtoDifficulty(uint32_t entry)
             else
                 getUnit()->getAIInterface()->setGuard(false);
 
-            //invisibility
-            if (properties_difficulty->invisibility_type > INVIS_FLAG_NORMAL)
-                // TODO: currently only invisibility type 15 is used for invisible trigger NPCs
-                // these are always invisible to players
-                getUnit()->modInvisibilityLevel(InvisibilityFlag(properties_difficulty->invisibility_type), 1);
-
 #ifdef FT_VEHICLES
             if (getUnit()->isVehicle())
             {

--- a/src/world/Objects/Units/Creatures/CreatureDefines.hpp
+++ b/src/world/Objects/Units/Creatures/CreatureDefines.hpp
@@ -23,14 +23,13 @@
 #if VERSION_STRING >= Cata
 #include "Storage/DB2/DB2Structures.h"
 #endif
-
 #include "Spell/Definitions/School.hpp"
-
-#include <ctime>
-
 #include "Util.hpp"
 #include "Server/Master.h"
 #include "Macros/CreatureMacros.hpp"
+
+#include <cstdint>
+#include <ctime>
 
 struct AI_Spell;
 
@@ -38,6 +37,9 @@ const uint8 creatureMaxProtoSpells = 8;
 const uint32 creatureMaxInventoryItems = 150;
 
 const time_t vendorItemsUpdate = 3600000;
+
+// APGL End
+// MIT Start
 
 enum class CreatureGroundMovementType : uint8
 {
@@ -95,6 +97,19 @@ struct SERVER_DECL CreatureMovementData
     CreatureChaseMovementType getChase() const { return Chase; }
     CreatureRandomMovementType getRandom() const { return Random; }
 };
+
+struct CreatureDisplayInfoData
+{
+    uint32_t id = 0;
+    uint32_t modelId = 0;
+    uint32_t extendedDisplayInfoId = 0;
+    float_t creatureModelScale = 0.0f;
+    bool isModelInvisibleStalker = false;
+    DBC::Structures::CreatureModelDataEntry const* modelInfo = nullptr;
+};
+
+// MIT End
+// APGL Start
 
 enum creatureguardtype
 {
@@ -196,7 +211,7 @@ struct CreatureProperties
     std::string aura_string;
     bool isBoss;
     uint32 money;
-    uint32 invisibility_type;
+    bool isTriggerNpc;
     float walk_speed;       /// base movement
     float run_speed;        /// most of the time mobs use this
     float fly_speed;
@@ -218,47 +233,16 @@ struct CreatureProperties
 
     std::string lowercase_name;
 
-    uint8 GetGenderAndCreateRandomDisplayID(uint32* des) const
-    {
-        uint32 models[] = { Male_DisplayID, Male_DisplayID2, Female_DisplayID, Female_DisplayID2 };
-        if (!models[0] && !models[1] && !models[2] && !models[3])
-        {
-            // All models are invalid.
-            DLLLogDetail("CreatureSpawn : All model IDs are invalid for creature %u", Id);
-            return 0;
-        }
+    // APGL End
+    // MIT Start
 
-        while (true)
-        {
-            uint32 res = Util::getRandomUInt(3);
-            if (models[res])
-            {
-                *des = models[res];
-                return res < 2 ? 0U : 1U;
-            }
-        }
-    }
+    uint8_t generateRandomDisplayIdAndReturnGender(uint32_t* displayId) const;
+    uint32_t getRandomModelId() const;
+    uint32_t getInvisibleModelForTriggerNpc() const;
+    uint32_t getVisibleModelForTriggerNpc() const;
 
-    uint32 GetRandomModelId() const
-    {
-        uint8 counter = 0;
-        uint32 model_ids[4];
-
-        if (Male_DisplayID)
-            model_ids[counter++] = Male_DisplayID;
-        if (Male_DisplayID2)
-            model_ids[counter++] = Male_DisplayID2;
-        if (Female_DisplayID)
-            model_ids[counter++] = Female_DisplayID;
-        if (Female_DisplayID2)
-            model_ids[counter++] = Female_DisplayID2;
-
-        if (counter > 0)
-            return model_ids[Util::getRandomUInt(0U, counter - 1U)];
-
-        DLLLogDetail("CreatureProperties : No random display_id found for entry %u", Id);
-        return 0;
-    }
+    // MIT End
+    // APGL Start
 
     //itemslots
     uint32 itemslot_1;

--- a/src/world/Objects/Units/Players/Player.h
+++ b/src/world/Objects/Units/Players/Player.h
@@ -1362,6 +1362,8 @@ public:
 
     void addQuestKill(uint32_t questId, uint8_t reqId, uint32_t delay = 0);
 
+    void updateNearbyQuestGameObjects();
+
     std::set<uint32_t> getFinishedQuests() const;
 
 private:
@@ -2010,10 +2012,6 @@ public:
         uint32 m_modblockvaluefromspells = 0;
         void SendInitialLogonPackets();
         void Reset_Spells();
-
-        void EventActivateGameObject(GameObject* obj);
-        void EventDeActivateGameObject(GameObject* obj);
-        void UpdateNearbyGameObjects();
 
         void CalcResistance(uint8_t type);
         float res_M_crit_get() { return m_resist_critical[0]; }

--- a/src/world/Objects/Units/Unit.Legacy.cpp
+++ b/src/world/Objects/Units/Unit.Legacy.cpp
@@ -8423,6 +8423,25 @@ void Unit::UpdateVisibility()
                         }
                     }
                 }
+                else if (pObj->isCreature() && plr->getSession() && plr->getSession()->HasGMPermissions())
+                {
+                    auto* const creature = dynamic_cast<Creature*>(pObj);
+
+                    uint32_t fieldIds[] =
+                    {
+                        // Update unit flags to remove not selectable flag
+                        getOffsetForStructuredField(WoWUnit, unit_flags),
+                        // Placeholder if creature is a trigger npc
+                        0,
+                        0
+                    };
+
+                    // Update trigger model
+                    if (creature->GetCreatureProperties()->isTriggerNpc)
+                        fieldIds[1] = getOffsetForStructuredField(WoWUnit, display_id);
+
+                    creature->forceBuildUpdateValueForFields(fieldIds, plr);
+                }
             }
         }
     }

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -955,11 +955,13 @@ void Unit::setPetExperience(uint32_t experience) { write(unitData()->pet_experie
 uint32_t Unit::getPetNextLevelExperience() const { return unitData()->pet_next_level_experience; }
 void Unit::setPetNextLevelExperience(uint32_t experience) { write(unitData()->pet_next_level_experience, experience); }
 
+#if VERSION_STRING < Mop
 uint32_t Unit::getDynamicFlags() const { return unitData()->dynamic_flags; }
 void Unit::setDynamicFlags(uint32_t dynamicFlags) { write(unitData()->dynamic_flags, dynamicFlags); }
 void Unit::addDynamicFlags(uint32_t dynamicFlags) { setDynamicFlags(getDynamicFlags() | dynamicFlags); }
 void Unit::removeDynamicFlags(uint32_t dynamicFlags) { setDynamicFlags(getDynamicFlags() & ~dynamicFlags); }
 bool Unit::hasDynamicFlags(uint32_t dynamicFlags) const { return (getDynamicFlags() & dynamicFlags) != 0; }
+#endif
 
 float Unit::getModCastSpeed() const { return unitData()->mod_cast_speed; }
 void Unit::setModCastSpeed(float modifier) { write(unitData()->mod_cast_speed, modifier); }
@@ -7406,23 +7408,23 @@ float Unit::getCollisionHeight() const
     // Mounted
     if (getMountDisplayId())
     {
-        if (DBC::Structures::CreatureDisplayInfoEntry const* mountDisplayInfo = sCreatureDisplayInfoStore.LookupEntry(getMountDisplayId()))
+        if (const auto* mountDisplayInfo = sObjectMgr.getCreatureDisplayInfoData(getMountDisplayId()))
         {
-            if (DBC::Structures::CreatureModelDataEntry const* mountModelData = sCreatureModelDataStore.LookupEntry(mountDisplayInfo->ModelID))
+            if (const auto* mountModelData = mountDisplayInfo->modelInfo)
             {
-                DBC::Structures::CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(getNativeDisplayId());
+                const auto* displayInfo = sObjectMgr.getCreatureDisplayInfoData(getNativeDisplayId());
                 if (!displayInfo)
                     return DEFAULT_COLLISION_HEIGHT;
 
-                DBC::Structures::CreatureModelDataEntry const* modelData = sCreatureModelDataStore.LookupEntry(displayInfo->ModelID);
+                const auto* modelData = displayInfo->modelInfo;
                 if (!modelData)
                     return DEFAULT_COLLISION_HEIGHT;
 
 #if VERSION_STRING > Classic
-                float const collisionHeight = scaleMod * (mountModelData->MountHeight + modelData->CollisionHeight * displayInfo->CreatureModelScale * 0.5f);
+                float const collisionHeight = scaleMod * (mountModelData->MountHeight + modelData->CollisionHeight * displayInfo->creatureModelScale * 0.5f);
 #else
                 // Do the Collision Calc without Mount height since there are not that many Different Mounts
-                float const collisionHeight = scaleMod * (modelData->CollisionHeight * displayInfo->CreatureModelScale * 0.5f);
+                float const collisionHeight = scaleMod * (modelData->CollisionHeight * displayInfo->creatureModelScale * 0.5f);
 #endif
                 return collisionHeight == 0.0f ? DEFAULT_COLLISION_HEIGHT : collisionHeight;
             }
@@ -7430,14 +7432,14 @@ float Unit::getCollisionHeight() const
     }
 
     // Dismounted case
-    DBC::Structures::CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(getNativeDisplayId());
+    const auto* displayInfo = sObjectMgr.getCreatureDisplayInfoData(getNativeDisplayId());
     if (!displayInfo)
         return DEFAULT_COLLISION_HEIGHT;
 
-    DBC::Structures::CreatureModelDataEntry const* modelData = sCreatureModelDataStore.LookupEntry(displayInfo->ModelID);
+    const auto* modelData = displayInfo->modelInfo;
     if (!modelData)
         return DEFAULT_COLLISION_HEIGHT;
 
-    float const collisionHeight = scaleMod * modelData->CollisionHeight * displayInfo->CreatureModelScale;
+    float const collisionHeight = scaleMod * modelData->CollisionHeight * displayInfo->creatureModelScale;
     return collisionHeight == 0.0f ? DEFAULT_COLLISION_HEIGHT : collisionHeight;
 }

--- a/src/world/Objects/Units/Unit.h
+++ b/src/world/Objects/Units/Unit.h
@@ -414,11 +414,13 @@ public:
     uint32_t getPetNextLevelExperience() const;
     void setPetNextLevelExperience(uint32_t experience);
 
+#if VERSION_STRING < Mop
     uint32_t getDynamicFlags() const;
     void setDynamicFlags(uint32_t dynamicFlags);
     void addDynamicFlags(uint32_t dynamicFlags);
     void removeDynamicFlags(uint32_t dynamicFlags);
     bool hasDynamicFlags(uint32_t dynamicFlags) const;
+#endif
 
     float getModCastSpeed() const;
     void setModCastSpeed(float modifier);

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -58,7 +58,7 @@ ConfigMgr Config;
 
 // DB version
 static const char* REQUIRED_CHAR_DB_VERSION = "20220415-00_account_instance_times";
-static const char* REQUIRED_WORLD_DB_VERSION = "20220415-00_spawn_groups";
+static const char* REQUIRED_WORLD_DB_VERSION = "20220513-00_creature_properties";
 
 void Master::_OnSignal(int s)
 {

--- a/src/world/Server/Packets/Handlers/LootHandler.cpp
+++ b/src/world/Server/Packets/Handlers/LootHandler.cpp
@@ -376,7 +376,11 @@ void WorldSession::handleLootReleaseOpcode(WorldPacket& recvPacket)
                 Player* plr = players->ToPlayer();
                 if (creature->isTaggedByPlayerOrItsGroup(plr))
                 {
+#if VERSION_STRING < Mop
                     creature->BuildFieldUpdatePacket(plr, getOffsetForStructuredField(WoWUnit, dynamic_flags), 0);
+#else
+                    creature->BuildFieldUpdatePacket(plr, getOffsetForStructuredField(WoWObject, dynamic_field), 0);
+#endif
                 }
             }
 

--- a/src/world/Server/Packets/Handlers/QuestHandler.cpp
+++ b/src/world/Server/Packets/Handlers/QuestHandler.cpp
@@ -637,7 +637,7 @@ void WorldSession::handleQuestlogRemoveQuestOpcode(WorldPacket& recvPacket)
         }
     }
 
-    _player->UpdateNearbyGameObjects();
+    _player->updateNearbyQuestGameObjects();
 
     sHookInterface.OnQuestCancelled(_player, qPtr);
 }

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -725,6 +725,7 @@ bool World::setInitialWorldSettings()
     VMAP::VMapManager2* vmmgr2 = VMAP::VMapFactory::createOrGetVMapManager();
     vmmgr2->GetLiquidFlagsPtr = &getLiquidFlags;
 
+    sObjectMgr.initialize();
     sInstanceMgr.loadInstances();
     loadMySQLStores();
 
@@ -924,7 +925,6 @@ void World::loadMySQLTablesByTask()
 {
     auto startTime = Util::TimeNow();
 
-    sObjectMgr.initialize();
     sAddonMgr.initialize();
     sTicketMgr.initialize();
     sGameEventMgr.initialize();

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -5009,7 +5009,11 @@ void Aura::SpellAuraEmphaty(AuraEffectModifier* /*aurEff*/, bool apply)
     if (apply)
         dynflags |= U_DYN_FLAG_PLAYER_INFO;
 
+#if VERSION_STRING < Mop
     m_target->BuildFieldUpdatePacket(caster, getOffsetForStructuredField(WoWUnit, dynamic_flags), dynflags);
+#else
+    m_target->BuildFieldUpdatePacket(caster, getOffsetForStructuredField(WoWObject, dynamic_field), dynflags);
+#endif
 }
 
 void Aura::SpellAuraModOffhandDamagePCT(AuraEffectModifier* aurEff, bool apply)

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -3601,7 +3601,7 @@ void Spell::SpellEffectOpenLock(uint8_t effectIndex)
 
             if (sQuestMgr.OnGameObjectActivate(p_caster, gameObjTarget))
             {
-                p_caster->UpdateNearbyGameObjects();
+                p_caster->updateNearbyQuestGameObjects();
                 return;
             }
 
@@ -4734,9 +4734,16 @@ void Spell::SpellEffectActivateObject(uint8_t effectIndex) // Activate Object
     }
 
     CALL_GO_SCRIPT_EVENT(gameObjTarget, OnActivate)(p_caster);
-    gameObjTarget->setDynamic(1);
 
-    sEventMgr.AddEvent(gameObjTarget, &GameObject::setDynamic, static_cast<uint32_t>(0), 0, GetDuration(), 1, 0);
+    gameObjTarget->setDynamicFlags(GO_DYN_FLAG_INTERACTABLE);
+
+#if VERSION_STRING < WotLK
+    sEventMgr.AddEvent(gameObjTarget, &GameObject::setDynamicFlags, static_cast<uint32_t>(0), 0, GetDuration(), 1, 0);
+#elif VERSION_STRING < Mop
+    sEventMgr.AddEvent(gameObjTarget, &GameObject::setDynamicFlags, static_cast<uint16_t>(0), 0, GetDuration(), 1, 0);
+#else
+    sEventMgr.AddEvent(dynamic_cast<Object*>(gameObjTarget), &Object::setDynamicFlags, static_cast<uint16_t>(0), 0, GetDuration(), 1, 0);
+#endif
 }
 
 void Spell::SpellEffectBuildingDamage(uint8_t effectIndex)

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -560,8 +560,8 @@ void MySQLDataStore::loadCreaturePropertiesTable()
                                                                 "mindamage, maxdamage, can_ranged, rangedattacktime, rangedmindamage, rangedmaxdamage, respawntime, armor, "
         //                                                            36           37           38            39          40           41            42             43
                                                                 "resistance1, resistance2, resistance3, resistance4, resistance5, resistance6, combat_reach, bounding_radius, "
-        //                                                         44    45     46         47                48         49        50          51            52     53      54
-                                                                "auras, boss, money, invisibility_type, walk_speed, run_speed, fly_speed, extra_a9_flags, spell1, spell2, spell3, "
+        //                                                         44    45     46         47          48         49        50          51            52     53      54
+                                                                "auras, boss, money, isTriggerNpc, walk_speed, run_speed, fly_speed, extra_a9_flags, spell1, spell2, spell3, "
         //                                                          55      56      57      58      59        60           61               62            63         64           65
                                                                 "spell4, spell5, spell6, spell7, spell8, spell_flags, modImmunities, isTrainingDummy, guardtype, summonguard, spelldataid, "
         //                                                          66         67        68          69          70          71          72          73         74         75
@@ -610,7 +610,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             creatureProperties.Male_DisplayID = fields[3].GetUInt32();
             if (creatureProperties.Male_DisplayID != 0)
             {
-                DBC::Structures::CreatureDisplayInfoEntry const* creature_display = sCreatureDisplayInfoStore.LookupEntry(creatureProperties.Male_DisplayID);
+                const auto* creature_display = sObjectMgr.getCreatureDisplayInfoData(creatureProperties.Male_DisplayID);
                 if (creature_display == nullptr)
                 {
                     sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table %s includes invalid Male_DisplayID %u for npc entry: %u. Set to 0!", (*tableiterator).c_str(), creatureProperties.Male_DisplayID, entry);
@@ -620,7 +620,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             creatureProperties.Female_DisplayID = fields[4].GetUInt32();
             if (creatureProperties.Female_DisplayID != 0)
             {
-                DBC::Structures::CreatureDisplayInfoEntry const* creature_display = sCreatureDisplayInfoStore.LookupEntry(creatureProperties.Female_DisplayID);
+                const auto* creature_display = sObjectMgr.getCreatureDisplayInfoData(creatureProperties.Female_DisplayID);
                 if (creature_display == nullptr)
                 {
                     sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table %s includes invalid Female_DisplayID %u for npc entry: %u. Set to 0!", (*tableiterator).c_str(), creatureProperties.Female_DisplayID, entry);
@@ -630,7 +630,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             creatureProperties.Male_DisplayID2 = fields[5].GetUInt32();
             if (creatureProperties.Male_DisplayID2 != 0)
             {
-                DBC::Structures::CreatureDisplayInfoEntry const* creature_display = sCreatureDisplayInfoStore.LookupEntry(creatureProperties.Male_DisplayID2);
+                const auto* creature_display = sObjectMgr.getCreatureDisplayInfoData(creatureProperties.Male_DisplayID2);
                 if (creature_display == nullptr)
                 {
                     sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table %s includes invalid Male_DisplayID2 %u for npc entry: %u. Set to 0!", (*tableiterator).c_str(), creatureProperties.Male_DisplayID2, entry);
@@ -640,7 +640,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             creatureProperties.Female_DisplayID2 = fields[6].GetUInt32();
             if (creatureProperties.Female_DisplayID2 != 0)
             {
-                DBC::Structures::CreatureDisplayInfoEntry const* creature_display = sCreatureDisplayInfoStore.LookupEntry(creatureProperties.Female_DisplayID2);
+                const auto* creature_display = sObjectMgr.getCreatureDisplayInfoData(creatureProperties.Female_DisplayID2);
                 if (creature_display == nullptr)
                 {
                     sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table %s includes invalid Female_DisplayID2 %u for npc entry: %u. Set to 0!", (*tableiterator).c_str(), creatureProperties.Female_DisplayID2, entry);
@@ -719,7 +719,7 @@ void MySQLDataStore::loadCreaturePropertiesTable()
             creatureProperties.aura_string = fields[44].GetString();
             creatureProperties.isBoss = fields[45].GetBool();
             creatureProperties.money = fields[46].GetUInt32();
-            creatureProperties.invisibility_type = fields[47].GetUInt32();
+            creatureProperties.isTriggerNpc = fields[47].GetBool();
             creatureProperties.walk_speed = fields[48].GetFloat();
             creatureProperties.run_speed = fields[49].GetFloat();
             creatureProperties.fly_speed = fields[50].GetFloat();
@@ -4274,18 +4274,18 @@ void MySQLDataStore::loadCreatureSpawns()
                     cspawn->o = fields[8].GetFloat();
                     cspawn->movetype = fields[9].GetUInt8();
                     cspawn->displayid = fields[10].GetUInt32();
-                    if (cspawn->displayid != 0)
+                    if (cspawn->displayid != 0 && !creature_properties->isTriggerNpc)
                     {
-                        DBC::Structures::CreatureDisplayInfoEntry const* creature_display = sCreatureDisplayInfoStore.LookupEntry(cspawn->displayid);
+                        const auto* creature_display = sObjectMgr.getCreatureDisplayInfoData(cspawn->displayid);
                         if (!creature_display)
                         {
                             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table %s includes invalid displayid %u for npc entry: %u, spawn_id: %u. Set to a random modelid!", (*tableiterator).c_str(), cspawn->displayid, cspawn->entry, cspawn->id);
-                            cspawn->displayid = creature_properties->GetRandomModelId();
+                            cspawn->displayid = creature_properties->getRandomModelId();
                         }
                     }
                     else
                     {
-                        cspawn->displayid = creature_properties->GetRandomModelId();
+                        cspawn->displayid = creature_properties->getRandomModelId();
                     }
 
                     cspawn->factionid = fields[11].GetUInt32();


### PR DESCRIPTION
**Description**
Objects: Refactor building object updates
- Proper quest gameobject sparkling
- Loot works after relog and out of range
- Creature tagging flag works
- Trigger npcs are properly invisible but visible if you activate GM mode

Database: Rename invisibilityType from creature_properties as it was only used for trigger npcs
Misc: Preload sCreatureDisplayInfoStore and for each row their respective sCreatureModelDataStore entry into ObjectMgr to avoid DBC lookup calls

I'm not 100% sure of WoWObject dynamic field in Mop and I could not obviously test it but I checked another mop emulator and they handled it as TWO_SHORT field instead of regular uint32_t field so I went with TWO_SHORT as well.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

***Multiversion Ingame Tests Performed:***
- [x] BC
- [x] WotLK
- [ ] Cata


