### PR TITLE
Disable options StormLib

### DIFF
--- a/dep/StormLib/CMakeLists.txt
+++ b/dep/StormLib/CMakeLists.txt
@@ -8,12 +8,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CMakeDependentOption)
 
-option(BUILD_SHARED_LIBS "Compile shared libraries" OFF)
-option(STORM_SKIP_INSTALL "Skip installing files" OFF)
-option(STORM_BUILD_TESTS
-    "Compile StormLib test application" OFF
+# option(BUILD_SHARED_LIBS "Compile shared libraries" OFF)
+# option(STORM_SKIP_INSTALL "Skip installing files" OFF)
+# option(STORM_BUILD_TESTS
+#   "Compile StormLib test application" OFF
 #   "BUILD_TESTING" OFF # Stay coherent with CTest variables
-)
+# )
 
 set(SRC_FILES
            src/adpcm/adpcm.cpp


### PR DESCRIPTION
**Description**
Disable options StormLib, for the extractor, these functions are not needed (only cata+)

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.


**Multiversion Ingame Tests Performed:**
- [x] Cata
