### PR TITLE
Fix spawns in Death Knight starting place for cata and mop

### DIFF
--- a/sql/world/updates/20220611-00_spawns.sql
+++ b/sql/world/updates/20220611-00_spawns.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_spawns` SET `max_build`='18414' WHERE `map`='609';
+UPDATE `gameobject_spawns` SET `max_build`='18414' WHERE `map`='609';
+
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('109', '20220611-00_spawns');

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -58,7 +58,7 @@ ConfigMgr Config;
 
 // DB version
 static const char* REQUIRED_CHAR_DB_VERSION = "20220415-00_account_instance_times";
-static const char* REQUIRED_WORLD_DB_VERSION = "20220524-00_creature_properties";
+static const char* REQUIRED_WORLD_DB_VERSION = "20220611-00_spawns";
 
 void Master::_OnSignal(int s)
 {


### PR DESCRIPTION
**Description**
Fix spawns in Death Knight starting place for cata and mop. They are same in wotlk - mop.

Fixes https://github.com/AscEmu/AscEmu/issues/1030

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [] WotLK
- [] Cata
-->
