### PR TITLE
Refactor how auras are stored

### DIFF
--- a/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
+++ b/src/scripts/Battlegrounds/AlteracValley/AlteracValley.cpp
@@ -1085,7 +1085,7 @@ void AlteracValley::OnStart()
     {
         for (std::set<Player*>::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
-            (*itr)->RemoveAura(BG_PREPARATION);
+            (*itr)->removeAllAurasById(BG_PREPARATION);
         }
     }
 
@@ -1122,7 +1122,7 @@ void AlteracValley::OnAddPlayer(Player* plr)
 
 void AlteracValley::OnRemovePlayer(Player* plr)
 {
-    plr->RemoveAura(BG_PREPARATION);
+    plr->removeAllAurasById(BG_PREPARATION);
 }
 
 LocationVector AlteracValley::GetStartingCoords(uint32_t Team)

--- a/src/scripts/Battlegrounds/ArathiBasin/ArathiBasin.cpp
+++ b/src/scripts/Battlegrounds/ArathiBasin/ArathiBasin.cpp
@@ -333,7 +333,7 @@ void ArathiBasin::OnStart()
     {
         for (std::set<Player*>::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
-            (*itr)->RemoveAura(BG_PREPARATION);
+            (*itr)->removeAllAurasById(BG_PREPARATION);
         }
     }
 
@@ -558,7 +558,7 @@ void ArathiBasin::OnAddPlayer(Player* plr)
 
 void ArathiBasin::OnRemovePlayer(Player* plr)
 {
-    plr->RemoveAura(BG_PREPARATION);
+    plr->removeAllAurasById(BG_PREPARATION);
 }
 
 void ArathiBasin::HookFlagDrop(Player* /*plr*/, GameObject* /*obj*/)

--- a/src/scripts/Battlegrounds/EyeOfTheStorm/EyeOfTheStorm.cpp
+++ b/src/scripts/Battlegrounds/EyeOfTheStorm/EyeOfTheStorm.cpp
@@ -390,7 +390,7 @@ void EyeOfTheStorm::HookOnAreaTrigger(Player* plr, uint32_t id)
     DropFlag2(plr, id);
     SetWorldState(EOTS_NETHERWING_FLAG_READY, 1);
 
-    plr->RemoveAura(EOTS_NETHERWING_FLAG_SPELL);
+    plr->removeAllAurasById(EOTS_NETHERWING_FLAG_SPELL);
     plr->m_bgScore.MiscData[BG_SCORE_EOTS_FLAGS_CAPTURED]++;
     UpdatePvPData();
 }
@@ -478,7 +478,7 @@ void EyeOfTheStorm::OnRemovePlayer(Player* plr)
     }
 
     if (!m_started)
-        plr->RemoveAura(BG_PREPARATION);
+        plr->removeAllAurasById(BG_PREPARATION);
 }
 
 void EyeOfTheStorm::DropFlag2(Player* plr, uint32_t id)
@@ -518,7 +518,7 @@ void EyeOfTheStorm::HookOnFlagDrop(Player* plr)
     if (m_flagHolder != plr->getGuidLow())
         return;
 
-    plr->RemoveAura(EOTS_NETHERWING_FLAG_SPELL);
+    plr->removeAllAurasById(EOTS_NETHERWING_FLAG_SPELL);
     plr->castSpell(plr, EOTS_RECENTLY_DROPPED_FLAG, true);
 
     m_dropFlag->SetPosition(plr->GetPosition());
@@ -927,7 +927,7 @@ void EyeOfTheStorm::OnStart()
     {
         for (std::set<Player*>::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
-            (*itr)->RemoveAura(BG_PREPARATION);
+            (*itr)->removeAllAurasById(BG_PREPARATION);
         }
     }
 

--- a/src/scripts/Battlegrounds/IsleOfConquest/IsleOfConquest.cpp
+++ b/src/scripts/Battlegrounds/IsleOfConquest/IsleOfConquest.cpp
@@ -449,7 +449,7 @@ void IsleOfConquest::OnStart()
     {
         for (std::set<Player* >::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
-            (*itr)->RemoveAura(BG_PREPARATION);
+            (*itr)->removeAllAurasById(BG_PREPARATION);
         }
     }
 
@@ -758,9 +758,9 @@ void IsleOfConquest::OnAddPlayer(Player *plr)
 
 void IsleOfConquest::OnRemovePlayer(Player *plr)
 {
-    plr->RemoveAura(BG_PREPARATION);
-    plr->RemoveAura(IOC_REFINERY_BONUS);
-    plr->RemoveAura(IOC_QUARRY_BONUS);
+    plr->removeAllAurasById(BG_PREPARATION);
+    plr->removeAllAurasById(IOC_REFINERY_BONUS);
+    plr->removeAllAurasById(IOC_QUARRY_BONUS);
 }
 
 void IsleOfConquest::HookOnShadowSight()

--- a/src/scripts/Battlegrounds/StrandOfTheAncient/StrandOfTheAncient.cpp
+++ b/src/scripts/Battlegrounds/StrandOfTheAncient/StrandOfTheAncient.cpp
@@ -384,7 +384,7 @@ void StrandOfTheAncient::OnRemovePlayer(Player* plr)
 {
     if (!m_started)
     {
-        plr->RemoveAura(BG_PREPARATION);
+        plr->removeAllAurasById(BG_PREPARATION);
     }
 }
 
@@ -796,7 +796,7 @@ void StrandOfTheAncient::StartRound()
         Player* p = *itr;
 
         p->safeTeleport(p->GetMapId(), p->GetInstanceID(), sotaAttackerStartingPosition[SOTA_ROUND_STARTED]);
-        p->RemoveAura(BG_PREPARATION);
+        p->removeAllAurasById(BG_PREPARATION);
     }
 
     RemoveAuraFromTeam(Defenders, BG_PREPARATION);

--- a/src/scripts/Battlegrounds/WarsongGulch/WarsongGulch.cpp
+++ b/src/scripts/Battlegrounds/WarsongGulch/WarsongGulch.cpp
@@ -198,7 +198,7 @@ void WarsongGulch::HookOnAreaTrigger(Player* plr, uint32_t id)
         plr->setHasBgFlag(false);
 
         // remove flag aura from player
-        plr->RemoveAura(23333 + (plr->getTeam() * 2));
+        plr->removeAllAurasById(23333 + (plr->getTeam() * 2));
 
         // capture flag points
         plr->m_bgScore.MiscData[BG_SCORE_WSG_FLAGS_CAPTURED]++;
@@ -272,7 +272,7 @@ void WarsongGulch::HookOnFlagDrop(Player* plr)
 
     m_flagHolders[plr->getTeam()] = 0;
     plr->setHasBgFlag(false);
-    plr->RemoveAura(23333 + (plr->getTeam() * 2));
+    plr->removeAllAurasById(23333 + (plr->getTeam() * 2));
 
     SetWorldState(plr->isTeamHorde() ? WORLDSTATE_WSG_ALLIANCE_FLAG_DISPLAY : WORLDSTATE_WSG_HORDE_FLAG_DISPLAY, 1);
 
@@ -445,7 +445,7 @@ void WarsongGulch::OnRemovePlayer(Player* plr)
     if (plr->hasBgFlag())
         HookOnMount(plr);
 
-    plr->RemoveAura(BG_PREPARATION);
+    plr->removeAllAurasById(BG_PREPARATION);
 }
 
 LocationVector WarsongGulch::GetStartingCoords(uint32_t Team)
@@ -462,7 +462,7 @@ void WarsongGulch::HookOnPlayerDeath(Player* plr)
 
     // do we have the flag?
     if (plr->hasBgFlag())
-        plr->RemoveAura(23333 + (plr->getTeam() * 2));
+        plr->removeAllAurasById(23333 + (plr->getTeam() * 2));
 
     UpdatePvPData();
 }
@@ -586,7 +586,7 @@ void WarsongGulch::OnStart()
     {
         for (std::set<Player*>::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
-            (*itr)->RemoveAura(BG_PREPARATION);
+            (*itr)->removeAllAurasById(BG_PREPARATION);
         }
     }
 

--- a/src/scripts/EventScripts/Event_Darkmoon_Faire.cpp
+++ b/src/scripts/EventScripts/Event_Darkmoon_Faire.cpp
@@ -148,7 +148,7 @@ void AIUpdate()
         // Kill then Despawn Tonk after 10 seconds
         Plr->castSpell(Tonk, 5, false); // Kill spell
         Plr->castSpell(Plr, 2880, false); // Stun Player
-        Plr->RemoveAura(33849);
+        Plr->removeAllAurasById(33849);
         Tonk->Despawn(10000,0);
 
         // Close the console so others can access it

--- a/src/scripts/InstanceScripts/Tbc/Auchindoun/SethekkHalls/Instance_SethekkHalls.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Auchindoun/SethekkHalls/Instance_SethekkHalls.cpp
@@ -478,7 +478,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAura(SP_ANZU_BANISH);
+        getCreature()->removeAllAurasById(SP_ANZU_BANISH);
 
         Banished = false;
     }
@@ -493,7 +493,7 @@ public:
 
         if (Banished)
         {
-            getCreature()->RemoveAura(SP_ANZU_BANISH);
+            getCreature()->removeAllAurasById(SP_ANZU_BANISH);
             Banished = false;
         }
     }

--- a/src/scripts/InstanceScripts/Tbc/BlackTemple/Raid_BlackTemple.cpp
+++ b/src/scripts/InstanceScripts/Tbc/BlackTemple/Raid_BlackTemple.cpp
@@ -254,7 +254,7 @@ enum
 
     // Other spells
     ILLIDAN_SHADOW_PRISON = 40647, // +
-    ILLIDAN_SKULL_INTRO = 39656, // + Works with RemoveAura
+    ILLIDAN_SKULL_INTRO = 39656, // + Works with removeAllAurasById
     //ILLIDAN_SUMMON_PARASITIC_SHADOWFIENDS = 41915, // ? Haven't Tried
     //ILLIDAN_PARASITIC_SHADOWFIEND_WITH_SE = 41914,
     ILLIDAN_BERSERK = 45078,
@@ -2861,7 +2861,7 @@ public:
         if (_getTargetToChannel() != NULL)
         {
             Unit* pUnit = _getTargetToChannel();
-            pUnit->RemoveAura(SHADOW_DEMON_PARALYZE);
+            pUnit->removeAllAurasById(SHADOW_DEMON_PARALYZE);
         }
     }
 
@@ -2878,7 +2878,7 @@ public:
         {
             if (getRangeToObject(pTarget) <= 8.0f)
             {
-                pTarget->RemoveAura(SHADOW_DEMON_PARALYZE);
+                pTarget->removeAllAurasById(SHADOW_DEMON_PARALYZE);
                 _castAISpell(mConsumeSoul);
 
                 RemoveAIUpdateEvent();

--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
@@ -399,7 +399,7 @@ public:
         if (!LeotherasEventGreyheartToKill[getCreature()->GetInstanceID()])
         {
             //remove banish & blocks
-            getCreature()->RemoveAllAuras();
+            getCreature()->removeAllAuras();
             getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_COMBAT);
             getCreature()->getAIInterface()->setAllowedToEnterCombat(true);
             getCreature()->setControlled(false, UNIT_STATE_ROOTED);
@@ -687,7 +687,7 @@ public:
             if (Leotheras)
             {
                 //remove banish & blocks
-                Leotheras->RemoveAllAuras();
+                Leotheras->removeAllAuras();
                 Leotheras->getAIInterface()->setAllowedToEnterCombat(true);
                 Leotheras->setControlled(false, UNIT_STATE_ROOTED);
                 Leotheras->setStandState(STANDSTATE_STAND);
@@ -904,7 +904,7 @@ public:
             FLK->SendScriptTextChatMessage(4743);     // I am more powerful than ever!
             if (static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft > 0)
                 static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft--;
-            FLK->RemoveAura(BLESSING_OF_THE_TIDES);
+            FLK->removeAllAurasById(BLESSING_OF_THE_TIDES);
         }
     }
 
@@ -960,7 +960,7 @@ public:
             FLK->SendScriptTextChatMessage(4742);     // Go on, kill them! I'll be the better for it!
             if (static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft > 0)
                 static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft--;
-            FLK->RemoveAura(BLESSING_OF_THE_TIDES);
+            FLK->removeAllAurasById(BLESSING_OF_THE_TIDES);
         }
     }
 };
@@ -990,7 +990,7 @@ public:
             FLK->SendScriptTextChatMessage(4744); // More knowledge, more power!
             if (static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft > 0)
                 static_cast< KarathressAI* >(FLK->GetScript())->AdvisorsLeft--;
-            FLK->RemoveAura(BLESSING_OF_THE_TIDES);
+            FLK->removeAllAurasById(BLESSING_OF_THE_TIDES);
         }
     }
 
@@ -1214,7 +1214,7 @@ public:
             }
         }
 
-        getCreature()->RemoveAura(VASHJ_SHIELD);
+        getCreature()->removeAllAurasById(VASHJ_SHIELD);
         getCreature()->getAIInterface()->setAllowedToEnterCombat(true);
         getCreature()->setControlled(false, UNIT_STATE_ROOTED);
         RemoveAIUpdateEvent();
@@ -1258,7 +1258,7 @@ public:
         {
             if (getCreature()->getHealthPct() <= 70)
             {
-                getCreature()->RemoveAllAuras();
+                getCreature()->removeAllAuras();
                 getCreature()->getAIInterface()->setAllowedToEnterCombat(false);
                 getCreature()->stopMoving();
                 getCreature()->getAIInterface()->setAiState(AI_STATE_SCRIPTMOVE);
@@ -1383,7 +1383,7 @@ public:
 
             //\todo to set flags will override all values from db. To add/remove flags use SetFlag(/RemoveFlag(
             getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_COMBAT);
-            getCreature()->RemoveAura(VASHJ_SHIELD);
+            getCreature()->removeAllAurasById(VASHJ_SHIELD);
             sendDBChatMessage(4765);     // You may want to take cover.
             getCreature()->setControlled(false, UNIT_STATE_ROOTED);
             Phase = 3;

--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SteamVault/Instance_TheSteamvault.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SteamVault/Instance_TheSteamvault.cpp
@@ -307,9 +307,9 @@ public:
         getCreature()->getMovementManager()->clear();
 
         if (getCreature()->getAuraWithId(37076))
-            getCreature()->RemoveAura(37076);
+            getCreature()->removeAllAurasById(37076);
         if (getCreature()->getAuraWithId(36453))
-            getCreature()->RemoveAura(36453);
+            getCreature()->removeAllAurasById(36453);
 
         Unit* pDistiller = NULL;
         pDistiller = GetClosestDistiller();
@@ -344,9 +344,9 @@ public:
                 RagePhase = 0;
 
                 if (getCreature()->getAuraWithId(31543))
-                    getCreature()->RemoveAura(31543);
+                    getCreature()->removeAllAurasById(31543);
                 if (getCreature()->getAuraWithId(37076))
-                    getCreature()->RemoveAura(37076);
+                    getCreature()->removeAllAurasById(37076);
             }
 
             else

--- a/src/scripts/InstanceScripts/Tbc/GruulsLair/GruulTheDragonKiller.cpp
+++ b/src/scripts/InstanceScripts/Tbc/GruulsLair/GruulTheDragonKiller.cpp
@@ -121,7 +121,7 @@ bool ShatterEffect(uint8_t /*effectIndex*/, Spell* pSpell)
     if (!target)
         return true;
 
-    target->RemoveAura(SPELL_STONED);
+    target->removeAllAurasById(SPELL_STONED);
     target->castSpell(target, SPELL_SHATTER_EFFECT, true);
 
     return true;

--- a/src/scripts/InstanceScripts/Tbc/Karazhan/Raid_Karazhan.cpp
+++ b/src/scripts/InstanceScripts/Tbc/Karazhan/Raid_Karazhan.cpp
@@ -1609,7 +1609,7 @@ public:
             {
                 ReSummon = false;
                 getCreature()->castSpell(getCreature(), sSpellMgr.getSpellInfo(S_KILREK), true);
-                getCreature()->RemoveAura(BROKEN_PACT);
+                getCreature()->removeAllAurasById(BROKEN_PACT);
             }
         }
     }
@@ -1792,7 +1792,7 @@ public:
         Unit* uIllhoof = getNearestCreature(getCreature()->GetPositionX(), getCreature()->GetPositionY(),
             getCreature()->GetPositionZ(), CN_ILLHOOF);
         if (uIllhoof != NULL && uIllhoof->isAlive())
-            uIllhoof->RemoveAura(SACRIFICE);
+            uIllhoof->removeAllAurasById(SACRIFICE);
 
         getCreature()->Despawn(10000, 0);
     }
@@ -2131,8 +2131,8 @@ public:
 
             getCreature()->castSpell(getCreature(), spells[8].info, spells[8].instant);
 */
-            getCreature()->RemoveAura(THRASH_AURA);
-            getCreature()->RemoveAura(WIELD_AXES);
+            getCreature()->removeAllAurasById(THRASH_AURA);
+            getCreature()->removeAllAurasById(WIELD_AXES);
 
             // Main hand weapon
             getCreature()->setVirtualItemSlotId(MELEE, 0);
@@ -2379,7 +2379,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAura(NETHERBURN);
+        getCreature()->removeAllAurasById(NETHERBURN);
 
         GameObject* NDoor = getNearestGameObject(-11186.2f, -1665.14f, 281.398f, 185521);
         if (NDoor)
@@ -3339,7 +3339,7 @@ public:
                 break;
         }
 
-        //_unit->RemoveAllAuras();
+        //_unit->removeAllAuras();
         //_unit->setEmoteState(EMOTE_ONESHOT_EAT);
         //_unit->addUnitFlags(UNIT_FLAG_NOT_SELECTABLE);
         spawnCreature(17533, -10891.582f, -1755.5177f, 90.476f, 4.61f);

--- a/src/scripts/InstanceScripts/Wotlk/CavernsOfTime/Instance_CullingOfStratholme.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/CavernsOfTime/Instance_CullingOfStratholme.cpp
@@ -49,7 +49,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 };
 
@@ -97,7 +97,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 };
 
@@ -134,7 +134,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 };
 
@@ -156,7 +156,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 };
 
@@ -198,7 +198,7 @@ public:
 
     void OnCombatStop(Unit* /*mTarget*/) override
     {
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 
     void OnDamageTaken(Unit* /*mAttacker*/, uint32_t fAmount) override

--- a/src/scripts/InstanceScripts/Wotlk/ChamberOfAspects/ObsidianSanctum/Raid_TheObsidianSanctum.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/ChamberOfAspects/ObsidianSanctum/Raid_TheObsidianSanctum.cpp
@@ -75,7 +75,7 @@ public:
             return;
 
         pSartharion->castSpell(pSartharion, pSpellEntry, true);
-        pSartharion->RemoveAura(pSpellEntry);   // unproper hackfix
+        pSartharion->removeAllAurasById(pSpellEntry);   // unproper hackfix
     }
 
     Creature* getCreature(uint8_t pData)

--- a/src/scripts/InstanceScripts/Wotlk/DraktharonKeep/Instance_DrakTharonKeep.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/DraktharonKeep/Instance_DrakTharonKeep.cpp
@@ -161,7 +161,7 @@ public:
         }
         getCreature()->setMoveRoot(true);
         getCreature()->interruptSpell();
-        getCreature()->RemoveAllAuras();
+        getCreature()->removeAllAuras();
     }
 
     void AIUpdate() override
@@ -194,7 +194,7 @@ public:
             if (new_phase)
             {
                 getCreature()->interruptSpell();
-                getCreature()->RemoveAllAuras();
+                getCreature()->removeAllAuras();
                 getCreature()->setMoveRoot(false);
                 _setMeleeDisabled(false);
                 setScriptPhase(2);
@@ -471,7 +471,7 @@ public:
             setScriptPhase(2);
             phase_length = Util::getMSTime() + WINDSERPENT_PHASE_LENGTH;
             getCreature()->setDisplayId(27073);
-            getCreature()->RemoveAllAuras();
+            getCreature()->removeAllAuras();
             getCreature()->castSpell(getCreature(), 49356, false);
         }
         if (getScriptPhase() == 2 && phase_length <Util::getMSTime())
@@ -479,7 +479,7 @@ public:
             setScriptPhase(1);
             phase_timer = Util::getMSTime() + WINDSERPENT_PHASE_INTERVAL;
             getCreature()->setDisplayId(getCreature()->getNativeDisplayId());
-            getCreature()->RemoveAllAuras();
+            getCreature()->removeAllAuras();
             getCreature()->castSpell(getCreature(), 53463, false);
         }
     }

--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/LadyDeathwhisper.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/LadyDeathwhisper.cpp
@@ -91,7 +91,7 @@ void LadyDeathwhisperAI::OnCombatStart(Unit* /*pTarget*/)
     _setMeleeDisabled(true);
     setRooted(true);
 
-    getCreature()->RemoveAura(SPELL_SHADOW_CHANNELING);
+    getCreature()->removeAllAurasById(SPELL_SHADOW_CHANNELING);
     _castAISpell(manaBarrierSpell);
 }
 
@@ -145,7 +145,7 @@ void LadyDeathwhisperAI::Reset()
     DeleteSummons();
 
     _castAISpell(shadowChannelingSpell);
-    getCreature()->RemoveAllAuras();
+    getCreature()->removeAllAuras();
 }
 
 void LadyDeathwhisperAI::AIUpdate(unsigned long time_passed)

--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/LordMarrowgar.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/LordMarrowgar.cpp
@@ -74,8 +74,8 @@ void LordMarrowgarAI::Reset()
     scriptEvents.resetEvents();
 
     getCreature()->setSpeedRate(TYPE_RUN, baseSpeed, true);
-    getCreature()->RemoveAura(SPELL_BONE_STORM);
-    getCreature()->RemoveAura(SPELL_BERSERK);
+    getCreature()->removeAllAurasById(SPELL_BONE_STORM);
+    getCreature()->removeAllAurasById(SPELL_BERSERK);
 
     boneSlice = false;
     boneSpikeImmune.clear();
@@ -388,13 +388,13 @@ void BoneSpikeAI::OnSummon(Unit* summoner)
 void BoneSpikeAI::OnTargetDied(Unit* pTarget)
 {
     getCreature()->Despawn(100, 0);
-    pTarget->RemoveAura(SPELL_IMPALED);
+    pTarget->removeAllAurasById(SPELL_IMPALED);
 }
 
 void BoneSpikeAI::OnDied(Unit* /*pTarget*/)
 {       
     if (summon)
-        summon->RemoveAura(SPELL_IMPALED);
+        summon->removeAllAurasById(SPELL_IMPALED);
      
     getCreature()->Despawn(100, 0);
 }
@@ -420,9 +420,7 @@ void BoneStorm::onAuraCreate(Aura* aur)
     if (aur->GetUnitCaster()->isCreature())
         duration = static_cast<Creature*>(aur->GetUnitCaster())->GetScript()->RAID_MODE<uint32_t>(20000, 30000, 20000, 30000);
 
-    aur->setOriginalDuration(duration);
-    aur->setMaxDuration(duration);
-    aur->setTimeLeft(duration);
+    aur->setNewMaxDuration(duration, false);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Raid_IceCrownCitadel.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Raid_IceCrownCitadel.cpp
@@ -805,16 +805,16 @@ void IceCrownCitadelScript::TransportBoarded(Unit* pUnit, Transporter* transport
 void IceCrownCitadelScript::TransportUnboarded(Unit* pUnit, Transporter* transport)
 {
     if (transport->getEntry() == GO_THE_SKYBREAKER_ALLIANCE_ICC)
-        pUnit->RemoveAura(SPELL_ON_SKYBREAKER_DECK);
+        pUnit->removeAllAurasById(SPELL_ON_SKYBREAKER_DECK);
 
     if (transport->getEntry() == GO_THE_SKYBREAKER_HORDE_ICC)
-        pUnit->RemoveAura(SPELL_ON_SKYBREAKER_DECK);
+        pUnit->removeAllAurasById(SPELL_ON_SKYBREAKER_DECK);
 
     if (transport->getEntry() == GO_ORGRIM_S_HAMMER_HORDE_ICC)
-        pUnit->RemoveAura(SPELL_ON_ORGRIMS_HAMMER_DECK);
+        pUnit->removeAllAurasById(SPELL_ON_ORGRIMS_HAMMER_DECK);
 
     if (transport->getEntry() == GO_ORGRIM_S_HAMMER_ALLIANCE_ICC)
-        pUnit->RemoveAura(SPELL_ON_ORGRIMS_HAMMER_DECK);
+        pUnit->removeAllAurasById(SPELL_ON_ORGRIMS_HAMMER_DECK);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/InstanceScripts/Wotlk/Naxxramas/Raid_Naxxramas.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/Naxxramas/Raid_Naxxramas.cpp
@@ -196,7 +196,7 @@ void WebWrapAI::OnDied(Unit* /*pKiller*/)
         Player* PlayerPtr = sObjectMgr.GetPlayer(static_cast<uint32_t>(mPlayerGuid));
         if (PlayerPtr != NULL && PlayerPtr->hasAurasWithId(MAEXXNA_WEB_WRAP))
         {
-            PlayerPtr->RemoveAura(MAEXXNA_WEB_WRAP);
+            PlayerPtr->removeAllAurasById(MAEXXNA_WEB_WRAP);
             PlayerPtr->setMoveRoot(false);
         }
 
@@ -225,7 +225,7 @@ void WebWrapAI::Destroy()
         Player* PlayerPtr = sObjectMgr.GetPlayer(static_cast<uint32_t>(mPlayerGuid));
         if (PlayerPtr != NULL && PlayerPtr->hasAurasWithId(MAEXXNA_WEB_WRAP))
         {
-            PlayerPtr->RemoveAura(MAEXXNA_WEB_WRAP);
+            PlayerPtr->removeAllAurasById(MAEXXNA_WEB_WRAP);
             PlayerPtr->setMoveRoot(false);
         }
 
@@ -410,9 +410,9 @@ void NaxxramasWorshipperAI::OnDied(Unit* /*pKiller*/)
             // Not sure about new Frenzy Timer
             mGrandWidow->_resetTimer(mGrandWidow->mFrenzyTimer, 60000 + Util::getRandomUInt(20) * 1000);
             if (mGrandWidow->getCreature()->hasAurasWithId(GRAND_WIDOW_FAERLINA_FRENZY_NORMAL))
-                mGrandWidow->getCreature()->RemoveAura(GRAND_WIDOW_FAERLINA_FRENZY_NORMAL);    // Really needed ?
+                mGrandWidow->getCreature()->removeAllAurasById(GRAND_WIDOW_FAERLINA_FRENZY_NORMAL);    // Really needed ?
             else if (mGrandWidow->getCreature()->hasAurasWithId(GRAND_WIDOW_FAERLINA_FRENZY_HEROIC))
-                mGrandWidow->getCreature()->RemoveAura(GRAND_WIDOW_FAERLINA_FRENZY_HEROIC);    // Really needed ?
+                mGrandWidow->getCreature()->removeAllAurasById(GRAND_WIDOW_FAERLINA_FRENZY_HEROIC);    // Really needed ?
             else
             {
                 mGrandWidow->_resetTimer(mGrandWidow->mPoisonVolleyBoltTimer, 30000);

--- a/src/scripts/InstanceScripts/Wotlk/UtgardeKeep/UtgardeKeep/Instance_UtgardeKeep.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/UtgardeKeep/UtgardeKeep/Instance_UtgardeKeep.cpp
@@ -615,7 +615,7 @@ public:
     {
         if (plr != nullptr && plr->hasAurasWithId(FROST_TOMB_SPELL))
         {
-            plr->RemoveAura(FROST_TOMB_SPELL);
+            plr->removeAllAurasById(FROST_TOMB_SPELL);
         }
 
         despawn(1);

--- a/src/scripts/LuaEngine/AuraFunctions.h
+++ b/src/scripts/LuaEngine/AuraFunctions.h
@@ -184,14 +184,14 @@ namespace LuaAura
     {
         if (!aura)
             RET_NIL();
-        RET_INT(aura->GetAuraSlot());
+        RET_INT(aura->getAuraSlot());
     }
 
     int SetAuraSlot(lua_State* L, Aura* aura)
     {
         if (!aura) return 0;
         uint16_t slot = CHECK_USHORT(L, 1);
-        aura->SetAuraSlot(slot);
+        aura->setAuraSlot(slot);
         return 0;
     }
 };

--- a/src/scripts/LuaEngine/UnitFunctions.h
+++ b/src/scripts/LuaEngine/UnitFunctions.h
@@ -1056,7 +1056,7 @@ public:
     {
         TEST_UNITPLAYER()
         uint32_t auraid = static_cast<uint32_t>(luaL_checkinteger(L, 1));
-        ptr->RemoveAura(auraid);
+        ptr->removeAllAurasById(auraid);
         return 0;
     }
 
@@ -1988,7 +1988,7 @@ public:
     {
         if (!ptr)
             return 0;
-        ptr->RemoveAllAuras();
+        ptr->removeAllAuras();
         return 0;
     }
 
@@ -3534,19 +3534,19 @@ public:
     static int RemoveAurasByMechanic(lua_State* L, Unit* ptr)
     {
         TEST_UNITPLAYER()
-        uint32_t mechanic = static_cast<uint32_t>(luaL_checkinteger(L, 1));
+        auto mechanic = static_cast<SpellMechanic>(luaL_checkinteger(L, 1));
         bool hostileonly = CHECK_BOOL(L, 2);
         if (mechanic)
-            ptr->RemoveAllAurasByMechanic(mechanic, 0, hostileonly);
+            ptr->removeAllAurasBySpellMechanic(mechanic, hostileonly);
         return 0;
     }
 
     static int RemoveAurasType(lua_State* L, Unit* ptr)
     {
         TEST_UNITPLAYER()
-        uint32_t type = static_cast<uint32_t>(luaL_checkinteger(L, 1));
+        auto type = static_cast<AuraEffect>(luaL_checkinteger(L, 1));
         if (type)
-            ptr->RemoveAllAuraType(type);
+            ptr->removeAllAurasByAuraEffect(type);
         return 0;
     }
 
@@ -4037,7 +4037,7 @@ public:
     {
         if (!ptr)
             return 0;
-        ptr->RemoveNegativeAuras();
+        ptr->removeAllNegativeAuras();
         return 0;
     }
 
@@ -4292,7 +4292,7 @@ public:
         if (ptr->isPlayer())
         {
             Player* plr = static_cast<Player*>(ptr);
-            plr->RemoveAura(plr->getMountSpellId());
+            plr->removeAllAurasById(plr->getMountSpellId());
             plr->setMountDisplayId(0);
         }
         else
@@ -5289,8 +5289,8 @@ public:
     static int HasAuraWithMechanic(lua_State* L, Unit* ptr)
     {
         TEST_UNITPLAYER_RET()
-        uint32_t mechanic = CHECK_ULONG(L, 1);
-        if (mechanic && ptr->HasAuraWithMechanics(mechanic))
+        auto mechanic = static_cast<SpellMechanic>(CHECK_ULONG(L, 1));
+        if (mechanic && ptr->hasAuraWithMechanic(mechanic))
             RET_BOOL(true)
             RET_BOOL(false)
     }
@@ -5298,9 +5298,9 @@ public:
     static int HasNegativeAura(lua_State* L, Unit* ptr)
     {
         TEST_UNITPLAYER_RET()
-        for (uint32_t x = MAX_NEGATIVE_VISUAL_AURAS_START; x < MAX_NEGATIVE_VISUAL_AURAS_END; ++x)
+        for (uint16_t x = AuraSlots::NEGATIVE_SLOT_START; x < AuraSlots::NEGATIVE_SLOT_END; ++x)
         {
-            if (ptr->m_auras[x])
+            if (ptr->getAuraWithAuraSlot(x))
                 RET_BOOL(true)
         }
         RET_BOOL(false)
@@ -5309,9 +5309,9 @@ public:
     static int HasPositiveAura(lua_State* L, Unit* ptr)
     {
         TEST_UNITPLAYER()
-        for (uint32_t x = MAX_POSITIVE_VISUAL_AURAS_START; x < MAX_POSITIVE_VISUAL_AURAS_END; ++x)
+        for (uint16_t x = AuraSlots::POSITIVE_SLOT_START; x < AuraSlots::POSITIVE_SLOT_END; ++x)
         {
-            if (ptr->m_auras[x])
+            if (ptr->getAuraWithAuraSlot(x))
                 RET_BOOL(true)
         }
         RET_BOOL(false)
@@ -5711,7 +5711,7 @@ public:
         Unit* o = v->getBase();
 
         if (o->isPlayer())
-            o->RemoveAllAuraType(SPELL_AURA_MOUNTED);
+            o->removeAllAurasByAuraEffect(SPELL_AURA_MOUNTED);
         else
             o->Delete();
 #endif
@@ -5807,7 +5807,7 @@ public:
         else
         {
             if (ptr->isPlayer() && ptr->getVehicle() != nullptr)
-                ptr->RemoveAllAuraType(SPELL_AURA_MOUNTED);
+                ptr->removeAllAurasByAuraEffect(SPELL_AURA_MOUNTED);
         }
 #endif
         return 0;

--- a/src/scripts/QuestScripts/Quest_DeathKnight.cpp
+++ b/src/scripts/QuestScripts/Quest_DeathKnight.cpp
@@ -193,7 +193,7 @@ public:
         setScriptPhase(PHASE_TO_EQUIP);
 
         getCreature()->setStandState(STANDSTATE_STAND);
-        getCreature()->RemoveAura(SPELL_SOUL_PRISON_CHAIN);
+        getCreature()->removeAllAurasById(SPELL_SOUL_PRISON_CHAIN);
 
         float z;
         if (Creature* anchor = getCreature()->getWorldMapCreature(anchorGUID))

--- a/src/scripts/QuestScripts/Quest_Dustwallow_Marsh.cpp
+++ b/src/scripts/QuestScripts/Quest_Dustwallow_Marsh.cpp
@@ -54,7 +54,7 @@ public:
         if (friendlyTimer == BALOS_FRIENDLY_TIMER)
         {
             // set Balos Jacken friendly and start friendlyTimer cooldown
-            getCreature()->RemoveNegativeAuras();
+            getCreature()->removeAllNegativeAuras();
             getCreature()->setFaction(35);
             getCreature()->SetHealthPct(100);
             getCreature()->getThreatManager().clearAllThreat();
@@ -125,7 +125,7 @@ public:
 
     void AIUpdate() override
     {
-        getCreature()->RemoveNegativeAuras();
+        getCreature()->removeAllNegativeAuras();
         getCreature()->setFaction(29);
         getCreature()->SetHealthPct(100);
         getCreature()->getThreatManager().clearAllThreat();
@@ -191,7 +191,7 @@ public:
     void AIUpdate() override
     {
         getCreature()->emote(EMOTE_STATE_KNEEL);
-        getCreature()->RemoveNegativeAuras();
+        getCreature()->removeAllNegativeAuras();
         getCreature()->setFaction(12);
         getCreature()->SetHealthPct(100);
         getCreature()->getThreatManager().clearAllThreat();

--- a/src/scripts/QuestScripts/Quest_Stormwind.cpp
+++ b/src/scripts/QuestScripts/Quest_Stormwind.cpp
@@ -51,7 +51,7 @@ public:
     void AIUpdate() override
     {
         getCreature()->sendChatMessage(CHAT_MSG_MONSTER_SAY, LANG_UNIVERSAL, "Okay, okay! Enough fighting. No one else needs to get hurt.");
-        getCreature()->RemoveNegativeAuras();
+        getCreature()->removeAllNegativeAuras();
         getCreature()->setFaction(12);
         getCreature()->SetHealthPct(100);
         getCreature()->getThreatManager().clearAllThreat();

--- a/src/scripts/QuestScripts/Quest_TirisfalGlades.cpp
+++ b/src/scripts/QuestScripts/Quest_TirisfalGlades.cpp
@@ -138,7 +138,7 @@ public:
     {
         getCreature()->getThreatManager().clearAllThreat();
         getCreature()->getThreatManager().removeMeFromThreatLists();
-        getCreature()->RemoveNegativeAuras();
+        getCreature()->removeAllNegativeAuras();
         getCreature()->setFaction(68);
         _setMeleeDisabled(true);
         getCreature()->getAIInterface()->setAllowedToEnterCombat(false);

--- a/src/scripts/QuestScripts/Quest_Warrior.cpp
+++ b/src/scripts/QuestScripts/Quest_Warrior.cpp
@@ -102,7 +102,7 @@ public:
 
     void AIUpdate() override
     {
-        getCreature()->RemoveNegativeAuras();
+        getCreature()->removeAllNegativeAuras();
         getCreature()->setFaction(11);
         getCreature()->SetHealthPct(100);
         getCreature()->getThreatManager().clearAllThreat();

--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -76,7 +76,7 @@ bool DeathStrike(uint8_t /*effectIndex*/, Spell* pSpell)
     Unit* Target = pSpell->GetUnitTarget();
 
     // Get count of diseases on target which were casted by caster
-    uint32_t count = Target->GetAuraCountWithDispelType(DISPEL_DISEASE, pSpell->getPlayerCaster()->getGuid());
+    uint32_t count = Target->getAuraCountWithDispelType(DISPEL_DISEASE, pSpell->getPlayerCaster()->getGuid());
 
     // Not a logical error, Death Strike should heal only when diseases are presented on its target
     if (count)

--- a/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DruidSpells.cpp
@@ -93,16 +93,16 @@ bool LifeBloom(uint8_t /*effectIndex*/, Aura* a, bool apply)
 
     // Remove other Lifeblooms - but do NOT handle unapply again
     bool expired = true;
-    for (uint32_t x = MAX_POSITIVE_AURAS_EXTEDED_START; x < MAX_POSITIVE_AURAS_EXTEDED_END; x++)
+    for (uint16_t x = AuraSlots::POSITIVE_SLOT_START; x < AuraSlots::POSITIVE_SLOT_END; ++x)
     {
-        if (m_target->m_auras[x])
+        if (auto* const aur = m_target->getAuraWithAuraSlot(x))
         {
-            if (m_target->m_auras[x]->getSpellId() == a->getSpellId())
+            if (aur->getSpellId() == a->getSpellId())
             {
-                m_target->m_auras[x]->m_ignoreunapply = true;
-                if (m_target->m_auras[x]->getTimeLeft())
+                aur->m_ignoreunapply = true;
+                if (aur->getTimeLeft())
                     expired = false;
-                m_target->m_auras[x]->removeAura();
+                aur->removeAura();
             }
         }
     }

--- a/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
@@ -81,22 +81,17 @@ bool TheBeastWithin(uint8_t /*effectIndex*/, Aura* a, bool apply)
 {
     Unit* m_target = a->getOwner();
 
-    uint32_t mechanics[15] = { MECHANIC_CHARMED, MECHANIC_DISORIENTED,    MECHANIC_DISTRACED, MECHANIC_FLEEING,
-                             MECHANIC_ROOTED, MECHANIC_ASLEEP, MECHANIC_ENSNARED, MECHANIC_STUNNED,
-                             MECHANIC_FROZEN, MECHANIC_INCAPACIPATED, MECHANIC_POLYMORPHED, MECHANIC_BANISHED,
-                             MECHANIC_SEDUCED, MECHANIC_HORRIFIED, MECHANIC_SAPPED
-    };
-
-    for (uint32_t x = 0; x < 15; x++)
+    const auto mechanics = sSpellMgr.getCrowdControlMechanicList(false);
+    for (int x = 0; mechanics[x] != MECHANIC_NONE; ++x)
     {
         if (apply)
-        {
             m_target->MechanicsDispels[mechanics[x]]++;
-            m_target->RemoveAllAurasByMechanic(mechanics[x], 0, false);
-        }
         else
             m_target->MechanicsDispels[mechanics[x]]--;
     }
+
+    if (apply)
+        m_target->removeAllAurasBySpellMechanic(mechanics);
 
     return true;
 }
@@ -106,22 +101,18 @@ bool BestialWrath(uint8_t /*effectIndex*/, Aura* a, bool apply)
 {
     Unit* m_target = a->getOwner();
 
-    uint32_t mechanics[15] = { MECHANIC_CHARMED, MECHANIC_DISORIENTED, MECHANIC_DISTRACED, MECHANIC_FLEEING,
-                             MECHANIC_ROOTED, MECHANIC_ASLEEP, MECHANIC_ENSNARED, MECHANIC_STUNNED,
-                             MECHANIC_FROZEN, MECHANIC_INCAPACIPATED, MECHANIC_POLYMORPHED, MECHANIC_BANISHED,
-                             MECHANIC_SEDUCED, MECHANIC_HORRIFIED, MECHANIC_SAPPED
-    };
-
-    for (uint32_t x = 0; x < 15; x++)
+    const auto mechanics = sSpellMgr.getCrowdControlMechanicList(false);
+    for (int x = 0; mechanics[x] != MECHANIC_NONE; ++x)
     {
         if (apply)
-        {
             m_target->MechanicsDispels[mechanics[x]]++;
-            m_target->RemoveAllAurasByMechanic(mechanics[x], 0, false);
-        }
         else
             m_target->MechanicsDispels[mechanics[x]]--;
     }
+
+    if (apply)
+        m_target->removeAllAurasBySpellMechanic(mechanics);
+
     return true;
 }
 

--- a/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
@@ -211,7 +211,7 @@ bool ForemansBlackjack(uint8_t /*effectIndex*/, Spell* pSpell)
         target->stopMoving();
 
     // Remove Zzz aura
-    c_target->RemoveAllAuras();
+    c_target->removeAllAuras();
 
     pSpell->getPlayerCaster()->sendPlayObjectSoundPacket(c_target->getGuid(), 6197);
 
@@ -881,9 +881,11 @@ bool X53Mount(uint8_t /*effectIndex*/, Aura *a, bool apply)
                 {
                     if (skill == 300)
                     {
+#if VERSION_STRING >= TBC
                         if (p->HasSpellWithAuraNameAndBasePoints(SPELL_AURA_ENABLE_FLIGHT2, 310))
                             newspell = 76154;
                         else
+#endif
                             newspell = 75972;
                     }
                     else

--- a/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/RogueSpells.cpp
@@ -92,8 +92,14 @@ bool ImprovedSprint(uint8_t effectIndex, Spell* pSpell)
         if (target == NULL)
             return true;
 
-        target->RemoveAllAurasByMechanic(MECHANIC_ENSNARED, 0, true);
-        target->RemoveAllAurasByMechanic(MECHANIC_ROOTED, 0, true);
+        SpellMechanic mechanics[3] =
+        {
+            MECHANIC_ENSNARED,
+            MECHANIC_ROOTED,
+            MECHANIC_NONE
+        };
+
+        target->removeAllAurasBySpellMechanic(mechanics);
     }
 
     return true;
@@ -106,12 +112,10 @@ bool CloakOfShadows(uint8_t /*effectIndex*/, Spell* s)
     if (!unitTarget || !unitTarget->isAlive())
         return false;
 
-    Aura* pAura;
-    for (uint32_t j = MAX_NEGATIVE_AURAS_EXTEDED_START; j < MAX_NEGATIVE_AURAS_EXTEDED_END; ++j)
+    for (uint16_t j = AuraSlots::NEGATIVE_SLOT_START; j < AuraSlots::NEGATIVE_SLOT_END; ++j)
     {
-        pAura = unitTarget->m_auras[j];
-        if (pAura != NULL && !pAura->IsPassive()
-            && pAura->isNegative()
+        auto pAura = unitTarget->getAuraWithAuraSlot(j);
+        if (pAura != NULL
             && !(pAura->getSpellInfo()->getAttributes() & ATTRIBUTES_IGNORE_INVULNERABILITY)
             && pAura->getSpellInfo()->getFirstSchoolFromSchoolMask() != 0
             )

--- a/src/scripts/SpellHandlers/LegacyFiles/WarlockSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarlockSpells.cpp
@@ -660,7 +660,7 @@ bool DemonicCircleSummon(uint8_t /*effectIndex*/, Aura* a, bool apply)
                 m_target->castSpell(m_target, 62388, true);
         }
         else
-            m_target->RemoveAura(62388);
+            m_target->removeAllAurasById(62388);
     }
     else
     {

--- a/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
@@ -100,22 +100,14 @@ bool HeroicFury(uint8_t /*effectIndex*/, Spell* s)
         p_caster->clearCooldownForSpell(20252);
     }
 
-    for (uint32_t x = MAX_NEGATIVE_AURAS_EXTEDED_START; x < MAX_NEGATIVE_AURAS_EXTEDED_END; ++x)
+    SpellMechanic mechanics[3] =
     {
-        if (p_caster->m_auras[x])
-        {
-            for (uint8_t y = 0; y < 3; ++y)
-            {
-                switch (p_caster->m_auras[x]->getSpellInfo()->getEffectApplyAuraName(y))
-                {
-                    case SPELL_AURA_MOD_ROOT:
-                    case SPELL_AURA_MOD_DECREASE_SPEED:
-                        p_caster->m_auras[x]->removeAura();
-                        break;
-                }
-            }
-        }
-    }
+        MECHANIC_ENSNARED,
+        MECHANIC_ROOTED,
+        MECHANIC_NONE
+    };
+
+    p_caster->removeAllAurasBySpellMechanic(mechanics);
 
     return true;
 }
@@ -192,18 +184,22 @@ bool BerserkerRage(uint8_t /*effectIndex*/, Aura* a, bool apply)
         p_target->rageFromDamageTaken -= 100;
     }
 
+    SpellMechanic mechanics[4] = { MECHANIC_NONE };
     for (uint8_t i = 0; i < 3; i++)
     {
         if (apply)
         {
             p_target->MechanicsDispels[a->getSpellInfo()->getEffectMiscValue(i)]++;
-            p_target->RemoveAllAurasByMechanic(a->getSpellInfo()->getEffectMiscValue(i), 0, false);
+            mechanics[i] = static_cast<SpellMechanic>(a->getSpellInfo()->getEffectMiscValue(i));
         }
         else
         {
             p_target->MechanicsDispels[a->getSpellInfo()->getEffectMiscValue(i)]--;
         }
     }
+
+    if (apply)
+        p_target->removeAllAurasBySpellMechanic(mechanics);
 
     return true;
 }

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -66,9 +66,9 @@ public:
         Aura const* improvedUnholyPresence = nullptr;
 
         // Get all auras in single loop
-        for (uint16_t i = MAX_TOTAL_AURAS_START; i < MAX_TOTAL_AURAS_END; ++i)
+        for (uint16_t i = AuraSlots::PASSIVE_SLOT_START; i < AuraSlots::PASSIVE_SLOT_END; ++i)
         {
-            const auto* const unitAura = aur->getOwner()->m_auras[i];
+            const auto* const unitAura = aur->getOwner()->getAuraWithAuraSlot(i);
             if (unitAura == nullptr)
                 continue;
 

--- a/src/scripts/SpellHandlers/Scripts/Mage.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Mage.cpp
@@ -276,8 +276,12 @@ public:
                 if (aurEff->getAuraEffectType() == SPELL_AURA_NONE)
                     continue;
 
+#if VERSION_STRING == Classic
+                if (aurEff->getAuraEffectType() == SPELL_AURA_PERIODIC_TRIGGER_SPELL)
+#else
                 if (aurEff->getAuraEffectType() == SPELL_AURA_PERIODIC_TRIGGER_SPELL ||
                     aurEff->getAuraEffectType() == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE)
+#endif
                 {
                     ticks = originalAura->getPeriodicTickCountForEffect(aurEff->getEffectIndex());
                     break;

--- a/src/scripts/SpellHandlers/Scripts/Priest.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Priest.cpp
@@ -67,7 +67,7 @@ public:
     void onAuraRemove(Aura* aur, AuraRemoveMode /*mode*/) override
     {
         // Remove Body and Soul poison proc
-        aur->getOwner()->RemoveAura(SPELL_BODY_AND_SOUL_POISON);
+        aur->getOwner()->removeAllAurasById(SPELL_BODY_AND_SOUL_POISON);
     }
 };
 #endif

--- a/src/scripts/SpellHandlers/Scripts/Rogue.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Rogue.cpp
@@ -42,9 +42,10 @@ public:
     bool canProc(SpellProc* spellProc, Unit* /*victim*/, SpellInfo const* /*castingSpell*/, DamageInfo /*damageInfo*/) override
     {
         // Find Slice and Dice aura
-        for (const auto& aur : spellProc->getProcOwner()->m_auras)
+        for (const auto& aurEff : spellProc->getProcOwner()->getAuraEffectList(SPELL_AURA_MOD_HASTE))
         {
-            if (aur == nullptr || aur->getCasterGuid() != spellProc->getCasterGuid())
+            auto* const aur = aurEff->getAura();
+            if (aur->getCasterGuid() != spellProc->getCasterGuid())
                 continue;
 
             const auto spinfo = aur->getSpellInfo();
@@ -61,10 +62,7 @@ public:
             }
         }
 
-        if (sliceAura == nullptr)
-            return false;
-
-        return true;
+        return sliceAura != nullptr;
     }
 
     SpellScriptExecuteState onDoProcEffect(SpellProc* /*spellProc*/, Unit* victim, SpellInfo const* /*castingSpell*/, DamageInfo /*damageInfo*/) override
@@ -79,8 +77,7 @@ public:
             maxDuration = durEntry->Duration3;
 
         // Override the original duration and refresh aura
-        sliceAura->setOriginalDuration(maxDuration);
-        sliceAura->refreshOrModifyStack();
+        sliceAura->setNewMaxDuration(maxDuration);
 
         sliceAura = nullptr;
         return SpellScriptExecuteState::EXECUTE_PREVENT;

--- a/src/world/Chat/Commands/AdminCommands.cpp
+++ b/src/world/Chat/Commands/AdminCommands.cpp
@@ -81,11 +81,17 @@ bool ChatHandler::HandleAdminDispelAllCommand(const char* args, WorldSession* m_
         {
             if (player->getWorldMap() != m_session->GetPlayer()->getWorldMap())
             {
-                sEventMgr.AddEvent(static_cast< Unit* >(player), &Unit::DispelAll, pos ? true : false, EVENT_PLAYER_CHECKFORCHEATS, 100, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+                if (pos)
+                    sEventMgr.AddEvent(static_cast<Unit*>(player), &Unit::removeAllPositiveAuras, EVENT_PLAYER_CHECKFORCHEATS, 100, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+                else
+                    sEventMgr.AddEvent(static_cast<Unit*>(player), &Unit::removeAllNegativeAuras, EVENT_PLAYER_CHECKFORCHEATS, 100, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
             }
             else
             {
-                player->DispelAll(pos ? true : false);
+                if (pos)
+                    player->removeAllPositiveAuras();
+                else
+                    player->removeAllNegativeAuras();
             }
         }
     }

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -263,10 +263,10 @@ bool ChatHandler::HandleCharRemoveAurasCommand(const char* /*args*/, WorldSessio
         return true;
 
     BlueSystemMessage(m_session, "Removing all auras...");
-    for (uint32 i = MAX_REMOVABLE_AURAS_START; i < MAX_REMOVABLE_AURAS_END; ++i)
+    for (uint16_t i = AuraSlots::REMOVABLE_SLOT_START; i < AuraSlots::REMOVABLE_SLOT_END; ++i)
     {
-        if (player_target->m_auras[i] != 0)
-            player_target->m_auras[i]->removeAura();
+        if (auto* const aur = player_target->getAuraWithAuraSlot(i))
+            aur->removeAura();
     }
 
     if (player_target != m_session->GetPlayer())
@@ -282,7 +282,7 @@ bool ChatHandler::HandleCharRemoveSickessCommand(const char* /*args*/, WorldSess
     if (player_target == nullptr)
         return true;
 
-    player_target->RemoveAura(15007);
+    player_target->removeAllAurasById(15007);
 
     if (player_target != m_session->GetPlayer())
     {

--- a/src/world/Chat/Commands/debugcmds.cpp
+++ b/src/world/Chat/Commands/debugcmds.cpp
@@ -810,7 +810,7 @@ bool ChatHandler::HandleAuraUpdateRemove(const char* args, WorldSession* m_sessi
         return false;
     uint8 VisualSlot = (uint8)atoi(pArgs);
     Player* Pl = m_session->GetPlayer();
-    Aura* AuraPtr = Pl->getAuraWithId(Pl->m_auravisuals[VisualSlot]);
+    Aura* AuraPtr = Pl->getAuraWithId(Pl->getVisualAuraList().at(VisualSlot));
     if (!AuraPtr)
     {
         SystemMessage(m_session, "No auraid found in slot %u", VisualSlot);

--- a/src/world/Macros/UnitMacros.hpp
+++ b/src/world/Macros/UnitMacros.hpp
@@ -10,29 +10,6 @@ This file is released under the MIT license. See README-MIT for more information
 
 #define UNIT_SUMMON_SLOTS 6
 
-// these refer to visibility ranges. We need to store each stack of the aura and not just visible count.
-#define MAX_POSITIVE_VISUAL_AURAS_START 0
-#define MAX_POSITIVE_VISUAL_AURAS_END 40
-
-#define MAX_NEGATIVE_VISUAL_AURAS_START MAX_POSITIVE_VISUAL_AURAS_END               // 40 buff slots, 16 debuff slots.
-#define MAX_NEGATIVE_VISUAL_AURAS_END (MAX_POSITIVE_VISUAL_AURAS_END + 16)          // 40 buff slots, 16 debuff slots.
-
-// you hardly get to this but since i was testing i got to it :) : 20 items * 11 (enchants) + 61 talents
-#define MAX_PASSIVE_AURAS_START 0                                                   // these are reserved for talents. No need to check them for removes ?
-#define MAX_PASSIVE_AURAS_END (MAX_PASSIVE_AURAS_START + 140)                       // these are reserved for talents. No need to check them for removes ?
-
-#define MAX_POSITIVE_AURAS_EXTEDED_START MAX_PASSIVE_AURAS_END                      // these are not talents.These are stacks from visible auras
-#define MAX_POSITIVE_AURAS_EXTEDED_END (MAX_POSITIVE_AURAS_EXTEDED_START + 100)     // these are not talents.These are stacks from visible auras
-
-#define MAX_NEGATIVE_AURAS_EXTEDED_START MAX_POSITIVE_AURAS_EXTEDED_END             // these are not talents.These are stacks from visible auras
-#define MAX_NEGATIVE_AURAS_EXTEDED_END (MAX_NEGATIVE_AURAS_EXTEDED_START + 100)     // these are not talents.These are stacks from visible auras
-
-#define MAX_REMOVABLE_AURAS_START (MAX_POSITIVE_AURAS_EXTEDED_START)                // do we need to handle talents at all ?
-#define MAX_REMOVABLE_AURAS_END (MAX_NEGATIVE_AURAS_EXTEDED_END)                    // do we need to handle talents at all ?
-
-#define MAX_TOTAL_AURAS_START (MAX_PASSIVE_AURAS_START)
-#define MAX_TOTAL_AURAS_END (MAX_REMOVABLE_AURAS_END)
-
 #define SPELL_GROUPS 96                                                             // This is actually on 64 bits !
 #define DIMINISHING_GROUP_COUNT 15
 

--- a/src/world/Management/Arenas.cpp
+++ b/src/world/Management/Arenas.cpp
@@ -201,14 +201,14 @@ void Arena::OnAddPlayer(Player* plr)
     plr->m_deathVision = true;
 
     // remove all buffs (exclude talents, include flasks)
-    for (uint32 x = MAX_REMOVABLE_AURAS_START; x < MAX_REMOVABLE_AURAS_END; x++)
+    for (uint32 x = AuraSlots::REMOVABLE_SLOT_START; x < AuraSlots::REMOVABLE_SLOT_END; x++)
     {
-        if (plr->m_auras[x])
+        if (auto* const aur = plr->getAuraWithAuraSlot(x))
         {
-            if (!plr->m_auras[x]->getSpellInfo()->getDurationIndex() && plr->m_auras[x]->getSpellInfo()->getAttributesExC() & ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD)
+            if (!aur->getSpellInfo()->getDurationIndex() && aur->getSpellInfo()->getAttributesExC() & ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD)
                 continue;
 
-            plr->m_auras[x]->removeAura();
+            aur->removeAura();
         }
     }
     // On arena start all conjured items are removed
@@ -248,12 +248,12 @@ void Arena::OnRemovePlayer(Player* plr)
     // remove arena readiness buff
     plr->m_deathVision = false;
 
-    plr->RemoveAllAuras();
+    plr->removeAllAuras();
 
     // Player has left arena, call HookOnPlayerDeath as if he died
     HookOnPlayerDeath(plr);
 
-    plr->RemoveAura(plr->getInitialTeam() ? 35775 - plr->getBgTeam() : 32725 - plr->getBgTeam());
+    plr->removeAllAurasById(plr->getInitialTeam() ? 35775 - plr->getBgTeam() : 32725 - plr->getBgTeam());
     plr->removeFfaPvpFlag();
 
     // Reset all their cooldowns and restore their HP/Mana/Energy to max
@@ -319,7 +319,7 @@ void Arena::OnStart()
         for (std::set<Player*>::iterator itr = m_players[i].begin(); itr != m_players[i].end(); ++itr)
         {
             Player* plr = *itr;
-            plr->RemoveAura(ARENA_PREPARATION);
+            plr->removeAllAurasById(ARENA_PREPARATION);
             m_players2[i].insert(plr->getGuidLow());
 
             // update arena team stats

--- a/src/world/Management/Battleground/Battleground.cpp
+++ b/src/world/Management/Battleground/Battleground.cpp
@@ -347,7 +347,7 @@ void CBattleground::PortPlayer(Player* plr, bool skip_teleport /* = false*/)
     if (!plr->isPvpFlagSet())
         plr->setPvpFlag();
 
-    plr->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_PVP_ENTER);
+    plr->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_PVP_ENTER);
 
     /* Reset the score */
     memset(&plr->m_bgScore, 0, sizeof(BGScore));
@@ -548,7 +548,7 @@ void CBattleground::RemoveAuraFromTeam(uint32 team, uint32 aura)
     for (std::set< Player* >::iterator itr = m_players[team].begin(); itr != m_players[team].end(); ++itr)
     {
         Player* p = *itr;
-        p->RemoveAura(aura);
+        p->removeAllAurasById(aura);
     }
 }
 
@@ -645,10 +645,10 @@ void CBattleground::RemovePlayer(Player* plr, bool logout)
     }
 
     /* remove buffs */
-    plr->RemoveAura(32727); // Arena preparation
-    plr->RemoveAura(44521); // BG preparation
-    plr->RemoveAura(44535);
-    plr->RemoveAura(21074);
+    plr->removeAllAurasById(32727); // Arena preparation
+    plr->removeAllAurasById(44521); // BG preparation
+    plr->removeAllAurasById(44535);
+    plr->removeAllAurasById(21074);
 
     plr->setMoveRoot(false);
 

--- a/src/world/Management/Group.cpp
+++ b/src/world/Management/Group.cpp
@@ -493,13 +493,14 @@ void Group::RemovePlayer(CachedCharacterInfo* info)
         }
 
         //Remove some party auras.
-        for (uint32 i = MAX_POSITIVE_AURAS_EXTEDED_START; i < MAX_POSITIVE_AURAS_EXTEDED_END; i++)
+        for (uint32 i = AuraSlots::POSITIVE_SLOT_START; i < AuraSlots::POSITIVE_SLOT_END; i++)
         {
-            if (pPlayer->m_auras[i] && pPlayer->m_auras[i]->m_areaAura)
+            auto* const aur = pPlayer->getAuraWithAuraSlot(i);
+            if (aur && aur->m_areaAura)
             {
-                Object* caster = pPlayer->m_auras[i]->getCaster();
+                Object* caster = aur->getCaster();
                 if (caster && pPlayer->getGuid() != caster->getGuid())
-                    pPlayer->m_auras[i]->removeAura();
+                    aur->removeAura();
             }
         }
     }
@@ -921,7 +922,7 @@ void Group::UpdateOutOfRangePlayer(Player* pPlayer, bool Distribute, WorldPacket
         {
             if (auramask & (uint64(1) << i))
             {
-                Aura * aurApp = pPlayer->GetAuraWithSlot(i);
+                Aura * aurApp = pPlayer->getAuraWithVisualSlot(i);
                 *data << uint32(aurApp ? aurApp->getSpellId() : 0);
                 *data << uint8(1);
             }
@@ -1013,7 +1014,7 @@ void Group::UpdateOutOfRangePlayer(Player* pPlayer, bool Distribute, WorldPacket
             {
                 if (auramask & (uint64(1) << i))
                 {
-                    Aura * aurApp = pet->GetAuraWithSlot(i);
+                    Aura * aurApp = pet->getAuraWithVisualSlot(i);
                     *data << uint32(aurApp ? aurApp->getSpellId() : 0);
                     *data << uint8(1);
                 }

--- a/src/world/Management/LFG/LFGMgr.cpp
+++ b/src/world/Management/LFG/LFGMgr.cpp
@@ -1781,7 +1781,7 @@ void LfgMgr::TeleportPlayer(Player* player, bool out, bool fromOpcode /*= false*
     sLogger.debug("%u is being teleported %s", player->getGuid(), out ? "out" : "in");
     if (out)
     {
-        player->RemoveAura(LFG_SPELL_LUCK_OF_THE_DRAW);
+        player->removeAllAurasById(LFG_SPELL_LUCK_OF_THE_DRAW);
         player->safeTeleport(player->getBGEntryMapId(), player->getBGEntryInstanceId(), player->getBGEntryPosition());
         return;
     }

--- a/src/world/Objects/DynamicObject.cpp
+++ b/src/world/Objects/DynamicObject.cpp
@@ -278,7 +278,7 @@ void DynamicObject::UpdateTargets()
 
             if ((target != nullptr) && (getDistanceSq(target) > radius))
             {
-                target->RemoveAura(m_spellProto->getId());
+                target->removeAllAurasById(m_spellProto->getId());
                 targets.erase(jtr2);
             }
         }
@@ -315,7 +315,7 @@ void DynamicObject::Remove()
         target = m_WorldMap->getUnit(TargetGUID);
 
         if (target != nullptr)
-            target->RemoveAura(m_spellProto->getId());
+            target->removeAllAurasById(m_spellProto->getId());
     }
 
     //\todo: Despawn animation only for GOs? Zyres.

--- a/src/world/Objects/Item.Legacy.cpp
+++ b/src/world/Objects/Item.Legacy.cpp
@@ -545,7 +545,7 @@ void Item::ApplyEnchantmentBonus(EnchantmentSlot Slot, bool Apply)
                     else
                     {
                         if (Entry->spell[c] != 0)
-                            m_owner->RemoveAuraByItemGUID(Entry->spell[c], getGuid());
+                            m_owner->removeAuraByItemGuid(Entry->spell[c], getGuid());
                     }
                 }
                 break;

--- a/src/world/Objects/Item.cpp
+++ b/src/world/Objects/Item.cpp
@@ -491,7 +491,11 @@ void Item::setItemProperties(ItemProperties const* itemProperties) { m_itemPrope
 bool Item::fitsToSpellRequirements(SpellInfo const* spellInfo) const
 {
     const auto itemProperties = getItemProperties();
+#if VERSION_STRING < WotLK
+    const auto isEnchantSpell = spellInfo->hasEffect(SPELL_EFFECT_ENCHANT_ITEM) || spellInfo->hasEffect(SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY);
+#else
     const auto isEnchantSpell = spellInfo->hasEffect(SPELL_EFFECT_ENCHANT_ITEM) || spellInfo->hasEffect(SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY) || spellInfo->hasEffect(SPELL_EFFECT_ADD_SOCKET);
+#endif
 
     if (spellInfo->getEquippedItemClass() != -1)
     {

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -814,11 +814,11 @@ DamageInfo Object::doSpellDamage(Unit* victim, uint32_t spellId, float_t dmg, ui
     if (isCreatureOrPlayer())
     {
         const auto casterUnit = static_cast<Unit*>(this);
-        casterUnit->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);
+        casterUnit->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);
     }
 
     // Mage talent - Torment the Weak
-    if (isPlayer() && (victim->HasAuraWithMechanics(MECHANIC_ENSNARED) || victim->HasAuraWithMechanics(MECHANIC_DAZED)))
+    if (isPlayer() && (victim->hasAuraWithMechanic(MECHANIC_ENSNARED) || victim->hasAuraWithMechanic(MECHANIC_DAZED)))
     {
         const auto pct = static_cast<float_t>(static_cast<Player*>(this)->m_IncreaseDmgSnaredSlowed);
         damage = damage * (1.0f + (pct / 100.0f));
@@ -1217,7 +1217,7 @@ DamageInfo Object::doSpellHealing(Unit* victim, uint32_t spellId, float_t amt, b
             case 75382:
             {
                 //Tidal Waves
-                casterUnit->RemoveAura(53390, casterUnit->getGuid());
+                casterUnit->removeAllAurasByIdForGuid(53390, casterUnit->getGuid());
             }
             //SPELL_HASH_CHAIN_HEAL
             case 1064:

--- a/src/world/Objects/Units/Creatures/AIInterface.cpp
+++ b/src/world/Objects/Units/Creatures/AIInterface.cpp
@@ -2375,7 +2375,7 @@ void AIInterface::eventDamageTaken(Unit* pUnit, uint32_t misc1)
         sendStoredText(mEmotesOnDamageTaken, pUnit);
     }
 
-    pUnit->RemoveAura(24575);
+    pUnit->removeAllAurasById(24575);
 
     CALL_SCRIPT_EVENT(m_Unit, OnDamageTaken)(pUnit, misc1);
 }
@@ -2520,9 +2520,9 @@ void AIInterface::eventLeaveCombat(Unit* /*pUnit*/, uint32_t /*misc1*/)
     if (m_Unit->isCreature())
     {
         if (m_Unit->isDead())
-            m_Unit->RemoveAllAuras();
+            m_Unit->removeAllAuras();
         else
-            m_Unit->RemoveNegativeAuras();
+            m_Unit->removeAllNegativeAuras();
     }
 
     // restart emote
@@ -2608,7 +2608,7 @@ void AIInterface::eventUnitDied(Unit* pUnit, uint32_t /*misc1*/)
     if (pUnit == nullptr)
         return;
 
-     pUnit->RemoveNegativeAuras();
+     pUnit->removeAllNegativeAuras();
 
     CALL_SCRIPT_EVENT(m_Unit, _internalOnDied)(pUnit);
     CALL_SCRIPT_EVENT(m_Unit, OnDied)(pUnit);
@@ -3599,7 +3599,7 @@ void AIInterface::UpdateAISpells()
             if (AISpell->mDurationTimer.isTimePassed() && AISpell->mForceRemoveAura)
             {
                 getUnit()->interruptSpell();
-                getUnit()->RemoveAura(AISpell->mSpellInfo->getId());
+                getUnit()->removeAllAurasById(AISpell->mSpellInfo->getId());
             }
         }
     }

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -1110,7 +1110,7 @@ void Creature::SetEnslaveSpell(uint32 spellId)
 
 bool Creature::RemoveEnslave()
 {
-    return RemoveAura(m_enslaveSpell);
+    return removeAllAurasByIdReturnCount(m_enslaveSpell) > 0;
 }
 
 void Creature::CalcResistance(uint8_t type)
@@ -2387,7 +2387,7 @@ void Creature::RemoveVendorItem(uint32 itemid)
 
 void Creature::PrepareForRemove()
 {
-    RemoveAllAuras();
+    removeAllAuras();
 
     getSummonInterface()->removeAllSummons();
 
@@ -2406,7 +2406,7 @@ void Creature::PrepareForRemove()
 #endif
 
             if (getCreatedBySpellId() != 0)
-                summoner->RemoveAura(getCreatedBySpellId());
+                summoner->removeAllAurasById(getCreatedBySpellId());
         }
     }
 
@@ -2501,7 +2501,7 @@ void Creature::die(Unit* pAttacker, uint32 /*damage*/, uint32 spellid)
     smsg_AttackStop(this);
     setHealth(0);
 
-    RemoveAllNonPersistentAuras();
+    removeAllNonPersistentAuras();
 
     CALL_SCRIPT_EVENT(pAttacker, _internalOnTargetDied)(this);
     CALL_SCRIPT_EVENT(pAttacker, OnTargetDied)(this);

--- a/src/world/Objects/Units/Creatures/Pet.cpp
+++ b/src/world/Objects/Units/Creatures/Pet.cpp
@@ -1259,7 +1259,7 @@ void Pet::DelayedRemove(bool bTime, bool dismiss, uint32 delay)
 
 void Pet::PrepareForRemove(bool bUpdate, bool bSetOffline)
 {
-    RemoveAllAuras();           // Prevent pet overbuffing
+    removeAllAuras();           // Prevent pet overbuffing
     m_Owner->eventDismissPet();
 
     if (bUpdate)
@@ -1861,7 +1861,7 @@ void Pet::ApplyPetLevelAbilities()
     };
 
     if (pet_family < 47)
-        RemoveAura(family_aura[pet_family]);  //If the pet gained a level, we need to remove the auras to re-calculate everything.
+        removeAllAurasById(family_aura[pet_family]);  //If the pet gained a level, we need to remove the auras to re-calculate everything.
 
     LoadPetAuras(-1);//These too
 
@@ -1945,7 +1945,7 @@ void Pet::LoadPetAuras(int32 id)
     if (id == -1)           //unload all
     {
         for (uint32 x = 0; x < 9; ++x)
-            RemoveAura(mod_auras[x]);
+            removeAllAurasById(mod_auras[x]);
     }
     else if (id == -2)      //load all
     {
@@ -1954,7 +1954,7 @@ void Pet::LoadPetAuras(int32 id)
     }
     else if (mod_auras[id])  //reload one
     {
-        RemoveAura(mod_auras[id]);
+        removeAllAurasById(mod_auras[id]);
         castSpell(this, mod_auras[id], true);
     }
 

--- a/src/world/Objects/Units/Creatures/Summons/Summon.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/Summon.cpp
@@ -92,7 +92,7 @@ void Summon::OnPreRemoveFromWorld()
         return;
 
     if (getCreatedBySpellId() != 0)
-        m_unitOwner->RemoveAura(getCreatedBySpellId());
+        m_unitOwner->removeAllAurasById(getCreatedBySpellId());
 
     if (!isTotem())
         m_unitOwner->getSummonInterface()->removeGuardian(this, false);
@@ -269,7 +269,7 @@ void TotemSummon::unSummon()
         setDeathState(DEAD);*/
 
     interruptSpell();
-    RemoveAllAuras();
+    removeAllAuras();
 
     Summon::unSummon();
 }

--- a/src/world/Server/Packets/Handlers/MovementHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MovementHandler.cpp
@@ -388,7 +388,7 @@ void WorldSession::handleMovementOpcodes(WorldPacket& recvData)
             {
                 if (movementInfo.position.getOrientation() != mover->GetOrientation())
                 {
-                    mover->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_TURNING);
+                    mover->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_TURNING);
                     mover->SetOrientation(movementInfo.position.getOrientation());
                 }
             }

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -228,7 +228,7 @@ void WorldSession::handleGossipHelloOpcode(WorldPacket& recvPacket)
         creature->SetSpawnLocation(creature->GetPosition());
 
         if (_player->isStealthed())
-            _player->RemoveAllAuraType(SPELL_AURA_MOD_STEALTH);
+            _player->removeAllAurasByAuraEffect(SPELL_AURA_MOD_STEALTH);
 
         _player->onTalkReputation(creature->m_factionEntry);
 
@@ -554,7 +554,8 @@ void WorldSession::handleSpiritHealerActivateOpcode(WorldPacket& /*recvPacket*/)
         if (_player->getLevel() < 20)
             duration = (_player->getLevel() - 10) * 60000;
 
-        _player->SetAurDuration(15007, duration);
+        if (const auto aur = _player->getAuraWithId(15007))
+            aur->setNewMaxDuration(duration);
     }
 
     _player->setHealth(_player->getMaxHealth() / 2);

--- a/src/world/Server/Packets/Handlers/PetHandler.cpp
+++ b/src/world/Server/Packets/Handlers/PetHandler.cpp
@@ -463,10 +463,10 @@ void WorldSession::handlePetCancelAura(WorldPacket& recvPacket)
     const auto creature = _player->getWorldMap()->getCreature(srlPacket.guid.getGuidLow());
 #ifdef FT_VEHICLES
     if (creature != nullptr && (creature->getPlayerOwner() == _player  || _player->getVehicleKit() && _player->getVehicleKit()->isControler(_player)))
-        creature->RemoveAura(srlPacket.spellId);
+        creature->removeAllAurasById(srlPacket.spellId);
 #else
     if (creature != nullptr && (creature->getPlayerOwner() == _player))
-        creature->RemoveAura(srlPacket.spellId);
+        creature->removeAllAurasById(srlPacket.spellId);
 #endif
 }
 

--- a/src/world/Server/Packets/Handlers/SpellHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SpellHandler.cpp
@@ -48,7 +48,7 @@ void WorldSession::handleSpellClick(WorldPacket& recvPacket)
 
     // Commented this out for now, it's not even working -Appled
     /*const uint32_t lightWellCharges = 59907;
-    if (creatureTarget->RemoveAura(lightWellCharges))
+    if (creatureTarget->removeAllAurasById(lightWellCharges))
     {
         uint32_t lightWellRenew[] =
         {
@@ -227,7 +227,7 @@ void WorldSession::handleCancelAuraOpcode(WorldPacket& recvPacket)
     if (spellAura->isNegative())
         return;
 
-    _player->removeAllAurasById(spellId);
+    spellAura->removeAura();
 }
 
 void WorldSession::handleCancelChannellingOpcode(WorldPacket& recvPacket)

--- a/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
+++ b/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
@@ -66,7 +66,7 @@ namespace AscEmu::Packets
                 packet << uint64_t(auramask);
                 for (uint8_t i = 0; i < 64; ++i)
                 {
-                    if (const auto aurApp = player->GetAuraWithSlot(i))
+                    if (const auto aurApp = player->getAuraWithVisualSlot(i))
                     {
                         auramask |= (uint64_t(1) << i);
                         packet << uint32_t(aurApp->getSpellId());
@@ -92,7 +92,7 @@ namespace AscEmu::Packets
                     packet << uint64_t(petauramask);
                     for (uint8_t i = 0; i < 64; ++i)
                     {
-                        if (const auto auraApp = playerPet->GetAuraWithSlot(i))
+                        if (const auto auraApp = playerPet->getAuraWithVisualSlot(i))
                         {
                             petauramask |= (uint64_t(1) << i);
                             packet << uint32_t(auraApp->getSpellId());

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -947,12 +947,12 @@ void CreatureAIScript::_applyAura(uint32_t spellId)
 
 void CreatureAIScript::_removeAura(uint32_t spellId)
 {
-    _creature->RemoveAura(spellId);
+    _creature->removeAllAurasById(spellId);
 }
 
 void CreatureAIScript::_removeAllAuras()
 {
-    _creature->RemoveAllAuras();
+    _creature->removeAllAuras();
 }
 
 void CreatureAIScript::_removeAuraOnPlayers(uint32_t spellId)
@@ -960,7 +960,7 @@ void CreatureAIScript::_removeAuraOnPlayers(uint32_t spellId)
     for (auto object : _creature->getInRangePlayersSet())
     {
         if (object != nullptr)
-            static_cast<Player*>(object)->RemoveAura(spellId);
+            static_cast<Player*>(object)->removeAllAurasById(spellId);
     }
 }
 

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -670,8 +670,10 @@ void ScriptMgr::register_dummy_aura(uint32 entry, exp_handle_dummy_aura callback
         return;
     }
 
+#if VERSION_STRING >= TBC
     if (!sp->hasEffectApplyAuraName(SPELL_AURA_DUMMY) && !sp->hasEffectApplyAuraName(SPELL_AURA_PERIODIC_TRIGGER_DUMMY))
         sLogger.debugFlag(AscEmu::Logging::LF_SPELL, "ScriptMgr registered a dummy aura handler for Spell ID: %u (%s), but spell has no dummy aura!", entry, sp->getName().c_str());
+#endif
 
     _auras.insert(HandleDummyAuraMap::value_type(entry, callback));
 }

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -374,7 +374,7 @@ void WorldSession::LogoutPlayer(bool Save)
         if (Save)
             _player->SaveToDB(false);
 
-        // Dismounting with RemoveAllAuras may in certain cases add a player
+        // Dismounting with removeAllAuras may in certain cases add a player
         // aura,
         // which can result in a nice crash during shutdown. Therefore let's
         // dismount on logout.
@@ -382,7 +382,7 @@ void WorldSession::LogoutPlayer(bool Save)
         // ;)
         _player->dismount();
 
-        _player->RemoveAllAuras();
+        _player->removeAllAuras();
         if (_player->IsInWorld())
             _player->RemoveFromWorld();
 

--- a/src/world/Spell/Customization/HackFixes.cpp
+++ b/src/world/Spell/Customization/HackFixes.cpp
@@ -756,11 +756,13 @@ void SpellMgr::applyHackFixes()
                 sp->removeAttributes(ATTRIBUTES_ONLY_OUTDOORS);
             }
 
+#if VERSION_STRING >= WotLK
             if (sp->getEffectApplyAuraName(b) == SPELL_AURA_PREVENT_RESURRECTION)
             {
                 sp->addAttributes(ATTRIBUTES_NEGATIVE);
                 sp->addAttributesExC(ATTRIBUTESEXC_CAN_PERSIST_AND_CASTED_WHILE_DEAD);
             }
+#endif
         }
 
         // DankoDJ: Refactoring session 16/02/2016 new functions
@@ -2795,6 +2797,7 @@ void SpellMgr::applyHackFixes()
         sp->setEffectImplicitTargetA(EFF_TARGET_SELF, 1);
     }
 
+#if VERSION_STRING >= TBC
     //    Empower Rune Weapon
     sp = getMutableSpellInfo(47568);
     if (sp != nullptr)
@@ -2803,6 +2806,7 @@ void SpellMgr::applyHackFixes()
         sp->setEffectBasePoints(1, 2);
         sp->setEffectMiscValue(RUNE_UNHOLY, 2);
     }
+#endif
 
     // DEATH AND DECAY
     sp = getMutableSpellInfo(49937);

--- a/src/world/Spell/Customization/SpellCustomizations.cpp
+++ b/src/world/Spell/Customization/SpellCustomizations.cpp
@@ -796,8 +796,11 @@ void SpellMgr::setSpellEffectAmplitude(SpellInfo* sp)
             continue;
 
         if (sp->getEffectApplyAuraName(i) == 0 &&
-            (sp->getEffectApplyAuraName(i) == SPELL_AURA_PERIODIC_TRIGGER_SPELL ||
-                sp->getEffectApplyAuraName(i) == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE))
+            (sp->getEffectApplyAuraName(i) == SPELL_AURA_PERIODIC_TRIGGER_SPELL
+#if VERSION_STRING >= TBC
+                || sp->getEffectApplyAuraName(i) == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE
+#endif
+            ))
         {
             sp->setEffectAmplitude(1000, i);
 

--- a/src/world/Spell/Definitions/AuraEffects.hpp
+++ b/src/world/Spell/Definitions/AuraEffects.hpp
@@ -5,6 +5,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "WorldConf.h"
+
 #include <cstdint>
 
 enum AuraEffect : uint32_t
@@ -195,6 +197,8 @@ enum AuraEffect : uint32_t
     SPELL_AURA_DECREASE_ATTACKER_CHANGE_TO_CRIT_RANGED = 188,           // Reduces Attacker Chance to Crit with Ranged (Melee?)
     SPELL_AURA_INCREASE_REPUTATION = 190,                               // Increases reputation from killed creatures
     SPELL_AURA_SPEED_LIMIT = 191,                                       // speed limit
+    // TBC begins
+#if VERSION_STRING >= TBC
     SPELL_AURA_MELEE_SLOW_PCT = 192,
     SPELL_AURA_INCREASE_TIME_BETWEEN_ATTACKS = 193,
     SPELL_AURA_INREASE_SPELL_DAMAGE_PCT_OF_INTELLECT = 194,             // NOT USED ANYMORE - 174 used instead
@@ -248,6 +252,9 @@ enum AuraEffect : uint32_t
     SPELL_AURA_259 = 259,
     SPELL_AURA_260 = 260,
     SPELL_AURA_PHASE = 261,
+#endif
+    // Wotlk begins
+#if VERSION_STRING >= WotLK
     SPELL_AURA_IGNORE_TARGET_AURA_STATE = 262,
     SPELL_AURA_ALLOW_ONLY_ABILITY = 263,
     SPELL_AURA_264 = 264,
@@ -303,6 +310,9 @@ enum AuraEffect : uint32_t
     SPELL_AURA_PREVENT_RESURRECTION = 314,
     SPELL_AURA_315 = 315,
     SPELL_AURA_ALLOW_HASTE_AFFECT_DURATION = 316,
+#endif
+    // Cata begins
+#if VERSION_STRING >= Cata
     SPELL_AURA_317 = 317,
     SPELL_AURA_318 = 318,
     SPELL_AURA_319 = 319,
@@ -357,6 +367,9 @@ enum AuraEffect : uint32_t
     SPELL_AURA_368 = 368,
     SPELL_AURA_369 = 369,
     SPELL_AURA_370 = 370,
+#endif
+    // Mop begins
+#if VERSION_STRING >= Mop
     SPELL_AURA_371 = 371,
     SPELL_AURA_372 = 372,
     SPELL_AURA_373 = 373,
@@ -424,5 +437,6 @@ enum AuraEffect : uint32_t
     SPELL_AURA_435 = 435,
     SPELL_AURA_436 = 436,
     SPELL_AURA_437 = 437,
+#endif
     TOTAL_SPELL_AURAS
 };

--- a/src/world/Spell/Definitions/AuraSlots.hpp
+++ b/src/world/Spell/Definitions/AuraSlots.hpp
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "WorldConf.h"
+
+#include <cstdint>
+
+namespace AuraSlots
+{
+    enum AuraSlotEnum : uint16_t
+    {
+        PASSIVE_SLOT_START      = 0,
+#if VERSION_STRING == Classic
+        // 100 passive aura slots for each unit
+        PASSIVE_SLOT_END        = PASSIVE_SLOT_START + 100,
+        // 32 helpful aura slots for each unit
+        POSITIVE_SLOT_START     = PASSIVE_SLOT_END,
+        POSITIVE_SLOT_END       = POSITIVE_SLOT_START + 32,
+        // 16 harmful aura slots for each unit
+        NEGATIVE_SLOT_START     = POSITIVE_SLOT_END,
+        NEGATIVE_SLOT_END       = NEGATIVE_SLOT_START + 16,
+#elif VERSION_STRING == TBC
+        // 170 passive aura slots for each unit
+        PASSIVE_SLOT_END        = PASSIVE_SLOT_START + 170,
+        // 40 helpful aura slots for each unit
+        POSITIVE_SLOT_START     = PASSIVE_SLOT_END,
+        POSITIVE_SLOT_END       = POSITIVE_SLOT_START + 40,
+        // 40 harmful aura slots for each unit
+        NEGATIVE_SLOT_START     = POSITIVE_SLOT_END,
+        NEGATIVE_SLOT_END       = NEGATIVE_SLOT_START + 40,
+#else
+        // 180 passive aura slots for each unit
+        PASSIVE_SLOT_END        = PASSIVE_SLOT_START + 180,
+        // 80 helpful aura slots for each unit
+        POSITIVE_SLOT_START     = PASSIVE_SLOT_END,
+        POSITIVE_SLOT_END       = POSITIVE_SLOT_START + 80,
+        // 100 harmful aura slots for each unit
+        NEGATIVE_SLOT_START     = POSITIVE_SLOT_END,
+        NEGATIVE_SLOT_END       = NEGATIVE_SLOT_START + 100,
+#endif
+
+        // Helpers
+
+        REMOVABLE_SLOT_START = POSITIVE_SLOT_START,
+        REMOVABLE_SLOT_END = NEGATIVE_SLOT_END,
+
+        TOTAL_SLOT_START = PASSIVE_SLOT_START,
+        TOTAL_SLOT_END = NEGATIVE_SLOT_END,
+    };
+
+    // These refer to visual slots (= auras visible on client)
+    enum VisualAuraSlots : uint8_t
+    {
+        POSITIVE_VISUAL_SLOT_START  = 0,
+#if VERSION_STRING == Classic
+        POSITIVE_VISUAL_SLOT_END    = POSITIVE_VISUAL_SLOT_START + 32,
+#else
+        POSITIVE_VISUAL_SLOT_END    = POSITIVE_VISUAL_SLOT_START + 40,
+#endif
+        NEGATIVE_VISUAL_SLOT_START  = POSITIVE_VISUAL_SLOT_END,
+        NEGATIVE_VISUAL_SLOT_END    = NEGATIVE_VISUAL_SLOT_START + 16,
+    };
+};

--- a/src/world/Spell/Definitions/CMakeLists.txt
+++ b/src/world/Spell/Definitions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC_SPELL_DEFINITIONS_FILES
     ${PATH_PREFIX}/AuraEffects.hpp
     ${PATH_PREFIX}/AuraInterruptFlags.hpp
     ${PATH_PREFIX}/AuraRemoveMode.hpp
+    ${PATH_PREFIX}/AuraSlots.hpp
     ${PATH_PREFIX}/AuraStates.hpp
     ${PATH_PREFIX}/CastInterruptFlags.hpp
     ${PATH_PREFIX}/ChannelInterruptFlags.hpp

--- a/src/world/Spell/Definitions/SpellEffects.hpp
+++ b/src/world/Spell/Definitions/SpellEffects.hpp
@@ -5,6 +5,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "WorldConf.h"
+
 enum SpellEffect
 {
     SPELL_EFFECT_NULL = 0,
@@ -137,6 +139,8 @@ enum SpellEffect
     SPELL_EFFECT_PROSPECTING,               //    127
     SPELL_EFFECT_APPLY_FRIEND_AREA_AURA,    //    128
     SPELL_EFFECT_APPLY_ENEMY_AREA_AURA,     //    129
+    // TBC begins
+#if VERSION_STRING >= TBC
     SPELL_EFFECT_UNKNOWN_130,               //    130
     SPELL_EFFECT_UNKNOWN_131,               //    131
     SPELL_EFFECT_PLAY_MUSIC,                //    132
@@ -161,6 +165,9 @@ enum SpellEffect
     SPELL_EFFECT_UNKNOWN_151,               //    151
     SPELL_EFFECT_UNKNOWN_152,               //    152
     SPELL_EFFECT_SUMMON_TARGET,             //    153
+#endif
+    // Wotlk begins
+#if VERSION_STRING >= WotLK
     SPELL_EFFECT_SUMMON_REFER_A_FRIEND,     //    154
     SPELL_EFFECT_DUAL_WIELD_2H,             //    155
     SPELL_EFFECT_ADD_SOCKET,                //    156
@@ -172,6 +179,9 @@ enum SpellEffect
     SPELL_EFFECT_ACTIVATE_SPEC,             //    162
     SPELL_EFFECT_UNKNOWN_163,               //    163
     SPELL_EFFECT_UNKNOWN_164,               //    164
+#endif
+    // Cata begins
+#if VERSION_STRING >= Cata
     SPELL_EFFECT_UNKNOWN_165,               //    165
     SPELL_EFFECT_UNKNOWN_166,               //    166
     SPELL_EFFECT_UNKNOWN_167,               //    167
@@ -190,5 +200,7 @@ enum SpellEffect
     SPELL_EFFECT_UNKNOWN_180,               //    180
     SPELL_EFFECT_UNKNOWN_181,               //    181
     SPELL_EFFECT_UNKNOWN_182,               //    182
-    TOTAL_SPELL_EFFECTS                     //    183
+#endif
+    // TODO: mop
+    TOTAL_SPELL_EFFECTS
 };

--- a/src/world/Spell/Definitions/SpellMechanics.hpp
+++ b/src/world/Spell/Definitions/SpellMechanics.hpp
@@ -5,6 +5,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include <cstdint>
+
 enum SpellMechanic : uint8_t
 {
     MECHANIC_NONE          = 0,

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -628,10 +628,12 @@ uint8 Spell::DidHit(uint32 effindex, Unit* target)
     /* Check if the player target is able to deflect spells                 */
     /* Currently (3.3.5a) there is only spell doing that: Deterrence        */
     /************************************************************************/
+#if VERSION_STRING >= WotLK
     if (p_victim && p_victim->hasAuraWithAuraEffect(SPELL_AURA_DEFLECT_SPELLS))
     {
         return SPELL_DID_HIT_DEFLECT;
     }
+#endif
 
     // APGL End
     // MIT Start
@@ -742,11 +744,13 @@ uint8 Spell::DidHit(uint32 effindex, Unit* target)
                 return SPELL_DID_HIT_IMMUNE;
         }
 
+#if VERSION_STRING >= TBC
         if (target->hasSpellImmunity(SPELL_IMMUNITY_SPELL_HASTE))
         {
             if (getSpellInfo()->getEffectApplyAuraName(effindex) == SPELL_AURA_INCREASE_CASTING_TIME_PCT)
                 return SPELL_DID_HIT_IMMUNE;
         }
+#endif
 
         if (target->hasSpellImmunity(SPELL_IMMUNITY_INTERRUPT_CAST))
         {
@@ -779,8 +783,11 @@ uint8 Spell::DidHit(uint32 effindex, Unit* target)
 
         if (target->hasSpellImmunity(SPELL_IMMUNITY_KNOCKBACK))
         {
-            if (getSpellInfo()->getEffect(effindex) == SPELL_EFFECT_KNOCK_BACK ||
-                getSpellInfo()->getEffect(effindex) == SPELL_EFFECT_KNOCK_BACK_DEST)
+            if (getSpellInfo()->getEffect(effindex) == SPELL_EFFECT_KNOCK_BACK
+#if VERSION_STRING >= TBC
+                || getSpellInfo()->getEffect(effindex) == SPELL_EFFECT_KNOCK_BACK_DEST
+#endif
+                )
                 return SPELL_DID_HIT_IMMUNE;
         }
 
@@ -844,11 +851,15 @@ uint8 Spell::DidHit(uint32 effindex, Unit* target)
                     if (reflectAura->charges <= 0)
                     {
                         // should delete + erase RSS too, if unit hasn't such an aura...
-                        if (!u_victim->RemoveAura(reflectAura->spellId))
+                        if (!u_victim->hasAurasWithId(reflectAura->spellId))
                         {
                             // ...do it manually
                             delete reflectAura;
                             u_victim->m_reflectSpellSchool.remove(reflectAura);
+                        }
+                        else
+                        {
+                            u_victim->removeAllAurasById(reflectAura->spellId);
                         }
                     }
                 }
@@ -1112,8 +1123,8 @@ void Spell::castMeOld()
             case 68010:
             case 71930:
             {
-                p_caster->RemoveAura(53672);
-                p_caster->RemoveAura(54149);
+                p_caster->removeAllAurasById(53672);
+                p_caster->removeAllAurasById(54149);
             } break;
         }
 
@@ -1133,8 +1144,8 @@ void Spell::castMeOld()
             };
             if (p_caster->hasAurasWithId(arcanePotency))
             {
-                p_caster->RemoveAura(57529);
-                p_caster->RemoveAura(57531);
+                p_caster->removeAllAurasById(57529);
+                p_caster->removeAllAurasById(57531);
             }
         }
 
@@ -1259,13 +1270,13 @@ void Spell::castMeOld()
                     if (p_caster->getBattleground()->GetType() == BATTLEGROUND_WARSONG_GULCH)
                     {
                         if (p_caster->getTeam() == 0)
-                            p_caster->RemoveAura(23333);    // ally player drop horde flag if they have it
+                            p_caster->removeAllAurasById(23333);    // ally player drop horde flag if they have it
                         else
-                            p_caster->RemoveAura(23335);    // horde player drop ally flag if they have it
+                            p_caster->removeAllAurasById(23335);    // horde player drop ally flag if they have it
                     }
                     if (p_caster->getBattleground()->GetType() == BATTLEGROUND_EYE_OF_THE_STORM)
 
-                        p_caster->RemoveAura(34976);        // drop the flag
+                        p_caster->removeAllAurasById(34976);        // drop the flag
                     break;
             }
         }
@@ -1478,7 +1489,7 @@ void Spell::HandleAddAura(uint64 guid)
     // remove any auras with same type
     if (getSpellInfo()->custom_BGR_one_buff_on_target > 0)
     {
-        Target->RemoveAurasByBuffType(getSpellInfo()->custom_BGR_one_buff_on_target, m_caster->getGuid(), getSpellInfo()->getId());
+        Target->removeAllAurasBySpellType(static_cast<SpellTypes>(getSpellInfo()->custom_BGR_one_buff_on_target), m_caster->getGuid(), getSpellInfo()->getId());
     }
 
     uint32 spellid = 0;

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -210,6 +210,7 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::SpellAuraIncreaseRating,                                         // 189 SPELL_AURA_INCREASE_RATING
     &Aura::SpellAuraIncreaseRepGainPct,                                     // 190 SPELL_AURA_INCREASE_REP_GAIN_PCT
     &Aura::SpellAuraLimitSpeed,                                             // 191 SPELL_AURA_LIMIT_SPEED
+#if VERSION_STRING >= TBC
     &Aura::SpellAuraMeleeHaste,                                             // 192 SPELL_AURA_MELEE_HASTE
     &Aura::SpellAuraIncreaseTimeBetweenAttacksPCT,                          // 193 SPELL_AURA_INCREASE_TIME_BETWEEN_ATTACKS_PCT
     &Aura::spellAuraEffectNotImplemented,                                   // 194 SPELL_AURA_194
@@ -280,6 +281,8 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::spellAuraEffectNotImplemented,                                   // 259 SPELL_AURA_259
     &Aura::spellAuraEffectNotImplemented,                                   // 260 SPELL_AURA_260
     &Aura::SpellAuraPhase,                                                  // 261 SPELL_AURA_PHASE
+#endif
+#if VERSION_STRING >= WotLK
     &Aura::spellAuraEffectNotImplemented,                                   // 262 SPELL_AURA_262
     &Aura::SpellAuraAllowOnlyAbility,                                       // 263 SPELL_AURA_ALLOW_ONLY_ABILITY
     &Aura::spellAuraEffectNotImplemented,                                   // 264 SPELL_AURA_264
@@ -335,6 +338,8 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::spellAuraEffectNotImplemented,                                   // 314 SPELL_AURA_314
     &Aura::spellAuraEffectNotImplemented,                                   // 315 SPELL_AURA_315
     &Aura::spellAuraEffectNotImplemented,                                   // 316 SPELL_AURA_ALLOW_HASTE_AFFECT_DURATION
+#endif
+#if VERSION_STRING >= Cata
     &Aura::spellAuraEffectNotImplemented,                                   // 317 SPELL_AURA_317
     &Aura::spellAuraEffectNotImplemented,                                   // 318 SPELL_AURA_318
     &Aura::spellAuraEffectNotImplemented,                                   // 319 SPELL_AURA_319
@@ -389,6 +394,8 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::spellAuraEffectNotImplemented,                                   // 368 SPELL_AURA_368
     &Aura::spellAuraEffectNotImplemented,                                   // 369 SPELL_AURA_369
     &Aura::spellAuraEffectNotImplemented,                                   // 370 SPELL_AURA_370
+#endif
+#if VERSION_STRING >= Mop
     &Aura::spellAuraEffectNotImplemented,                                   // 371 SPELL_AURA_371
     &Aura::spellAuraEffectNotImplemented,                                   // 372 SPELL_AURA_372
     &Aura::spellAuraEffectNotImplemented,                                   // 373 SPELL_AURA_373
@@ -456,6 +463,7 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
     &Aura::spellAuraEffectNotImplemented,                                   // 435 SPELL_AURA_435
     &Aura::spellAuraEffectNotImplemented,                                   // 436 SPELL_AURA_436
     &Aura::spellAuraEffectNotImplemented,                                   // 437 SPELL_AURA_437
+#endif
 };
 
 const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
@@ -652,6 +660,7 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
     "SPELL_AURA_INCREASE_RATING",                                           // 189 missing // Apply Aura: Increases Rating
     "SPELL_AURA_INCREASE_REP_GAIN_PCT",                                     // 190 // used // Apply Aura: Increases Reputation Gained by % // https://classic.wowhead.com/spell=30754/ (SPELL_AURA_MOD_FACTION_REPUTATION_GAIN)
     "SPELL_AURA_LIMIT_SPEED",                                               // 191 speed limit // https://classic.wowhead.com/spell=29894/
+#if VERSION_STRING >= TBC
     "SPELL_AURA_MELEE_HASTE",                                               // 192 Apply Aura: Melee Slow %
     "SPELL_AURA_INCREASE_TIME_BETWEEN_ATTACKS_PCT",                         // 193 Apply Aura: Increase Time Between Attacks (Melee, Ranged and Spell) by %
     "SPELL_AURA_194",                                                       // 194 NOT USED ANYMORE - 174 used instead // Apply Aura: Increase Spell Damage by % of Intellect (All)
@@ -722,6 +731,8 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
     "SPELL_AURA_259",                                                       // 259 Mod Periodic Damage Taken Pct - Periodic Shadow damage taken increased by 3% // http://thottbot.com/s60448
     "SPELL_AURA_260",                                                       // 260 Screen Effect
     "SPELL_AURA_PHASE",                                                     // 261
+#endif
+#if VERSION_STRING >= WotLK
     "SPELL_AURA_262",                                                       // 262
     "SPELL_AURA_ALLOW_ONLY_ABILITY",                                        // 263
     "SPELL_AURA_264",                                                       // 264
@@ -777,6 +788,8 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
     "SPELL_AURA_314",                                                       // 314
     "SPELL_AURA_315",                                                       // 315
     "SPELL_AURA_ALLOW_HASTE_AFFECT_DURATION",                               // 316
+#endif
+#if VERSION_STRING >= Cata
     "SPELL_AURA_317",                                                       // 317
     "SPELL_AURA_318",                                                       // 318
     "SPELL_AURA_319",                                                       // 319
@@ -831,6 +844,8 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
     "SPELL_AURA_368",                                                       // 368
     "SPELL_AURA_369",                                                       // 369
     "SPELL_AURA_370",                                                       // 370
+#endif
+#if VERSION_STRING >= Mop
     "SPELL_AURA_371",                                                       // 371
     "SPELL_AURA_372",                                                       // 372
     "SPELL_AURA_373",                                                       // 373
@@ -898,6 +913,7 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
     "SPELL_AURA_435",                                                       // 435
     "SPELL_AURA_436",                                                       // 436
     "SPELL_AURA_437",                                                       // 437
+#endif
 };
 
 void Aura::spellAuraEffectNotImplemented(AuraEffectModifier* aurEff, bool /*apply*/)
@@ -1359,9 +1375,9 @@ void Aura::spellAuraEffectModShapeshift(AuraEffectModifier* aurEff, bool apply)
             }
             else
             {
-                getOwner()->RemoveAura(54817);
-                getOwner()->RemoveAura(54879);
-                getOwner()->RemoveAura(61610);
+                getOwner()->removeAllAurasById(54817);
+                getOwner()->removeAllAurasById(54879);
+                getOwner()->removeAllAurasById(61610);
             }
         } break;
 #endif
@@ -1422,7 +1438,7 @@ void Aura::spellAuraEffectModShapeshift(AuraEffectModifier* aurEff, bool apply)
     if (apply)
     {
         if (removePolymorph && getOwner()->hasUnitStateFlag(UNIT_STATE_POLYMORPHED))
-            getOwner()->RemoveAura(getOwner()->getTransformAura());
+            getOwner()->removeAllAurasById(getOwner()->getTransformAura());
 
         if (modelId != 0)
         {
@@ -1466,15 +1482,16 @@ void Aura::spellAuraEffectModShapeshift(AuraEffectModifier* aurEff, bool apply)
         getOwner()->restoreDisplayId();
 
         if (passiveSpellId != 0)
-            getOwner()->RemoveAura(passiveSpellId);
+            getOwner()->removeAllAurasById(passiveSpellId);
         if (secondaryPassiveSpell != 0)
-            getOwner()->RemoveAura(secondaryPassiveSpell);
+            getOwner()->removeAllAurasById(secondaryPassiveSpell);
     }
 
     // Remove auras which unit should not have anymore
-    for (auto& aur : getOwner()->m_auras)
+    for (uint16_t i = AuraSlots::PASSIVE_SLOT_START; i < AuraSlots::POSITIVE_SLOT_END; ++i)
     {
-        if (aur == nullptr || aur->isNegative())
+        auto* const aur = getOwner()->getAuraWithAuraSlot(i);
+        if (aur == nullptr)
             continue;
 
         const auto requiredForm = aur->getSpellInfo()->getRequiredShapeShift();
@@ -1569,9 +1586,9 @@ void Aura::spellAuraEffectPeriodicLeech(AuraEffectModifier* aurEff, bool apply)
                 int32_t count = 0;
 
                 auras.clear();
-                for (auto i = MAX_TOTAL_AURAS_START; i < MAX_TOTAL_AURAS_END; ++i)
+                for (uint16_t i = AuraSlots::TOTAL_SLOT_START; i < AuraSlots::TOTAL_SLOT_END; ++i)
                 {
-                    Aura* aura = m_target->m_auras[i];
+                    Aura* aura = m_target->getAuraWithAuraSlot(i);
                     if (aura == nullptr)
                         continue;
 

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -233,7 +233,7 @@ void Aura::EventUpdateGroupAA(AuraEffectModifier* /*aurEff*/, float r)
                 if (owner->hasAurasWithId(m_spellInfo->getId()))
                 {
                     targets.erase(owner->getGuidLow());
-                    owner->RemoveAura(m_spellInfo->getId());
+                    owner->removeAllAurasById(m_spellInfo->getId());
                 }
             }
         }
@@ -308,7 +308,7 @@ void Aura::EventUpdateGroupAA(AuraEffectModifier* /*aurEff*/, float r)
         if (removable)
         {
             targets.erase(itr2);
-            tp->RemoveAura(m_spellInfo->getId());
+            tp->removeAllAurasById(m_spellInfo->getId());
         }
     }
 }
@@ -336,7 +336,7 @@ void Aura::EventUpdateRaidAA(AuraEffectModifier* /*aurEff*/, float r)
                 if (owner->hasAurasWithId(m_spellInfo->getId()))
                 {
                     targets.erase(owner->getGuidLow());
-                    owner->RemoveAura(m_spellInfo->getId());
+                    owner->removeAllAurasById(m_spellInfo->getId());
                 }
             }
         }
@@ -410,7 +410,7 @@ void Aura::EventUpdateRaidAA(AuraEffectModifier* /*aurEff*/, float r)
         if (removable)
         {
             targets.erase(itr2);
-            tp->RemoveAura(m_spellInfo->getId());
+            tp->removeAllAurasById(m_spellInfo->getId());
         }
     }
 }
@@ -456,7 +456,7 @@ void Aura::EventUpdatePetAA(AuraEffectModifier* aurEff, float r)
         if (p->getDistanceSq(pet) <= r)
             continue;
 
-        pet->RemoveAura(m_spellInfo->getId());
+        pet->removeAllAurasById(m_spellInfo->getId());
     }
 }
 
@@ -524,7 +524,7 @@ void Aura::EventUpdateFriendAA(AuraEffectModifier* /*aurEff*/, float r)
 
         if (removable)
         {
-            tu->RemoveAura(m_spellInfo->getId());
+            tu->removeAllAurasById(m_spellInfo->getId());
             targets.erase(itr2);
         }
     }
@@ -591,7 +591,7 @@ void Aura::EventUpdateEnemyAA(AuraEffectModifier* /*aurEff*/, float r)
 
         if (removable)
         {
-            tu->RemoveAura(m_spellInfo->getId());
+            tu->removeAllAurasById(m_spellInfo->getId());
             targets.erase(itr2);
         }
     }
@@ -626,7 +626,7 @@ void Aura::EventUpdateOwnerAA(AuraEffectModifier* aurEff, float r)
 
 
     if (!ou->isAlive() || (c->getDistanceSq(ou) > r))
-        ou->RemoveAura(m_spellInfo->getId());
+        ou->removeAllAurasById(m_spellInfo->getId());
 }
 
 void Aura::EventUpdateAreaAura(uint8_t effIndex, float r)
@@ -677,9 +677,11 @@ void Aura::EventUpdateAreaAura(uint8_t effIndex, float r)
             EventUpdateEnemyAA(&m_auraEffects[effIndex], r);
             break;
 
+#if VERSION_STRING >= TBC
         case SPELL_EFFECT_APPLY_OWNER_AREA_AURA:
             EventUpdateOwnerAA(&m_auraEffects[effIndex], r);
             break;
+#endif
 
         default:
             sLogger.failure("Spell %u (%s) has tried to update Area Aura targets but Spell has no valid Area Aura effect %u.", m_spellInfo->getId(), m_spellInfo->getName().c_str(), AreaAuraEffectId);
@@ -714,7 +716,7 @@ void Aura::ClearAATargets()
         if (tu == nullptr)
             continue;
 
-        tu->RemoveAura(spellid);
+        tu->removeAllAurasById(spellid);
     }
     targets.clear();
 
@@ -727,18 +729,20 @@ void Aura::ClearAATargets()
         {
             Pet* pet = *itr;
 
-            pet->RemoveAura(spellid);
+            pet->removeAllAurasById(spellid);
         }
     }
 
+#if VERSION_STRING >= TBC
     if (m_spellInfo->hasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
     {
         Unit* u = m_target->getWorldMap()->getUnit(m_target->getCreatedByGuid());
 
         if (u != nullptr)
-            u->RemoveAura(spellid);
+            u->removeAllAurasById(spellid);
 
     }
+#endif
 }
 
 //------------------------- Aura Effects -----------------------------
@@ -818,7 +822,7 @@ void Aura::SpellAuraModPossess(AuraEffectModifier* /*aurEff*/, bool apply)
         if (caster != nullptr && caster->IsInWorld())
         {
             caster->UnPossess();
-            m_target->RemoveAura(getSpellId());
+            m_target->removeAllAurasById(getSpellId());
         }
 
         // make sure Player::UnPossess() didn't fail, if it did we will just free the target here
@@ -1216,7 +1220,7 @@ void Aura::SpellAuraModStun(AuraEffectModifier* aurEff, bool apply)
         // sap
         Unit* c = GetUnitCaster();
         if (c)
-        c->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);  // remove stealth
+        c->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);  // remove stealth
         }break;
         case 1776:
         case 1777:
@@ -1240,7 +1244,7 @@ void Aura::SpellAuraModStun(AuraEffectModifier* aurEff, bool apply)
         //TO< Player* >(c)->CombatModeDelay = 10;
         TO< Player* >(c)->EventAttackStop();
         c->smsg_AttackStop(m_target);
-        c->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);  // remove stealth
+        c->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);  // remove stealth
         }
         }
         }
@@ -1430,7 +1434,7 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
                 player->setPlayerFieldBytes2(0x2000);
 #endif
 
-        m_target->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_STEALTH | AURA_INTERRUPT_ON_INVINCIBLE);
+        m_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_STEALTH | AURA_INTERRUPT_ON_INVINCIBLE);
         m_target->modStealthLevel(StealthFlag(aurEff->getEffectMiscValue()), aurEff->getEffectDamage());
 
         // hack fix for vanish stuff
@@ -1491,28 +1495,13 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
 
                     m_target->getCombatHandler().clearCombat();
 
-                    for (uint32 x = MAX_POSITIVE_AURAS_EXTEDED_START; x < MAX_POSITIVE_AURAS_EXTEDED_END; x++)
+                    SpellMechanic mechanicList[] =
                     {
-                        if (m_target->m_auras[x] != nullptr)
-                        {
-                            if (m_target->m_auras[x]->getSpellInfo()->getMechanicsType() == MECHANIC_ROOTED || m_target->m_auras[x]->getSpellInfo()->getMechanicsType() == MECHANIC_ENSNARED)   // Remove roots and slow spells
-                            {
-                                m_target->m_auras[x]->removeAura();
-                            }
-                            else // if got immunity for slow, remove some that are not in the mechanics
-                            {
-                                for (uint8 i = 0; i < 3; i++)
-                                {
-                                    uint32 AuraEntry = m_target->m_auras[x]->getSpellInfo()->getEffectApplyAuraName(i);
-                                    if (AuraEntry == SPELL_AURA_MOD_DECREASE_SPEED || AuraEntry == SPELL_AURA_MOD_ROOT || AuraEntry == SPELL_AURA_MOD_STALKED)
-                                    {
-                                        m_target->m_auras[x]->removeAura();
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                        MECHANIC_ROOTED,
+                        MECHANIC_ENSNARED,
+                        MECHANIC_NONE,
+                    };
+                    m_target->removeAllAurasBySpellMechanic(mechanicList, true);
 
                     // Cast stealth spell/dismount/drop BG flag
                     if (p_target != nullptr)
@@ -1603,13 +1592,17 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
             case 52188:
             case 58506:
             {
-                for (uint32 x = MAX_POSITIVE_AURAS_EXTEDED_START; x < MAX_POSITIVE_AURAS_EXTEDED_END; x++)
+                for (uint16_t x = AuraSlots::POSITIVE_SLOT_START; x < AuraSlots::POSITIVE_SLOT_END; ++x)
                 {
-                    if (m_target->m_auras[x] && m_target->m_auras[x]->getSpellInfo()->getEffectApplyAuraName(0) != SPELL_AURA_DUMMY)
+                    auto* const aur = m_target->getAuraWithAuraSlot(x);
+                    if (aur == nullptr)
+                        continue;
+
+                    if (aur->getSpellInfo()->getEffectApplyAuraName(0) != SPELL_AURA_DUMMY)
                     {
                         uint32 tmp_duration = 0;
 
-                        switch (m_target->m_auras[x]->getSpellInfo()->getId())
+                        switch (aur->getSpellInfo()->getId())
                         {
                             //SPELL_HASH_MASTER_OF_SUBTLETY
                             case 31221:
@@ -1631,11 +1624,11 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
 
                         if (tmp_duration != 0)
                         {
-                            m_target->m_auras[x]->setTimeLeft(tmp_duration);
-                            m_target->m_auras[x]->refreshOrModifyStack();
+                            aur->setTimeLeft(tmp_duration);
+                            aur->refreshOrModifyStack();
 
-                            sEventMgr.ModifyEventTimeLeft(m_target->m_auras[x], EVENT_AURA_REMOVE, tmp_duration);
-                            sEventMgr.AddEvent(m_target->m_auras[x], &Aura::removeAura, AURA_REMOVE_ON_EXPIRE, EVENT_AURA_REMOVE, tmp_duration, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT | EVENT_FLAG_DELETES_OBJECT);
+                            sEventMgr.ModifyEventTimeLeft(aur, EVENT_AURA_REMOVE, tmp_duration);
+                            sEventMgr.AddEvent(aur, &Aura::removeAura, AURA_REMOVE_ON_EXPIRE, EVENT_AURA_REMOVE, tmp_duration, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT | EVENT_FLAG_DELETES_OBJECT);
                         }
                     }
                 }
@@ -1672,7 +1665,7 @@ void Aura::SpellAuraModInvisibility(AuraEffectModifier* aurEff, bool apply)
 #endif
         }
 
-        m_target->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_INVINCIBLE);
+        m_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_INVINCIBLE);
     }
     else
     {
@@ -1989,6 +1982,12 @@ void Aura::SpellAuraModSkill(AuraEffectModifier* aurEff, bool apply)
         const auto amount = static_cast<int16_t>(aurEff->getEffectDamage());
         if (apply)
         {
+            if (!p_target->hasSkillLine(skillLine))
+            {
+                aurEff->setEffectActive(false);
+                return;
+            }
+
             mPositive = true;
             static_cast< Player* >(m_target)->modifySkillBonus(skillLine, amount, false);
         }
@@ -2293,10 +2292,9 @@ void Aura::SpellAuraModSchoolImmunity(AuraEffectModifier* aurEff, bool apply)
                 if (!m_target->isAlive())
                     return;
 
-                Aura* pAura;
-                for (uint32 i = MAX_NEGATIVE_AURAS_EXTEDED_START; i < MAX_NEGATIVE_AURAS_EXTEDED_END; ++i)
+                for (uint16_t i = AuraSlots::NEGATIVE_SLOT_START; i < AuraSlots::NEGATIVE_SLOT_END; ++i)
                 {
-                    pAura = m_target->m_auras[i];
+                    auto* const pAura = m_target->getAuraWithAuraSlot(i);
                     if (pAura != this &&
                         pAura != nullptr &&
                         !pAura->IsPassive() &&
@@ -2341,7 +2339,7 @@ void Aura::SpellAuraModSchoolImmunity(AuraEffectModifier* aurEff, bool apply)
         case 69924:
         {
             if (apply)
-                m_target->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_INVINCIBLE);
+                m_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_INVINCIBLE);
         } break;
     }
 
@@ -2359,12 +2357,12 @@ void Aura::SpellAuraModSchoolImmunity(AuraEffectModifier* aurEff, bool apply)
             mPositive = true;
 
         sLogger.debug("SpellAuraModSchoolImmunity called with misValue = %x", aurEff->getEffectMiscValue());
+        m_target->removeAllAurasBySchoolMask(static_cast<SchoolMask>(getSpellInfo()->getSchoolMask()), true, true);
         for (uint8 i = 0; i < TOTAL_SPELL_SCHOOLS; i++)
         {
             if (aurEff->getEffectMiscValue() & (1 << i))
             {
                 m_target->SchoolImmunityList[i]++;
-                m_target->RemoveAurasOfSchool(i, false, true);
             }
         }
         m_target->getThreatManager().evaluateSuppressed();
@@ -2399,12 +2397,13 @@ void Aura::SpellAuraModDispelImmunity(AuraEffectModifier* aurEff, bool apply)
 
         if (apply)
         {
-            for (uint32 x = MAX_POSITIVE_AURAS_EXTEDED_START; x < MAX_POSITIVE_AURAS_EXTEDED_END; x++)
+            for (uint16_t x = AuraSlots::POSITIVE_SLOT_START; x < AuraSlots::POSITIVE_SLOT_END; ++x)
             {
+                auto* const aur = m_target->getAuraWithAuraSlot(x);
                 // HACK FIX FOR: 41425 and 25771
-                if (m_target->m_auras[x] && m_target->m_auras[x]->getSpellId() != 41425 && m_target->m_auras[x]->getSpellId() != 25771)
-                    if (m_target->m_auras[x]->getSpellInfo()->getDispelType() == (uint32)aurEff->getEffectMiscValue())
-                        m_target->m_auras[x]->removeAura();
+                if (aur && aur->getSpellId() != 41425 && aur->getSpellId() != 25771)
+                    if (aur->getSpellInfo()->getDispelType() == (uint32)aurEff->getEffectMiscValue())
+                        aur->removeAura();
             }
         }
     }
@@ -2486,7 +2485,7 @@ void Aura::SpellAuraTrackCreatures(AuraEffectModifier* aurEff, bool apply)
         if (apply)
         {
             if (p_target->TrackingSpell != 0)
-                p_target->RemoveAura(p_target->TrackingSpell);
+                p_target->removeAllAurasById(p_target->TrackingSpell);
 
             p_target->setTrackCreature((uint32)1 << (aurEff->getEffectMiscValue() - 1));
             p_target->TrackingSpell = getSpellId();
@@ -2506,7 +2505,7 @@ void Aura::SpellAuraTrackResources(AuraEffectModifier* aurEff, bool apply)
         if (apply)
         {
             if (p_target->TrackingSpell != 0)
-                p_target->RemoveAura(p_target->TrackingSpell);
+                p_target->removeAllAurasById(p_target->TrackingSpell);
 
             p_target->setTrackResource((uint32)1 << (aurEff->getEffectMiscValue() - 1));
             p_target->TrackingSpell = getSpellId();
@@ -2906,10 +2905,12 @@ void Aura::SpellAuraModDisarm(AuraEffectModifier* aurEff, bool apply)
             field = UnitFlag2;
             flag = UNIT_FLAG2_DISARM_OFFHAND;
             break;
+#if VERSION_STRING > TBC
         case SPELL_AURA_MOD_DISARM_RANGED:
             field = UnitFlag2;
             flag = UNIT_FLAG2_DISARM_RANGED;
             break;
+#endif
 #endif
         default:
             return;
@@ -3081,36 +3082,13 @@ void Aura::SpellAuraMechanicImmunity(AuraEffectModifier* aurEff, bool apply)
 
         if (aurEff->getEffectMiscValue() != 16 && aurEff->getEffectMiscValue() != 25 && aurEff->getEffectMiscValue() != 19) // don't remove bandages, Power Word and protection effect
         {
-            /* Supa's test run of Unit::RemoveAllAurasByMechanic */
-            m_target->RemoveAllAurasByMechanic((uint32)aurEff->getEffectMiscValue(), 0, false);
+            /* Supa's test run of Unit::removeAllAurasBySpellMechanic */
+            m_target->removeAllAurasBySpellMechanic(static_cast<SpellMechanic>(aurEff->getEffectMiscValue()), false);
 
             //Insignia/Medallion of A/H //Every Man for Himself
             if (m_spellInfo->getId() == 42292 || m_spellInfo->getId() == 59752)
             {
-                for (uint32 x = MAX_NEGATIVE_AURAS_EXTEDED_START; x < MAX_NEGATIVE_AURAS_EXTEDED_END; ++x)
-                {
-                    if (m_target->m_auras[x])
-                    {
-                        for (uint8_t y = 0; y < 3; ++y)
-                        {
-                            switch (m_target->m_auras[x]->getSpellInfo()->getEffectApplyAuraName(y))
-                            {
-                            case SPELL_AURA_MOD_STUN:
-                            case SPELL_AURA_MOD_CONFUSE:
-                            case SPELL_AURA_MOD_ROOT:
-                            case SPELL_AURA_MOD_FEAR:
-                            case SPELL_AURA_MOD_DECREASE_SPEED:
-                                m_target->m_auras[x]->removeAura();
-                                goto out;
-                                break;
-                            }
-                            continue;
-
-                        out:
-                            break;
-                        }
-                    }
-                }
+                m_target->removeAllAurasBySpellMechanic(sSpellMgr.getCrowdControlMechanicList(true));
             }
         }
         }
@@ -3144,7 +3122,7 @@ void Aura::SpellAuraMounted(AuraEffectModifier* aurEff, bool apply)
     {
     uint32 id = m_target->m_stealth;
     m_target->m_stealth = 0;
-    m_target->RemoveAura(id);
+    m_target->removeAllAurasById(id);
     }*/
 
     if (apply)
@@ -3159,7 +3137,7 @@ void Aura::SpellAuraMounted(AuraEffectModifier* aurEff, bool apply)
 
         p_target->dismount();
 
-        m_target->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_MOUNT);
+        m_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_MOUNT);
 
         CreatureProperties const* ci = sMySQLStore.getCreatureProperties(aurEff->getEffectMiscValue());
         if (ci == nullptr)
@@ -3221,7 +3199,7 @@ void Aura::SpellAuraMounted(AuraEffectModifier* aurEff, bool apply)
 
         //if we had pet then respawn
         p_target->spawnActivePet();
-        p_target->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_DISMOUNT);
+        p_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_DISMOUNT);
     }
 }
 
@@ -3365,7 +3343,10 @@ void Aura::SpellAuraSplitDamage(AuraEffectModifier* aurEff, bool apply)
     Object* caster = getCaster();
 
     // We don't want to split our damage with the owner
-    if ((m_spellInfo->getEffect(aurEff->getEffectIndex()) == SPELL_EFFECT_APPLY_OWNER_AREA_AURA) &&
+    if (
+#if VERSION_STRING >= TBC
+        (m_spellInfo->getEffect(aurEff->getEffectIndex()) == SPELL_EFFECT_APPLY_OWNER_AREA_AURA) &&
+#endif
         (caster != nullptr) &&
         (m_target != nullptr) &&
         caster->isPet() &&
@@ -3652,6 +3633,12 @@ void Aura::SpellAuraSkillTalent(AuraEffectModifier* aurEff, bool apply)
 
         if (apply)
         {
+            if (!p_target->hasSkillLine(skillLine))
+            {
+                aurEff->setEffectActive(false);
+                return;
+            }
+
             mPositive = true;
             p_target->modifySkillBonus(skillLine, amount, true);
         }
@@ -5611,7 +5598,7 @@ void Aura::SpellAuraSpiritOfRedemption(AuraEffectModifier* /*aurEff*/, bool appl
     else
     {
         m_target->setScale(1);
-        m_target->RemoveAura(27792);
+        m_target->removeAllAurasById(27792);
         m_target->setHealth(0);
     }
 }
@@ -5992,6 +5979,7 @@ void Aura::SpellAuraConsumeNoAmmo(AuraEffectModifier* /*aurEff*/, bool apply)
 
         switch (m_spellInfo->getId())
         {
+#if VERSION_STRING >= WotLK
             //SPELL_HASH_REQUIRES_NO_AMMO
             case 46699:
             {
@@ -5999,6 +5987,7 @@ void Aura::SpellAuraConsumeNoAmmo(AuraEffectModifier* /*aurEff*/, bool apply)
                 if (p_target->hasAuraWithAuraEffect(SPELL_AURA_CONSUMES_NO_AMMO))
                     other = true;
             } break;
+#endif
             default:
             {
                 // we have Thori'dal too
@@ -6007,9 +5996,11 @@ void Aura::SpellAuraConsumeNoAmmo(AuraEffectModifier* /*aurEff*/, bool apply)
             }
         }
 
+#if VERSION_STRING >= WotLK
         // We have more than 1 aura with no ammo consumption effect
         if (p_target->getAuraCountForEffect(SPELL_AURA_CONSUMES_NO_AMMO) >= 2)
             other = true;
+#endif
 
         p_target->m_requiresNoAmmo = other;
     }
@@ -6100,6 +6091,7 @@ void Aura::SpellAuraDeflectSpells(AuraEffectModifier* /*aurEff*/, bool /*apply*/
 
 void Aura::SpellAuraPhase(AuraEffectModifier* aurEff, bool apply)
 {
+#if VERSION_STRING >= TBC
     if (m_target->getAuraCountForId(SPELL_AURA_PHASE) > 1)
     {
         if (m_target->isPlayer())
@@ -6107,6 +6099,7 @@ void Aura::SpellAuraPhase(AuraEffectModifier* aurEff, bool apply)
         removeAura();
         return;
     }
+#endif
 
     if (apply)
     {
@@ -6156,8 +6149,11 @@ bool Aura::IsAreaAura() const
         sp->hasEffect(SPELL_EFFECT_APPLY_RAID_AREA_AURA) ||
         sp->hasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA) ||
         sp->hasEffect(SPELL_EFFECT_APPLY_FRIEND_AREA_AURA) ||
-        sp->hasEffect(SPELL_EFFECT_APPLY_ENEMY_AREA_AURA) ||
-        sp->hasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA))
+        sp->hasEffect(SPELL_EFFECT_APPLY_ENEMY_AREA_AURA)
+#if VERSION_STRING >= TBC
+        || sp->hasEffect(SPELL_EFFECT_APPLY_OWNER_AREA_AURA)
+#endif
+        )
         return true;
 
     return false;

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -211,6 +211,7 @@ pSpellEffect SpellEffectsHandler[TOTAL_SPELL_EFFECTS] =
     &Spell::SpellEffectProspecting,             // 127 SPELL_EFFECT_PROSPECTING
     &Spell::SpellEffectApplyFriendAA,           // 128 SPELL_EFFECT_APPLY_FRIEND_AA
     &Spell::SpellEffectApplyEnemyAA,            // 129 SPELL_EFFECT_APPLY_ENEMY_AA
+#if VERSION_STRING >= TBC
     &Spell::SpellEffectRedirectThreat,          // 130 SPELL_EFFECT_REDIRECT_THREAT
     &Spell::spellEffectNotImplemented,          // 131 SPELL_EFFECT_NULL_131
     &Spell::SpellEffectPlayMusic,               // 132 SPELL_EFFECT_PLAY_MUSIC
@@ -235,6 +236,8 @@ pSpellEffect SpellEffectsHandler[TOTAL_SPELL_EFFECTS] =
     &Spell::spellEffectTriggerSpell,            // 151 SPELL_EFFECT_TRIGGER_SPELL
     &Spell::spellEffectNotImplemented,          // 152 SPELL_EFFECT_NULL_152
     &Spell::SpellEffectCreatePet,               // 153 SPELL_EFFECT_CREATE_PET
+#endif
+#if VERSION_STRING >= WotLK
     &Spell::SpellEffectTeachTaxiPath,           // 154 SPELL_EFFECT_TEACH_TAXI_PATH
     &Spell::SpellEffectDualWield2H,             // 155 SPELL_EFFECT_DUAL_WIELD_2H
     &Spell::SpellEffectEnchantItemPrismatic,    // 156 SPELL_EFFECT_ENCHANT_ITEM_PRISMATIC
@@ -245,7 +248,9 @@ pSpellEffect SpellEffectsHandler[TOTAL_SPELL_EFFECTS] =
     &Spell::SpellEffectLearnSpec,               // 161 SPELL_EFFECT_LEARN_SPEC
     &Spell::SpellEffectActivateSpec,            // 162 SPELL_EFFECT_ACTIVATE_SPEC
     &Spell::spellEffectNotImplemented,          // 163 SPELL_EFFECT_NULL_163
-    &Spell::spellEffectNotImplemented,          // 164 SPELL_EFFECT_NULL_154
+    &Spell::spellEffectNotImplemented,          // 164 SPELL_EFFECT_NULL_164
+#endif
+#if VERSION_STRING >= Cata
     &Spell::spellEffectNotImplemented,          // 165 SPELL_EFFECT_NULL_165
     &Spell::spellEffectNotImplemented,          // 166 SPELL_EFFECT_NULL_166
     &Spell::spellEffectNotImplemented,          // 167 SPELL_EFFECT_NULL_167
@@ -264,6 +269,8 @@ pSpellEffect SpellEffectsHandler[TOTAL_SPELL_EFFECTS] =
     &Spell::spellEffectNotImplemented,          // 180 SPELL_EFFECT_NULL_180
     &Spell::spellEffectNotImplemented,          // 181 SPELL_EFFECT_NULL_181
     &Spell::spellEffectNotImplemented           // 182 SPELL_EFFECT_NULL_182
+#endif
+    // TODO: mop
 };
 
 const char* SpellEffectNames[TOTAL_SPELL_EFFECTS] =
@@ -398,6 +405,7 @@ const char* SpellEffectNames[TOTAL_SPELL_EFFECTS] =
     "SPELL_EFFECT_PROSPECTING",                 //    127 Search 5 ore of a base metal for precious gems.  This will destroy the ore in the process.
     "SPELL_EFFECT_APPLY_FRIEND_AA",             //    128 Apply Aura friendly
     "SPELL_EFFECT_APPLY_ENEMY_AA",              //    129 Apply Aura enemy
+#if VERSION_STRING >= TBC
     "SPELL_EFFECT_REDIRECT_THREAT",             //    130 unknown // https://www.wowhead.com/spell=34477
     "SPELL_EFFECT_NULL_131",                    //    131 unknown // test spell
     "SPELL_EFFECT_PLAY_MUSIC",                  //    132 Play Music // https://www.wowhead.com/spell=46852
@@ -422,6 +430,8 @@ const char* SpellEffectNames[TOTAL_SPELL_EFFECTS] =
     "SPELL_EFFECT_TRIGGER_SPELL",               //    151
     "SPELL_EFFECT_NULL_152",                    //    152 Summon Refer-a-Friend
     "SPELL_EFFECT_CREATE_PET",                  //    153 Create tamed pet
+#endif
+#if VERSION_STRING >= WotLK
     "SPELL_EFFECT_TEACH_TAXI_PATH",             //    154 "Teach" a taxi path
     "SPELL_EFFECT_DUAL_WIELD_2H",               //    155
     "SPELL_EFFECT_ENCHANT_ITEM_PRISMATIC",      //    156
@@ -433,6 +443,8 @@ const char* SpellEffectNames[TOTAL_SPELL_EFFECTS] =
     "SPELL_EFFECT_ACTIVATE_SPEC"                //    162
     "SPELL_EFFECT_NULL_163"                     //    163
     "SPELL_EFFECT_NULL_154"                     //    164
+#endif
+#if VERSION_STRING >= Cata
     "SPELL_EFFECT_NULL_165"                     //    165
     "SPELL_EFFECT_NULL_166"                     //    166
     "SPELL_EFFECT_NULL_167"                     //    167
@@ -451,6 +463,7 @@ const char* SpellEffectNames[TOTAL_SPELL_EFFECTS] =
     "SPELL_EFFECT_NULL_180"                     //    180
     "SPELL_EFFECT_NULL_181"                     //    181
     "SPELL_EFFECT_NULL_182"                     //    182
+#endif
 };
 
 // APGL End
@@ -718,8 +731,10 @@ void Spell::ApplyAreaAura(uint8_t effectIndex)
             case SPELL_EFFECT_APPLY_ENEMY_AREA_AURA:
                 eventtype = EVENT_ENEMY_AREA_AURA_UPDATE;
                 break;
+#if VERSION_STRING >= TBC
             case SPELL_EFFECT_APPLY_OWNER_AREA_AURA:
                 eventtype = EVENT_ENEMY_AREA_AURA_UPDATE; //Zyres: The same event as SPELL_EFFECT_APPLY_ENEMY_AREA_AURA? @Appled o.O
+#endif
                 break;
         }
 
@@ -1906,7 +1921,7 @@ void Spell::SpellEffectApplyAura(uint8_t effectIndex)  // Apply Aura
 
             if (unitTarget->getEntry() == 16483)
             {
-                unitTarget->RemoveAura(29152);
+                unitTarget->removeAllAurasById(29152);
                 unitTarget->setStandState(STANDSTATE_STAND);
                 static const char* testo[12] = { "None", "Warrior", "Paladin", "Hunter", "Rogue", "Priest", "Death Knight", "Shaman", "Mage", "Warlock", "None", "Druid" };
                 char msg[150];
@@ -2210,7 +2225,7 @@ void Spell::SpellEffectHeal(uint8_t effectIndex) // Heal
                         spell = nullptr;
                         new_dmg = healamount * 18.0f / amplitude;
 
-                        unitTarget->RemoveAura(taura);
+                        taura->removeAura();
 
                         //do not remove flag if we still can cast it again
                         uint32 rejuvenation[] =
@@ -2322,7 +2337,7 @@ void Spell::SpellEffectHeal(uint8_t effectIndex) // Heal
                             spell = nullptr;
                             new_dmg = healamount * 12.0f / amplitude;
 
-                            unitTarget->RemoveAura(taura);
+                            taura->removeAura();
 
                             unitTarget->removeAuraStateAndAuras(AURASTATE_FLAG_SWIFTMEND);
                             sEventMgr.RemoveEvents(unitTarget, EVENT_REJUVENATION_FLAG_EXPIRE);
@@ -3179,7 +3194,7 @@ void Spell::SpellEffectLeap(uint8_t effectIndex) // Leap
         return;
 
     float radius = getEffectRadius(effectIndex);
-    unitTarget->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_ANY_DAMAGE_TAKEN);
+    unitTarget->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_ANY_DAMAGE_TAKEN);
 
     MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
     dtNavMesh* nav = const_cast<dtNavMesh*>(mmap->GetNavMesh(m_caster->GetMapId()));
@@ -3804,31 +3819,30 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
     if (u_caster == nullptr || unitTarget == nullptr)
         return;
 
-    uint32 start, end;
+    uint16_t start, end;
 
     if (isAttackable(u_caster, unitTarget) || getSpellInfo()->getEffectMiscValue(effectIndex) == DISPEL_STEALTH)    // IsAttackable returns false for stealthed
     {
-        start = MAX_POSITIVE_AURAS_EXTEDED_START;
-        end = MAX_POSITIVE_AURAS_EXTEDED_END;
+        start = AuraSlots::POSITIVE_SLOT_START;
+        end = AuraSlots::POSITIVE_SLOT_END;
         if (unitTarget->SchoolImmunityList[getSpellInfo()->getFirstSchoolFromSchoolMask()])
             return;
     }
     else
     {
-        start = MAX_NEGATIVE_AURAS_EXTEDED_START;
-        end = MAX_NEGATIVE_AURAS_EXTEDED_END;
+        start = AuraSlots::NEGATIVE_SLOT_START;
+        end = AuraSlots::NEGATIVE_SLOT_END;
     }
 
-    Aura* aur;
     SpellInfo const* aursp;
     std::list< uint32 > dispelledSpells;
     bool finish = false;
 
     for (uint32 x = start; x < end; x++)
-        if (unitTarget->m_auras[x] != nullptr)
+    {
+        if (auto* const aur = unitTarget->getAuraWithAuraSlot(x))
         {
             bool AuraRemoved = false;
-            aur = unitTarget->m_auras[x];
             aursp = aur->getSpellInfo();
 
             //Nothing can dispel resurrection sickness;
@@ -3894,6 +3908,7 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
             if (finish)
                 break;
         }
+    }
 
     // send spell dispell log packet
     if (!dispelledSpells.empty())
@@ -4199,11 +4214,11 @@ void Spell::SpellEffectSummonPet(uint8_t effectIndex) //summon - pet
         if (p_caster->getClass() == WARLOCK)
         {
             //if demonic sacrifice auras are still active, remove them
-            p_caster->RemoveAura(18789);
-            p_caster->RemoveAura(18790);
-            p_caster->RemoveAura(18791);
-            p_caster->RemoveAura(18792);
-            p_caster->RemoveAura(35701);
+            p_caster->removeAllAurasById(18789);
+            p_caster->removeAllAurasById(18790);
+            p_caster->removeAllAurasById(18791);
+            p_caster->removeAllAurasById(18792);
+            p_caster->removeAllAurasById(35701);
         }
 
         Pet* summon = sObjectMgr.CreatePet(getSpellInfo()->getEffectMiscValue(effectIndex));
@@ -4573,7 +4588,7 @@ void Spell::SpellEffectUseGlyph(uint8_t effectIndex)
         {
             auto glyph_prop_old = sGlyphPropertiesStore.LookupEntry(glyph_old);
             if (glyph_prop_old)
-                p_caster->RemoveAura(glyph_prop_old->SpellID);
+                p_caster->removeAllAurasById(glyph_prop_old->SpellID);
         }
     }
 
@@ -4628,7 +4643,7 @@ void Spell::SpellEffectSanctuary(uint8_t /*effectIndex*/) // Stop all attacks ma
         return;
 
     if (p_caster != nullptr)
-        p_caster->RemoveAllAuraType(SPELL_AURA_MOD_ROOT);
+        p_caster->removeAllAurasByAuraEffect(SPELL_AURA_MOD_ROOT);
 
     for (const auto& itr : u_caster->getInRangeObjectsSet())
     {
@@ -4940,6 +4955,7 @@ void Spell::SpellEffectKnockBack(uint8_t effectIndex)
         return;
 
     float x, y;
+#if VERSION_STRING >= TBC
     if (m_spellInfo->getEffect(effectIndex) == SPELL_EFFECT_KNOCK_BACK_DEST)
     {
         if (m_targets.hasDestination())
@@ -4952,7 +4968,10 @@ void Spell::SpellEffectKnockBack(uint8_t effectIndex)
             return;
     }
     else
+#endif
+    {
         m_caster->getPosition(x, y);
+    }
 
     unitTarget->knockbackFrom(x, y, speedxy, speedz);
 }
@@ -5175,7 +5194,7 @@ void Spell::SpellEffectDispelMechanic(uint8_t effectIndex)
     if (!unitTarget || !unitTarget->isAlive())
         return;
 
-    unitTarget->RemoveAllAurasByMechanic(getSpellInfo()->getEffectMiscValue(effectIndex), getSpellInfo()->getEffectBasePoints(effectIndex), false);
+    unitTarget->removeAllAurasBySpellMechanic(static_cast<SpellMechanic>(getSpellInfo()->getEffectMiscValue(effectIndex)), false);
 }
 
 void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
@@ -5452,11 +5471,11 @@ void Spell::SpellEffectDummyMelee(uint8_t /*effectIndex*/)   // Normalized Weapo
             //count the number of sunder armors on target
             uint32 sunder_count = 0;
             SpellInfo const* spellInfo = nullptr;
-            for (uint32 x = MAX_NEGATIVE_AURAS_EXTEDED_START; x < MAX_NEGATIVE_AURAS_EXTEDED_END; ++x)
+            for (uint16_t x = AuraSlots::NEGATIVE_SLOT_START; x < AuraSlots::NEGATIVE_SLOT_END; ++x)
             {
-                if (unitTarget->m_auras[x])
+                if (const auto* aur = unitTarget->getAuraWithAuraSlot(x))
                 {
-                    switch (unitTarget->m_auras[x]->getSpellInfo()->getId())
+                    switch (aur->getSpellInfo()->getId())
                     {
                         //SPELL_HASH_SUNDER_ARMOR
                         case 7386:
@@ -5490,7 +5509,7 @@ void Spell::SpellEffectDummyMelee(uint8_t /*effectIndex*/)   // Normalized Weapo
                         case 71554:
                         {
                             sunder_count++;
-                            spellInfo = unitTarget->m_auras[x]->getSpellInfo();
+                            spellInfo = aur->getSpellInfo();
                         } break;
                         default:
                             spellInfo = sSpellMgr.getSpellInfo(7386);
@@ -5779,11 +5798,11 @@ void Spell::SpellEffectSpellSteal(uint8_t /*effectIndex*/)
             p_caster->togglePvP();
     }
 
-    uint32 start, end;
+    uint16_t start, end;
     if (isAttackable(u_caster, unitTarget))
     {
-        start = MAX_POSITIVE_AURAS_EXTEDED_START;
-        end = MAX_POSITIVE_AURAS_EXTEDED_END;
+        start = AuraSlots::POSITIVE_SLOT_START;
+        end = AuraSlots::POSITIVE_SLOT_END;
     }
     else
         return;
@@ -5792,9 +5811,8 @@ void Spell::SpellEffectSpellSteal(uint8_t /*effectIndex*/)
 
     for (uint32 x = start; x < end; x++)
     {
-        if (unitTarget->m_auras[x] != nullptr)
+        if (auto* const aur = unitTarget->getAuraWithAuraSlot(x))
         {
-            Aura* aur = unitTarget->m_auras[x];
             SpellInfo const* aursp = aur->getSpellInfo();
 
             if (aursp->getId() != 15007 && !aur->IsPassive()

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -86,7 +86,10 @@ bool SpellInfo::hasEffectApplyAuraName(uint32_t auraType) const
     for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         if (Effect[i] != SPELL_EFFECT_APPLY_AURA && Effect[i] != SPELL_EFFECT_PERSISTENT_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_ENEMY_AREA_AURA &&
-            Effect[i] != SPELL_EFFECT_APPLY_FRIEND_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_GROUP_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_OWNER_AREA_AURA &&
+            Effect[i] != SPELL_EFFECT_APPLY_FRIEND_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_GROUP_AREA_AURA &&
+#if VERSION_STRING >= TBC
+            Effect[i] != SPELL_EFFECT_APPLY_OWNER_AREA_AURA &&
+#endif
             Effect[i] != SPELL_EFFECT_APPLY_PET_AREA_AURA && Effect[i] != SPELL_EFFECT_APPLY_RAID_AREA_AURA)
             continue;
 
@@ -463,11 +466,15 @@ bool SpellInfo::isNegativeAura() const
             case SPELL_AURA_GHOST:
             case SPELL_AURA_PERIODIC_POWER_BURN:
             case SPELL_AURA_AREA_CHARM:
+#if VERSION_STRING >= TBC
             case SPELL_AURA_MOD_DISARM_OFFHAND:
+#endif
+#if VERSION_STRING >= WotLK
             case SPELL_AURA_MOD_DISARM_RANGED:
             case SPELL_AURA_298:
             case SPELL_AURA_301:
             case SPELL_AURA_PREVENT_RESURRECTION:
+#endif
                 // No need to do other checks, definitely negative
                 return true;
             case SPELL_AURA_MOD_ATTACKSPEED:
@@ -501,11 +508,13 @@ bool SpellInfo::isNegativeAura() const
             case SPELL_AURA_MOD_HASTE:
             case SPELL_AURA_MOD_RANGED_HASTE:
             case SPELL_AURA_MOD_ATTACK_POWER_PCT:
+#if VERSION_STRING >= TBC
             case SPELL_AURA_MELEE_SLOW_PCT:
             case SPELL_AURA_INCREASE_TIME_BETWEEN_ATTACKS:
             case SPELL_AURA_INCREASE_CASTING_TIME_PCT:
             case SPELL_AURA_252:
             case SPELL_AURA_259:
+#endif
                 // Negative if effect value is negative
                 if (effValue < 0)
                     return true;
@@ -513,8 +522,12 @@ bool SpellInfo::isNegativeAura() const
             case SPELL_AURA_MOD_DAMAGE_TAKEN:
             case SPELL_AURA_MOD_POWER_COST:
             case SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN:
+#if VERSION_STRING >= TBC
             case SPELL_AURA_MOD_MECHANIC_DAMAGE_TAKEN_PERCENT:
+#endif
+#if VERSION_STRING >= WotLK
             case SPELL_AURA_INCREASE_SPELL_DOT_DAMAGE_PCT:
+#endif
                 // Negative if effect value is positive
                 if (effValue > 0)
                     return true;
@@ -1090,7 +1103,9 @@ bool SpellInfo::isAreaAuraEffect(uint8_t effIndex) const
         case SPELL_EFFECT_APPLY_PET_AREA_AURA:
         case SPELL_EFFECT_APPLY_FRIEND_AREA_AURA:
         case SPELL_EFFECT_APPLY_ENEMY_AREA_AURA:
+#if VERSION_STRING >= TBC
         case SPELL_EFFECT_APPLY_OWNER_AREA_AURA:
+#endif
             return true;
         default:
             break;

--- a/src/world/Spell/SpellMgr.hpp
+++ b/src/world/Spell/SpellMgr.hpp
@@ -5,6 +5,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "Definitions/SpellMechanics.hpp"
 #include "Spell.h"
 #include "SpellAuras.h"
 #include "SpellInfo.hpp"
@@ -83,6 +84,8 @@ public:
     void addSpellById(uint32_t spellId, SpellScriptLinker spellScript);
     // Registering legacy aura scripts (DO NOT USE, use ScriptMgr and SpellScript instead!)
     void addAuraById(uint32_t spellId, AuraScriptLinker auraScript);
+
+    SpellMechanic const* getCrowdControlMechanicList(bool includeSilence) const;
 
     // Spell required
     SpellRequiredMapBounds getSpellsRequiredForSpellBounds(uint32_t spellId) const;

--- a/src/world/Spell/Spell_ClassScripts.cpp
+++ b/src/world/Spell/Spell_ClassScripts.cpp
@@ -331,7 +331,7 @@ public:
     {
         if (target != NULL)
         {
-            uint32 count = target->GetAuraCountWithDispelType(DISPEL_DISEASE, m_caster->getGuid());
+            uint32 count = target->getAuraCountWithDispelType(DISPEL_DISEASE, m_caster->getGuid());
             if (count)
                 value += value * count * (getSpellInfo()->calculateEffectValue(2)) / 200;
         }
@@ -402,7 +402,7 @@ public:
     void DoAfterHandleEffect(Unit* /*target*/, uint32 /*i*/)
     {
         if (u_caster != NULL)
-            u_caster->RemoveAura(56817);
+            u_caster->removeAllAurasById(56817);
     }
 };
 


### PR DESCRIPTION
**Description**
Refactor how auras are stored. Auras are still stored in a fixed size array but in addition to that each individual aura effect is stored in another list for faster access. Before if you wanted to find for example a dummy aura effect you would have had to loop through entire aura array and loop all aura effects for each aura in the array.
<details>
<summary>Now it's very simple</summary>

```
for (const auto& aurEff : unit->getAuraEffectList(SPELL_AURA_DUMMY))
{
   Aura* aur = aurEff->getAura();
   ...
}
```

</details>

Aura effect lists contain only valid aura effects so nullptr checks are not needed.

<details>
<summary>Looping through all auras is mostly unchanged.</summary>

```
for (uint16_t i = AuraSlots::TOTAL_SLOT_START; i < AuraSlots::TOTAL_SLOT_END; ++i)
{
   Aura* aur = unit->getAuraWithAuraSlot(i);
   if (aur == nullptr)
      continue;
   ...
}

or

for (const auto& aur : unit->getAuraList())
{
   if (aur == nullptr)
      continue;
   ...
}
```
</details>

Since the aura list is an array you must check for nullptr.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [ ] TBC
- [x] WotLK
- [x] Cata
