### PR TITLE
Fix TBC vmaps extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 src/logonserver/logon_conf.h
 src/shared/git_version.h
 src/shared/Common.hpp
+src/shared/AEVersion.hpp
 src/world/world_conf.h
 src/logonserver/LogonConf.h
+src/logonserver/LogonConf.hpp
 src/world/WorldConf.h
 CMakeLists.txt.user
 

--- a/src/logonserver/CMakeLists.txt
+++ b/src/logonserver/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "kFre
     target_link_libraries(${PROJECT_NAME} c++experimental)
 endif ()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.h.in ${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/LogonConf.hpp)
 
 # link our shared lib.
 target_link_libraries(${PROJECT_NAME} shared ${MYSQL_LIBRARIES} ${ZLIB_LIBRARIES} ${PCRE_LIBRARIES})
@@ -75,7 +75,7 @@ if (USE_PCH)
     <Auth/WowCrypt.hpp>
     <Database/Database.h>
     <Network/Network.h>
-    LogonConf.h
+    LogonConf.hpp
     Console/LogonConsole.h
     Realm/RealmManager.hpp
     Server/IpBanMgr.h

--- a/src/logonserver/Console/LogonConsole.cpp
+++ b/src/logonserver/Console/LogonConsole.cpp
@@ -25,7 +25,7 @@
 #include <Server/AccountMgr.h>
 #include <Server/IpBanMgr.h>
 #include <Network/Network.h>
-#include <LogonConf.h>
+#include <LogonConf.hpp>
 #include <Util/Strings.cpp>
 
 LogonConsole& LogonConsole::getInstance()

--- a/src/logonserver/LogonConf.hpp.in
+++ b/src/logonserver/LogonConf.hpp.in
@@ -1,5 +1,11 @@
-#ifndef LOGON_CONF_HPP
-#define LOGON_CONF_HPP
+/*
+Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "AEVersion.hpp"
 
 #define CONFDIR "@ASCEMU_CONFIGSFILE_PATH@"
 
@@ -20,5 +26,3 @@
 #elif VERSION_STRING == Legion
     #define AE_EXPANSION_VERSION 256  // Legion (untested)
 #endif
-
-#endif // LOGON_CONF_HPP

--- a/src/logonserver/Server/LogonConfig.cpp
+++ b/src/logonserver/Server/LogonConfig.cpp
@@ -5,7 +5,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "LogonConfig.h"
 #include "Server/LogonServerDefines.hpp"
-#include "LogonConf.h"
+#include "LogonConf.hpp"
 #include "Logging/Logger.hpp"
 
 LogonConfig::LogonConfig()

--- a/src/logonserver/Server/Master.cpp
+++ b/src/logonserver/Server/Master.cpp
@@ -16,7 +16,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Auth/AutoPatcher.h"
 #include <Network/Network.h>
 #include "Console/LogonConsole.h"
-#include "LogonConf.h"
+#include "LogonConf.hpp"
 #include <Util/Strings.hpp>
 
 using std::chrono::milliseconds;

--- a/src/shared/AEVersion.hpp.in
+++ b/src/shared/AEVersion.hpp.in
@@ -1,0 +1,15 @@
+/*
+Copyright (c) 2014-2022 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+/*! \brief VERSION_STRING is defined by cmake option (dropdown)*/
+#define Classic 5875
+#define TBC 8606
+#define WotLK 12340
+#define Cata 15595
+#define Mop 18414
+
+#define VERSION_STRING @ASCEMU_VERSION@

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -75,6 +75,7 @@ include_directories(
 add_library(${PROJECT_NAME} STATIC ${sources} ${headers})
 target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${MYSQL_LIBRARY} ${OPENSSL_LIBRARIES} ${EXTRA_LIBS})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Common.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/Common.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AEVersion.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/AEVersion.hpp)
 
 if (APPLE)
     target_link_libraries(${PROJECT_NAME} c++)

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -175,3 +175,4 @@ New code has to be placed inside a MIT file. The current standard is C++14 and n
 * 2020 | Database/DatabaseUpdater.cpp
 * 2020 | Database/DatabaseUpdater.hpp
 * 2021 | Database/DatabaseCommon.hpp
+* 2022 | AEVersion.hpp

--- a/src/tools/ToolsCataMop/map_extractor/CMakeLists.txt
+++ b/src/tools/ToolsCataMop/map_extractor/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB source *.cpp *.h)
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/dep/StormLib/src
+    ${CMAKE_SOURCE_DIR}/src/shared
     ${CMAKE_CURRENT_SOURCE_DIR}/loadlib
     ${CMAKE_SOURCE_DIR}/dep/g3dlite/include
 )

--- a/src/tools/ToolsCataMop/map_extractor/System.cpp
+++ b/src/tools/ToolsCataMop/map_extractor/System.cpp
@@ -28,7 +28,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "../../../world/WorldConf.h"
+#include "AEVersion.hpp"
 
 #ifdef PLATFORM_WINDOWS
 #undef PLATFORM_WINDOWS

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/CMakeLists.txt
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/CMakeLists.txt
@@ -14,6 +14,7 @@ endif ()
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/dep/StormLib/src
+    ${CMAKE_SOURCE_DIR}/src/shared
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${BZIP2_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -18,6 +18,7 @@
  */
 
 #define _CRT_SECURE_NO_DEPRECATE
+#include "AEVersion.hpp"
 #include <cstdio>
 #include <iostream>
 #include <vector>

--- a/src/tools/map_extractor/CMakeLists.txt
+++ b/src/tools/map_extractor/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/dep/libmpq/libmpq
     ${CMAKE_SOURCE_DIR}/dep/dbcfile 
     ${CMAKE_SOURCE_DIR}/dep/loadlib
+    ${CMAKE_SOURCE_DIR}/src/shared
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -19,7 +19,7 @@
 
 #define _CRT_SECURE_NO_DEPRECATE
 
-#include "../../src/world/WorldConf.h"
+#include "AEVersion.hpp"
 
 #include <stdio.h>
 #include <deque>

--- a/src/tools/vmap_tools/vmap4_extractor/CMakeLists.txt
+++ b/src/tools/vmap_tools/vmap4_extractor/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/dep/loadlib
     ${CMAKE_SOURCE_DIR}/dep/dbcfile 
     ${CMAKE_SOURCE_DIR}/dep/libmpq/libmpq
+    ${CMAKE_SOURCE_DIR}/src/shared
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${BZIP2_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}

--- a/src/tools/vmap_tools/vmap4_extractor/modelheaders.h
+++ b/src/tools/vmap_tools/vmap4_extractor/modelheaders.h
@@ -22,6 +22,8 @@
 
 #pragma pack(push,1)
 
+#include "AEVersion.hpp"
+
 struct ModelHeader
 {
     char id[4];
@@ -35,6 +37,10 @@ struct ModelHeader
     uint32 ofsAnimations;
     uint32 nAnimationLookup;
     uint32 ofsAnimationLookup;
+#if VERSION_STRING < WotLK
+    uint32_t nD;
+    uint32_t ofsD;
+#endif
     uint32 nBones;
     uint32 ofsBones;
     uint32 nKeyBoneLookup;
@@ -42,12 +48,19 @@ struct ModelHeader
     uint32 nVertices;
     uint32 ofsVertices;
     uint32 nViews;
+#if VERSION_STRING < WotLK
+    uint32_t ofsViews;
+#endif
     uint32 nColors;
     uint32 ofsColors;
     uint32 nTextures;
     uint32 ofsTextures;
     uint32 nTransparency;
     uint32 ofsTransparency;
+#if VERSION_STRING < WotLK
+    uint32_t nI;
+    uint32_t ofsI;
+#endif
     uint32 nTextureanimations;
     uint32 ofsTextureanimations;
     uint32 nTexReplace;

--- a/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -19,6 +19,8 @@
 
 #define _CRT_SECURE_NO_DEPRECATE
 
+#include "AEVersion.hpp"
+
 #include "adtfile.h"
 #include "wdtfile.h"
 #include "dbcfile.h"
@@ -289,6 +291,8 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
 
     char path[512];
     std::string in_path(input_path);
+
+#if VERSION_STRING >= TBC
     std::vector<std::string> locales, searchLocales;
 
     searchLocales.push_back("enGB");
@@ -324,14 +328,28 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
     {
         pArchiveNames.push_back(in_path + *i + "/locale-" + *i + ".MPQ");
         pArchiveNames.push_back(in_path + *i + "/expansion-locale-" + *i + ".MPQ");
+#if VERSION_STRING >= WotLK
         pArchiveNames.push_back(in_path + *i + "/lichking-locale-" + *i + ".MPQ");
+#endif
     }
+#endif
 
     // open expansion and common files
+#if VERSION_STRING == Classic
+    pArchiveNames.push_back(input_path + std::string("terrain.MPQ"));
+    pArchiveNames.push_back(input_path + std::string("model.MPQ"));
+    pArchiveNames.push_back(input_path + std::string("texture.MPQ"));
+    pArchiveNames.push_back(input_path + std::string("wmo.MPQ"));
+    pArchiveNames.push_back(input_path + std::string("base.MPQ"));
+    pArchiveNames.push_back(input_path + std::string("misc.MPQ"));
+#else
     pArchiveNames.push_back(input_path + std::string("common.MPQ"));
-    pArchiveNames.push_back(input_path + std::string("common-2.MPQ"));
     pArchiveNames.push_back(input_path + std::string("expansion.MPQ"));
+#if VERSION_STRING >= WotLK
+    pArchiveNames.push_back(input_path + std::string("common-2.MPQ"));
     pArchiveNames.push_back(input_path + std::string("lichking.MPQ"));
+#endif
+#endif
 
     // now, scan for the patch levels in the core dir
     printf("Scanning patch levels from data directory.\n");
@@ -339,6 +357,9 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
     if (!scan_patches(path, pArchiveNames))
         return(false);
 
+#if VERSION_STRING == Classic
+    printf("\n");
+#else
     // now, scan for the patch levels in locale dirs
     printf("Scanning patch levels from locale directories.\n");
     bool foundOne = false;
@@ -357,6 +378,7 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
         printf("no locale found\n");
         return false;
     }
+#endif
 
     return true;
 }

--- a/src/world/WorldConf.h.in
+++ b/src/world/WorldConf.h.in
@@ -5,20 +5,13 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "AEVersion.hpp"
+
 #define CONFDIR "@ASCEMU_CONFIGSFILE_PATH@"
 #define PREFIX "@ASCEMU_SCRIPTLIB_PATH@"
 
 /*! \brief USE_PCH_INCLUDES is commented/uncommented by cmake option USE_PCH. */
 @ASCEMU_COMMENT_PCH@#define USE_PCH_INCLUDES
-
-/*! \brief VERSION_STRING is defined by cmake option (dropdown)*/
-#define Classic 5875
-#define TBC 8606
-#define WotLK 12340
-#define Cata 15595
-#define Mop 18414
-
-#define VERSION_STRING @ASCEMU_VERSION@
 
 #if VERSION_STRING == Classic
     #define AE_CLASSIC


### PR DESCRIPTION
**Description**
Misc: Move VERSION_STRING to shared project from world
Logon: Logonserver properly includes VERSION_STRING now. It used to be undefined.
Extractors: Fix VMaps extractor for classic and TBC, and possibly for mop too
Classic and TBC have some extra fields in model headers. Mop/cata extractor has now access to VERSION_STRING as well.
TBC extractor had been broken since 2020 XD (https://github.com/AscEmu/AscEmu/commit/293d0a737c4d10c1c40aea4b00609bbc35de4391)

Closes https://github.com/AscEmu/AscEmu/issues/1065

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Extracted VMaps on TBC and wotlk client 
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [] WotLK
- [] Cata
-->
