### PR TITLE
Fix NPC equipments in TBC and implement offhand attacks for creatures

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
@@ -479,8 +479,8 @@ public:
     void SwitchToHumanForm()
     {
         getCreature()->setDisplayId(20514);
-        getCreature()->setVirtualItemSlotId(MELEE, (getCreature()->m_spawn != nullptr) ? getCreature()->m_spawn->Item1SlotDisplay : 0);
-        getCreature()->setVirtualItemSlotId(OFFHAND, (getCreature()->m_spawn != nullptr) ?  getCreature()->m_spawn->Item2SlotDisplay : 0);
+        getCreature()->setVirtualItemSlotId(MELEE, (getCreature()->m_spawn != nullptr) ? getCreature()->m_spawn->Item1SlotEntry : 0);
+        getCreature()->setVirtualItemSlotId(OFFHAND, (getCreature()->m_spawn != nullptr) ?  getCreature()->m_spawn->Item2SlotEntry : 0);
     }
 
     void SwitchToDemonForm()

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -82,9 +82,6 @@ bool ChatHandler::HandleMoveHardcodedScriptsToDBCommand(const char* args, WorldS
         creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;
         creature_spawn->Item3SlotEntry = creature_properties->itemslot_3;
 
-        creature_spawn->Item1SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item1SlotEntry);
-        creature_spawn->Item2SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item2SlotEntry);
-        creature_spawn->Item3SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item3SlotEntry);
         creature_spawn->CanFly = 0;
         creature_spawn->phase = session->GetPlayer()->GetPhase();
 

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -489,9 +489,15 @@ bool ChatHandler::HandleNpcInfoCommand(const char* /*args*/, WorldSession* m_ses
     //////////////////////////////////////////////////////////////////////////////////////////
     // equipment
     GreenSystemMessage(m_session, "Equipment ============================");
-    GreenSystemMessage(m_session, "-- Melee: %u (displayid)", creature_target->getVirtualItemSlotId(MELEE));
-    GreenSystemMessage(m_session, "-- Offhand: %u (displayid)", creature_target->getVirtualItemSlotId(OFFHAND));
-    GreenSystemMessage(m_session, "-- Ranged: %u (displayid)", creature_target->getVirtualItemSlotId(RANGED));
+#if VERSION_STRING < WotLK
+    GreenSystemMessage(m_session, "-- Melee: %u", creature_target->getVirtualItemEntry(MELEE));
+    GreenSystemMessage(m_session, "-- Offhand: %u", creature_target->getVirtualItemEntry(OFFHAND));
+    GreenSystemMessage(m_session, "-- Ranged: %u", creature_target->getVirtualItemEntry(RANGED));
+#else
+    GreenSystemMessage(m_session, "-- Melee: %u", creature_target->getVirtualItemSlotId(MELEE));
+    GreenSystemMessage(m_session, "-- Offhand: %u", creature_target->getVirtualItemSlotId(OFFHAND));
+    GreenSystemMessage(m_session, "-- Ranged: %u", creature_target->getVirtualItemSlotId(RANGED));
+#endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // transport
@@ -738,9 +744,6 @@ bool ChatHandler::HandleNpcSpawnCommand(const char* args, WorldSession* m_sessio
     creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;
     creature_spawn->Item3SlotEntry = creature_properties->itemslot_3;
 
-    creature_spawn->Item1SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item1SlotEntry);
-    creature_spawn->Item2SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item2SlotEntry);
-    creature_spawn->Item3SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(creature_spawn->Item3SlotEntry);
     creature_spawn->CanFly = 0;
     creature_spawn->phase = m_session->GetPlayer()->GetPhase();
     creature_spawn->waypoint_id = 0;
@@ -1050,27 +1053,33 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         return true;
     }
 
+#if VERSION_STRING < WotLK
+    const auto previousValue = creature_target->getVirtualItemEntry(equipment_slot);
+#else
+    const auto previousValue = creature_target->getVirtualItemSlotId(equipment_slot);
+#endif
+
     switch (equipment_slot)
     {
         case MELEE:
         {
             creature_target->m_spawn->Item1SlotEntry = item_id;
-            GreenSystemMessage(m_session, "Melee slot successfull changed from %u to %u for Creature %s", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->GetCreatureProperties()->Name.c_str());
-            sGMLog.writefromsession(m_session, "changed melee slot from %u to %u for creature spawn %u", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->spawnid);
+            GreenSystemMessage(m_session, "Melee slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
+            sGMLog.writefromsession(m_session, "changed melee slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
         }
         case OFFHAND:
         {
             creature_target->m_spawn->Item2SlotEntry = item_id;
-            GreenSystemMessage(m_session, "Offhand slot successfull changed from %u to %u for Creature %s", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->GetCreatureProperties()->Name.c_str());
-            sGMLog.writefromsession(m_session, "changed offhand slot from %u to %u for creature spawn %u", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->spawnid);
+            GreenSystemMessage(m_session, "Offhand slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
+            sGMLog.writefromsession(m_session, "changed offhand slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
         }
         case RANGED:
         {
             creature_target->m_spawn->Item3SlotEntry = item_id;
-            GreenSystemMessage(m_session, "Ranged slot successfull changed from %u to %u for Creature %s", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->GetCreatureProperties()->Name.c_str());
-            sGMLog.writefromsession(m_session, "changed ranged slot from %u to %u for creature spawn %u", creature_target->getVirtualItemSlotId(equipment_slot), item_entry->DisplayId, creature_target->spawnid);
+            GreenSystemMessage(m_session, "Ranged slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
+            sGMLog.writefromsession(m_session, "changed ranged slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
         }
         default:
@@ -1080,7 +1089,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         }
     }
 
-    creature_target->setVirtualItemSlotId(equipment_slot, item_entry->DisplayId);
+    creature_target->setVirtualItemSlotId(equipment_slot, item_id);
     creature_target->SaveToDB();
     return true;
 }

--- a/src/world/Data/WoWUnit.hpp
+++ b/src/world/Data/WoWUnit.hpp
@@ -32,6 +32,20 @@ union
 {
     struct
     {
+        uint8_t itemClass;
+        uint8_t itemSubClass;
+        int8_t unk0;
+        uint8_t material;
+        uint8_t inventoryType;
+        uint8_t sheath;
+    } fields;
+    uint64_t raw;
+} typedef unit_virtual_item_info;
+
+union
+{
+    struct
+    {
         uint8_t stand_state;
         uint8_t pet_talent_points; // 0 for non pet creature
         uint8_t stand_state_flag;
@@ -54,7 +68,6 @@ union
 
 #if VERSION_STRING == Classic
 #define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_VIRTUAL_ITEM_INFO_COUNT 6
 #define WOWUNIT_AURA_COUNT 48
 #define WOWUNIT_AURA_FLAGS_COUNT 6
 #define WOWUNIT_AURA_LEVELS_COUNT 12
@@ -90,8 +103,8 @@ struct WoWUnit : WoWObject
     uint32_t level;
     uint32_t faction_template;
     field_bytes_0_union field_bytes_0;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];    //0 = melee, 1 = offhand, 2 = ranged
-    uint32_t virtual_item_info[WOWUNIT_VIRTUAL_ITEM_INFO_COUNT];
+    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];       //0 = melee, 1 = offhand, 2 = ranged
+    unit_virtual_item_info virtual_item_info[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT]; //0 = melee, 1 = offhand, 2 = ranged
     uint32_t unit_flags;
     uint32_t aura[WOWUNIT_AURA_COUNT];
     uint32_t aura_flags[WOWUNIT_AURA_FLAGS_COUNT];
@@ -139,7 +152,6 @@ struct WoWUnit : WoWObject
 };
 #elif VERSION_STRING == TBC
 #define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_VIRTUAL_ITEM_INFO_COUNT 6
 #define WOWUNIT_AURA_COUNT 56
 #define WOWUNIT_AURA_FLAGS_COUNT 14
 #define WOWUNIT_AURA_LEVELS_COUNT 14
@@ -177,8 +189,8 @@ struct WoWUnit : WoWObject
     uint32_t level;
     uint32_t faction_template;
     field_bytes_0_union field_bytes_0;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];    //0 = melee, 1 = offhand, 2 = ranged
-    uint32_t virtual_item_info[WOWUNIT_VIRTUAL_ITEM_INFO_COUNT];
+    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];       //0 = melee, 1 = offhand, 2 = ranged
+    unit_virtual_item_info virtual_item_info[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT]; //0 = melee, 1 = offhand, 2 = ranged
     uint32_t unit_flags;
     uint32_t unit_flags_2;
     uint32_t aura[WOWUNIT_AURA_COUNT];

--- a/src/world/Management/GameEvent.cpp
+++ b/src/world/Management/GameEvent.cpp
@@ -37,9 +37,9 @@ void GameEvent::CreateNPCs()
         c->setFaction(npc.faction);
 
         // Equipment
-        c->setVirtualItemSlotId(MELEE, sMySQLStore.getItemDisplayIdForEntry(cp->itemslot_1));
-        c->setVirtualItemSlotId(OFFHAND, sMySQLStore.getItemDisplayIdForEntry(cp->itemslot_2));
-        c->setVirtualItemSlotId(RANGED, sMySQLStore.getItemDisplayIdForEntry(cp->itemslot_3));
+        c->setVirtualItemSlotId(MELEE, cp->itemslot_1);
+        c->setVirtualItemSlotId(OFFHAND, cp->itemslot_2);
+        c->setVirtualItemSlotId(RANGED, cp->itemslot_3);
 
         if (npc.mountdisplayid != 0)
             c->setMountDisplayId(npc.mountdisplayid);

--- a/src/world/Map/Maps/MapScriptInterface.cpp
+++ b/src/world/Map/Maps/MapScriptInterface.cpp
@@ -124,10 +124,6 @@ Creature* MapScriptInterface::spawnCreature(uint32_t Entry, LocationVector pos, 
     spawn->Item2SlotEntry = creature_properties->itemslot_2;
     spawn->Item3SlotEntry = creature_properties->itemslot_3;
 
-    spawn->Item1SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(spawn->Item1SlotEntry);
-    spawn->Item2SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(spawn->Item2SlotEntry);
-    spawn->Item3SlotDisplay = sMySQLStore.getItemDisplayIdForEntry(spawn->Item3SlotEntry);
-
     spawn->CanFly = 0;
     spawn->phase = phase;
 

--- a/src/world/Objects/ItemDefines.hpp
+++ b/src/world/Objects/ItemDefines.hpp
@@ -410,6 +410,29 @@ enum Item_Subclass
     ITEM_SUBCLASS_MISC_JUNK                 = 0,
 };
 
+enum Item_Sheaths : uint8_t
+{
+    ITEM_SHEATH_NONE                    = 0,
+    ITEM_SHEATH_TWO_HANDED_WEAPON       = 1,
+    ITEM_SHEATH_STAFF                   = 2,
+    ITEM_SHEATH_ONE_HANDED_WEAPON       = 3,
+    ITEM_SHEATH_SHIELD                  = 4,
+    ITEM_SHEATH_ENCHANTER_ROD           = 5,
+    ITEM_SHEATH_OFF_HAND                = 6,
+};
+
+enum Item_Materials : uint8_t
+{
+    ITEM_MATERIAL_METAL                 = 1,
+    ITEM_MATERIAL_WOOD                  = 2,
+    ITEM_MATERIAL_LIQUID                = 3,
+    ITEM_MATERIAL_JEWELRY               = 4,
+    ITEM_MATERIAL_CHAIN                 = 5,
+    ITEM_MATERIAL_PLATE                 = 6,
+    ITEM_MATERIAL_CLOTH                 = 7,
+    ITEM_MATERIAL_LEATHER               = 8,
+};
+
 enum ITEM_QUALITY
 {
     ITEM_QUALITY_POOR_GREY              = 0,

--- a/src/world/Objects/Transporter.cpp
+++ b/src/world/Objects/Transporter.cpp
@@ -315,9 +315,9 @@ Creature* Transporter::createNPCPassenger(MySQLStructure::CreatureSpawn* data)
     pCreature->obj_movement_info.addMovementFlag(MOVEFLAG_TRANSPORT);
 
     // Equipment
-    pCreature->setVirtualItemSlotId(MELEE, sMySQLStore.getItemDisplayIdForEntry(creature_properties->itemslot_1));
-    pCreature->setVirtualItemSlotId(OFFHAND, sMySQLStore.getItemDisplayIdForEntry(creature_properties->itemslot_2));
-    pCreature->setVirtualItemSlotId(RANGED, sMySQLStore.getItemDisplayIdForEntry(creature_properties->itemslot_3));
+    pCreature->setVirtualItemSlotId(MELEE, creature_properties->itemslot_1);
+    pCreature->setVirtualItemSlotId(OFFHAND, creature_properties->itemslot_2);
+    pCreature->setVirtualItemSlotId(RANGED, creature_properties->itemslot_3);
 
     if (data->emote_state)
         pCreature->setEmoteState(data->emote_state);

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -310,6 +310,24 @@ void Creature::setVirtualItemEntry(uint8_t slot, uint32_t itemId)
 }
 #endif
 
+void Creature::toggleDualwield(bool enable)
+{
+    setDualWield(enable);
+    if (enable)
+    {
+        setBaseAttackTime(OFFHAND, getBaseAttackTime(MELEE));
+        // Creatures deal 50% damage on offhand hits
+        setMinOffhandDamage(getMinDamage() * 0.5f);
+        setMaxOffhandDamage(getMaxDamage() * 0.5f);
+    }
+    else
+    {
+        setBaseAttackTime(OFFHAND, 0);
+        setMinOffhandDamage(0.0f);
+        setMaxOffhandDamage(0.0f);
+    }
+}
+
 std::vector<CreatureItem>* Creature::getSellItems()
 {
     return m_SellItems;

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -292,6 +292,24 @@ void Creature::setMaxWanderDistance(float_t dist)
     m_wanderDistance = dist;
 }
 
+#if VERSION_STRING < WotLK
+uint32_t Creature::getVirtualItemEntry(uint8_t slot) const
+{
+    if (slot >= TOTAL_WEAPON_DAMAGE_TYPES)
+        return 0;
+
+    return m_virtualItemEntry[slot];
+}
+
+void Creature::setVirtualItemEntry(uint8_t slot, uint32_t itemId)
+{
+    if (slot >= TOTAL_WEAPON_DAMAGE_TYPES)
+        return;
+
+    m_virtualItemEntry[slot] = itemId;
+}
+#endif
+
 std::vector<CreatureItem>* Creature::getSellItems()
 {
     return m_SellItems;
@@ -791,13 +809,15 @@ void Creature::SaveToDB()
         m_spawn->channel_spell = 0;
         m_spawn->MountedDisplayID = getMountDisplayId();
 
-        m_spawn->Item1SlotEntry = 0;
-        m_spawn->Item2SlotEntry = 0;
-        m_spawn->Item3SlotEntry = 0;
-
-        m_spawn->Item1SlotDisplay = getVirtualItemSlotId(MELEE);
-        m_spawn->Item2SlotDisplay = getVirtualItemSlotId(OFFHAND);
-        m_spawn->Item3SlotDisplay = getVirtualItemSlotId(RANGED);
+#if VERSION_STRING < WotLK
+        m_spawn->Item1SlotEntry = getVirtualItemEntry(MELEE);
+        m_spawn->Item2SlotEntry = getVirtualItemEntry(OFFHAND);
+        m_spawn->Item3SlotEntry = getVirtualItemEntry(RANGED);
+#else
+        m_spawn->Item1SlotEntry = getVirtualItemSlotId(MELEE);
+        m_spawn->Item2SlotEntry = getVirtualItemSlotId(OFFHAND);
+        m_spawn->Item3SlotEntry = getVirtualItemSlotId(RANGED);
+#endif
 
         if (IsFlying())
             m_spawn->CanFly = 1;
@@ -1526,19 +1546,9 @@ bool Creature::Load(MySQLStructure::CreatureSpawn* spawn, uint8 mode, MySQLStruc
     setMinRangedDamage(creature_properties->RangedMinDamage);
     setMaxRangedDamage(creature_properties->RangedMaxDamage);
 
-    setVirtualItemSlotId(MELEE, spawn->Item1SlotDisplay);
-    setVirtualItemSlotId(OFFHAND, spawn->Item2SlotDisplay);
-    setVirtualItemSlotId(RANGED, spawn->Item3SlotDisplay);
-
-#if VERSION_STRING < WotLK
-    setVirtualItemInfo(0, 0);
-    setVirtualItemInfo(1, 0);
-    setVirtualItemInfo(2, 0);
-
-    setVirtualItemInfo(3, 0);
-    setVirtualItemInfo(4, 0);
-    setVirtualItemInfo(5, 0);
-#endif
+    setVirtualItemSlotId(MELEE, spawn->Item1SlotEntry);
+    setVirtualItemSlotId(OFFHAND, spawn->Item2SlotEntry);
+    setVirtualItemSlotId(RANGED, spawn->Item3SlotEntry);
 
     setFaction(spawn->factionid);
     setUnitFlags(spawn->flags);

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -104,6 +104,11 @@ public:
     float_t getMaxWanderDistance() const;
     void setMaxWanderDistance(float_t dist);
 
+#if VERSION_STRING < WotLK
+    uint32_t getVirtualItemEntry(uint8_t slot) const;
+    void setVirtualItemEntry(uint8_t slot, uint32_t itemId);
+#endif
+
     std::vector<CreatureItem>* getSellItems();
 
     uint32_t getWaypointPath() const { return _waypointPathId; }
@@ -145,6 +150,12 @@ public:
 
     bool isDungeonBoss() { return (GetCreatureProperties()->extra_a9_flags & 0x10000000) != 0; }
 
+private:
+#if VERSION_STRING < WotLK
+    uint32_t m_virtualItemEntry[TOTAL_WEAPON_DAMAGE_TYPES] = { 0 };
+#endif
+
+public:
  //AGPL Starts
 
         bool teleport(const LocationVector& vec, WorldMap* map);

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -108,6 +108,7 @@ public:
     uint32_t getVirtualItemEntry(uint8_t slot) const;
     void setVirtualItemEntry(uint8_t slot, uint32_t itemId);
 #endif
+    void toggleDualwield(bool);
 
     std::vector<CreatureItem>* getSellItems();
 

--- a/src/world/Objects/Units/Creatures/Summons/Summon.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/Summon.cpp
@@ -197,9 +197,6 @@ void Summon::unSummon()
         if (getCreatedBySpellId() != 0)
             getSummonerUnit()->removeAllAurasById(getCreatedBySpellId());
 
-        if (getPlayerOwner() != nullptr)
-            getPlayerOwner()->sendDestroyObjectPacket(getGuid());
-
         // Clear Our Summon Slot
         if (m_Properties)
         {
@@ -243,6 +240,9 @@ void Summon::OnPushToWorld()
 
 void Summon::OnPreRemoveFromWorld()
 {
+    if (getPlayerOwner() != nullptr)
+        getPlayerOwner()->sendDestroyObjectPacket(getGuid());
+
     // Make sure unit is unsummoned properly before removing from world
     if (m_summonerGuid)
         unSummon();

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -3359,10 +3359,17 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, max_power_7));
 #endif
 
-#if VERSION_STRING > TBC
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[0]));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[1]));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[2]));
+
+#if VERSION_STRING <= TBC
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[0]));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[0]) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[1]));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[1]) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[2]));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[2]) + 1);
 #endif
 
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, level));

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -6,6 +6,7 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "CombatHandler.hpp"
+#include "Data/WoWUnit.hpp"
 #include "Management/LootMgr.h"
 #include "Macros/UnitMacros.hpp"
 #include "Movement/AbstractFollower.h"
@@ -263,12 +264,19 @@ public:
         setServersideFaction();
     }
 
+#if VERSION_STRING >= WotLK
+    // Returns item entry in wotlk and above
     uint32_t getVirtualItemSlotId(uint8_t slot) const;
+#else
+    // Returns item display id in classic and tbc
+    uint32_t getVirtualItemDisplayId(uint8_t slot) const;
+#endif
     void setVirtualItemSlotId(uint8_t slot, uint32_t item_id);
 
 #if VERSION_STRING < WotLK
-    uint32_t getVirtualItemInfo(uint8_t offset) const;
-    void setVirtualItemInfo(uint8_t offset, uint32_t item_info);
+    uint64_t getVirtualItemInfo(uint8_t slot) const;
+    unit_virtual_item_info getVirtualItemInfoFields(uint8_t slot) const;
+    void setVirtualItemInfo(uint8_t slot, uint64_t item_info);
 #endif
 
     uint32_t getUnitFlags() const;

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -927,7 +927,11 @@ void CreatureAIScript::_setWieldWeapon(bool setWieldWeapon)
 
 void CreatureAIScript::_setDisplayWeapon(bool setMainHand, bool setOffHand)
 {
+#if VERSION_STRING < WotLK
+    _setDisplayWeaponIds(setMainHand ? _creature->getVirtualItemEntry(MELEE) : 0, setOffHand ? _creature->getVirtualItemEntry(OFFHAND) : 0);
+#else
     _setDisplayWeaponIds(setMainHand ? _creature->getVirtualItemSlotId(MELEE) : 0, setOffHand ? _creature->getVirtualItemSlotId(OFFHAND) : 0);
+#endif
 }
 
 void CreatureAIScript::_setDisplayWeaponIds(uint32_t itemId1, uint32_t itemId2)

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -1544,7 +1544,7 @@ void WorldSession::loadHandlers() // TBC
     WorldPacketHandlers[CMSG_CANCEL_AURA].handler = &WorldSession::handleCancelAuraOpcode;
     //WorldPacketHandlers[CMSG_CANCEL_CHANNELLING].handler = &WorldSession::handleCancelChannellingOpcode;
     //WorldPacketHandlers[CMSG_CANCEL_AUTO_REPEAT_SPELL].handler = &WorldSession::handleCancelAutoRepeatSpellOpcode;
-    //WorldPacketHandlers[CMSG_TOTEM_DESTROYED].handler = &WorldSession::handleCancelTotem;
+    WorldPacketHandlers[CMSG_TOTEM_DESTROYED].handler = &WorldSession::handleCancelTotem;
     //WorldPacketHandlers[CMSG_LEARN_TALENT].handler = &WorldSession::handleLearnTalentOpcode;
     //WorldPacketHandlers[CMSG_LEARN_TALENTS_MULTIPLE].handler = &WorldSession::handleLearnMultipleTalentsOpcode;
     //WorldPacketHandlers[CMSG_UNLEARN_TALENTS].handler = &WorldSession::handleUnlearnTalents;

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -6220,6 +6220,7 @@ void Aura::SpellAuraMirrorImage2(AuraEffectModifier* /*aurEff*/, bool apply)
             if (item != nullptr)
                 m_target->setVirtualItemSlotId(OFFHAND, item->getItemProperties()->ItemId);
         }
+#if VERSION_STRING >= WotLK
         else if (getCaster()->isCreatureOrPlayer())
         {
             auto unit = static_cast<Unit*>(getCaster());
@@ -6227,5 +6228,6 @@ void Aura::SpellAuraMirrorImage2(AuraEffectModifier* /*aurEff*/, bool apply)
             m_target->setVirtualItemSlotId(OFFHAND, unit->getVirtualItemSlotId(OFFHAND));
             m_target->setVirtualItemSlotId(RANGED, unit->getVirtualItemSlotId(RANGED));
         }
+#endif
     }
 }

--- a/src/world/Storage/MySQLDataStore.hpp
+++ b/src/world/Storage/MySQLDataStore.hpp
@@ -126,7 +126,6 @@ public:
     ItemPageContainer const* getItemPagesStore() { return &_itemPagesStore; }
     ItemProperties const* getItemProperties(uint32_t entry);
     ItemPropertiesContainer const* getItemPropertiesStore() { return &_itemPropertiesStore; }
-    uint32_t const getItemDisplayIdForEntry(uint32_t entry);
     std::string getItemLinkByProto(ItemProperties const* iProto, uint32_t language = 0);
 
     CreatureProperties const* getCreatureProperties(uint32_t entry);

--- a/src/world/Storage/MySQLStructures.h
+++ b/src/world/Storage/MySQLStructures.h
@@ -161,10 +161,6 @@ namespace MySQLStructure
         uint32_t Item2SlotEntry;
         uint32_t Item3SlotEntry;
 
-        uint32_t Item1SlotDisplay;
-        uint32_t Item2SlotDisplay;
-        uint32_t Item3SlotDisplay;
-
         uint32_t CanFly;
         uint32_t phase;
         //event_entry


### PR DESCRIPTION
**Description**
Creatures: Fix an issue where some NPC equipments are not showing correctly in TBC (thanks for the help @Zyres 😃 )
Creatures: Implement dual wield and offhand attacks for creatures
Summons: Fix an issue when summoned unit is unsummoned

Closes https://github.com/AscEmu/AscEmu/issues/1067 and https://github.com/AscEmu/AscEmu/issues/227

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [x] TBC
- [x] WotLK
- [ ] Cata
