### PR TITLE
Fix non-pch build Classic, TBC, WotLK

### DIFF
--- a/src/collision/BoundingIntervalHierarchy.h
+++ b/src/collision/BoundingIntervalHierarchy.h
@@ -20,17 +20,17 @@
 #ifndef _BIH_H
 #define _BIH_H
 
-#include "G3D/Vector3.h"
-#include "G3D/Ray.h"
-#include "G3D/AABox.h"
-
-#include "Common.hpp"
+#include <Common.hpp>
 
 #include <stdexcept>
 #include <vector>
 #include <algorithm>
 #include <limits>
 #include <cmath>
+
+#include "G3D/Vector3.h"
+#include "G3D/Ray.h"
+#include "G3D/AABox.h"
 
 #define MAX_STACK_SIZE 64
 

--- a/src/collision/Management/MMapManager.cpp
+++ b/src/collision/Management/MMapManager.cpp
@@ -17,9 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
+
 #include "MMapManager.h"
 #include "MapDefines.h"
-
 #include "Errors.h"
 #include "Logging/Logger.hpp"
 #include "Server/World.h"

--- a/src/collision/Maps/TileAssembler.cpp
+++ b/src/collision/Maps/TileAssembler.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
+
 #include "TileAssembler.h"
 #include "MapTree.h"
 #include "BoundingIntervalHierarchy.h"

--- a/src/collision/Models/GameObjectModel.cpp
+++ b/src/collision/Models/GameObjectModel.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
+
 #include "VMapFactory.h"
 #include "VMapManager2.h"
 #include "VMapDefinitions.h"

--- a/src/collision/Models/ModelInstance.cpp
+++ b/src/collision/Models/ModelInstance.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
+
 #include "ModelInstance.h"
 #include "WorldModel.h"
 #include "MapTree.h"

--- a/src/collision/Models/WorldModel.cpp
+++ b/src/collision/Models/WorldModel.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
+
 #include "WorldModel.h"
 #include "VMapDefinitions.h"
 #include "MapTree.h"

--- a/src/logonserver/LogonCommServer/LogonCommServer.cpp
+++ b/src/logonserver/LogonCommServer/LogonCommServer.cpp
@@ -19,6 +19,8 @@
 
 #include "LogonCommServer.h"
 #include "LogonCommDefines.h"
+
+#include <Common.hpp>
 #include <Log.hpp>
 #include <Logging/Logger.hpp>
 #include <Realm/RealmManager.hpp>

--- a/src/logonserver/Server/Master.cpp
+++ b/src/logonserver/Server/Master.cpp
@@ -3,6 +3,7 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
+#include <Common.hpp>
 #include <Threading/AEThreadPool.h>
 #include "Util.hpp"
 #include "Database/DatabaseUpdater.hpp"

--- a/src/shared/ByteConverter.h
+++ b/src/shared/ByteConverter.h
@@ -6,7 +6,6 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include <Common.hpp>
-#include <algorithm>
 
 namespace ByteConverter
 {

--- a/src/shared/Common.Legacy.h
+++ b/src/shared/Common.Legacy.h
@@ -105,8 +105,8 @@
 
 // Include all threading files
 #include <cassert>
-#include "Threading/LegacyThreading.h"
 
+#include "Threading/LegacyThreading.h"
 #include "Threading/ConditionVariable.h"
 
 #if COMPILER == COMPILER_MICROSOFT

--- a/src/world/Management/Guild/Guild.cpp
+++ b/src/world/Management/Guild/Guild.cpp
@@ -372,7 +372,7 @@ void Guild::handleRoster(WorldSession* session)
         memberData.WriteByteSeq(guid[4]);
         memberData << uint8_t(0);
         memberData.WriteByteSeq(guid[1]);
-        memberData << float(member->isOnline() ? 0.0f : float(::time(nullptr) - member->getLogoutTime()) / DAY);
+        memberData << float(member->isOnline() ? 0.0f : float(::time(nullptr) - member->getLogoutTime()) / static_cast<uint64_t>(DAY));
 
         if (offNoteLength)
         {

--- a/src/world/Map/Area/AreaStorage.hpp
+++ b/src/world/Map/Area/AreaStorage.hpp
@@ -5,7 +5,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
-#include "Common.hpp"
+#include <Common.hpp>
+
 #include "Storage/DBC/DBCStorage.hpp"
 #include "Storage/DBC/DBCStructures.hpp"
 #include "Map/Maps/WorldMap.hpp"

--- a/src/world/Movement/MovementDefines.cpp
+++ b/src/world/Movement/MovementDefines.cpp
@@ -3,14 +3,14 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
-#define CONTACT_DISTANCE 0.5f
+#include <Common.hpp>
 
 #include "MovementDefines.h"
 #include "LocationVector.h"
-
-#include <algorithm>
-
+#include "Logging/Logger.hpp"
 #include "Objects/MovementInfo.h"
+
+#define CONTACT_DISTANCE 0.5f
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // ChaseRange

--- a/src/world/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
+++ b/src/world/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
@@ -3,6 +3,8 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
+#include <Common.hpp>
+
 #include "SplineChainMovementGenerator.h"
 #include "Objects/Units/Creatures/Creature.h"
 #include "Objects/Units/Creatures/AIInterface.h"

--- a/src/world/Movement/Spline/MoveSpline.cpp
+++ b/src/world/Movement/Spline/MoveSpline.cpp
@@ -3,9 +3,8 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
+#include <Common.hpp>
 #include "MoveSpline.h"
-
-#include <sstream>
 #include "WorldConf.h"
 #include "CommonDefines.hpp"
 #include "Logging/Logger.hpp"

--- a/src/world/Movement/Spline/Spline.cpp
+++ b/src/world/Movement/Spline/Spline.cpp
@@ -3,6 +3,7 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
+#include <Common.hpp>
 #include "Spline.h"
 #include <sstream>
 #include <G3D/Matrix4.h>

--- a/src/world/Objects/Transporter.cpp
+++ b/src/world/Objects/Transporter.cpp
@@ -3,6 +3,7 @@ Copyright (c) 2014-2023 AscEmu Team <http://www.ascemu.org>
 This file is released under the MIT license. See README-MIT for more information.
 */
 
+#include <Common.hpp>
 #include <G3D/Vector3.h>
 #include "Storage/MySQLDataStore.hpp"
 #include "Macros/ScriptMacros.hpp"

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Common.hpp>
 
 #include "WorldConf.h"
 #include "Server/LogonCommClient/LogonCommHandler.h"


### PR DESCRIPTION
**Description**
Fix non-pch build Classic, TBC, WotLK
Cata+ versions not checked

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [x] Classic
- [x] TBC
- [x] WotLK