### PR TITLE
Fix Cataclysm Transporters

### DIFF
--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -183,7 +183,7 @@ bool DeathGrip(uint8_t effectIndex, Spell* s)
 
         // Blizzard screwed this up, so we won't.
         // ^^^^^^^^^^^^ glass houses
-        if (playerTarget->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
+        if (playerTarget->getTransGuid())
             return false;
 
         s->SpellEffectPlayerPull(effectIndex);

--- a/src/world/Chat/Commands/MiscCommands.cpp
+++ b/src/world/Chat/Commands/MiscCommands.cpp
@@ -548,11 +548,13 @@ bool ChatHandler::HandleGPSCommand(const char* args, WorldSession* m_session)
         out_map_id, out_zone_id, out_area_id, out_phase, out_x, out_y, out_z, out_o, out_area_name);
     SystemMessage(m_session, buf);
 
+#if VERSION_STRING < Cata
     if (obj->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
     {
         SystemMessage(m_session, "Position on Transport:");
         SystemMessage(m_session, "  tX: %f  tY: %f  tZ: %f  tO: %f", obj->GetTransOffsetX(), obj->GetTransOffsetY(), obj->GetTransOffsetZ(), obj->GetTransOffsetO());
     }
+#endif
 
     // ".gps 1" will save gps info to file logs/gps.log - This probably isn't very multithread safe so don't have many gms spamming it!
     if (args != NULL && *args == '1')

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -504,10 +504,12 @@ bool ChatHandler::HandleNpcInfoCommand(const char* /*args*/, WorldSession* m_ses
     if (auto transporter = creature_target->GetTransport())
     {
         SystemMessage(m_session, "Creature is on Transporter!");
+#if VERSION_STRING < Cata
         if (creature_target->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
             SystemMessage(m_session, "Creature has MovementFlag MOVEFLAG_TRANSPORT");
         else
             SystemMessage(m_session, "!!!!!!!!! NO MovementFlag MOVEFLAG_TRANSPORT !!!!!!!!!!!!");
+#endif
     }
 
     if (sScriptMgr.has_creature_script(creature_target->getEntry()))

--- a/src/world/Map/Maps/WorldMap.cpp
+++ b/src/world/Map/Maps/WorldMap.cpp
@@ -2521,8 +2521,13 @@ float WorldMap::getUpdateDistance(Object* curObj, Object* obj, Player* plObj)
     static float no_distance = 0.0f;
 
     // unlimited distance for people on same boat
+#if VERSION_STRING < Cata
     if (curObj->isPlayer() && obj->isPlayer() && plObj != nullptr && plObj->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT) && plObj->obj_movement_info.transport_guid == curObj->obj_movement_info.transport_guid)
         return no_distance;
+#else
+    if (curObj->isPlayer() && obj->isPlayer() && plObj != nullptr && plObj->obj_movement_info.transport_guid == curObj->obj_movement_info.transport_guid)
+        return no_distance;
+#endif
     // unlimited distance for transporters (only up to 2 cells +/- anyway.)
     if (curObj->GetTypeFromGUID() == HIGHGUID_TYPE_TRANSPORTER)
         return no_distance;

--- a/src/world/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/world/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -146,8 +146,13 @@ bool WaypointMovementGenerator<Creature>::doUpdate(Creature* owner, uint32_t dif
     if (!owner->movespline->Finalized())
     {
         // set home position at place (every MotionMaster::UpdateMotion)
+#if VERSION_STRING <= WotLK
         if (!owner->hasUnitMovementFlag(MOVEFLAG_TRANSPORT) || owner->getTransGuid())
             owner->SetSpawnLocation(owner->GetPosition());
+#else
+        if (owner->getTransGuid())
+            owner->SetSpawnLocation(owner->GetPosition());
+#endif
 
         // relaunch movement if its speed has changed
         if (hasFlag(MOVEMENTGENERATOR_FLAG_SPEED_UPDATE_PENDING))
@@ -252,7 +257,11 @@ void WaypointMovementGenerator<Creature>::startMove(Creature* owner, bool relaun
         return;
     }
 
+#if VERSION_STRING <= WotLK
     bool const transportPath = owner->hasUnitMovementFlag(MOVEFLAG_TRANSPORT) && owner->getTransGuid();
+#else
+    bool const transportPath = owner->GetTransport() != nullptr;
+#endif
 
     if (hasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED) && hasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))
     {

--- a/src/world/Movement/Spline/MoveSplineInit.cpp
+++ b/src/world/Movement/Spline/MoveSplineInit.cpp
@@ -50,7 +50,11 @@ int32_t MoveSplineInit::Launch()
     MoveSpline& move_spline = *unit->movespline;
 
     // Elevators also use MOVEFLAG_TRANSPORT but we do not keep track of their position changes
+#if VERSION_STRING <= WotLK
     bool transport = unit->hasUnitMovementFlag(MOVEFLAG_TRANSPORT) && unit->getTransGuid();
+#else
+    bool transport = unit->getTransGuid() != 0;
+#endif
     Location real_position;
     // there is a big chance that current position is unknown if current state is not finalized, need compute it
     // this also allows CalculatePath spline position and update map position in much greater intervals
@@ -148,7 +152,12 @@ void MoveSplineInit::Stop()
     if (move_spline.Finalized())
         return;
 
+#if VERSION_STRING <= WotLK
     bool transport = unit->hasUnitMovementFlag(MOVEFLAG_TRANSPORT) && unit->getTransGuid();
+#else
+    bool transport = unit->getTransGuid() != 0;
+#endif
+
     Location loc;
     if (move_spline.onTransport == transport)
     {

--- a/src/world/Objects/MovementDefines.hpp
+++ b/src/world/Objects/MovementDefines.hpp
@@ -199,7 +199,6 @@ enum MovementFlags
     MOVEFLAG_FEATHER_FALL           = 0x08000000,
     MOVEFLAG_HOVER                  = 0x10000000,
     MOVEFLAG_NO_COLLISION           = 0x20000000,
-    MOVEFLAG_TRANSPORT              = 0x40000000,
 
     // Masks
     MOVEFLAG_MOVING_MASK =

--- a/src/world/Objects/Transporter.cpp
+++ b/src/world/Objects/Transporter.cpp
@@ -239,7 +239,9 @@ void Transporter::AddPassenger(Player* passenger)
     if (_passengers.insert(passenger).second)
     {
         passenger->SetTransport(this);
+#if VERSION_STRING <= WotLK
         passenger->obj_movement_info.addMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
         passenger->obj_movement_info.transport_guid = getGuid();
         if (passenger->isPlayer())
         {
@@ -271,7 +273,9 @@ void Transporter::RemovePassenger(Object* passenger)
     if (erased || _staticPassengers.erase(passenger))
     {
         passenger->SetTransport(nullptr);
+#if VERSION_STRING <= WotLK
         passenger->obj_movement_info.removeMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
         passenger->obj_movement_info.clearTransportData();
         if (passenger->isPlayer())
         {
@@ -313,8 +317,10 @@ Creature* Transporter::createNPCPassenger(MySQLStructure::CreatureSpawn* data)
 
     // AddToWorld
     pCreature->AddToWorld(map);
+#if VERSION_STRING <= WotLK
     pCreature->setUnitMovementFlags(MOVEFLAG_TRANSPORT);
     pCreature->obj_movement_info.addMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
 
     // Equipment
     pCreature->setVirtualItemSlotId(MELEE, creature_properties->itemslot_1);

--- a/src/world/Objects/Units/Creatures/Vehicle.cpp
+++ b/src/world/Objects/Units/Creatures/Vehicle.cpp
@@ -228,8 +228,10 @@ void Vehicle::loadAccessory(uint32_t entry, int8_t seatId, bool minion, uint8_t 
     accessory->setFaction(getBase()->getFactionTemplate());
     accessory->PushToWorld(getBase()->getWorldMap());
 
+#if VERSION_STRING <= WotLK
     accessory->obj_movement_info.addMovementFlag(MOVEFLAG_TRANSPORT);
     accessory->addUnitMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
 
     if (minion)
         accessory->addUnitStateFlag(UNIT_STATE_ACCESSORY);
@@ -406,7 +408,9 @@ Vehicle* Vehicle::removePassenger(Unit* unit)
     {
         if (!getBase()->GetTransport())
         {
+#if VERSION_STRING <= WotLK
             unit->removeUnitMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
             unit->obj_movement_info.clearTransportData();
         }
         else
@@ -569,7 +573,9 @@ bool Vehicle::tryAddPassenger(Unit* passenger, SeatMap::iterator &Seat)
     float y = veSeat->attachmentOffsetY;
     float z = veSeat->attachmentOffsetZ;
 
+#if VERSION_STRING <= WotLK
     passenger->addUnitMovementFlag(MOVEFLAG_TRANSPORT);
+#endif
     passenger->obj_movement_info.transport_position.changeCoords(x, y, z, o);
     passenger->obj_movement_info.transport_time = 0;
     passenger->obj_movement_info.transport_seat = Seat->first;

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -1830,7 +1830,7 @@ void Unit::setFacingTo(float ori, bool force)
     MovementMgr::MoveSplineInit init(this);
     init.MoveTo(GetPositionX(), GetPositionY(), GetPositionZ(), false);
 
-    if (hasUnitMovementFlag(MOVEFLAG_TRANSPORT) /*&& GetTransGUID()*/)
+    if (getTransGuid())
         init.DisableTransportPathTransformations(); // It makes no sense to target global orientation
     init.SetFacing(ori);
 

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -2299,7 +2299,7 @@ void WorldSession::handleListInventoryOpcode(WorldPacket& recvPacket)
     MySQLStructure::VendorRestrictions const* vendor = sMySQLStore.getVendorRestriction(unit->GetCreatureProperties()->Id);
 
     //this is a blizzlike check
-    if (!_player->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT) && !unit->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
+    if (!_player->getTransGuid() && !unit->getTransGuid())
     {
         //avoid talking to anyone by guid hacking. Like sell farmed items anytime ? Low chance hack
         if (_player->getDistanceSq(unit) > 100)

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -1646,7 +1646,7 @@ void WorldSession::handleRepopRequestOpcode(WorldPacket& /*recvPacket*/)
     if (_player->getDeathState() != JUST_DIED)
         return;
 
-    if (_player->obj_movement_info.hasMovementFlag(MOVEFLAG_TRANSPORT))
+    if (_player->getTransGuid())
     {
         auto transport = _player->GetTransport();
         if (transport != nullptr)


### PR DESCRIPTION
**Description**
In cata and beyond is no Movementflag Transport

Fix: #1100 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [x] Cata
