### PR TITLE
Reworked SpellForcedBasePoints wrapper

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
@@ -843,9 +843,7 @@ public:
             if (random_target == nullptr)
                 return;
             //let's force this effect
-            SpellForcedBasePoints* forcedBasePoints;
-            forcedBasePoints->set(0, random_target->getMaxHealth() / 2);
-            getCreature()->castSpell(random_target, info_cataclysmic_bolt, *forcedBasePoints, true);
+            getCreature()->castSpell(random_target, info_cataclysmic_bolt, { random_target->getMaxHealth() / 2 }, true);
             TargetTable.clear();
         }
 

--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -263,13 +263,13 @@ bool DeathCoil(uint8_t /*effectIndex*/, Spell* s)
     SpellForcedBasePoints* forcedBasePoints;
     if (s->getPlayerCaster()->isValidTarget(unitTarget))
     {
-        forcedBasePoints->set(EFF_INDEX_0, dmg);
+        forcedBasePoints->setValue(EFF_INDEX_0, dmg);
         s->getPlayerCaster()->castSpell(unitTarget, 47632, *forcedBasePoints, true);
     }
     else if (unitTarget->isPlayer() && unitTarget->getRace() == RACE_UNDEAD)
     {
         float multiplier = 1.5f;
-        forcedBasePoints->set(EFF_INDEX_0, static_cast<int32_t>((dmg * multiplier)));
+        forcedBasePoints->setValue(EFF_INDEX_0, static_cast<int32_t>((dmg * multiplier)));
         s->getPlayerCaster()->castSpell(unitTarget, 47633, *forcedBasePoints, true);
     }
 
@@ -301,7 +301,7 @@ bool DeathAndDecay(uint8_t effectIndex, Aura* pAura, bool apply)
             return true;
 
         SpellForcedBasePoints* forcedBasePoints;
-        forcedBasePoints->set(EFF_INDEX_0, static_cast<uint32_t>(pAura->getEffectDamage(effectIndex) + caster->getCalculatedAttackPower() * 0.064));
+        forcedBasePoints->setValue(EFF_INDEX_0, static_cast<uint32_t>(pAura->getEffectDamage(effectIndex) + caster->getCalculatedAttackPower() * 0.064));
 
         caster->castSpell(pAura->getOwner(), 52212, *forcedBasePoints, true);
     }

--- a/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/DeathKnightSpells.cpp
@@ -260,17 +260,13 @@ bool DeathCoil(uint8_t /*effectIndex*/, Spell* s)
 
     int32_t dmg = s->damage;
 
-    SpellForcedBasePoints* forcedBasePoints;
     if (s->getPlayerCaster()->isValidTarget(unitTarget))
     {
-        forcedBasePoints->setValue(EFF_INDEX_0, dmg);
-        s->getPlayerCaster()->castSpell(unitTarget, 47632, *forcedBasePoints, true);
+        s->getPlayerCaster()->castSpell(unitTarget, 47632, { dmg }, true);
     }
     else if (unitTarget->isPlayer() && unitTarget->getRace() == RACE_UNDEAD)
     {
-        float multiplier = 1.5f;
-        forcedBasePoints->setValue(EFF_INDEX_0, static_cast<int32_t>((dmg * multiplier)));
-        s->getPlayerCaster()->castSpell(unitTarget, 47633, *forcedBasePoints, true);
+        s->getPlayerCaster()->castSpell(unitTarget, 47633, { static_cast<int32_t>((dmg * 1.5f)) }, true);
     }
 
     return true;
@@ -296,14 +292,10 @@ bool DeathAndDecay(uint8_t effectIndex, Aura* pAura, bool apply)
 {
     if (apply)
     {
-        Player* caster = pAura->GetPlayerCaster();
-        if (caster == NULL)
-            return true;
-
-        SpellForcedBasePoints* forcedBasePoints;
-        forcedBasePoints->setValue(EFF_INDEX_0, static_cast<uint32_t>(pAura->getEffectDamage(effectIndex) + caster->getCalculatedAttackPower() * 0.064));
-
-        caster->castSpell(pAura->getOwner(), 52212, *forcedBasePoints, true);
+        if (Player* caster = pAura->GetPlayerCaster())
+        {
+            caster->castSpell(pAura->getOwner(), 52212, { static_cast<uint32_t>(pAura->getEffectDamage(effectIndex) + caster->getCalculatedAttackPower() * 0.064f) }, true);
+        }
     }
 
     return true;

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -123,7 +123,7 @@ public:
                 for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
                     forcedBasePoints.setValue(static_cast<SpellEffIndex>(i), basePoints);
 
-                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), { p_damage }, true);
+                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), forcedBasePoints, true);
             }
 #else
             // Cast Improved Unholy Presence in Blood and Frost presences

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -121,7 +121,7 @@ public:
                 SpellForcedBasePoints forcedBasePoints;
                 const auto basePoints = improvedUnholyPresence->getSpellInfo()->calculateEffectValue(EFF_INDEX_1);
                 for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                    forcedBasePoints.setValue(i, basePoints);
+                    forcedBasePoints.setValue(static_cast<SpellEffIndex>(i), basePoints);
 
                 aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), { p_damage }, true);
             }

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -95,7 +95,7 @@ public:
         }
 
         // Cast Improved Blood Presence in Frost and Unholy presences
-        int32 const p_damage = improvedFrostPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage();
+        int32_t const p_damage = improvedFrostPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage();
         if (!isBloodPresence() && improvedBloodPresence != nullptr)
         {
             aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_BLOOD_PRESENCE_DUMMY), { p_damage }, true);

--- a/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
+++ b/src/scripts/SpellHandlers/Scripts/DeathKnight.cpp
@@ -95,19 +95,16 @@ public:
         }
 
         // Cast Improved Blood Presence in Frost and Unholy presences
+        int32 const p_damage = improvedFrostPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage();
         if (!isBloodPresence() && improvedBloodPresence != nullptr)
         {
-            SpellForcedBasePoints forcedBasePoints;
-            forcedBasePoints.set(EFF_INDEX_0, improvedBloodPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage());
-            aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_BLOOD_PRESENCE_DUMMY), forcedBasePoints, true);
+            aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_BLOOD_PRESENCE_DUMMY), { p_damage }, true);
         }
 
         // Cast Improved Frost Presence in Blood and Unholy presences
         if (!isFrostPresence() && improvedFrostPresence != nullptr)
         {
-            SpellForcedBasePoints forcedBasePoints;
-            forcedBasePoints.set(EFF_INDEX_0, improvedFrostPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage());
-            aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_FROST_PRESENCE_DUMMY), forcedBasePoints, true);
+            aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_FROST_PRESENCE_DUMMY), { p_damage }, true);
         }
 
         if (improvedUnholyPresence != nullptr)
@@ -116,9 +113,7 @@ public:
             // Cast Unholy Presence speed aura in Blood and Frost presences
             if (!isUnholyPresence())
             {
-                SpellForcedBasePoints forcedBasePoints;
-                forcedBasePoints.set(EFF_INDEX_0, improvedUnholyPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage());
-                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_UNHOLY_PRESENCE_MOVE_SPEED), forcedBasePoints, true);
+                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_UNHOLY_PRESENCE_MOVE_SPEED), { p_damage }, true);
             }
             // Cast Improved Unholy Presence in Unholy Presence
             else
@@ -126,17 +121,15 @@ public:
                 SpellForcedBasePoints forcedBasePoints;
                 const auto basePoints = improvedUnholyPresence->getSpellInfo()->calculateEffectValue(EFF_INDEX_1);
                 for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                    forcedBasePoints.set(i, basePoints);
+                    forcedBasePoints.setValue(i, basePoints);
 
-                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), forcedBasePoints, true);
+                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), { p_damage }, true);
             }
 #else
             // Cast Improved Unholy Presence in Blood and Frost presences
             if (!isUnholyPresence())
             {
-                SpellForcedBasePoints forcedBasePoints;
-                forcedBasePoints.set(EFF_INDEX_0, improvedUnholyPresence->getAuraEffect(EFF_INDEX_0)->getEffectDamage());
-                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), forcedBasePoints, true);
+                aur->getOwner()->castSpell(aur->getOwner(), sSpellMgr.getSpellInfo(SPELL_IMPROVED_UNHOLY_PRESENCE_DUMMY), { p_damage }, true);
             }
 #endif
         }
@@ -195,7 +188,7 @@ public:
 
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->set(EFF_INDEX_0, heal);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, heal);
         heal = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }

--- a/src/scripts/SpellHandlers/Scripts/Mage.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Mage.cpp
@@ -312,7 +312,7 @@ public:
 
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->set(EFF_INDEX_0, manaReturn);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, manaReturn);
         manaReturn = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }

--- a/src/scripts/SpellHandlers/Scripts/Paladin.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Paladin.cpp
@@ -99,7 +99,7 @@ public:
 
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->set(EFF_INDEX_0, damage);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, damage);
         damage = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }

--- a/src/scripts/SpellHandlers/Scripts/Priest.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Priest.cpp
@@ -193,7 +193,7 @@ public:
 
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->set(EFF_INDEX_0, absorbAmount);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, absorbAmount);
         absorbAmount = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }
@@ -464,10 +464,10 @@ public:
     {
 #if VERSION_STRING < WotLK
         // Same amount for party and self in Classic and TBC
-        spell->forced_basepoints->set(EFF_INDEX_0, selfHeal);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, selfHeal);
 #else
-        spell->forced_basepoints->set(EFF_INDEX_0, partyHeal);
-        spell->forced_basepoints->set(EFF_INDEX_1, selfHeal);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, partyHeal);
+        spell->forced_basepoints.setValue(EFF_INDEX_1, selfHeal);
 #endif
         selfHeal = 0;
         partyHeal = 0;
@@ -532,11 +532,8 @@ public:
             return;
 
         // Create backfire damage on dispel
-        SpellForcedBasePoints forcedBasePoints;
-        forcedBasePoints.set(EFF_INDEX_0, aur->getAuraEffect(EFF_INDEX_1)->getEffectDamage() * 8);
-        const auto caster = aur->GetUnitCaster();
-        if (caster != nullptr)
-            caster->castSpell(aur->getOwner(), SPELL_VAMPIRIC_TOUCH_DISPEL, forcedBasePoints, true);
+        if (Unit* caster = aur->GetUnitCaster())
+            caster->castSpell(aur->getOwner(), SPELL_VAMPIRIC_TOUCH_DISPEL, { aur->getAuraEffect(EFF_INDEX_1)->getEffectDamage() * 8 }, true);
     }
 #endif
 };

--- a/src/scripts/SpellHandlers/Scripts/Priest.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Priest.cpp
@@ -580,7 +580,7 @@ public:
 #if VERSION_STRING == TBC
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->set(EFF_INDEX_0, manaReturn);
+        spell->forced_basepoints->setValue(EFF_INDEX_0, manaReturn);
         manaReturn = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }

--- a/src/scripts/SpellHandlers/Scripts/Priest.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Priest.cpp
@@ -580,7 +580,7 @@ public:
 #if VERSION_STRING == TBC
     SpellScriptExecuteState onCastProcSpell(SpellProc* /*spellProc*/, Unit* /*caster*/, Unit* /*victim*/, Spell* spell) override
     {
-        spell->forced_basepoints->setValue(EFF_INDEX_0, manaReturn);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, manaReturn);
         manaReturn = 0;
         return SpellScriptExecuteState::EXECUTE_OK;
     }

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -992,11 +992,10 @@ DamageInfo Object::doSpellDamage(Unit* victim, uint32_t spellId, float_t dmg, ui
             if (spellpower > hp)
                 spellpower = hp;
 
-            SpellInfo const* entry = sSpellMgr.getSpellInfo(44413);
-            SpellForcedBasePoints forcedBasePoints;
-            forcedBasePoints.set(0, spellpower);
-            if (entry != nullptr)
-                pl->castSpell(pl->getGuid(), entry, forcedBasePoints, true);
+            if (SpellInfo const* entry = sSpellMgr.getSpellInfo(44413))
+            {
+                pl->castSpell(pl->getGuid(), entry, { spellpower }, true);
+            }
         }
     }
 

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -3521,35 +3521,31 @@ void Unit::setDualWield(bool enable)
 
 void Unit::castSpell(uint64_t targetGuid, uint32_t spellId, bool triggered/* = false*/)
 {
-    const SpellForcedBasePoints forcedBasePoints;
-    castSpell(targetGuid, spellId, forcedBasePoints, triggered);
+    castSpell(targetGuid, spellId, {}, triggered);
 }
 
 void Unit::castSpell(Unit* target, uint32_t spellId, bool triggered/* = false*/)
 {
-    const SpellForcedBasePoints forcedBasePoints;
-    castSpell(target, spellId, forcedBasePoints, triggered);
+    castSpell(target, spellId, {}, triggered);
 }
 
 void Unit::castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, bool triggered/* = false*/)
 {
-    if (spellInfo == nullptr)
-        return;
-
-    const SpellForcedBasePoints forcedBasePoints;
-    castSpell(targetGuid, spellInfo, forcedBasePoints, triggered);
+    if (spellInfo != nullptr)
+    {
+        castSpell(targetGuid, spellInfo, {}, triggered);
+    }   
 }
 
 void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, bool triggered/* = false*/)
 {
-    if (spellInfo == nullptr)
-        return;
-    
-    const SpellForcedBasePoints forcedBasePoints;
-    castSpell(target, spellInfo, forcedBasePoints, triggered);
+    if (spellInfo != nullptr)
+    {
+        castSpell(target, spellInfo, {}, triggered);
+    } 
 }
 
-void Unit::castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints forcedBasepoints, bool triggered/* = false*/)
+void Unit::castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints const& forcedBasepoints, bool triggered/* = false*/)
 {
     const auto spellInfo = sSpellMgr.getSpellInfo(spellId);
     if (spellInfo == nullptr)
@@ -3558,7 +3554,7 @@ void Unit::castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoint
     castSpell(targetGuid, spellInfo, forcedBasepoints, triggered);
 }
 
-void Unit::castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints forcedBasepoints, bool triggered/* = false*/)
+void Unit::castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints const& forcedBasepoints, bool triggered/* = false*/)
 {
     const auto spellInfo = sSpellMgr.getSpellInfo(spellId);
     if (spellInfo == nullptr)
@@ -3567,13 +3563,13 @@ void Unit::castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints force
     castSpell(target, spellInfo, forcedBasepoints, triggered);
 }
 
-void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasePoints, int32_t spellCharges, bool triggered/* = false*/)
+void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasePoints, int32_t spellCharges, bool triggered/* = false*/)
 {
     if (spellInfo == nullptr)
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasePoints;
+    newSpell->forced_basepoints = forcedBasePoints;
     newSpell->m_charges = spellCharges;
 
     SpellCastTargets targets(0);
@@ -3633,13 +3629,13 @@ void Unit::eventCastSpell(Unit* target, SpellInfo const* spellInfo)
         sLogger.failure("Unit::eventCastSpell tried to cast invalid spell with no spellInfo (nullptr)");
 }
 
-void Unit::castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered)
+void Unit::castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasepoints, bool triggered)
 {
     if (spellInfo == nullptr)
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasepoints;
+    newSpell->forced_basepoints = forcedBasepoints;
 
     SpellCastTargets targets(targetGuid);
 
@@ -3647,13 +3643,13 @@ void Unit::castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForce
     newSpell->prepare(&targets);
 }
 
-void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered)
+void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasepoints, bool triggered)
 {
     if (spellInfo == nullptr)
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasepoints;
+    newSpell->forced_basepoints = forcedBasepoints;
 
     SpellCastTargets targets(0);
     if (target != nullptr)
@@ -8141,7 +8137,7 @@ void Unit::handleSpellClick(Unit* clicker, int8_t seatId /*= -1*/)
                     //   HANDLE_AURA_CONTROL_VEHICLE will call enterVehicle or exitVehicle
 
                     SpellForcedBasePoints bp;
-                    bp.set(i, seatId + 1);
+                    bp.setValue(i, seatId + 1);
                     caster->castSpell(target, clickPair.spellId, bp, true);
                 }
             }
@@ -8172,7 +8168,7 @@ void Unit::callEnterVehicle(Unit* base, int8_t seatId /*= -1*/)
     //   HANDLE_AURA_CONTROL_VEHICLE will call enterVehicle or exitVehicle
 
     SpellForcedBasePoints bp;
-    bp.set(0, seatId + 1);
+    bp.setValue(0, seatId + 1);
     castSpell(base, VEHICLE_SPELL_RIDE_HARDCODED, bp, true);
 }
 
@@ -13892,7 +13888,7 @@ uint32_t Unit::handleProc(uint32_t flag, Unit* victim, SpellInfo const* CastingS
                     continue;
                 int32_t val = parentproc->calculateEffectValue(0);
                 Spell* spell = sSpellMgr.newSpell(this, spellInfo, true, NULL);
-                spell->forced_basepoints->set(0, (val * damageInfo.realDamage) / 300); //per tick
+                spell->forced_basepoints.setValue(0, (val * damageInfo.realDamage) / 300); //per tick
                 SpellCastTargets targets(getGuid());
                 spell->prepare(&targets);
                 continue;

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -3626,9 +3626,8 @@ void Unit::castSpellLoc(const LocationVector location, SpellInfo const* spellInf
 
 void Unit::eventCastSpell(Unit* target, SpellInfo const* spellInfo)
 {
-    const SpellForcedBasePoints forcedBasePoints;
     if (spellInfo != nullptr)
-        castSpell(target, spellInfo, forcedBasePoints, true);
+        castSpell(target, spellInfo, {}, true);
     else
         sLogger.failure("Unit::eventCastSpell tried to cast invalid spell with no spellInfo (nullptr)");
 }

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -23,7 +23,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Spell/Definitions/SpellModifierType.hpp"
 #include "Spell/Definitions/SpellTypes.hpp"
 #include "Spell/SpellProc.hpp"
-
 #include <array>
 #include <list>
 #include <optional>
@@ -733,17 +732,17 @@ public:
     void castSpell(Unit* target, uint32_t spellId, bool triggered = false);
     void castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, bool triggered = false);
     void castSpell(Unit* target, SpellInfo const* spellInfo, bool triggered = false);
-    void castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints forcedBasepoints, bool triggered = false);
-    void castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints forcedBasePoints, bool triggered = false);
-    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasePoints, int32_t spellCharges, bool triggered = false);
+    void castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints const& forcedBasepoints, bool triggered = false);
+    void castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints const& forcedBasePoints, bool triggered = false);
+    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasePoints, int32_t spellCharges, bool triggered = false);
     void castSpell(SpellCastTargets targets, uint32_t spellId, bool triggered = false);
     void castSpell(SpellCastTargets targets, SpellInfo const* spellInfo, bool triggered = false);
     void castSpellLoc(const LocationVector location, uint32_t spellId, bool triggered = false);
     void castSpellLoc(const LocationVector location, SpellInfo const* spellInfo, bool triggered = false);
     void eventCastSpell(Unit* target, SpellInfo const* spellInfo);
 
-    void castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
-    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
+    void castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasepoints, bool triggered);
+    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints const& forcedBasepoints, bool triggered);
 
     SpellProc* addProcTriggerSpell(uint32_t spellId, uint32_t originalSpellId, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t const* spellFamilyMask, uint32_t const* procClassMask = nullptr, Aura* createdByAura = nullptr, Object* obj = nullptr);
     // Gets proc chance and proc flags from spellInfo

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -335,7 +335,7 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
     spell->setItemCaster(tmpItem);
 
     if (spellToLearn != 0)
-        spell->forced_basepoints.setValue(0, spellToLearn);
+        spell->forced_basepoints.setValue(EFF_INDEX_0, spellToLearn);
 
 #if VERSION_STRING >= WotLK
     spell->m_glyphslot = srlPacket.glyphIndex;

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -335,7 +335,7 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
     spell->setItemCaster(tmpItem);
 
     if (spellToLearn != 0)
-        spell->forced_basepoints->set(0, spellToLearn);
+        spell->forced_basepoints.setValue(0, spellToLearn);
 
 #if VERSION_STRING >= WotLK
     spell->m_glyphslot = srlPacket.glyphIndex;

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -1438,7 +1438,7 @@ void Spell::HandleAddAura(uint64 guid)
                     Spell* spell = sSpellMgr.newSpell(p_caster, spellInfo, true, nullptr);
 
 
-                    spell->forced_basepoints->set(0, p_caster->getAuraWithId(kingOfTheJungle)->getSpellInfo()->custom_RankNumber * 5);
+                    spell->forced_basepoints.setValue(0, p_caster->getAuraWithId(kingOfTheJungle)->getSpellInfo()->custom_RankNumber * 5);
                     SpellCastTargets targets(p_caster->getGuid());
                     spell->prepare(&targets);
                 }
@@ -1542,7 +1542,7 @@ void Spell::HandleAddAura(uint64 guid)
         };
 
         if (spellid == 31665 && Target->hasAurasWithId(masterOfSubtlety))
-            spell->forced_basepoints->set(0, Target->getAuraWithId(masterOfSubtlety)->getSpellInfo()->getEffectBasePoints(0));
+            spell->forced_basepoints.setValue(0, Target->getAuraWithId(masterOfSubtlety)->getSpellInfo()->getEffectBasePoints(0));
 
         SpellCastTargets targets(Target->getGuid());
         spell->prepare(&targets);

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -1438,7 +1438,7 @@ void Spell::HandleAddAura(uint64 guid)
                     Spell* spell = sSpellMgr.newSpell(p_caster, spellInfo, true, nullptr);
 
 
-                    spell->forced_basepoints.setValue(0, p_caster->getAuraWithId(kingOfTheJungle)->getSpellInfo()->custom_RankNumber * 5);
+                    spell->forced_basepoints.setValue(EFF_INDEX_0, p_caster->getAuraWithId(kingOfTheJungle)->getSpellInfo()->custom_RankNumber * 5);
                     SpellCastTargets targets(p_caster->getGuid());
                     spell->prepare(&targets);
                 }
@@ -1542,7 +1542,7 @@ void Spell::HandleAddAura(uint64 guid)
         };
 
         if (spellid == 31665 && Target->hasAurasWithId(masterOfSubtlety))
-            spell->forced_basepoints.setValue(0, Target->getAuraWithId(masterOfSubtlety)->getSpellInfo()->getEffectBasePoints(0));
+            spell->forced_basepoints.setValue(EFF_INDEX_0, Target->getAuraWithId(masterOfSubtlety)->getSpellInfo()->getEffectBasePoints(0));
 
         SpellCastTargets targets(Target->getGuid());
         spell->prepare(&targets);

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -203,8 +203,6 @@ Spell::Spell(Object* _caster, SpellInfo const* _spellInfo, bool _triggered, Aura
                 break;
         }
     }
-
-    forced_basepoints = new SpellForcedBasePoints;
 }
 
 Spell::~Spell()
@@ -249,10 +247,7 @@ Spell::~Spell()
 
         itr = m_pendingAuras.erase(itr);
     }
-
-    delete forced_basepoints;
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Main control flow
@@ -1492,7 +1487,7 @@ void Spell::cancel()
 
 int32_t Spell::calculateEffect(uint8_t effIndex)
 {
-    auto value = getSpellInfo()->calculateEffectValue(effIndex, getUnitCaster(), getItemCaster(), *forced_basepoints);
+    int32_t value = getSpellInfo()->calculateEffectValue(effIndex, getUnitCaster(), getItemCaster(), forced_basepoints);
 
     // Legacy script hook
     value = DoCalculateEffect(effIndex, getUnitTarget(), value);

--- a/src/world/Spell/Spell.hpp
+++ b/src/world/Spell/Spell.hpp
@@ -13,6 +13,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Movement/Spline/MovementTypedefs.h"
 #include "Objects/DamageInfo.hpp"
 #include "SpellDefines.hpp"
+#include "SpellInfo.hpp"
 #include "Storage/WDB/WDBDefines.hpp"
 
 #include <map>
@@ -25,7 +26,6 @@ namespace WDB::Structures
 }
 
 struct AuraEffectModifier;
-struct SpellForcedBasePoints;
 class Object;
 class SpellInfo;
 class Corpse;
@@ -243,7 +243,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
     // Some spells inherit base points from the mother spell
-    SpellForcedBasePoints* forced_basepoints;
+    SpellForcedBasePoints forced_basepoints;
 
     Aura* getTriggeredByAura() const;
 

--- a/src/world/Spell/SpellAura.cpp
+++ b/src/world/Spell/SpellAura.cpp
@@ -1006,7 +1006,7 @@ void Aura::periodicTick(AuraEffectModifier* aurEff)
                 if (aurEff->getAuraEffectType() == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE)
                 {
                     for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                        triggerSpell->forced_basepoints->set(i, customDamage);
+                        triggerSpell->forced_basepoints.setValue(i, customDamage);
                 }
 #endif
 

--- a/src/world/Spell/SpellAura.cpp
+++ b/src/world/Spell/SpellAura.cpp
@@ -1006,7 +1006,7 @@ void Aura::periodicTick(AuraEffectModifier* aurEff)
                 if (aurEff->getAuraEffectType() == SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE)
                 {
                     for (uint8_t i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                        triggerSpell->forced_basepoints.setValue(i, customDamage);
+                        triggerSpell->forced_basepoints.setValue(static_cast<SpellEffIndex>(i), customDamage);
                 }
 #endif
 

--- a/src/world/Spell/SpellDefines.hpp
+++ b/src/world/Spell/SpellDefines.hpp
@@ -440,5 +440,13 @@ enum SpellVisualIds : uint32_t
     SPELL_VISUAL_DRINK                              = 438,
 };
 
+// Helpers for spell script
+enum SpellEffIndex : uint8_t
+{
+    EFF_INDEX_0                                     = 0,
+    EFF_INDEX_1                                     = 1,
+    EFF_INDEX_2                                     = 2
+};
+
 // todo: move this to each dbc structure file
 #define MAX_SPELL_ID 121820

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -3872,7 +3872,7 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
                         {
                             const auto spellInfo = sSpellMgr.getSpellInfo(31117);
                             Spell* spell = sSpellMgr.newSpell(u_caster, spellInfo, true, nullptr);
-                            spell->forced_basepoints->set(0, (aursp->calculateEffectValue(0)) * 9);   //damage effect
+                            spell->forced_basepoints.setValue(0, (aursp->calculateEffectValue(0)) * 9);   //damage effect
                             spell->ProcedOnSpell = getSpellInfo();
                             spell->pSpellId = aursp->getId();
                             SpellCastTargets targets(u_caster->getGuid());
@@ -5138,7 +5138,7 @@ void Spell::SpellEffectFeedPet(uint8_t effectIndex)  // Feed Pet
 
     const auto spellInfo = sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(effectIndex));
     Spell* sp = sSpellMgr.newSpell(p_caster, spellInfo, true, nullptr);
-    sp->forced_basepoints->set(0, damage);
+    sp->forced_basepoints.setValue(0, damage);
     SpellCastTargets tgt(pPet->getGuid());
     sp->prepare(&tgt);
 
@@ -5980,9 +5980,9 @@ void Spell::SpellEffectTriggerSpellWithValue(uint8_t effectIndex)
     for (uint8_t x = 0; x < 3; x++)
     {
         if (effectIndex == x)
-            sp->forced_basepoints->set(x, damage);  //prayer of mending should inherit heal bonus ?
+            sp->forced_basepoints.setValue(x, damage);  //prayer of mending should inherit heal bonus ?
         else
-            sp->forced_basepoints->set(x, TriggeredSpell->getEffectBasePoints(effectIndex));
+            sp->forced_basepoints.setValue(x, TriggeredSpell->getEffectBasePoints(effectIndex));
 
     }
 

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -3872,7 +3872,7 @@ void Spell::SpellEffectDispel(uint8_t effectIndex) // Dispel
                         {
                             const auto spellInfo = sSpellMgr.getSpellInfo(31117);
                             Spell* spell = sSpellMgr.newSpell(u_caster, spellInfo, true, nullptr);
-                            spell->forced_basepoints.setValue(0, (aursp->calculateEffectValue(0)) * 9);   //damage effect
+                            spell->forced_basepoints.setValue(EFF_INDEX_0, (aursp->calculateEffectValue(0)) * 9);   //damage effect
                             spell->ProcedOnSpell = getSpellInfo();
                             spell->pSpellId = aursp->getId();
                             SpellCastTargets targets(u_caster->getGuid());
@@ -5138,7 +5138,7 @@ void Spell::SpellEffectFeedPet(uint8_t effectIndex)  // Feed Pet
 
     const auto spellInfo = sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(effectIndex));
     Spell* sp = sSpellMgr.newSpell(p_caster, spellInfo, true, nullptr);
-    sp->forced_basepoints.setValue(0, damage);
+    sp->forced_basepoints.setValue(EFF_INDEX_0, damage);
     SpellCastTargets tgt(pPet->getGuid());
     sp->prepare(&tgt);
 
@@ -5979,11 +5979,8 @@ void Spell::SpellEffectTriggerSpellWithValue(uint8_t effectIndex)
 
     for (uint8_t x = 0; x < 3; x++)
     {
-        if (effectIndex == x)
-            sp->forced_basepoints.setValue(x, damage);  //prayer of mending should inherit heal bonus ?
-        else
-            sp->forced_basepoints.setValue(x, TriggeredSpell->getEffectBasePoints(effectIndex));
-
+        //prayer of mending should inherit heal bonus ?
+        sp->forced_basepoints.setValue(static_cast<SpellEffIndex>(x), effectIndex == x ? damage : TriggeredSpell->getEffectBasePoints(effectIndex));
     }
 
     SpellCastTargets tgt(m_unitTarget->getGuid());

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -1073,7 +1073,7 @@ int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = n
 
     if (forcedBasePoints.has_value())
     {
-        basePoints = (*forcedBasePoints).getValue(effIndex);
+        basePoints = (*forcedBasePoints).getValue(static_cast<SpellEffIndex>(effIndex));
     }
 
     // Check if value increases with level

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -1012,7 +1012,7 @@ bool SpellInfo::isStackableFromMultipleCasters() const
     return getMaxstack() > 1 && !isChanneled() && !(getAttributesExC() & ATTRIBUTESEXC_APPLY_OWN_STACK_FOR_EACH_CASTER);
 }
 
-int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = nullptr*/, Item* itemCaster/* = nullptr*/, SpellForcedBasePoints forcedBasePoints/* = SpellForcedBasePoints()*/) const
+int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = nullptr*/, Item* itemCaster/* = nullptr*/, std::optional<SpellForcedBasePoints> const& forcedBasePoints/* = {}*/) const
 {
     if (effIndex >= MAX_SPELL_EFFECTS)
         return 0;
@@ -1071,7 +1071,10 @@ int32_t SpellInfo::calculateEffectValue(uint8_t effIndex, Unit* unitCaster/* = n
     basePoints = getEffectBasePoints(effIndex) + 1;
 #endif
 
-    forcedBasePoints.get(effIndex, &basePoints);
+    if (forcedBasePoints.has_value())
+    {
+        basePoints = (*forcedBasePoints).getValue(effIndex);
+    }
 
     // Check if value increases with level
     if (unitCaster != nullptr)

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -12,8 +12,9 @@ This file is released under the MIT license. See README-MIT for more information
 #include "SpellScript.hpp"
 #include "CommonTypes.hpp"
 #include "Storage/WDB/WDBDefines.hpp"
-
+#include <array>
 #include <string>
+#include <optional>
 
 class Item;
 class Player;
@@ -21,40 +22,45 @@ class Unit;
 
 struct SpellForcedBasePoints
 {
-    void set(uint8_t effIndex, int32_t value)
+    SpellForcedBasePoints(std::optional<int32_t> const pointValue0 = {}, std::optional<int32_t> const pointValue1 = {}, std::optional<int32_t> const pointValue2 = {})
     {
-        if (effIndex >= MAX_SPELL_EFFECTS)
-            return;
+        m_forcedBasePoints.fill(0);
 
-        for (auto& values : m_forcedBasePoints)
+        if (pointValue0.has_value())
         {
-            if (values.first == effIndex)
-            {
-                values.second = value;
-                return;
-            }
+            m_forcedBasePoints[0] = *pointValue0;
         }
 
-        m_forcedBasePoints.push_back(std::make_pair(effIndex, value));
+        if (pointValue1.has_value())
+        {
+            m_forcedBasePoints[1] = *pointValue1;
+        }
+
+        if (pointValue2.has_value())
+        {
+            m_forcedBasePoints[2] = *pointValue2;
+        }
     }
 
-    void get(uint8_t effIndex, int32_t* basePoints) const
-    {
-        if (effIndex >= MAX_SPELL_EFFECTS)
-            return;
+    SpellForcedBasePoints(const SpellForcedBasePoints& other) = default;
+    SpellForcedBasePoints(SpellForcedBasePoints&&) = default;
+    SpellForcedBasePoints& operator=(SpellForcedBasePoints const&) = default;
 
-        for (const auto& values : m_forcedBasePoints)
+    void setValue(uint8_t effIndex, int32_t value)
+    {
+        if (effIndex < MAX_SPELL_EFFECTS)
         {
-            if (values.first == effIndex)
-            {
-                *basePoints = values.second;
-                break;
-            }
+            m_forcedBasePoints[effIndex] = value;
         }
+    }
+
+    int32_t getValue(uint8_t effIndex) const
+    {
+        return effIndex < MAX_SPELL_EFFECTS ? m_forcedBasePoints[effIndex] : 0;
     }
 
 private:
-    std::vector<std::pair<uint8_t, int32_t>> m_forcedBasePoints;
+    std::array<int32_t, MAX_SPELL_EFFECTS> m_forcedBasePoints;
 };
 
 class SERVER_DECL SpellInfo
@@ -118,7 +124,7 @@ public:
     // If spell stacks from different casters (i.e. Sunder Armor)
     bool isStackableFromMultipleCasters() const;
 
-    int32_t calculateEffectValue(uint8_t effIndex, Unit* unitCaster = nullptr, Item* itemCaster = nullptr, SpellForcedBasePoints forcedBasePoints = SpellForcedBasePoints()) const;
+    int32_t calculateEffectValue(uint8_t effIndex, Unit* unitCaster = nullptr, Item* itemCaster = nullptr, std::optional<SpellForcedBasePoints> const& forcedBasePoints = {}) const;
 
     bool doesEffectApplyAura(uint8_t effIndex) const;
 

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -46,7 +46,7 @@ struct SpellForcedBasePoints
     SpellForcedBasePoints(SpellForcedBasePoints&&) = default;
     SpellForcedBasePoints& operator=(SpellForcedBasePoints const&) = default;
 
-    void setValue(uint8_t effIndex, int32_t value)
+    void setValue(SpellEffIndex effIndex, int32_t value)
     {
         if (effIndex < MAX_SPELL_EFFECTS)
         {
@@ -54,7 +54,7 @@ struct SpellForcedBasePoints
         }
     }
 
-    int32_t getValue(uint8_t effIndex) const
+    int32_t getValue(SpellEffIndex effIndex) const
     {
         return effIndex < MAX_SPELL_EFFECTS ? m_forcedBasePoints[effIndex] : 0;
     }

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -24,40 +24,46 @@ struct SpellForcedBasePoints
 {
     SpellForcedBasePoints(std::optional<int32_t> const pointValue0 = {}, std::optional<int32_t> const pointValue1 = {}, std::optional<int32_t> const pointValue2 = {})
     {
-        m_forcedBasePoints.fill(0);
-
         if (pointValue0.has_value())
         {
-            m_forcedBasePoints[0] = *pointValue0;
+            m_values[0] = *pointValue0;
         }
 
         if (pointValue1.has_value())
         {
-            m_forcedBasePoints[1] = *pointValue1;
+            m_values[1] = *pointValue1;
         }
 
         if (pointValue2.has_value())
         {
-            m_forcedBasePoints[2] = *pointValue2;
+            m_values[2] = *pointValue2;
         }
     }
 
     SpellForcedBasePoints(const SpellForcedBasePoints& other) = default;
     SpellForcedBasePoints(SpellForcedBasePoints&&) = default;
-    SpellForcedBasePoints& operator=(SpellForcedBasePoints const&) = default;
+    SpellForcedBasePoints& operator=(SpellForcedBasePoints const& basePoints)
+    {
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        {
+            if (basePoints.m_values[i].has_value())
+            {
+                m_values[i] = basePoints.m_values[i];
+            }
+        }
+    }
 
     void setValue(SpellEffIndex effIndex, int32_t value)
     {
-        m_forcedBasePoints[effIndex] = value;
+        m_values[effIndex] = value;
     }
 
     int32_t getValue(SpellEffIndex effIndex) const
     {
-        return m_forcedBasePoints[effIndex];
+        return m_values[effIndex].has_value() ? *m_values[effIndex] : 0;
     }
 
-private:
-    std::array<int32_t, MAX_SPELL_EFFECTS> m_forcedBasePoints;
+    std::array<std::optional<int32_t>, MAX_SPELL_EFFECTS> m_values;
 };
 
 class SERVER_DECL SpellInfo

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -48,15 +48,12 @@ struct SpellForcedBasePoints
 
     void setValue(SpellEffIndex effIndex, int32_t value)
     {
-        if (effIndex < MAX_SPELL_EFFECTS)
-        {
-            m_forcedBasePoints[effIndex] = value;
-        }
+        m_forcedBasePoints[effIndex] = value;
     }
 
     int32_t getValue(SpellEffIndex effIndex) const
     {
-        return effIndex < MAX_SPELL_EFFECTS ? m_forcedBasePoints[effIndex] : 0;
+        return m_forcedBasePoints[effIndex];
     }
 
 private:

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -51,6 +51,7 @@ struct SpellForcedBasePoints
                 m_values[i] = basePoints.m_values[i];
             }
         }
+        return *this;
     }
 
     void setValue(SpellEffIndex effIndex, int32_t value)

--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -172,12 +172,12 @@ void SpellProc::setCastedByProcCreator(bool enable) { m_castedByProcCreator = en
 bool SpellProc::isCastedOnProcOwner() const { return m_castOnProcOwner; }
 void SpellProc::setCastedOnProcOwner(bool enable) { m_castOnProcOwner = enable; }
 
-int32_t SpellProc::getOverrideEffectDamage(uint8_t effIndex) const
+int32_t SpellProc::getOverrideEffectDamage(SpellEffIndex effIndex) const
 {
     return mOverrideEffectDamage.getValue(effIndex);
 }
 
-void SpellProc::setOverrideEffectDamage(uint8_t effIndex, int32_t damage)
+void SpellProc::setOverrideEffectDamage(SpellEffIndex effIndex, int32_t damage)
 {
     mOverrideEffectDamage.setValue(effIndex, damage);
 }

--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -12,15 +12,9 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Server/Script/ScriptMgr.hpp"
 #include "Objects/Units/Players/Player.hpp"
 
-SpellProc::SpellProc()
-{
-    mOverrideEffectDamage = new SpellForcedBasePoints;
-}
+SpellProc::SpellProc() = default;
 
-SpellProc::~SpellProc()
-{
-    delete mOverrideEffectDamage;
-}
+SpellProc::~SpellProc() = default;
 
 void SpellProc::init(Object* /*obj*/) { }
 
@@ -180,14 +174,12 @@ void SpellProc::setCastedOnProcOwner(bool enable) { m_castOnProcOwner = enable; 
 
 int32_t SpellProc::getOverrideEffectDamage(uint8_t effIndex) const
 {
-    int32_t overrideValue = 0;
-    mOverrideEffectDamage->get(effIndex, &overrideValue);
-    return overrideValue;
+    return mOverrideEffectDamage.getValue(effIndex);
 }
 
 void SpellProc::setOverrideEffectDamage(uint8_t effIndex, int32_t damage)
 {
-    mOverrideEffectDamage->set(effIndex, damage);
+    mOverrideEffectDamage.setValue(effIndex, damage);
 }
 
 Aura* SpellProc::getCreatedByAura() const { return m_createdByAura; }

--- a/src/world/Spell/SpellProc.hpp
+++ b/src/world/Spell/SpellProc.hpp
@@ -98,8 +98,8 @@ class SERVER_DECL SpellProc
         void setCastedOnProcOwner(bool);
 
         // Returns 0 if effect index has not been overridden
-        int32_t getOverrideEffectDamage(uint8_t effIndex) const;
-        void setOverrideEffectDamage(uint8_t effIndex, int32_t damage);
+        int32_t getOverrideEffectDamage(SpellEffIndex effIndex) const;
+        void setOverrideEffectDamage(SpellEffIndex effIndex, int32_t damage);
 
         Aura* getCreatedByAura() const;
         void setCreatedByAura(Aura* aur);

--- a/src/world/Spell/SpellProc.hpp
+++ b/src/world/Spell/SpellProc.hpp
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "CommonTypes.hpp"
 #include "Definitions/ProcFlags.hpp"
+#include "SpellInfo.hpp"
 #include <unordered_map>
 
 class Aura;
@@ -16,7 +17,6 @@ class SpellProc;
 class Unit;
 
 struct DamageInfo;
-struct SpellForcedBasePoints;
 
 typedef SpellProc* (*spell_proc_factory_function)();
 typedef std::unordered_map<uint32_t, spell_proc_factory_function> SpellProcMap;
@@ -151,7 +151,7 @@ class SERVER_DECL SpellProc
         // Mask used on spell effect
         uint32_t mGroupRelation[3] = { 0, 0, 0 };
 
-        SpellForcedBasePoints* mOverrideEffectDamage;
+        SpellForcedBasePoints mOverrideEffectDamage;
 
         // Indicates that this proc will be skipped on next ::handleProc call
         // used to avoid some spell procs from procing themselves

--- a/src/world/Spell/SpellProc_ClassScripts.cpp
+++ b/src/world/Spell/SpellProc_ClassScripts.cpp
@@ -446,9 +446,9 @@ public:
         SpellCastTargets targets(victim->getGuid());
 
         Spell* spell = sSpellMgr.newSpell(getProcOwner(), getSpell(), true, nullptr);
-        spell->forced_basepoints->set(0, getOverrideEffectDamage(0));
-        spell->forced_basepoints->set(1, getOverrideEffectDamage(1));
-        spell->forced_basepoints->set(2, getOverrideEffectDamage(2));
+        spell->forced_basepoints.setValue(0, getOverrideEffectDamage(0));
+        spell->forced_basepoints.setValue(1, getOverrideEffectDamage(1));
+        spell->forced_basepoints.setValue(2, getOverrideEffectDamage(2));
         spell->ProcedOnSpell = CastingSpell;
 
         spell->prepare(&targets);
@@ -490,7 +490,7 @@ public:
         }
 
         SpellForcedBasePoints forcedBasePoints;
-        forcedBasePoints.set(0, aura->getEffectDamage(0));
+        forcedBasePoints.setValue(0, aura->getEffectDamage(0));
 
         caster->castSpell(getProcOwner(), 33110, forcedBasePoints, true);
 

--- a/src/world/Spell/SpellScriptDefines.hpp
+++ b/src/world/Spell/SpellScriptDefines.hpp
@@ -26,11 +26,3 @@ enum class SpellScriptCheckDummy : uint8_t
     DUMMY_NOT_HANDLED = 0,      // Default value, generates warning to debug log of unhandled dummy effect
     DUMMY_OK                    // Dummy effect handled, no warning to debug log
 };
-
-// Helpers for spell script
-enum SpellEffects : uint8_t
-{
-    EFF_INDEX_0 = 0,
-    EFF_INDEX_1,
-    EFF_INDEX_2
-};


### PR DESCRIPTION
**Description**
This is quick rework where I replaced pointer based storage to basic referenced storage. Also i did improvements to this wrapper, these changes allows inline params which allows to make cleaner code. This also fixed memory managment issues.
I also added some typesafe adjusts to prevent wrong index being passed

**Todo / Checklist**
- Other expansion compilation tests

**Tests Performed:** 
- Server startup.
- Log into world.
- Related spell casts where this wrapper is involved

**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
