### PR TITLE
Fixed memory leak in MySQLDataStore::loadCreatureAIScriptsTable()

### DIFF
--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -4599,19 +4599,22 @@ void MySQLDataStore::loadCreatureAIScriptsTable()
         if (!getCreatureProperties(creature_entry))
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid creature entry %u <skipped>", creature_entry);
+            delete ai_script;
             continue;
         }
-           
+
         SpellInfo const* spell = sSpellMgr.getSpellInfo(spellId);
         if (spell == nullptr && spellId != 0)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid spellId for creature entry %u <skipped>", spellId, creature_entry);
+            delete ai_script;
             continue;
         }
 
         if (!sMySQLStore.getNpcScriptText(textId) && textId != 0)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid textId for creature entry %u <skipped>", textId, creature_entry);
+            delete ai_script;
             continue;
         }
 

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -4596,22 +4596,21 @@ void MySQLDataStore::loadCreatureAIScriptsTable()
         uint32_t spellId = fields[9].GetUInt32();
         uint32_t textId = fields[17].GetUInt32();
 
-        if (!getCreatureProperties(creature_entry))
+        if (getCreatureProperties(creature_entry) == nullptr)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid creature entry %u <skipped>", creature_entry);
             delete ai_script;
             continue;
         }
 
-        SpellInfo const* spell = sSpellMgr.getSpellInfo(spellId);
-        if (spell == nullptr && spellId != 0)
+        if (spellId != 0 && sSpellMgr.getSpellInfo(spellId) == nullptr)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid spellId for creature entry %u <skipped>", spellId, creature_entry);
             delete ai_script;
             continue;
         }
 
-        if (!sMySQLStore.getNpcScriptText(textId) && textId != 0)
+        if (textId != 0 && sMySQLStore.getNpcScriptText(textId) == nullptr)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid textId for creature entry %u <skipped>", textId, creature_entry);
             delete ai_script;

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -4407,6 +4407,7 @@ void MySQLDataStore::loadCreatureSpawns()
                 if (creature_properties == nullptr)
                 {
                     sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Creature spawn ID: %u has invalid entry: %u which is not in creature_properties table! Skipped loading.", cspawn->id, creature_entry);
+                    delete cspawn;
                     continue;
                 }
 


### PR DESCRIPTION
**Description**
This fixes memory leak in MySQLDataStore::loadCreatureAIScriptsTable().

At base "MySQLStructure::CreatureAIScripts* ai_script = new MySQLStructure::CreatureAIScripts;" is created but function code block has several "continue" operators on invalid data and it never frees memory.

In this PR i added additional "delete" operators to free memory

**Todo / Checklist**
- None

**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
-->
