### PR TITLE
Creature equip improvements

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
@@ -486,8 +486,8 @@ public:
     void SwitchToHumanForm()
     {
         getCreature()->setDisplayId(20514);
-        getCreature()->setVirtualItemSlotId(MELEE, (getCreature()->m_spawn != nullptr) ? getCreature()->m_spawn->Item1SlotEntry : 0);
-        getCreature()->setVirtualItemSlotId(OFFHAND, (getCreature()->m_spawn != nullptr) ?  getCreature()->m_spawn->Item2SlotEntry : 0);
+        getCreature()->setVirtualItemSlotId(MELEE, (getCreature()->m_spawn != nullptr) ? getCreature()->m_spawn->itemEquipSlots[MELEE] : 0);
+        getCreature()->setVirtualItemSlotId(OFFHAND, (getCreature()->m_spawn != nullptr) ?  getCreature()->m_spawn->itemEquipSlots[OFFHAND] : 0);
     }
 
     void SwitchToDemonForm()

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -91,9 +91,7 @@ bool ChatHandler::HandleMoveHardcodedScriptsToDBCommand(const char* args, WorldS
         creature_spawn->channel_target_creature = creature_spawn->channel_target_go = creature_spawn->channel_spell = 0;
         creature_spawn->MountedDisplayID = 0;
 
-        creature_spawn->Item1SlotEntry = creature_properties->itemslot_1;
-        creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;
-        creature_spawn->Item3SlotEntry = creature_properties->itemslot_3;
+        creature_spawn->itemEquipSlots = creature_properties->itemEquipSlots;
 
         creature_spawn->CanFly = 0;
         creature_spawn->phase = session->GetPlayer()->GetPhase();
@@ -361,7 +359,7 @@ bool ChatHandler::HandleDebugState(const char* /*args*/, WorldSession* m_session
         return false;
 
     GreenSystemMessage(m_session, "Display unitStateFlag: %u", selected_unit->getUnitStateFlags());
-    
+
     return true;
 }
 

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -748,9 +748,7 @@ bool ChatHandler::HandleNpcSpawnCommand(const char* args, WorldSession* m_sessio
     creature_spawn->channel_target_creature = creature_spawn->channel_target_go = creature_spawn->channel_spell = 0;
     creature_spawn->MountedDisplayID = 0;
 
-    creature_spawn->Item1SlotEntry = creature_properties->itemslot_1;
-    creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;
-    creature_spawn->Item3SlotEntry = creature_properties->itemslot_3;
+    creature_spawn->itemEquipSlots = creature_properties->itemEquipSlots;
 
     creature_spawn->CanFly = 0;
     creature_spawn->phase = m_session->GetPlayer()->GetPhase();
@@ -1076,7 +1074,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case MELEE:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->Item1SlotEntry = item_id;
+                creature_target->m_spawn->itemEquipSlots[0] = item_id;
             GreenSystemMessage(m_session, "Melee slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed melee slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
@@ -1084,7 +1082,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case OFFHAND:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->Item2SlotEntry = item_id;
+                creature_target->m_spawn->itemEquipSlots[1] = item_id;
             GreenSystemMessage(m_session, "Offhand slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed offhand slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
@@ -1092,7 +1090,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case RANGED:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->Item3SlotEntry = item_id;
+                creature_target->m_spawn->itemEquipSlots[2] = item_id;
             GreenSystemMessage(m_session, "Ranged slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed ranged slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -1080,7 +1080,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case MELEE:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->itemEquipSlots[0] = item_id;
+                creature_target->m_spawn->itemEquipSlots[MELEE] = item_id;
             GreenSystemMessage(m_session, "Melee slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed melee slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
@@ -1088,7 +1088,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case OFFHAND:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->itemEquipSlots[1] = item_id;
+                creature_target->m_spawn->itemEquipSlots[OFFHAND] = item_id;
             GreenSystemMessage(m_session, "Offhand slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed offhand slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;
@@ -1096,7 +1096,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         case RANGED:
         {
             if (creature_target->m_spawn != nullptr)
-                creature_target->m_spawn->itemEquipSlots[2] = item_id;
+                creature_target->m_spawn->itemEquipSlots[RANGED] = item_id;
             GreenSystemMessage(m_session, "Ranged slot successfull changed from %u to %u for Creature %s", previousValue, item_id, creature_target->GetCreatureProperties()->Name.c_str());
             sGMLog.writefromsession(m_session, "changed ranged slot from %u to %u for creature spawn %u", previousValue, item_id, creature_target->spawnid);
             break;

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -1051,6 +1051,12 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         return true;
     }
 
+    if (equipment_slot >= TOTAL_WEAPON_DAMAGE_TYPES)
+    {
+        RedSystemMessage(m_session, "Invalid equipment slot. Available slots are: (0)melee, (1)offhand, (2)ranged");
+        return true;
+    }
+
     Creature* creature_target = GetSelectedCreature(m_session, true);
     if (creature_target == nullptr)
         return true;
@@ -1063,9 +1069,9 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
     }
 
 #if VERSION_STRING < WotLK
-    const auto previousValue = creature_target->getVirtualItemEntry(equipment_slot);
+    const auto previousValue = creature_target->getVirtualItemEntry(static_cast<WeaponDamageType>(equipment_slot));
 #else
-    const auto previousValue = creature_target->getVirtualItemSlotId(equipment_slot);
+    const auto previousValue = creature_target->getVirtualItemSlotId(static_cast<WeaponDamageType>(equipment_slot));
 #endif
 
 
@@ -1102,7 +1108,7 @@ bool ChatHandler::HandleNpcSetEquipCommand(const char* args, WorldSession* m_ses
         }
     }
 
-    creature_target->setVirtualItemSlotId(equipment_slot, item_id);
+    creature_target->setVirtualItemSlotId(static_cast<WeaponDamageType>(equipment_slot), item_id);
     creature_target->SaveToDB();
     return true;
 }

--- a/src/world/Management/GameEvent.cpp
+++ b/src/world/Management/GameEvent.cpp
@@ -179,9 +179,9 @@ void GameEvent::CreateNPCs()
         creature->setFaction(npc.faction);
 
         // Equipment
-        creature->setVirtualItemSlotId(MELEE, creatureProperties->itemslot_1);
-        creature->setVirtualItemSlotId(OFFHAND, creatureProperties->itemslot_2);
-        creature->setVirtualItemSlotId(RANGED, creatureProperties->itemslot_3);
+        creature->setVirtualItemSlotId(MELEE, creatureProperties->itemEquipSlots[MELEE]);
+        creature->setVirtualItemSlotId(OFFHAND, creatureProperties->itemEquipSlots[OFFHAND]);
+        creature->setVirtualItemSlotId(RANGED, creatureProperties->itemEquipSlots[RANGED]);
 
         if (npc.mountdisplayid != 0)
             creature->setMountDisplayId(npc.mountdisplayid);

--- a/src/world/Map/Maps/MapScriptInterface.cpp
+++ b/src/world/Map/Maps/MapScriptInterface.cpp
@@ -355,11 +355,7 @@ Creature* MapScriptInterface::spawnCreature(uint32_t Entry, LocationVector pos, 
     spawn->channel_target_go = 0;
     spawn->channel_spell = 0;
     spawn->MountedDisplayID = 0;
-
-    spawn->Item1SlotEntry = creature_properties->itemslot_1;
-    spawn->Item2SlotEntry = creature_properties->itemslot_2;
-    spawn->Item3SlotEntry = creature_properties->itemslot_3;
-
+    spawn->itemEquipSlots = creature_properties->itemEquipSlots;
     spawn->CanFly = 0;
     spawn->phase = phase;
 

--- a/src/world/Objects/Transporter.cpp
+++ b/src/world/Objects/Transporter.cpp
@@ -332,9 +332,9 @@ Creature* Transporter::createNPCPassenger(MySQLStructure::CreatureSpawn* data)
 #endif
 
     // Equipment
-    pCreature->setVirtualItemSlotId(MELEE, creature_properties->itemslot_1);
-    pCreature->setVirtualItemSlotId(OFFHAND, creature_properties->itemslot_2);
-    pCreature->setVirtualItemSlotId(RANGED, creature_properties->itemslot_3);
+    pCreature->setVirtualItemSlotId(MELEE, creature_properties->itemEquipSlots[MELEE]);
+    pCreature->setVirtualItemSlotId(OFFHAND, creature_properties->itemEquipSlots[OFFHAND]);
+    pCreature->setVirtualItemSlotId(RANGED, creature_properties->itemEquipSlots[RANGED]);
 
     if (data->emote_state)
         pCreature->setEmoteState(data->emote_state);

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -884,15 +884,15 @@ void Creature::SaveToDB()
         m_spawn->channel_spell = 0;
         m_spawn->MountedDisplayID = getMountDisplayId();
 
-#if VERSION_STRING >= WotLK
-        m_spawn->itemEquipSlots[MELEE] = getVirtualItemSlotId(MELEE);
-        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemSlotId(OFFHAND);
-        m_spawn->itemEquipSlots[RANGED] = getVirtualItemSlotId(RANGED);
-#else
+#if VERSION_STRING < WotLK
         m_spawn->itemEquipSlots[MELEE] = getVirtualItemDisplayId(MELEE);
         m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemDisplayId(OFFHAND);
         m_spawn->itemEquipSlots[RANGED] = getVirtualItemDisplayId(RANGED);
-#endif
+#else
+        m_spawn->itemEquipSlots[MELEE] = getVirtualItemSlotId(MELEE);
+        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemSlotId(OFFHAND);
+        m_spawn->itemEquipSlots[RANGED] = getVirtualItemSlotId(RANGED);
+#endif // VERSION_STRING < WotLK
 
         if (IsFlying())
             m_spawn->CanFly = 1;

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -884,9 +884,15 @@ void Creature::SaveToDB()
         m_spawn->channel_spell = 0;
         m_spawn->MountedDisplayID = getMountDisplayId();
 
+#if VERSION_STRING >= WotLK
         m_spawn->itemEquipSlots[MELEE] = getVirtualItemSlotId(MELEE);
         m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemSlotId(OFFHAND);
         m_spawn->itemEquipSlots[RANGED] = getVirtualItemSlotId(RANGED);
+#else
+        m_spawn->itemEquipSlots[MELEE] = getVirtualItemDisplayId(MELEE);
+        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemDisplayId(OFFHAND);
+        m_spawn->itemEquipSlots[RANGED] = getVirtualItemDisplayId(RANGED);
+#endif
 
         if (IsFlying())
             m_spawn->CanFly = 1;

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -885,9 +885,9 @@ void Creature::SaveToDB()
         m_spawn->MountedDisplayID = getMountDisplayId();
 
 #if VERSION_STRING < WotLK
-        m_spawn->itemEquipSlots[MELEE] = getVirtualItemDisplayId(MELEE);
-        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemDisplayId(OFFHAND);
-        m_spawn->itemEquipSlots[RANGED] = getVirtualItemDisplayId(RANGED);
+        m_spawn->itemEquipSlots[MELEE] = getVirtualItemEntry(MELEE);
+        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemEntry(OFFHAND);
+        m_spawn->itemEquipSlots[RANGED] = getVirtualItemEntry(RANGED);
 #else
         m_spawn->itemEquipSlots[MELEE] = getVirtualItemSlotId(MELEE);
         m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemSlotId(OFFHAND);

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -309,7 +309,7 @@ void Creature::setMaxWanderDistance(float_t dist)
 }
 
 #if VERSION_STRING < WotLK
-uint32_t Creature::getVirtualItemEntry(uint8_t slot) const
+uint32_t Creature::getVirtualItemEntry(WeaponDamageType slot) const
 {
     if (slot >= TOTAL_WEAPON_DAMAGE_TYPES)
         return 0;
@@ -317,7 +317,7 @@ uint32_t Creature::getVirtualItemEntry(uint8_t slot) const
     return m_virtualItemEntry[slot];
 }
 
-void Creature::setVirtualItemEntry(uint8_t slot, uint32_t itemId)
+void Creature::setVirtualItemEntry(WeaponDamageType slot, uint32_t itemId)
 {
     if (slot >= TOTAL_WEAPON_DAMAGE_TYPES)
         return;

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -884,15 +884,9 @@ void Creature::SaveToDB()
         m_spawn->channel_spell = 0;
         m_spawn->MountedDisplayID = getMountDisplayId();
 
-#if VERSION_STRING < WotLK
-        m_spawn->Item1SlotEntry = getVirtualItemEntry(MELEE);
-        m_spawn->Item2SlotEntry = getVirtualItemEntry(OFFHAND);
-        m_spawn->Item3SlotEntry = getVirtualItemEntry(RANGED);
-#else
-        m_spawn->Item1SlotEntry = getVirtualItemSlotId(MELEE);
-        m_spawn->Item2SlotEntry = getVirtualItemSlotId(OFFHAND);
-        m_spawn->Item3SlotEntry = getVirtualItemSlotId(RANGED);
-#endif
+        m_spawn->itemEquipSlots[MELEE] = getVirtualItemSlotId(MELEE);
+        m_spawn->itemEquipSlots[OFFHAND] = getVirtualItemSlotId(OFFHAND);
+        m_spawn->itemEquipSlots[RANGED] = getVirtualItemSlotId(RANGED);
 
         if (IsFlying())
             m_spawn->CanFly = 1;
@@ -950,9 +944,9 @@ void Creature::SaveToDB()
     ss << m_spawn->death_state << ",";
 
     ss << getMountDisplayId() << ","
-        << m_spawn->Item1SlotEntry << ","
-        << m_spawn->Item2SlotEntry << ","
-        << m_spawn->Item3SlotEntry << ",";
+        << m_spawn->itemEquipSlots[MELEE] << ","
+        << m_spawn->itemEquipSlots[OFFHAND] << ","
+        << m_spawn->itemEquipSlots[RANGED] << ",";
 
     if (IsFlying())
         ss << 1 << ",";
@@ -1617,9 +1611,9 @@ bool Creature::Load(MySQLStructure::CreatureSpawn* spawn, uint8 mode, MySQLStruc
     setMinRangedDamage(creature_properties->RangedMinDamage);
     setMaxRangedDamage(creature_properties->RangedMaxDamage);
 
-    setVirtualItemSlotId(MELEE, spawn->Item1SlotEntry);
-    setVirtualItemSlotId(OFFHAND, spawn->Item2SlotEntry);
-    setVirtualItemSlotId(RANGED, spawn->Item3SlotEntry);
+    setVirtualItemSlotId(MELEE, spawn->itemEquipSlots[MELEE]);
+    setVirtualItemSlotId(OFFHAND, spawn->itemEquipSlots[OFFHAND]);
+    setVirtualItemSlotId(RANGED, spawn->itemEquipSlots[RANGED]);
 
     setFaction(spawn->factionid);
     setUnitFlags(spawn->flags);
@@ -1943,9 +1937,9 @@ void Creature::Load(CreatureProperties const* properties_, float x, float y, flo
     setPowerType(POWER_TYPE_MANA);
 
     // Equipment
-    setVirtualItemSlotId(MELEE, creature_properties->itemslot_1);
-    setVirtualItemSlotId(OFFHAND, creature_properties->itemslot_2);
-    setVirtualItemSlotId(RANGED, creature_properties->itemslot_3);
+    setVirtualItemSlotId(MELEE, creature_properties->itemEquipSlots[MELEE]);
+    setVirtualItemSlotId(OFFHAND, creature_properties->itemEquipSlots[OFFHAND]);
+    setVirtualItemSlotId(RANGED, creature_properties->itemEquipSlots[RANGED]);
 
     /*  // Dont was Used in old AIInterface left the code here if needed at other Date
     if (creature_properties->guardtype == GUARDTYPE_CITY)

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -113,8 +113,8 @@ public:
     void setMaxWanderDistance(float_t dist);
 
 #if VERSION_STRING < WotLK
-    uint32_t getVirtualItemEntry(uint8_t slot) const;
-    void setVirtualItemEntry(uint8_t slot, uint32_t itemId);
+    uint32_t getVirtualItemEntry(uint8_t slot) const override;
+    void setVirtualItemEntry(uint8_t slot, uint32_t itemId) override;
 #endif
     void toggleDualwield(bool);
 

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -112,10 +112,6 @@ public:
     float_t getMaxWanderDistance() const;
     void setMaxWanderDistance(float_t dist);
 
-#if VERSION_STRING < WotLK
-    uint32_t getVirtualItemEntry(uint8_t slot) const override;
-    void setVirtualItemEntry(uint8_t slot, uint32_t itemId) override;
-#endif
     void toggleDualwield(bool);
 
     std::shared_ptr<std::vector<CreatureItem>> getSellItems();

--- a/src/world/Objects/Units/Creatures/CreatureDefines.hpp
+++ b/src/world/Objects/Units/Creatures/CreatureDefines.hpp
@@ -21,7 +21,9 @@
 #include "CommonTypes.hpp"
 #include "Spell/Definitions/School.hpp"
 #include "Macros/CreatureMacros.hpp"
+#include "Objects/Units/UnitDefines.hpp"
 
+#include <array>
 #include <ctime>
 #include <list>
 #include <set>
@@ -246,9 +248,7 @@ struct CreatureProperties
     // APGL Start
 
     //itemslots
-    uint32 itemslot_1;
-    uint32 itemslot_2;
-    uint32 itemslot_3;
+    std::array<uint32_t, TOTAL_WEAPON_DAMAGE_TYPES> itemEquipSlots;
 
     // AI Stuff
     bool m_canRangedAttack;

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -971,11 +971,11 @@ uint32_t Unit::getFactionTemplate() const { return unitData()->faction_template;
 void Unit::setFactionTemplate(uint32_t id) { write(unitData()->faction_template, id); }
 
 #if VERSION_STRING >= WotLK
-uint32_t Unit::getVirtualItemSlotId(uint8_t slot) const { return unitData()->virtual_item_slot_display[slot]; }
+uint32_t Unit::getVirtualItemSlotId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
 #else
-uint32_t Unit::getVirtualItemDisplayId(uint8_t slot) const { return unitData()->virtual_item_slot_display[slot]; }
+uint32_t Unit::getVirtualItemDisplayId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
 #endif
-void Unit::setVirtualItemSlotId(uint8_t slot, uint32_t item_id)
+void Unit::setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id)
 {
     const auto isProperOffhandWeapon = [](uint32_t itemClass, uint32_t itemSubClass) -> bool
     {

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -1053,7 +1053,7 @@ void Unit::setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id)
 
         if (isCreature())
         {
-            dynamic_cast<Creature*>(this)->setVirtualItemEntry(slot, 0);
+            setVirtualItemEntry(slot, 0);
 
             if (slot == OFFHAND)
                 dynamic_cast<Creature*>(this)->toggleDualwield(false);

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -970,11 +970,8 @@ void Unit::setLevel(uint32_t level)
 uint32_t Unit::getFactionTemplate() const { return unitData()->faction_template; }
 void Unit::setFactionTemplate(uint32_t id) { write(unitData()->faction_template, id); }
 
-#if VERSION_STRING >= WotLK
 uint32_t Unit::getVirtualItemSlotId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
-#else
-uint32_t Unit::getVirtualItemDisplayId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
-#endif
+
 void Unit::setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id)
 {
     const auto isProperOffhandWeapon = [](uint32_t itemClass, uint32_t itemSubClass) -> bool

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -970,8 +970,11 @@ void Unit::setLevel(uint32_t level)
 uint32_t Unit::getFactionTemplate() const { return unitData()->faction_template; }
 void Unit::setFactionTemplate(uint32_t id) { write(unitData()->faction_template, id); }
 
+#if VERSION_STRING >= WotLK
 uint32_t Unit::getVirtualItemSlotId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
-
+#else
+uint32_t Unit::getVirtualItemDisplayId(WeaponDamageType slot) const { return unitData()->virtual_item_slot_display[slot]; }
+#endif
 void Unit::setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id)
 {
     const auto isProperOffhandWeapon = [](uint32_t itemClass, uint32_t itemSubClass) -> bool

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -282,12 +282,12 @@ public:
 
 #if VERSION_STRING >= WotLK
     // Returns item entry in wotlk and above
-    uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
-    void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
+    virtual uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
+    virtual void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 #else
     // Returns item display id in classic and tbc
-    uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
-    void setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id);
+    virtual uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
+    virtual void setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id);
 #endif
 
 #if VERSION_STRING < WotLK

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -280,7 +280,13 @@ public:
         setServersideFaction();
     }
 
+#if VERSION_STRING >= WotLK
+    // Returns item entry in wotlk and above
     uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
+#else
+    // Returns item display id in classic and tbc
+    uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
+#endif
     void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 
 #if VERSION_STRING < WotLK

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -282,12 +282,12 @@ public:
 
 #if VERSION_STRING >= WotLK
     // Returns item entry in wotlk and above
-    virtual uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
-    virtual void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
+    uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
+    void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 #else
     // Returns item display id in classic and tbc
-    virtual uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
-    virtual void setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id);
+    uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
+    void setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id);
 #endif
 
 #if VERSION_STRING < WotLK

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -283,11 +283,12 @@ public:
 #if VERSION_STRING >= WotLK
     // Returns item entry in wotlk and above
     uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
+    void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 #else
     // Returns item display id in classic and tbc
     uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
+    void setVirtualItemDisplayId(WeaponDamageType slot, uint32_t item_id);
 #endif
-    void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 
 #if VERSION_STRING < WotLK
     uint64_t getVirtualItemInfo(uint8_t slot) const;

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -280,13 +280,7 @@ public:
         setServersideFaction();
     }
 
-#if VERSION_STRING >= WotLK
-    // Returns item entry in wotlk and above
     uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
-#else
-    // Returns item display id in classic and tbc
-    uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
-#endif
     void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 
 #if VERSION_STRING < WotLK

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -282,12 +282,12 @@ public:
 
 #if VERSION_STRING >= WotLK
     // Returns item entry in wotlk and above
-    uint32_t getVirtualItemSlotId(uint8_t slot) const;
+    uint32_t getVirtualItemSlotId(WeaponDamageType slot) const;
 #else
     // Returns item display id in classic and tbc
-    uint32_t getVirtualItemDisplayId(uint8_t slot) const;
+    uint32_t getVirtualItemDisplayId(WeaponDamageType slot) const;
 #endif
-    void setVirtualItemSlotId(uint8_t slot, uint32_t item_id);
+    void setVirtualItemSlotId(WeaponDamageType slot, uint32_t item_id);
 
 #if VERSION_STRING < WotLK
     uint64_t getVirtualItemInfo(uint8_t slot) const;

--- a/src/world/Objects/Units/UnitDefines.hpp
+++ b/src/world/Objects/Units/UnitDefines.hpp
@@ -980,8 +980,9 @@ enum WeaponDamageType : uint8_t
     MELEE   = 0,
     OFFHAND = 1,
     RANGED  = 2,
-    TOTAL_WEAPON_DAMAGE_TYPES
 };
+
+constexpr uint8_t TOTAL_WEAPON_DAMAGE_TYPES = 3;
 
 enum AURA_CHECK_RESULT
 {

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -5392,12 +5392,12 @@ void Spell::writeProjectileDataToPacket(WorldPacket *data)
     {
         // Get creature's ranged weapon
         // Need to loop through all weapon slots because NPCs can have the ranged weapon in main hand
-        for (uint8_t i = 0; i <= RANGED; ++i)
+        for (uint8_t i = 0; i < TOTAL_WEAPON_DAMAGE_TYPES; ++i)
         {
 #if VERSION_STRING > TBC
-            const auto entryId = u_caster->getVirtualItemSlotId(i);
+            const auto entryId = u_caster->getVirtualItemSlotId(static_cast<WeaponDamageType>(i));
 #else
-            const auto entryId = dynamic_cast<Creature*>(u_caster)->getVirtualItemEntry(i);
+            const auto entryId = dynamic_cast<Creature*>(u_caster)->getVirtualItemEntry(static_cast<WeaponDamageType>(i));
 #endif
             if (entryId == 0)
                 continue;

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -3073,7 +3073,11 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                     }
 
                     // Check if creature is even wielding a weapon
+#if VERSION_STRING < WotLK
+                    if (target->getVirtualItemDisplayId(MELEE) == 0)
+#else
                     if (target->getVirtualItemSlotId(MELEE) == 0)
+#endif
                         return SPELL_FAILED_TARGET_NO_WEAPONS;
                 }
             } break;

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -5395,7 +5395,7 @@ void Spell::writeProjectileDataToPacket(WorldPacket *data)
 #if VERSION_STRING > TBC
             const auto entryId = u_caster->getVirtualItemSlotId(static_cast<WeaponDamageType>(i));
 #else
-            const auto entryId = dynamic_cast<Creature*>(u_caster)->getVirtualItemEntry(static_cast<WeaponDamageType>(i));
+            const auto entryId = u_caster->getVirtualItemEntry(static_cast<WeaponDamageType>(i));
 #endif
             if (entryId == 0)
                 continue;

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -3073,11 +3073,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                     }
 
                     // Check if creature is even wielding a weapon
-#if VERSION_STRING < WotLK
-                    if (target->getVirtualItemDisplayId(MELEE) == 0)
-#else
                     if (target->getVirtualItemSlotId(MELEE) == 0)
-#endif
                         return SPELL_FAILED_TARGET_NO_WEAPONS;
                 }
             } break;

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -6254,7 +6254,7 @@ void Aura::SpellAuraMirrorImage2(AuraEffectModifier* /*aurEff*/, bool apply)
 
             item = p->getItemInterface()->GetInventoryItem(EQUIPMENT_SLOT_MAINHAND);
             if (item != nullptr)
-                m_target->setVirtualItemSlotId(0, item->getItemProperties()->ItemId);
+                m_target->setVirtualItemSlotId(MELEE, item->getItemProperties()->ItemId);
 
             item = p->getItemInterface()->GetInventoryItem(EQUIPMENT_SLOT_OFFHAND);
             if (item != nullptr)

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -2449,7 +2449,7 @@ void MySQLDataStore::loadCreatureInitialEquipmentTable()
             continue;
         }
 
-        for (uint8 i = 0; i < TOTAL_WEAPON_DAMAGE_TYPES; ++i)
+        for (uint8_t i = 0; i < TOTAL_WEAPON_DAMAGE_TYPES; ++i)
         {
             uint32_t const itemId = fields[1 + i].GetUInt32();
             if (itemId != 0)

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -4594,8 +4594,7 @@ void MySQLDataStore::loadCreatureAIScriptsTable()
             continue;
         }
 
-        SpellInfo const* spell = sSpellMgr.getSpellInfo(spellId);
-        if (spell == nullptr && spellId != 0)
+        if (spellId != 0 && sSpellMgr.getSpellInfo(spellId) == nullptr)
         {
             sLogger.debugFlag(AscEmu::Logging::LF_DB_TABLES, "Table `creature_ai_scripts` includes invalid spellId for creature entry %u <skipped>", spellId, creature_entry);
             continue;

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -2449,7 +2449,7 @@ void MySQLDataStore::loadCreatureInitialEquipmentTable()
             continue;
         }
 
-        for (uint32 i = 0; i < 3; ++i)
+        for (uint8 i = 0; i < TOTAL_WEAPON_DAMAGE_TYPES; ++i)
         {
             uint32_t const itemId = fields[1 + i].GetUInt32();
             if (itemId != 0)

--- a/src/world/Storage/MySQLStructures.h
+++ b/src/world/Storage/MySQLStructures.h
@@ -36,7 +36,7 @@ enum WorldMapInfoFlag
 
     WMI_INSTANCE_XPACK_01 = 0x008, // TBC
     WMI_INSTANCE_XPACK_02 = 0x010, // WotLK
-    
+
     WMI_INSTANCE_HAS_NORMAL_10MEN = 0x020,
     WMI_INSTANCE_HAS_NORMAL_25MEN = 0x040,
     WMI_INSTANCE_HAS_HEROIC_10MEN = 0x080,
@@ -156,9 +156,7 @@ namespace MySQLStructure
         uint32_t MountedDisplayID;
 
         // store item entry
-        uint32_t Item1SlotEntry;
-        uint32_t Item2SlotEntry;
-        uint32_t Item3SlotEntry;
+        std::array<uint32_t, TOTAL_WEAPON_DAMAGE_TYPES> itemEquipSlots;
 
         uint32_t CanFly;
         uint32_t phase;
@@ -693,7 +691,7 @@ namespace MySQLStructure
         uint32_t hordeEntry;
         uint32_t allianceEntry;
     };
-    
+
 
     //////////////////////////////////////////////////////////////////////////////////////////
     /* CHARACTERS DB Structures


### PR DESCRIPTION
**Description**
In this PR i changed static variables to array based container for item equipment entries.
I changed WeaponDamageType enum and separated TOTAL_WEAPON_DAMAGE_TYPES definition.
In various version functions WeaponDamageType enum usage was enforced to least prevent from wrong equipment types being used

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
-->
