### PR TITLE
Fix Crash on Login and Server Startup

### DIFF
--- a/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/InstanceScripts/Tbc/CoilfangReservoir/SerpentShrine/Raid_SerpentshrineCavern.cpp
@@ -843,9 +843,10 @@ public:
             if (random_target == nullptr)
                 return;
             //let's force this effect
-            SpellForcedBasePoints* forcedBasePoints;
-            forcedBasePoints->set(0, random_target->getMaxHealth() / 2);
-            getCreature()->castSpell(random_target, info_cataclysmic_bolt, *forcedBasePoints, true);
+            SpellForcedBasePoints forcedBasePoints;
+            forcedBasePoints.set(0, random_target->getMaxHealth() / 2);
+
+            getCreature()->castSpell(random_target, info_cataclysmic_bolt, forcedBasePoints, true);
             TargetTable.clear();
         }
 

--- a/src/world/Management/Group.h
+++ b/src/world/Management/Group.h
@@ -232,7 +232,7 @@ public:
 
     uint64 m_targetIcons[8];
     bool m_disbandOnNoMembers;
-    inline std::mutex & getLock() { return m_groupLock; }
+    inline std::recursive_mutex& getLock() { return m_groupLock; }
     inline void Lock() { m_groupLock.lock(); }
     inline void Unlock() { return m_groupLock.unlock(); }
     bool m_isqueued;
@@ -316,7 +316,7 @@ protected:
     uint64 m_guid;
 
     uint32 m_MemberCount;
-    std::mutex m_groupLock;
+    std::recursive_mutex m_groupLock;
     bool m_dirty;
     bool m_updateblock;
     uint32 updatecounter;

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -1496,11 +1496,15 @@ void Object::removeTravelingSpell(Spell* spell)
 
 void Object::addGarbageSpell(Spell* spell)
 {
+    std::lock_guard<std::mutex> lock(m_garbageMutex);
+
     m_garbageSpells.push_back(spell);
 }
 
 void Object::removeGarbageSpells()
 {
+    std::lock_guard<std::mutex> lock(m_garbageMutex);
+
     for (auto itr = m_garbageSpells.begin(); itr != m_garbageSpells.end();)
     {
         delete *itr;

--- a/src/world/Objects/Object.hpp
+++ b/src/world/Objects/Object.hpp
@@ -227,6 +227,7 @@ private:
 
     std::map<Spell*, bool> m_travelingSpells;
     std::list<Spell*> m_garbageSpells;
+    std::mutex m_garbageMutex;
 
 public:
     Spell* getCurrentSpell(CurrentSpellType spellType) const;

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -3573,7 +3573,7 @@ void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePo
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasePoints;
+    newSpell->forced_basepoints = std::make_shared<SpellForcedBasePoints>(forcedBasePoints);
     newSpell->m_charges = spellCharges;
 
     SpellCastTargets targets(0);
@@ -3639,7 +3639,7 @@ void Unit::castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForce
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasepoints;
+    newSpell->forced_basepoints = std::make_shared<SpellForcedBasePoints>(forcedBasepoints);
 
     SpellCastTargets targets(targetGuid);
 
@@ -3653,7 +3653,7 @@ void Unit::castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePo
         return;
 
     Spell* newSpell = sSpellMgr.newSpell(this, spellInfo, triggered, nullptr);
-    newSpell->forced_basepoints = &forcedBasepoints;
+    newSpell->forced_basepoints = std::make_shared<SpellForcedBasePoints>(forcedBasepoints);
 
     SpellCastTargets targets(0);
     if (target != nullptr)

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -204,7 +204,7 @@ Spell::Spell(Object* _caster, SpellInfo const* _spellInfo, bool _triggered, Aura
         }
     }
 
-    forced_basepoints = new SpellForcedBasePoints;
+    forced_basepoints = std::make_shared<SpellForcedBasePoints>();
 }
 
 Spell::~Spell()
@@ -249,8 +249,6 @@ Spell::~Spell()
 
         itr = m_pendingAuras.erase(itr);
     }
-
-    delete forced_basepoints;
 }
 
 

--- a/src/world/Spell/Spell.hpp
+++ b/src/world/Spell/Spell.hpp
@@ -243,7 +243,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
     // Some spells inherit base points from the mother spell
-    SpellForcedBasePoints* forced_basepoints;
+    std::shared_ptr<SpellForcedBasePoints> forced_basepoints;
 
     Aura* getTriggeredByAura() const;
 

--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -14,12 +14,11 @@ This file is released under the MIT license. See README-MIT for more information
 
 SpellProc::SpellProc()
 {
-    mOverrideEffectDamage = new SpellForcedBasePoints;
+    mOverrideEffectDamage = std::make_shared<SpellForcedBasePoints>();
 }
 
 SpellProc::~SpellProc()
 {
-    delete mOverrideEffectDamage;
 }
 
 void SpellProc::init(Object* /*obj*/) { }
@@ -118,7 +117,7 @@ void SpellProc::castSpell(Unit* victim, SpellInfo const* castingSpell)
     SpellCastTargets targets(victim->getGuid());
     Spell* spell = sSpellMgr.newSpell(caster, mSpell, true, nullptr);
 
-    spell->forced_basepoints = mOverrideEffectDamage;
+    spell->forced_basepoints = mOverrideEffectDamage.lock();
 
     spell->ProcedOnSpell = castingSpell;
     if (mOrigSpell != nullptr)
@@ -180,14 +179,24 @@ void SpellProc::setCastedOnProcOwner(bool enable) { m_castOnProcOwner = enable; 
 
 int32_t SpellProc::getOverrideEffectDamage(uint8_t effIndex) const
 {
-    int32_t overrideValue = 0;
-    mOverrideEffectDamage->get(effIndex, &overrideValue);
-    return overrideValue;
+    auto sharedPtr = mOverrideEffectDamage.lock();
+    if (sharedPtr)
+    {
+        int32_t overrideValue = 0;
+        sharedPtr->get(effIndex, &overrideValue);
+        return overrideValue;
+    }
+
+    return 0;
 }
 
 void SpellProc::setOverrideEffectDamage(uint8_t effIndex, int32_t damage)
 {
-    mOverrideEffectDamage->set(effIndex, damage);
+    auto sharedPtr = mOverrideEffectDamage.lock();
+    if (sharedPtr)
+    {
+        sharedPtr->set(effIndex, damage);
+    }
 }
 
 Aura* SpellProc::getCreatedByAura() const { return m_createdByAura; }

--- a/src/world/Spell/SpellProc.hpp
+++ b/src/world/Spell/SpellProc.hpp
@@ -151,7 +151,7 @@ class SERVER_DECL SpellProc
         // Mask used on spell effect
         uint32_t mGroupRelation[3] = { 0, 0, 0 };
 
-        SpellForcedBasePoints* mOverrideEffectDamage;
+        std::weak_ptr<SpellForcedBasePoints> mOverrideEffectDamage;
 
         // Indicates that this proc will be skipped on next ::handleProc call
         // used to avoid some spell procs from procing themselves


### PR DESCRIPTION
**Description**
Fixed a Crash when Starting the Worldserver where Groups would cause a Deadlock
Fixed Garbage Spells Crashing on entering World

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [x] Cata
