### PR TITLE
make shared ptr

### DIFF
--- a/src/world/Spell/SpellProc.cpp
+++ b/src/world/Spell/SpellProc.cpp
@@ -117,7 +117,7 @@ void SpellProc::castSpell(Unit* victim, SpellInfo const* castingSpell)
     SpellCastTargets targets(victim->getGuid());
     Spell* spell = sSpellMgr.newSpell(caster, mSpell, true, nullptr);
 
-    spell->forced_basepoints = mOverrideEffectDamage.lock();
+    spell->forced_basepoints = mOverrideEffectDamage;
 
     spell->ProcedOnSpell = castingSpell;
     if (mOrigSpell != nullptr)
@@ -179,24 +179,14 @@ void SpellProc::setCastedOnProcOwner(bool enable) { m_castOnProcOwner = enable; 
 
 int32_t SpellProc::getOverrideEffectDamage(uint8_t effIndex) const
 {
-    auto sharedPtr = mOverrideEffectDamage.lock();
-    if (sharedPtr)
-    {
-        int32_t overrideValue = 0;
-        sharedPtr->get(effIndex, &overrideValue);
-        return overrideValue;
-    }
-
-    return 0;
+    int32_t overrideValue = 0;
+    mOverrideEffectDamage->get(effIndex, &overrideValue);
+    return overrideValue;
 }
 
 void SpellProc::setOverrideEffectDamage(uint8_t effIndex, int32_t damage)
 {
-    auto sharedPtr = mOverrideEffectDamage.lock();
-    if (sharedPtr)
-    {
-        sharedPtr->set(effIndex, damage);
-    }
+    mOverrideEffectDamage->set(effIndex, damage);
 }
 
 Aura* SpellProc::getCreatedByAura() const { return m_createdByAura; }

--- a/src/world/Spell/SpellProc.hpp
+++ b/src/world/Spell/SpellProc.hpp
@@ -151,7 +151,7 @@ class SERVER_DECL SpellProc
         // Mask used on spell effect
         uint32_t mGroupRelation[3] = { 0, 0, 0 };
 
-        std::weak_ptr<SpellForcedBasePoints> mOverrideEffectDamage;
+        std::shared_ptr<SpellForcedBasePoints> mOverrideEffectDamage;
 
         // Indicates that this proc will be skipped on next ::handleProc call
         // used to avoid some spell procs from procing themselves


### PR DESCRIPTION
**Description**
I was not realy sure about the deletion of the pointer sorry i should have testet it more xD
Now the Spell Proc is an shared_ptr and wait until all references are cleared for deletion. I wantet to avoid a situation where the pointer dont gets freed when 2 hold the same reference thats why i used weak_ptr for one....

fix #1146 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
