### PR TITLE
Core/Creatures: fixed code mistake in Creature::setRespawnTime

### DIFF
--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -366,7 +366,7 @@ public:
 
         void SetType(uint32 t);
 
-        void setRespawnTime(uint32_t respawn) { respawn ? std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + respawn : 0; }
+        void setRespawnTime(uint32_t respawn) { m_respawnTime = respawn ? std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + respawn : 0; }
         time_t getRespawnTime() { return m_respawnTime; }
 
     protected:

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -366,7 +366,7 @@ public:
 
         void SetType(uint32 t);
 
-        void setRespawnTime(uint32_t respawn) { m_respawnTime = respawn ? std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + respawn : 0; }
+        void setRespawnTime(uint32_t respawn) { m_respawnTime = respawn != 0 ? std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + respawn : 0; }
         time_t getRespawnTime() { return m_respawnTime; }
 
     protected:


### PR DESCRIPTION
**Description**
In this PR i'm corrected mistake in SetRespawnTime. I found this error when i was preparing another PR for warning fixes. In general this function result is not set to anything but its purpose is to set respawn time to m_respawnTime variable
**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
-->
