### PR TITLE
[Core / Tools] vMAP Extractor

### DIFF
--- a/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -357,7 +357,6 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
 #elif VERSION_STRING == TBC
     pArchiveNames.push_back(input_path + std::string("patch.MPQ"));
     pArchiveNames.push_back(input_path + std::string("patch-2.MPQ"));
-    pArchiveNames.push_back(input_path + std::string("expansion.MPQ"));
     pArchiveNames.push_back(input_path + std::string("common.MPQ"));
 #elif VERSION_STRING == WotLK
     pArchiveNames.push_back(input_path + std::string("patch.MPQ"));

--- a/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -327,8 +327,6 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
         pArchiveNames.push_back(in_path + *i + "/patch-" + *i + "-2" ".MPQ");
         pArchiveNames.push_back(in_path + *i + "/locale-" + *i + ".MPQ");
         pArchiveNames.push_back(in_path + *i + "/speech-" + *i + ".MPQ");
-        pArchiveNames.push_back(in_path + *i + "/expansion-locale-" + *i + ".MPQ");
-        pArchiveNames.push_back(in_path + *i + "/expansion-speech-" + *i + ".MPQ");
 #elif VERSION_STRING == WotLK
         pArchiveNames.push_back(in_path + *i + "/patch-" + *i + ".MPQ");
         pArchiveNames.push_back(in_path + *i + "/patch-" + *i + "-2" ".MPQ");


### PR DESCRIPTION
There are no expansion- files in 2.4.3, this feature comes with only tbc.

**Description**
<!-- Short description about this PR. NOTE: Never mix style changes, refactorings and new implementations in one PR. Keep it as simple as possible -->

**Todo / Checklist**
- [] Target is branch develop.
- [] Detailed description about this pull request.
- [] Checked AE-Coding standards.
-
**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [] Server startup.
- [] Log into world.
-
<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [] WotLK
- [] Cata
-->
TBC