### PR TITLE
Fixed crash in CMSG_WHO handler

### DIFF
--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -140,7 +140,7 @@ void WorldSession::handleWhoOpcode(WorldPacket& recvPacket)
         }
 
         // Guild name
-        if (hasGuildName && !player->getGuild() || srlPacket.guild_name.compare(player->getGuild()->getName()) != 0)
+        if (hasGuildName && (!player->getGuild() || srlPacket.guild_name.compare(player->getGuild()->getName()) != 0))
         {
             continue;
         }


### PR DESCRIPTION
**Description**
Fixed crash in CMSG_WHO. Crash is caused because of incorrect conditional code blocks.

**Todo / Checklist**
- None

**Tests Performed:** 
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
-->
