### PR TITLE
Fixed invalid "delete" operator call in WMOLiquid assign/copy operator

### DIFF
--- a/src/collision/Models/WorldModel.cpp
+++ b/src/collision/Models/WorldModel.cpp
@@ -127,8 +127,8 @@ namespace VMAP
         iTilesY = other.iTilesY;
         iCorner = other.iCorner;
         iType = other.iType;
-        delete iHeight;
-        delete iFlags;
+        delete[] iHeight;
+        delete[] iFlags;
         if (other.iHeight)
         {
             iHeight = new float[(iTilesX+1)*(iTilesY+1)];


### PR DESCRIPTION
**Description**
array-like pointers needs to be deleted with "delete[]" call

**Todo / Checklist**
- None

**Tests Performed:** 
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
-->
