### PR TITLE
fix compilation 

### DIFF
--- a/src/shared/Database/Field.hpp
+++ b/src/shared/Database/Field.hpp
@@ -6,6 +6,7 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include <sstream>
+#include <cstdint>
 
 class Field
 {

--- a/src/world/Map/Maps/BaseMap.hpp
+++ b/src/world/Map/Maps/BaseMap.hpp
@@ -7,6 +7,8 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Map/Cells/TerrainMgr.hpp"
 #include <vector>
+#include <string>
+
 namespace WDB::Structures
 {
     struct MapEntry;

--- a/src/world/Map/Maps/WorldMap.hpp
+++ b/src/world/Map/Maps/WorldMap.hpp
@@ -11,6 +11,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Server/EventableObject.h"
 
 #include <queue>
+#include <algorithm>
 
 #include "InstanceDefines.hpp"
 #include "Debugging/Errors.h"


### PR DESCRIPTION
fix compilation 

```
[ 57%] Building CXX object src/scripts/Battlegrounds/CMakeFiles/Battlegrounds.dir/cmake_pch.hxx.gch
In file included from /home/ascemu/installer/ascemu_code/src/world/Map/Cells/MapCell.hpp:8,
                 from /home/ascemu/installer/ascemu_code/src/world/Map/Cells/CellHandler.hpp:9,
                 from /home/ascemu/installer/ascemu_code/src/world/Map/Maps/WorldMap.hpp:8,
                 from /home/ascemu/installer/ascemu_code/src/world/Map/Maps/BattleGroundMap.hpp:8,
                 from /home/ascemu/installer/ascemu_code/src/scripts/Battlegrounds/pchBattleGrounds.hpp:10,
                 from /home/ascemu/installer/build/src/scripts/Battlegrounds/CMakeFiles/Battlegrounds.dir/cmake_pch.hxx:5,
                 from <command-line>:
/home/ascemu/installer/ascemu_code/src/world/Map/Maps/BaseMap.hpp:45:10: error: ‘string’ in namespace ‘std’ does not name a type
   45 |     std::string getMapName();
```

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.
