### PR TITLE
fix warning C4996: 'strnicmp'

### DIFF
--- a/src/shared/Common.Legacy.h
+++ b/src/shared/Common.Legacy.h
@@ -102,6 +102,7 @@
 #endif
 
 #if COMPILER == COMPILER_MICROSOFT
+    #define strnicmp _strnicmp
 #else
     #define strnicmp strncasecmp
 #endif


### PR DESCRIPTION

**Description**

fix warning C4996: 'strnicmp' The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strnicmp.


**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.
