### PR TITLE
Rewrite pet files part 1

### DIFF
--- a/sql/character/updates/20241206-00_playerpets.sql
+++ b/sql/character/updates/20241206-00_playerpets.sql
@@ -1,0 +1,16 @@
+ALTER TABLE `playerpets` DROP COLUMN `happinessupdate`;
+ALTER TABLE `playerpets` MODIFY COLUMN `petnumber` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `ownerguid`;
+ALTER TABLE `playerpets` MODIFY COLUMN `type` TINYINT UNSIGNED NOT NULL DEFAULT 1 AFTER `petnumber`;
+ALTER TABLE `playerpets` ADD COLUMN `model` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `entry`;
+ALTER TABLE `playerpets` MODIFY COLUMN `level` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `model`;
+ALTER TABLE `playerpets` ADD COLUMN `slot` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `xp`;
+ALTER TABLE `playerpets` MODIFY COLUMN `alive` TINYINT UNSIGNED NOT NULL DEFAULT 1 AFTER `active`;
+ALTER TABLE `playerpets` MODIFY COLUMN `actionbar` LONGTEXT NOT NULL AFTER `alive`;
+ALTER TABLE `playerpets` MODIFY COLUMN `petstate` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `spellid`;
+ALTER TABLE `playerpets` MODIFY COLUMN `renamable` TINYINT UNSIGNED NOT NULL DEFAULT 1 AFTER `current_happiness`;
+
+UPDATE `playerpets` SET `slot`='5' WHERE `active` >= '20';
+UPDATE `playerpets` SET `slot`='0' WHERE `active` >= '10';
+UPDATE `playerpets` SET `active`='0';
+
+UPDATE `character_db_version` SET LastUpdate = '20241206-00_playerpets';

--- a/src/scripts/InstanceScripts/Classic/Deadmines/Instance_Deadmines.cpp
+++ b/src/scripts/InstanceScripts/Classic/Deadmines/Instance_Deadmines.cpp
@@ -271,7 +271,7 @@ public:
         if (pTarget->isPlayer())
             sprintf(msg, "And stay down, %s.", dynamic_cast<Player*>(pTarget)->getName().c_str());
         else if (pTarget->GetTypeFromGUID() == HIGHGUID_TYPE_PET)
-            sprintf(msg, "And stay down, %s.", dynamic_cast<Pet*>(pTarget)->GetName().c_str());
+            sprintf(msg, "And stay down, %s.", dynamic_cast<Pet*>(pTarget)->getName().c_str());
 
         sendChatMessage(CHAT_MSG_MONSTER_YELL, 5781, msg);
     }

--- a/src/scripts/LuaEngine/LuaUnit.cpp
+++ b/src/scripts/LuaEngine/LuaUnit.cpp
@@ -5986,7 +5986,7 @@ int LuaUnit::ResetPetTalents(lua_State* /*L*/, Unit* ptr)
         return 0;
     }
 
-    Pet* pet = dynamic_cast<Player*>(ptr)->getFirstPetFromSummons();
+    Pet* pet = dynamic_cast<Player*>(ptr)->getPet();
     if (pet != nullptr)
     {
         pet->WipeTalents();

--- a/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/HunterSpells.cpp
@@ -66,7 +66,7 @@ bool MastersCall(uint8_t effectIndex, Spell* pSpell)
     if (caster == NULL)
         return true;
 
-    Pet* Summon = caster->getFirstPetFromSummons();
+    Pet* Summon = caster->getPet();
     if (Summon == NULL || Summon->isDead())
         return true;
 

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -50,7 +50,7 @@ namespace Util
             return 8;
 
         // Cata
-        if (langstr.compare("ptBR") == 0)
+        if (langstr.compare("ptBR") == 0 || langstr.compare("ptPT") == 0)
             return 10;
 
         // Mop
@@ -74,7 +74,7 @@ namespace Util
             case 7: return "esMX";
             case 8: return "ruRU";
             // Cata
-            case 10: return "ptBR";
+            case 10: return "ptBR"; // also ptPT
             // Mop
             case 11: return "itIT";
 

--- a/src/world/Chat/ChatHandler.hpp
+++ b/src/world/Chat/ChatHandler.hpp
@@ -5,8 +5,10 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include "ChatDefines.hpp"
 #include "CommonTypes.hpp"
 #include "AEVersion.hpp"
+#include "Logging/StringFormat.hpp"
 
 #include <string>
 
@@ -392,7 +394,9 @@ public:
     bool HandleModifyFlags(const char* args, WorldSession* session);
     bool HandleModifyFaction(const char* args, WorldSession* session);
     bool HandleModifyDynamicflags(const char* args, WorldSession* session);
+#if VERSION_STRING < Cata
     bool HandleModifyHappiness(const char* args, WorldSession* session);
+#endif
     bool HandleModifyBoundingradius(const char* args, WorldSession* session);
     bool HandleModifyCombatreach(const char* args, WorldSession* session);
     bool HandleModifyEmotestate(const char* args, WorldSession* session);

--- a/src/world/Chat/CommandTableStorage.cpp
+++ b/src/world/Chat/CommandTableStorage.cpp
@@ -325,7 +325,9 @@ void CommandTableStorage::Init()
         { "flags",                  'm', &ChatHandler::HandleModifyFlags,                                  "Mods flags of the selected target.",                                                nullptr },
         { "faction",                'm', &ChatHandler::HandleModifyFaction,                                "Mods faction template of the selected target.",                                     nullptr },
         { "dynamicflags",           'm', &ChatHandler::HandleModifyDynamicflags,                           "Mods dynamic flags of the selected target.",                                        nullptr },
+#if VERSION_STRING < Cata
         { "happiness",              'm', &ChatHandler::HandleModifyHappiness,                              "Mods happiness value of the selected target.",                                      nullptr },
+#endif
         { "boundingradius",         'm', &ChatHandler::HandleModifyBoundingradius,                         "Mods bounding radius of the selected target.",                                      nullptr },
         { "combatreach",            'm', &ChatHandler::HandleModifyCombatreach,                            "Mods combat reach of the selected target.",                                         nullptr },
         { "emotestate",             'm', &ChatHandler::HandleModifyEmotestate,                             "Mods Unit emote state of the selected target.",                                     nullptr },

--- a/src/world/Chat/Commands/MiscCommands.cpp
+++ b/src/world/Chat/Commands/MiscCommands.cpp
@@ -257,8 +257,7 @@ bool ChatHandler::HandleKillCommand(const char* args, WorldSession* m_session)
             RedSystemMessage(m_session, "Player %s is not online or does not exist!", args);
             return true;
         }
-        named_player->setHealth(0);
-        named_player->kill();
+        named_player->die(nullptr, 0, 0);
         RedSystemMessage(named_player->getSession(), "You were killed by %s with a GM command.", m_session->GetPlayer()->getName().c_str());
         GreenSystemMessage(m_session, "Killed player %s.", args);
         sGMLog.writefromsession(m_session, "used kill command on Player Name: %s Guid: %s ", named_player->getName().c_str(), std::to_string(named_player->getGuid()).c_str());
@@ -289,7 +288,7 @@ bool ChatHandler::HandleKillCommand(const char* args, WorldSession* m_session)
                     auto player = static_cast<Player*>(unit_target);
 
                     player->setHealth(0);
-                    player->kill();
+                    player->die(nullptr, 0, 0);
                     RedSystemMessage(player->getSession(), "You were killed by %s with a GM command.", m_session->GetPlayer()->getName().c_str());
                     GreenSystemMessage(m_session, "Killed player %s.", player->getName().c_str());
                     sGMLog.writefromsession(m_session, "used kill command on Player Name: %s Guid: %s", m_session->GetPlayer()->getName().c_str(), std::to_string(player->getGuid()).c_str());

--- a/src/world/Chat/Commands/ModifyCommands.cpp
+++ b/src/world/Chat/Commands/ModifyCommands.cpp
@@ -983,6 +983,7 @@ bool ChatHandler::HandleModifyDynamicflags(const char* args, WorldSession* sessi
     return false;
 }
 
+#if VERSION_STRING < Cata
 //.modify happiness
 bool ChatHandler::HandleModifyHappiness(const char* args, WorldSession* session)
 {
@@ -1020,6 +1021,7 @@ bool ChatHandler::HandleModifyHappiness(const char* args, WorldSession* session)
 
     return false;
 }
+#endif
 
 //.modify boundingradius
 bool ChatHandler::HandleModifyBoundingradius(const char* args, WorldSession* session)

--- a/src/world/Macros/PetMacros.hpp
+++ b/src/world/Macros/PetMacros.hpp
@@ -13,7 +13,8 @@ This file is released under the MIT license. See README-MIT for more information
 #define PET_SUCCUBUS 1863
 #define PET_FELHUNTER 417
 #define PET_FELGUARD 17252
-#define SHADOWFIEND 19668
+#define PET_SHADOWFIEND 19668
+#define PET_GHOUL 26125
 
 /// -
 //#define SPIRITWOLF 29264

--- a/src/world/Management/Arenas.cpp
+++ b/src/world/Management/Arenas.cpp
@@ -252,7 +252,7 @@ void Arena::HookOnPlayerKill(Player* _player, Player* _playerVictim)
 {
     if (!m_hasStarted)
     {
-        _player->kill(); //cheater.
+        _player->die(nullptr, 0, 0); //cheater.
         return;
     }
 

--- a/src/world/Management/Gossip/GossipScript.cpp
+++ b/src/world/Management/Gossip/GossipScript.cpp
@@ -339,7 +339,7 @@ void GossipPetTrainer::onHello(Object* object, Player* player)
 
         menu.addItem(GOSSIP_ICON_TRAINER, BEASTTRAINING, 1);
 
-        if (player->getClass() == ::HUNTER && player->getFirstPetFromSummons() != nullptr)
+        if (player->getClass() == ::HUNTER && player->getPet() != nullptr)
             menu.addItem(GOSSIP_ICON_CHAT, PETTRAINER_TALENTRESET, 2);
 
         sQuestMgr.FillQuestMenu(creature, player, menu);

--- a/src/world/Management/Group.cpp
+++ b/src/world/Management/Group.cpp
@@ -907,7 +907,7 @@ void Group::UpdateOutOfRangePlayer(Player* pPlayer, bool Distribute, WorldPacket
         }
     }
 
-    Pet* pet = pPlayer->getFirstPetFromSummons();
+    Pet* pet = pPlayer->getPet();
     if (mask & GROUP_UPDATE_FLAG_PET_GUID)
     {
         if (pet)
@@ -919,7 +919,7 @@ void Group::UpdateOutOfRangePlayer(Player* pPlayer, bool Distribute, WorldPacket
     if (mask & GROUP_UPDATE_FLAG_PET_NAME)
     {
         if (pet)
-            *data << pet->GetName().c_str();
+            *data << pet->getName().c_str();
         else
             *data << uint8(0);
     }

--- a/src/world/Management/ObjectMgr.cpp
+++ b/src/world/Management/ObjectMgr.cpp
@@ -2438,10 +2438,10 @@ std::shared_ptr<LevelInfo> ObjectMgr::getLevelInfo(uint32_t _race, uint32_t _cla
     return nullptr;
 }
 
-std::shared_ptr<Pet> ObjectMgr::createPet(uint32_t _entry)
+Pet* ObjectMgr::createPet(uint32_t _entry, WDB::Structures::SummonPropertiesEntry const* properties)
 {
     const uint32_t guid = ++m_hiPetGuid;
-    return std::make_shared<Pet>(WoWGuid(guid, _entry, HIGHGUID_TYPE_PET));
+    return new Pet(WoWGuid(guid, _entry, HIGHGUID_TYPE_PET), properties);
 }
 
 void ObjectMgr::loadPetSpellCooldowns()

--- a/src/world/Management/ObjectMgr.hpp
+++ b/src/world/Management/ObjectMgr.hpp
@@ -15,11 +15,15 @@ This file is released under the MIT license. See README-MIT for more information
 
 #if VERSION_STRING >= WotLK
     #include "AchievementMgr.h"
+#endif
+
 namespace WDB::Structures
 {
+#if VERSION_STRING >= WotLK
     struct DungeonEncounterEntry;
-}
 #endif
+    struct SummonPropertiesEntry;
+}
 
 class Object;
 class Corpse;
@@ -404,7 +408,7 @@ public:
     void generateLevelUpInfo();
     std::shared_ptr<LevelInfo> getLevelInfo(uint32_t _race, uint32_t _class, uint32_t _level);
 
-    std::shared_ptr<Pet> createPet(uint32_t _entry);
+    Pet* createPet(uint32_t _entry, WDB::Structures::SummonPropertiesEntry const* properties);
     void loadPetSpellCooldowns();
     uint32_t getPetSpellCooldown(uint32_t _spellId);
 

--- a/src/world/Map/Management/InstanceNumberGen.hpp
+++ b/src/world/Map/Management/InstanceNumberGen.hpp
@@ -5,6 +5,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 #include <queue>

--- a/src/world/Map/Maps/WorldMap.hpp
+++ b/src/world/Map/Maps/WorldMap.hpp
@@ -396,6 +396,7 @@ public:
     uint32_t m_lastTransportUpdateTimer = 0;
     uint32_t m_lastDynamicUpdateTimer = 0;
     uint32_t m_lastPlayerUpdateTimer = 0;
+    uint32_t m_lastPetUpdateTimer = 0;
     uint32_t m_lastCreatureUpdateTimer = 0;
     uint32_t m_lastGameObjectUpdateTimer = 0;
     uint32_t m_lastSessionUpdateTimer = 0;

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -292,7 +292,23 @@ Unit* GameObject::getUnitOwner()
     return nullptr;
 }
 
+Unit const* GameObject::getUnitOwner() const
+{
+    if (getCreatedByGuid() != 0)
+        return getWorldMapUnit(getCreatedByGuid());
+
+    return nullptr;
+}
+
 Player* GameObject::getPlayerOwner()
+{
+    if (getCreatedByGuid() != 0)
+        return getWorldMapPlayer(getCreatedByGuid());
+
+    return nullptr;
+}
+
+Player const* GameObject::getPlayerOwner() const
 {
     if (getCreatedByGuid() != 0)
         return getWorldMapPlayer(getCreatedByGuid());

--- a/src/world/Objects/GameObject.h
+++ b/src/world/Objects/GameObject.h
@@ -187,9 +187,14 @@ public:
     uint8_t invisibilityFlag = INVIS_FLAG_NORMAL;
     uint8_t stealthFlag = STEALTH_FLAG_NORMAL;
 
-    // Owner
+    // Returns unit owner
     Unit* getUnitOwner() override;
+    // Returns unit owner
+    Unit const* getUnitOwner() const override;
+    // Returns player owner
     Player* getPlayerOwner() override;
+    // Returns player owner
+    Player const* getPlayerOwner() const override;
 
     // MIT End
 

--- a/src/world/Objects/Item.cpp
+++ b/src/world/Objects/Item.cpp
@@ -241,6 +241,29 @@ void Item::setCreatePlayedTime(uint32_t time) { write(itemData()->create_played_
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////
+// Override Object functions
+
+Unit* Item::getUnitOwner()
+{
+    return m_owner;
+}
+
+Unit const* Item::getUnitOwner() const
+{
+    return m_owner;
+}
+
+Player* Item::getPlayerOwner()
+{
+    return m_owner;
+}
+
+Player const* Item::getPlayerOwner() const
+{
+    return m_owner;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 // m_enchantments
 EnchantmentInstance* Item::getEnchantment(EnchantmentSlot slot)
 {

--- a/src/world/Objects/Item.hpp
+++ b/src/world/Objects/Item.hpp
@@ -108,6 +108,18 @@ public:
 #endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
+    // Override Object functions
+
+    // Returns unit owner
+    Unit* getUnitOwner() override;
+    // Returns unit owner
+    Unit const* getUnitOwner() const override;
+    // Returns player owner
+    Player* getPlayerOwner() override;
+    // Returns player owner
+    Player const* getPlayerOwner() const override;
+
+    //////////////////////////////////////////////////////////////////////////////////////////
     // m_enchantments
     EnchantmentInstance* getEnchantment(EnchantmentSlot slot);
     EnchantmentInstance const* getEnchantment(EnchantmentSlot slot) const;
@@ -178,6 +190,7 @@ protected:
 public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
+    // TODO: remove this and replace it with virtual Object::getPlayerOwner()
     Player* getOwner() const;
     void setOwner(Player* owner);
 

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -1748,20 +1748,13 @@ void Object::removeObjectFromInRangeSameFactionSet(Object* obj)
 //////////////////////////////////////////////////////////////////////////////////////////
 // Owner
 Unit* Object::getUnitOwner() { return nullptr; }
+Unit const* Object::getUnitOwner() const { return nullptr; }
 Unit* Object::getUnitOwnerOrSelf() { return getUnitOwner(); }
+Unit const* Object::getUnitOwnerOrSelf() const { return getUnitOwner(); }
 Player* Object::getPlayerOwner() { return nullptr; }
+Player const* Object::getPlayerOwner() const { return nullptr; }
 Player* Object::getPlayerOwnerOrSelf() { return getPlayerOwner(); }
-
-Player* Object::getAffectingPlayer()
-{
-    if (!getUnitOwner())
-        return ToPlayer();
-
-    if (Unit* owner = getPlayerOwner())
-        return owner->getPlayerOwnerOrSelf();
-
-    return nullptr;
-}
+Player const* Object::getPlayerOwnerOrSelf() const { return getPlayerOwner(); }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Misc
@@ -3902,8 +3895,8 @@ Standing Object::getEnemyReaction(Object* target)
     if (getUnitOwnerOrSelf() == target->getUnitOwnerOrSelf())
         return Standing::STANDING_FRIENDLY;
 
-    Player* selfPlayerOwner = getAffectingPlayer();
-    Player* targetPlayerOwner = target->getAffectingPlayer();
+    Player* selfPlayerOwner = getPlayerOwnerOrSelf();
+    Player* targetPlayerOwner = target->getPlayerOwnerOrSelf();
 
     // check forced reputation
     // which could be applied by spell auras
@@ -3996,7 +3989,7 @@ Standing Object::getFactionReaction(WDB::Structures::FactionTemplateEntry const*
     if (!targetFactionTemplateEntry)
         return STANDING_NEUTRAL;
 
-    if (Player* targetPlayerOwner = target->getAffectingPlayer())
+    if (Player* targetPlayerOwner = target->getPlayerOwnerOrSelf())
     {
         // check contested flags
         if ((factionTemplateEntry->FactionGroup & FACTION_TEMPLATE_FLAG_CONTESTED_GUARD) &&
@@ -4177,8 +4170,8 @@ bool Object::isValidTarget(Object* target, SpellInfo const* bySpell)
     if (isFriendlyTo(target) || target->isFriendlyTo(this))
         return false;
 
-    Player* playerAffectingAttacker = unit && unit->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE) ? getAffectingPlayer() : go ? getAffectingPlayer() : nullptr;
-    Player* playerAffectingTarget = unitTarget && unitTarget->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE) ? unitTarget->getAffectingPlayer() : nullptr;
+    Player* playerAffectingAttacker = unit && unit->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE) ? getPlayerOwnerOrSelf() : go ? getPlayerOwner() : nullptr;
+    Player* playerAffectingTarget = unitTarget && unitTarget->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE) ? unitTarget->getPlayerOwnerOrSelf() : nullptr;
 
     // Not all neutral creatures can be attacked (even some unfriendly faction does not react aggresive to you, like Sporaggar)
     if ((playerAffectingAttacker && !playerAffectingTarget) || (!playerAffectingAttacker && playerAffectingTarget))
@@ -4311,8 +4304,8 @@ bool Object::isValidAssistTarget(Unit* target, SpellInfo const* bySpell)
     {
         if (unit && unit->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
         {
-            Player const* selfPlayerOwner = getAffectingPlayer();
-            Player const* targetPlayerOwner = unitTarget->getAffectingPlayer();
+            Player const* selfPlayerOwner = getPlayerOwnerOrSelf();
+            Player const* targetPlayerOwner = unitTarget->getPlayerOwnerOrSelf();
             if (selfPlayerOwner && targetPlayerOwner)
             {
                 // can't assist player which is dueling someone
@@ -4571,7 +4564,7 @@ void Object::SendCreatureChatMessageInRange(Creature* creature, uint32_t textId,
     }
 }
 
-Object* Object::getWorldMapObject(const uint64 & guid)
+Object* Object::getWorldMapObject(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4579,7 +4572,7 @@ Object* Object::getWorldMapObject(const uint64 & guid)
     return getWorldMap()->getObject(guid);
 }
 
-Pet* Object::getWorldMapPet(const uint64 & guid)
+Pet* Object::getWorldMapPet(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4590,7 +4583,7 @@ Pet* Object::getWorldMapPet(const uint64 & guid)
     return getWorldMap()->getPet(wowGuid.getGuidLowPart());
 }
 
-Unit* Object::getWorldMapUnit(const uint64 & guid)
+Unit* Object::getWorldMapUnit(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4598,7 +4591,7 @@ Unit* Object::getWorldMapUnit(const uint64 & guid)
     return getWorldMap()->getUnit(guid);
 }
 
-Player* Object::getWorldMapPlayer(const uint64 & guid)
+Player* Object::getWorldMapPlayer(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4609,7 +4602,7 @@ Player* Object::getWorldMapPlayer(const uint64 & guid)
     return getWorldMap()->getPlayer(wowGuid.getGuidLowPart());
 }
 
-Creature* Object::getWorldMapCreature(const uint64 & guid)
+Creature* Object::getWorldMapCreature(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4620,7 +4613,7 @@ Creature* Object::getWorldMapCreature(const uint64 & guid)
     return getWorldMap()->getCreature(wowGuid.getGuidLowPart());
 }
 
-GameObject* Object::getWorldMapGameObject(const uint64 & guid)
+GameObject* Object::getWorldMapGameObject(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;
@@ -4631,7 +4624,7 @@ GameObject* Object::getWorldMapGameObject(const uint64 & guid)
     return getWorldMap()->getGameObject(wowGuid.getGuidLowPart());
 }
 
-DynamicObject* Object::getWorldMapDynamicObject(const uint64 & guid)
+DynamicObject* Object::getWorldMapDynamicObject(const uint64 & guid) const
 {
     if (!IsInWorld())
         return nullptr;

--- a/src/world/Objects/Object.hpp
+++ b/src/world/Objects/Object.hpp
@@ -310,14 +310,20 @@ public:
 
     // Returns unit charmer or unit owner
     virtual Unit* getUnitOwner();
+    // Returns unit charmer or unit owner
+    virtual Unit const* getUnitOwner() const;
     // Returns unit charmer, unit owner or self
     virtual Unit* getUnitOwnerOrSelf();
-    // Returns player charmer and player owner
+    // Returns unit charmer, unit owner or self
+    virtual Unit const* getUnitOwnerOrSelf() const;
+    // Returns player charmer or player owner
     virtual Player* getPlayerOwner();
+    // Returns player charmer or player owner
+    virtual Player const* getPlayerOwner() const;
     // Returns player charmer, player owner or self
     virtual Player* getPlayerOwnerOrSelf();
-
-    Player* getAffectingPlayer();
+    // Returns player charmer, player owner or self
+    virtual Player const* getPlayerOwnerOrSelf() const;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
@@ -450,13 +456,13 @@ public:
         // Only for WorldMap use
         WorldMap* getWorldMap() const { return m_WorldMap; }
 
-        Object* getWorldMapObject(const uint64_t & guid);
-        Pet* getWorldMapPet(const uint64_t & guid);
-        Unit* getWorldMapUnit(const uint64_t & guid);
-        Player* getWorldMapPlayer(const uint64_t & guid);
-        Creature* getWorldMapCreature(const uint64_t & guid);
-        GameObject* getWorldMapGameObject(const uint64_t & guid);
-        DynamicObject* getWorldMapDynamicObject(const uint64_t & guid);
+        Object* getWorldMapObject(const uint64_t & guid) const;
+        Pet* getWorldMapPet(const uint64_t & guid) const;
+        Unit* getWorldMapUnit(const uint64_t & guid) const;
+        Player* getWorldMapPlayer(const uint64_t & guid) const;
+        Creature* getWorldMapCreature(const uint64_t & guid) const;
+        GameObject* getWorldMapGameObject(const uint64_t & guid) const;
+        DynamicObject* getWorldMapDynamicObject(const uint64_t & guid) const;
 
         void SetMapId(uint32 newMap) { m_mapId = newMap; }
         void setZoneId(uint32 newZone);

--- a/src/world/Objects/Units/Creatures/AIInterface.cpp
+++ b/src/world/Objects/Units/Creatures/AIInterface.cpp
@@ -514,7 +514,7 @@ void AIInterface::enterEvadeMode()
         {
             if (m_Unit->isPet())
             {
-                static_cast<Pet*>(m_Unit)->SetPetAction(PET_ACTION_FOLLOW);
+                static_cast<Pet*>(m_Unit)->setPetAction(PET_ACTION_FOLLOW);
                 if (m_Unit->isAlive() && m_Unit->IsInWorld())
                 {
                     static_cast<Pet*>(m_Unit)->HandleAutoCastEvent(AUTOCAST_EVENT_LEAVE_COMBAT);
@@ -2155,9 +2155,8 @@ void AIInterface::justEnteredCombat(Unit* pUnit)
 {
     if (!isEngaged() && getUnit()->getThreatManager().canHaveThreatList())
         engagementStart(pUnit);
-    // Zyres: this looks pretty wrong - fix it if needed otherwise everything sill start engagement @aaron02
-    // else // maybe add more here this part down is for petAI
-    //    engagementStart(pUnit);
+    else if (getUnit()->isPet()) // maybe add more here this part down is for petAI
+       engagementStart(pUnit);
 }
 
 void AIInterface::engagementStart(Unit* target)

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -45,13 +45,13 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // Essential functions
 
-    void Update(unsigned long time_passed);             // hides function Unit::Update
+    virtual void Update(unsigned long time_passed);     // hides function Unit::Update
     void AddToWorld();                                  // hides virtual function Object::AddToWorld
     void AddToWorld(WorldMap* pMapMgr);                 // hides virtual function Object::AddToWorld
     // void PushToWorld(WorldMap*);                     // not used
-    void RemoveFromWorld(bool free_guid);               // hides virtual function Unit::RemoveFromWorld
+    virtual void RemoveFromWorld(bool free_guid);       // hides virtual function Unit::RemoveFromWorld
     void OnPrePushToWorld() override;                   // overrides virtual function Unit::OnPrePushToWorld
-    void OnPushToWorld() override;                      // overrides virtual function Unit::OnPushToWorld
+    virtual void OnPushToWorld() override;              // overrides virtual function Unit::OnPushToWorld
     // void OnPreRemoveFromWorld();                     // not used
     // void OnRemoveFromWorld();                        // not used
 
@@ -102,9 +102,18 @@ public:
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Owner
+    // Returns unit charmer or unit owner
     Unit* getUnitOwner() override;
+    // Returns unit charmer or unit owner
+    Unit const* getUnitOwner() const override;
+    // Returns unit charmer, unit owner or self
     Unit* getUnitOwnerOrSelf() override;
+    // Returns unit charmer, unit owner or self
+    Unit const* getUnitOwnerOrSelf() const override;
+    // Returns player charmer or player owner
     Player* getPlayerOwner() override;
+    // Returns player charmer or player owner
+    Player const* getPlayerOwner() const override;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc
@@ -174,7 +183,7 @@ public:
         void RemoveFromWorld(bool addrespawnevent, bool free_guid);
 
         // remove auras, guardians, scripts
-        void PrepareForRemove();
+        virtual void PrepareForRemove();
 
         // Creation
         void Create(uint32 mapid, float x, float y, float z, float ang);

--- a/src/world/Objects/Units/Creatures/CreatureDefines.hpp
+++ b/src/world/Objects/Units/Creatures/CreatureDefines.hpp
@@ -242,6 +242,8 @@ struct CreatureProperties
     uint32_t getInvisibleModelForTriggerNpc() const;
     uint32_t getVisibleModelForTriggerNpc() const;
 
+    bool isExotic() const;
+
     // MIT End
     // APGL Start
 

--- a/src/world/Objects/Units/Creatures/PetDefines.hpp
+++ b/src/world/Objects/Units/Creatures/PetDefines.hpp
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2014-2024 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "AEVersion.hpp"
+#include <cstdint>
+
+/* Taken from ItemPetFood.dbc
+ * Each value is equal to a flag
+ * so 1 << PET_FOOD_BREAD for example
+ * will result in a usable value.
+ */
+enum PetFoodDiets : uint8_t
+{
+    PET_FOOD_NONE,
+    PET_FOOD_MEAT,
+    PET_FOOD_FISH,
+    PET_FOOD_CHEESE,
+    PET_FOOD_BREAD,
+    PET_FOOD_FUNGUS,
+    PET_FOOD_FRUIT,
+    PET_FOOD_RAW_MEAT,                  /// not used in pet diet
+    PET_FOOD_RAW_FISH                   /// not used in pet diet
+};
+
+enum PetReactStates : uint8_t
+{
+    PET_STATE_PASSIVE                   = 0,
+    PET_STATE_DEFENSIVE                 = 1,
+    PET_STATE_AGGRESSIVE                = 2
+};
+
+enum PetCommands : uint8_t
+{
+    PET_ACTION_STAY                     = 0,
+    PET_ACTION_FOLLOW                   = 1,
+    PET_ACTION_ATTACK                   = 2,
+    PET_ACTION_DISMISS                  = 3,
+    PET_ACTION_CASTING                  = 4
+};
+
+enum PetActionFeedback : uint8_t
+{
+    PET_FEEDBACK_NONE,
+    PET_FEEDBACK_PET_DEAD,
+    PET_FEEDBACK_NOTHING_TO_ATTACK,
+    PET_FEEDBACK_CANT_ATTACK_TARGET
+};
+
+enum PetSpells : uint32_t
+{
+    PET_SPELL_PASSIVE                   = 0x06000000,
+    PET_SPELL_DEFENSIVE,
+    PET_SPELL_AGRESSIVE,
+    PET_SPELL_STAY                      = 0x07000000,
+    PET_SPELL_FOLLOW,
+    PET_SPELL_ATTACK
+};
+
+enum PetSlots : uint8_t
+{
+#if VERSION_STRING < WotLK
+    PET_SLOT_MAX_ACTIVE_SLOT            = 1,
+    PET_SLOT_MAX_STABLE_SLOT            = 2,
+#elif VERSION_STRING == WotLK
+    PET_SLOT_MAX_ACTIVE_SLOT            = 1,
+    PET_SLOT_MAX_STABLE_SLOT            = 4,
+#elif VERSION_STRING == Cata
+    PET_SLOT_MAX_ACTIVE_SLOT            = 5,
+    PET_SLOT_MAX_STABLE_SLOT            = 20,
+#elif VERSION_STRING >= Mop
+    PET_SLOT_MAX_ACTIVE_SLOT            = 5,
+    PET_SLOT_MAX_STABLE_SLOT            = 50,
+#endif
+
+    PET_SLOT_FIRST_ACTIVE_SLOT          = 0,
+    PET_SLOT_FIRST_STABLE_SLOT          = 5, // Reserve 0-4 slots for active pets in all versions
+    PET_SLOT_LAST_STABLE_SLOT           = PET_SLOT_FIRST_STABLE_SLOT + PET_SLOT_MAX_STABLE_SLOT, // Slot is zero indexed so actual value is -1
+    PET_SLOT_MAX_TOTAL_PET_COUNT        = PET_SLOT_MAX_ACTIVE_SLOT + PET_SLOT_MAX_STABLE_SLOT,
+};
+
+enum HappinessStates : uint8_t
+{
+    HAPPINESS_STATE_UNHAPPY             = 1,
+    HAPPINESS_STATE_CONTENT             = 2,
+    HAPPINESS_STATE_HAPPY               = 3
+};
+
+enum AutoCastEvents : uint8_t
+{
+    AUTOCAST_EVENT_NONE                 = 0,
+    AUTOCAST_EVENT_ATTACK               = 1,
+    AUTOCAST_EVENT_ON_SPAWN             = 2,
+    AUTOCAST_EVENT_OWNER_ATTACKED       = 3,
+    AUTOCAST_EVENT_LEAVE_COMBAT         = 4,
+    AUTOCAST_EVENT_COUNT                = 5
+};
+
+enum PetTypes : uint8_t
+{
+    PET_TYPE_NONE                       = 0,
+    PET_TYPE_HUNTER                     = 1, // Hunter pet
+    PET_TYPE_SUMMON                     = 2, // All summoned pets (warlock minions, water elemental etc)
+};
+
+namespace PetStableResult
+{
+    enum Messages : uint8_t
+    {
+        NotEnoughMoney                  = 1,
+#if VERSION_STRING >= Cata
+        SlotLocked                      = 3,
+#endif
+        Error                           = 6, // todo: confirm if exists in cata or replaced by 12
+        StableSuccess                   = 8,
+        UnstableSuccess                 = 9,
+        BuySuccess                      = 10,
+#if VERSION_STRING == WotLK
+        ExoticNotAvailable              = 12,
+#elif VERSION_STRING >= Cata
+        ExoticNotAvailable              = 11,
+        InternalError                   = 12,
+#endif
+    };
+}

--- a/src/world/Objects/Units/Creatures/Summons/Summon.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/Summon.cpp
@@ -10,6 +10,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "SummonHandler.hpp"
 #include "Logging/Logger.hpp"
 #include "Objects/Units/Players/Player.hpp"
+#include "Server/EventMgr.h"
 #include "Storage/MySQLDataStore.hpp"
 #include "Storage/MySQLStructures.h"
 #include "Spell/SpellAura.hpp"
@@ -24,56 +25,86 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "CommonTime.hpp"
 
-Summon::Summon(uint64_t guid, WDB::Structures::SummonPropertiesEntry const* properties) : Creature(guid), m_Properties(properties)
+static CreatureSummonDespawnType getDefaultDespawnTypeForSummon(Summon const* summon)
 {
+    if (summon->getLifeTime() != 0)
+    {
+        // todo: should scripted summons behave same like summons from spells?
+        return summon->isPet() || summon->getSummonProperties() != nullptr
+            ? TIMED_OR_CORPSE_DESPAWN
+            : TIMED_DESPAWN;
+    }
+    else
+    {
+        return DEAD_DESPAWN;
+    }
+}
+
+Summon::Summon(uint64_t guid, WDB::Structures::SummonPropertiesEntry const* properties) : Creature(guid), m_summonProperties(properties)
+{
+    // Disable respawn in Creature class
+    m_noRespawn = true;
     // Override initialization from Creature class
     getThreatManager().initialize();
 }
 
-Summon::~Summon() {}
+Summon::~Summon() = default;
 
-void Summon::load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellId)
+void Summon::load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellId)
 {
-    Creature::Load(creatureProperties, position.x, position.y, position.z, position.o);
+    if (!isPet())
+        Creature::Load(creatureProperties, position.x, position.y, position.z, position.o);
 
     setTimeLeft(duration);
     setLifeTime(duration);
 
     // Despawn Type
     if (m_despawnType == MANUAL_DESPAWN)
-        m_despawnType = (duration == 0) ? DEAD_DESPAWN : TIMED_DESPAWN;
+        m_despawnType = getDefaultDespawnTypeForSummon(this);
 
     setCreatedBySpellId(spellId);
     SetSpawnLocation(position);
 
-    if (unitOwner)
+    m_summonActive = true;
+
+    if (unitOwner == nullptr)
+        return;
+
+    setZoneId(unitOwner->getZoneId());
+
+    if (unitOwner->isPvpFlagSet())
+        setPvpFlag();
+    else
+        removePvpFlag();
+
+    if (unitOwner->isFfaPvpFlagSet())
+        setFfaPvpFlag();
+    else
+        removeFfaPvpFlag();
+
+    if (unitOwner->isSanctuaryFlagSet())
+        setSanctuaryFlag();
+    else
+        removeSanctuaryFlag();
+
+    if (unitOwner->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
+        addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
+
+    m_unitOwner = unitOwner;
+
+    // Non-scripted summons
+    if (isPet() || m_summonProperties != nullptr)
     {
-        m_summonerGuid = unitOwner->getGuid();
-
-        if (!m_Properties)
-            return;
-
-        if (uint32_t slot = m_Properties->Slot)
-        {
-            WoWGuid guid = getGuid();
-
-            if (SummonHandler* summonHandler = unitOwner->getSummonInterface())
-            {
-                // Unsummon Summon in old Slot
-                if (summonHandler->m_SummonSlot[slot] && summonHandler->m_SummonSlot[slot] != guid.getGuidLowPart())
-                {
-                    Creature* oldSummon = unitOwner->getWorldMap()->getCreature(summonHandler->m_SummonSlot[slot]);
-                    if (oldSummon && oldSummon->isSummon())
-                        static_cast<Summon*>(oldSummon)->unSummon();
-                }
-                summonHandler->m_SummonSlot[slot] = guid.getGuidLowPart();
-            }
-        }
-
-        if (m_Properties->FactionID)
-            setFaction(m_Properties->FactionID);
-        else if (isVehicle() && unitOwner) // properties should be vehicle
+        if (m_summonProperties != nullptr && m_summonProperties->FactionID != 0)
+            setFaction(m_summonProperties->FactionID);
+        else
             setFaction(unitOwner->getFactionTemplate());
+
+        setCreatedByGuid(unitOwner->getGuid());
+        if (unitOwner->getSummonedByGuid() != 0)
+            setSummonedByGuid(unitOwner->getSummonedByGuid());
+        else
+            setSummonedByGuid(unitOwner->getGuid());
     }
 }
 
@@ -85,16 +116,20 @@ void Summon::Update(unsigned long time_passed)
         return;
     }
 
-    switch (getDespawnType())
+    switch (m_despawnType)
     {
-        case MANUAL_DESPAWN:
         case DEAD_DESPAWN:
             break;
+        case MANUAL_DESPAWN:
+        {
+            // Set correct despawn type if not set
+            m_despawnType = getDefaultDespawnTypeForSummon(this);
+        } break;
         case TIMED_DESPAWN:
         {
             if (getTimeLeft() <= time_passed)
             {
-                unSummon();
+                dieAndDisappearOnExpire();
                 return;
             }
 
@@ -106,7 +141,7 @@ void Summon::Update(unsigned long time_passed)
             {
                 if (getTimeLeft() <= time_passed)
                 {
-                    unSummon();
+                    dieAndDisappearOnExpire();
                     return;
                 }
 
@@ -142,97 +177,87 @@ void Summon::Update(unsigned long time_passed)
         {
             if (getDeathState() == CORPSE)
             {
+                // There is a small delay before summon should despawn
+                m_despawnType = CORPSE_TIMED_DESPAWN;
+                if (_hasExtendedDespawnDelayInDeath())
+                    setNewLifeTime(SUMMON_CORPSE_DESPAWN_EXTENDED_TIMER);
+                else
+                    setNewLifeTime(SUMMON_CORPSE_DESPAWN_DEFAULT_TIMER);
+                return;
+            }
+
+            if (getTimeLeft() <= time_passed)
+            {
+                dieAndDisappearOnExpire();
+                return;
+            }
+
+            setTimeLeft(getTimeLeft() - time_passed);
+        } break;
+        case TIMED_OR_DEAD_DESPAWN:
+        {
+            if (getDeathState() == DEAD)
+            {
                 unSummon();
                 return;
             }
 
-            if (!isInCombat())
+            if (getTimeLeft() <= time_passed)
             {
-                if (getTimeLeft() <= time_passed)
-                {
-                    unSummon();
-                    return;
-                }
-                else
-                {
-                    setTimeLeft(getTimeLeft() - time_passed);
-                }
-            }
-            else if (getTimeLeft() != getLifeTime())
-            {
-                setTimeLeft(getLifeTime());
-            }
-        } break;
-        case TIMED_OR_DEAD_DESPAWN:
-        {
-            if (!isInCombat() && isAlive())
-            {
-                if (getTimeLeft() <= time_passed)
-                {
-                    unSummon();
-                    return;
-                }
-                else
-                {
-                    setTimeLeft(getTimeLeft() - time_passed);
-                }
-            }
-            else if (getTimeLeft() != getLifeTime())
-            {
-                setTimeLeft(getLifeTime());
+                dieAndDisappearOnExpire();
+                return;
             }
 
+            setTimeLeft(getTimeLeft() - time_passed);
         } break;
         default:
+        {
             unSummon();
+        } break;
     }
+
+    // Call superclass method last in case if dead summon is removed from world
+    Creature::Update(time_passed);
 }
 
 void Summon::unSummon()
-{   
-    // If this summon is summoned by a totem, unsummon the totem also
-    if (getSummonerUnit() && getSummonerUnit()->isTotem())
-        dynamic_cast<TotemSummon*>(getSummonerUnit())->unSummon();
-
-    // Script Call
-    if (Unit* owner = getSummonerUnit())
-    {
-        if (owner->ToCreature() && owner->IsInWorld() && owner->ToCreature()->GetScript())
-            owner->ToCreature()->GetScript()->OnSummonDespawn(this);
-    }
-
-    if (getSummonerUnit())
-    {
-        if (getCreatedBySpellId() != 0)
-            getSummonerUnit()->removeAllAurasById(getCreatedBySpellId());
-
-        // Clear Our Summon Slot
-        if (m_Properties)
-        {
-            if (uint32_t slot = m_Properties->Slot)
-            {
-                WoWGuid guid = getGuid();
-                if (Unit* owner = getSummonerUnit())
-                {
-                    if (SummonHandler* summonHandler = owner->getSummonInterface())
-                    {
-                        if (summonHandler->m_SummonSlot[slot] == guid.getGuidLowPart())
-                            summonHandler->m_SummonSlot[slot] = 0;
-                    }
-                }
-            }
-        }
-    }
-
-    // Clear Owner
-    m_summonerGuid = 0;
-
+{
+    _onUnsummon();
     // Remove us
-    Despawn(10, 0);
+    Despawn(0, 0);
+}
+
+void Summon::dieAndDisappearOnExpire()
+{
+    // Most summons die and disappear shortly after when they expire
+    m_despawnType = CORPSE_TIMED_DESPAWN;
+    if (_hasExtendedDespawnDelayInDeath())
+        setNewLifeTime(SUMMON_CORPSE_DESPAWN_EXTENDED_TIMER);
+    else
+        setNewLifeTime(SUMMON_CORPSE_DESPAWN_DEFAULT_TIMER);
+
+    if (isAlive())
+        die(nullptr, 0, 0);
 }
 
 CreatureSummonDespawnType Summon::getDespawnType() const { return m_despawnType; }
 void Summon::setDespawnType(CreatureSummonDespawnType type) { m_despawnType = type; }
+
+WDB::Structures::SummonPropertiesEntry const* Summon::getSummonProperties() const { return m_summonProperties; }
+
+bool Summon::isSummonActive() const
+{
+    return m_summonActive;
+}
+
+bool Summon::isPermanentSummon() const
+{
+    if (m_lifetime == 0)
+        return true;
+
+    // Summon may have pre defined corpse remove time so check for despawn type
+    return m_despawnType != TIMED_OR_DEAD_DESPAWN && m_despawnType != TIMED_OR_CORPSE_DESPAWN && m_despawnType != TIMED_DESPAWN && m_despawnType != TIMED_DESPAWN_OUT_OF_COMBAT;
+}
 
 uint32_t Summon::getTimeLeft() const { return m_duration; }
 void Summon::setTimeLeft(uint32_t time) { m_duration = time; }
@@ -240,30 +265,50 @@ void Summon::setTimeLeft(uint32_t time) { m_duration = time; }
 uint32_t Summon::getLifeTime() const { return m_lifetime; }
 void Summon::setLifeTime(uint32_t time) { m_lifetime = time; }
 
+void Summon::setNewLifeTime(uint32_t time)
+{
+    m_lifetime = time;
+    m_duration = time;
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Override Object functions
 void Summon::OnPushToWorld()
 {
+    // Add summon to owner
+    if (m_unitOwner != nullptr && (m_summonProperties != nullptr || isPet()))
+        m_unitOwner->getSummonInterface()->addSummonToHandler(this);
+
     Creature::OnPushToWorld();
 }
 
 void Summon::OnPreRemoveFromWorld()
 {
-    if (getPlayerOwner() != nullptr)
-        getPlayerOwner()->sendDestroyObjectPacket(getGuid());
-
     // Make sure unit is unsummoned properly before removing from world
-    if (m_summonerGuid)
-        unSummon();
+    if (m_summonActive)
+        _onUnsummon();
+
+    //if (const auto plrOwner = getPlayerOwner())
+        //plrOwner->sendDestroyObjectPacket(getGuid());
+
+    m_unitOwner = nullptr;
+    Creature::OnPreRemoveFromWorld();
 }
 
 bool Summon::isSummon() const { return true; }
 
 void Summon::onRemoveInRangeObject(Object* object)
 {
-    // Remove us when we are Summoned by the Object which got removed
-    if (object->getGuid() == m_summonerGuid && m_Properties != nullptr)
-        unSummon();
+    if (m_summonProperties != nullptr || isPet())
+    {
+        // Remove non-scripted summon or pet when it goes out of range from owner
+        if (m_unitOwner != nullptr && object->getGuid() == m_unitOwner->getGuid())
+        {
+            // Delay unsummon a bit to prevent mutex loop in inrange vectors
+            sEventMgr.AddEvent(this, &Summon::unSummon, EVENT_PET_DELAYED_REMOVE, 10, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT | EVENT_FLAG_DELETES_OBJECT);
+            return;
+        }
+    }
 
     Creature::onRemoveInRangeObject(object);
 }
@@ -272,29 +317,29 @@ void Summon::onRemoveInRangeObject(Object* object)
 // Override Unit functions
 void Summon::die(Unit* pAttacker, uint32 damage, uint32 spellid)
 {
-    // If this summon is summoned by a totem, unsummon the totem on death
-    if (getUnitOwner() && getUnitOwner()->isTotem())
-        static_cast<TotemSummon*>(getUnitOwner())->unSummon();
-
     Creature::die(pAttacker, damage, spellid);
-}
 
-Unit* Summon::getSummonerUnit()
-{
-    return m_summonerGuid ? getWorldMapUnit(m_summonerGuid) : nullptr;
+    // If this summon is summoned by a totem, unsummon the totem on death
+    if (m_unitOwner != nullptr)
+    {
+        if (auto* const totemOwner = m_unitOwner->isTotem() ? dynamic_cast<TotemSummon*>(m_unitOwner) : nullptr)
+        {
+            // Prevent unsummon loop if owner is already dead
+            // Also delay unsummon a bit to prevent memory corruption
+            if (totemOwner->isSummonActive() && totemOwner->isAlive())
+                sEventMgr.AddEvent(totemOwner, &TotemSummon::unSummon, EVENT_PET_DELAYED_REMOVE, 10, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT | EVENT_FLAG_DELETES_OBJECT);
+        }
+    }
 }
 
 Unit* Summon::getUnitOwner()
 {
-    return getCreatedByGuid() ? getWorldMapUnit(getCreatedByGuid()) : nullptr;
+    return m_unitOwner;
 }
 
-Unit* Summon::getUnitOwnerOrSelf()
+Unit const* Summon::getUnitOwner() const
 {
-    if (auto* const unitOwner = getUnitOwner())
-        return unitOwner;
-
-    return this;
+    return m_unitOwner;
 }
 
 Player* Summon::getPlayerOwner()
@@ -308,22 +353,76 @@ Player* Summon::getPlayerOwner()
     return nullptr;
 }
 
+Player const* Summon::getPlayerOwner() const
+{
+    if (auto* const unitOwner = getUnitOwner())
+    {
+        if (unitOwner->isPlayer())
+            return dynamic_cast<Player const*>(unitOwner);
+    }
+
+    return nullptr;
+}
+
+void Summon::_onUnsummon()
+{
+    if (m_unitOwner != nullptr)
+    {
+        // If this summon is summoned by a totem, unsummon the totem also
+        if (auto* const totemOwner = m_unitOwner->isTotem() ? dynamic_cast<TotemSummon*>(m_unitOwner) : nullptr)
+        {
+            // Prevent unsummon loop if owner is already dead
+            if (totemOwner->isSummonActive() && totemOwner->isAlive())
+                totemOwner->unSummon();
+        }
+
+        // Script Call
+        if (m_unitOwner->ToCreature() && m_unitOwner->IsInWorld() && m_unitOwner->ToCreature()->GetScript())
+            m_unitOwner->ToCreature()->GetScript()->OnSummonDespawn(this);
+
+        if (getCreatedBySpellId() != 0)
+            m_unitOwner->removeAllAurasById(getCreatedBySpellId());
+
+        // Remove summon from owner
+        if (m_summonProperties != nullptr || isPet())
+            m_unitOwner->getSummonInterface()->removeSummonFromHandler(this);
+    }
+
+    // Prevent unsummon loop
+    m_summonActive = false;
+}
+
+bool Summon::_hasExtendedDespawnDelayInDeath() const
+{
+    if (m_summonProperties == nullptr)
+        return false;
+
+    switch (m_summonProperties->ID)
+    {
+        // Generic id that is used in many npc summon spells
+        case 67:
+        // Warlock Inferno uses only this id
+        case 711:
+        // Warlock Curse of Doom uses only this id
+        case 1221:
+        // Druid Force of Nature uses only this id
+        case 1562:
+            return true;
+        default:
+            break;
+    }
+
+    return false;
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 
 GuardianSummon::GuardianSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties) : Summon(GUID, properties) {}
-GuardianSummon::~GuardianSummon() {}
+GuardianSummon::~GuardianSummon() = default;
 
-void GuardianSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector& position, uint32_t duration, uint32_t spellid)
+void GuardianSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector const& position, uint32_t duration, uint32_t spellid)
 {
     Summon::load(properties_, pOwner, position, duration, spellid);
-
-    // Summoner
-    if (pOwner)
-    {
-        setCreatedByGuid(pOwner->getGuid());
-        setSummonedByGuid(pOwner->getGuid());
-        setFaction(pOwner->getFactionTemplate());
-    }
 
     // Stats
     setPowerType(POWER_TYPE_MANA);
@@ -336,26 +435,16 @@ void GuardianSummon::load(CreatureProperties const* properties_, Unit* pOwner, L
 
     m_aiInterface->Init(this, pOwner);
     m_aiInterface->setPetOwner(pOwner);
-
-    m_noRespawn = true;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
 CompanionSummon::CompanionSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties) : Summon(GUID, properties) {}
-CompanionSummon::~CompanionSummon() {}
+CompanionSummon::~CompanionSummon() = default;
 
-void CompanionSummon::load(CreatureProperties const* properties_, Unit* companionOwner, LocationVector& position, uint32_t duration, uint32_t spellid)
+void CompanionSummon::load(CreatureProperties const* properties_, Unit* companionOwner, LocationVector const& position, uint32_t duration, uint32_t spellid)
 {
     Summon::load(properties_, companionOwner, position, duration, spellid);
-
-    // Summoner
-    if (companionOwner)
-    {
-        setCreatedByGuid(companionOwner->getGuid());
-        setSummonedByGuid(companionOwner->getGuid());
-        setFaction(companionOwner->getFactionTemplate());
-    }
 
     setFaction(35);
     setLevel(1);
@@ -373,19 +462,11 @@ void CompanionSummon::load(CreatureProperties const* properties_, Unit* companio
 //////////////////////////////////////////////////////////////////////////////////////////
 
 PossessedSummon::PossessedSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties) : Summon(GUID, properties) {}
-PossessedSummon::~PossessedSummon() {}
+PossessedSummon::~PossessedSummon() = default;
 
-void PossessedSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector& position, uint32_t duration, uint32_t spellid)
+void PossessedSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector const& position, uint32_t duration, uint32_t spellid)
 {
     Summon::load(properties_, pOwner, position, duration, spellid);
-
-    // Summoner
-    if (pOwner)
-    {
-        setCreatedByGuid(pOwner->getGuid());
-        setSummonedByGuid(pOwner->getGuid());
-        setFaction(pOwner->getFactionTemplate());
-    }
 
     setLevel(pOwner->getLevel());
     setAItoUse(false);
@@ -395,19 +476,11 @@ void PossessedSummon::load(CreatureProperties const* properties_, Unit* pOwner, 
 //////////////////////////////////////////////////////////////////////////////////////////
 
 WildSummon::WildSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties) : Summon(GUID, properties) {}
-WildSummon::~WildSummon() {}
+WildSummon::~WildSummon() = default;
 
-void WildSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector& position, uint32_t duration, uint32_t spellid)
+void WildSummon::load(CreatureProperties const* properties_, Unit* pOwner, LocationVector const& position, uint32_t duration, uint32_t spellid)
 {
     Summon::load(properties_, pOwner, position, duration, spellid);
-
-    // Summoner
-    if (pOwner)
-    {
-        setCreatedByGuid(pOwner->getGuid());
-        setSummonedByGuid(pOwner->getGuid());
-        setFaction(pOwner->getFactionTemplate());
-    }
 
     setLevel(pOwner->getLevel());
 }
@@ -420,36 +493,23 @@ TotemSummon::TotemSummon(uint64_t guid, WDB::Structures::SummonPropertiesEntry c
     getThreatManager().initialize();
 }
 
-TotemSummon::~TotemSummon() {}
+TotemSummon::~TotemSummon() = default;
 
-void TotemSummon::load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellId)
+void TotemSummon::load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellId)
 {
     Summon::load(creatureProperties, unitOwner, position, duration, spellId);
 
-    const MySQLStructure::TotemDisplayIds* displayIds = nullptr;
-
-    // Summoner
-    if (unitOwner)
+    uint32_t displayId = 0;
+    if (unitOwner != nullptr)
     {
-        setCreatedByGuid(unitOwner->getGuid());
-        setSummonedByGuid(unitOwner->getGuid());
-        setFaction(unitOwner->getFactionTemplate());
-
-        displayIds = sMySQLStore.getTotemDisplayId(unitOwner->getRace(), creature_properties->Male_DisplayID);
-
-        setLevel(unitOwner->getLevel());
-    }
-    else
-    {
-        setLevel(1);
+        if (const auto displayIds = sMySQLStore.getTotemDisplayId(unitOwner->getRace(), creature_properties->Male_DisplayID))
+            displayId = displayIds->race_specific_id;
     }
 
-    uint32_t displayId;
-    if (displayIds != nullptr)
-        displayId = displayIds->race_specific_id;
-    else
+    if (displayId == 0)
         displayId = creature_properties->Male_DisplayID;
 
+    setLevel(unitOwner != nullptr ? unitOwner->getLevel() : 1);
     setRace(0);
     setClass(1); // Creature class warrior
     setGender(GENDER_NONE);
@@ -463,7 +523,10 @@ void TotemSummon::load(CreatureProperties const* creatureProperties, Unit* unitO
     setModCastSpeed(1.0f);
     setDynamicFlags(0);
 
-    if (unitOwner)
+    // Totems should always be unsummoned on death or when expired
+    m_despawnType = duration == 0 ? CORPSE_DESPAWN : TIMED_OR_CORPSE_DESPAWN;
+
+    if (unitOwner != nullptr)
     {
         for (uint8_t school = 0; school < TOTAL_SPELL_SCHOOLS; school++)
         {
@@ -474,22 +537,11 @@ void TotemSummon::load(CreatureProperties const* creatureProperties, Unit* unitO
         m_aiInterface->Init(this, unitOwner);
 
         setAItoUse(false);
-
-        if (unitOwner->isPlayer())
-        {
-            uint32_t slot = m_Properties->Slot;
-            if (slot >= SUMMON_SLOT_TOTEM_FIRE && slot < SUMMON_SLOT_MINIPET)
-                dynamic_cast<Player*>(unitOwner)->sendTotemCreatedPacket(static_cast<uint8_t>(slot - SUMMON_SLOT_TOTEM_FIRE), getGuid(), getTimeLeft(), getCreatedBySpellId());
-        }
     }
 }
 
 void TotemSummon::unSummon()
 {
-    ///\ todo: death animation for totems, should happen on unsummon
-    /*if (isAlive())
-        setDeathState(DEAD);*/
-
     interruptSpell();
     removeAllAuras();
 
@@ -506,16 +558,6 @@ void TotemSummon::OnPushToWorld()
 }
 
 bool TotemSummon::isTotem() const { return true; }
-
-//////////////////////////////////////////////////////////////////////////////////////////
-// Override Unit functions
-void TotemSummon::die(Unit* /*pAttacker*/, uint32_t /*damage*/, uint32_t /*spellid*/)
-{
-    // Clear health batch on death
-    clearHealthBatch();
-
-    unSummon();
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Misc

--- a/src/world/Objects/Units/Creatures/Summons/Summon.hpp
+++ b/src/world/Objects/Units/Creatures/Summons/Summon.hpp
@@ -6,7 +6,6 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "Objects/Units/Creatures/Creature.h"
-//#include "Objects/Units/Unit.hpp"
 
 namespace WDB::Structures
 {
@@ -17,15 +16,22 @@ class SERVER_DECL Summon : public Creature
 {
 public:
     Summon(uint64_t guid, WDB::Structures::SummonPropertiesEntry const* properties);
-    ~Summon();
+    virtual ~Summon();
 
-    virtual void load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellId);
+    virtual void load(CreatureProperties const* creatureProperties, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellId);
 
     virtual void unSummon();
+    void dieAndDisappearOnExpire();
 
     // Despawn Type
     CreatureSummonDespawnType getDespawnType() const;
     void setDespawnType(CreatureSummonDespawnType type);
+
+    // Summon properties
+    WDB::Structures::SummonPropertiesEntry const* getSummonProperties() const;
+
+    bool isSummonActive() const;
+    bool isPermanentSummon() const;
 
     // Duration
     uint32_t getTimeLeft() const;
@@ -35,36 +41,46 @@ public:
     uint32_t getLifeTime() const;
     void setLifeTime(uint32_t time);
 
+    // Resets life time and time left
+    void setNewLifeTime(uint32_t time);
+
     //////////////////////////////////////////////////////////////////////////////////////////
     // Override Object functions
-    void OnPushToWorld() override;
+    virtual void OnPushToWorld() override;
     void OnPreRemoveFromWorld() override;
     bool isSummon() const override;
     void onRemoveInRangeObject(Object* object) override;
-    void Update(unsigned long /*time_passed*/);
+    virtual void Update(unsigned long /*time_passed*/) override;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Override Unit functions
     void die(Unit* pAttacker, uint32 damage, uint32 spellid) override;
-    Unit* getUnitOwner() override;          // override creature function
-    Unit* getUnitOwnerOrSelf() override;    // override creature function
-    Player* getPlayerOwner() override;      // override creature function
+    // Returns unit owner
+    Unit* getUnitOwner() override;
+    // Returns unit owner
+    Unit const* getUnitOwner() const override;
+    // Returns player owner
+    Player* getPlayerOwner() override;
+    // Returns player owner
+    Player const* getPlayerOwner() const override;
 
-    //////////////////////////////////////////////////////////////////////////////////////////
-    // Summoner Unit functions
-    uint64_t getSummonerGuid() const { return m_summonerGuid; }
+protected:
+    void _onUnsummon();
+    bool _hasExtendedDespawnDelayInDeath() const;
 
-    // Summon Information from DBC, when this is nullptr its mostly an Scripted Summon
-    WDB::Structures::SummonPropertiesEntry const* const m_Properties;
-
-private:
-    Unit* getSummonerUnit();
+    Unit* m_unitOwner = nullptr;
+    bool m_summonActive = false;
 
     // This determines how Despawning of our Summon is Handled
     CreatureSummonDespawnType m_despawnType = MANUAL_DESPAWN;
-    uint32_t m_duration = 0;    // Duration Left
-    uint32_t m_lifetime = 0;    // Max Duration
-    uint64_t m_summonerGuid = 0;
+
+    // Summon Information from DBC, when this is nullptr its mostly an Scripted Summon
+    WDB::Structures::SummonPropertiesEntry const* const m_summonProperties;
+
+    // Duration Left
+    uint32_t m_duration = 0;
+    // Max Duration
+    uint32_t m_lifetime = 0;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +92,7 @@ public:
     GuardianSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties);
     ~GuardianSummon();
 
-    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellid) override;
+    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellid) override;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -88,7 +104,7 @@ public:
     CompanionSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties);
     ~CompanionSummon();
 
-    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellid) override;
+    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellid) override;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -100,7 +116,7 @@ public:
     PossessedSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties);
     ~PossessedSummon();
 
-    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellid) override;
+    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellid) override;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -112,7 +128,7 @@ public:
     WildSummon(uint64_t GUID, WDB::Structures::SummonPropertiesEntry const* properties);
     ~WildSummon();
 
-    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellid) override;
+    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellid) override;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -123,7 +139,7 @@ public:
     TotemSummon(uint64_t guid, WDB::Structures::SummonPropertiesEntry const* properties);
     ~TotemSummon();
 
-    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector& position, uint32_t duration, uint32_t spellId) override;
+    void load(CreatureProperties const* properties_, Unit* unitOwner, LocationVector const& position, uint32_t duration, uint32_t spellId) override;
 
     void unSummon() override;
 
@@ -131,10 +147,6 @@ public:
     // Override Object functions
     void OnPushToWorld() override;
     bool isTotem() const override;
-
-    //////////////////////////////////////////////////////////////////////////////////////////
-    // Override Unit functions
-    void die(Unit* /*pAttacker*/, uint32_t /*damage*/, uint32_t /*spellid*/) override;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc

--- a/src/world/Objects/Units/Creatures/Summons/SummonDefines.hpp
+++ b/src/world/Objects/Units/Creatures/Summons/SummonDefines.hpp
@@ -26,8 +26,8 @@ enum SummonType
 
 enum SummonSlot : uint8_t
 {
-    SUMMON_SLOT_PET                 = 0,
-    SUMMON_SLOT_TOTEM_FIRE          = 1,
+    SUMMON_SLOT_NONE                = 0,
+    SUMMON_SLOT_TOTEM_FIRE          = 1,    // Not just totem, seems to be default slot for different summon types
     SUMMON_SLOT_TOTEM_EARTH         = 2,
     SUMMON_SLOT_TOTEM_WATER         = 3,
     SUMMON_SLOT_TOTEM_AIR           = 4,
@@ -35,4 +35,10 @@ enum SummonSlot : uint8_t
     SUMMON_SLOT_QUEST               = 6,
 
     MAX_SUMMON_SLOT
+};
+
+enum SummonCorpseDespawnTimers : uint16_t
+{
+    SUMMON_CORPSE_DESPAWN_DEFAULT_TIMER     = 400,
+    SUMMON_CORPSE_DESPAWN_EXTENDED_TIMER    = 10000
 };

--- a/src/world/Objects/Units/Creatures/Summons/SummonHandler.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/SummonHandler.cpp
@@ -4,95 +4,294 @@ This file is released under the MIT license. See README-MIT for more information
 */
 
 #include "SummonHandler.hpp"
-#include "Map/Maps/WorldMap.hpp"
+#include "Logging/Logger.hpp"
+#include "Objects/Units/Creatures/AIInterface.h"
+#include "Objects/Units/Creatures/Pet.h"
 #include "Objects/Units/Creatures/Summons/Summon.hpp"
+#include "Objects/Units/Players/Player.hpp"
+#include "Storage/WDB/WDBStructures.hpp"
 
-SummonHandler::SummonHandler()
-{
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
-        m_SummonSlot[i] = 0;
-}
+SummonHandler::SummonHandler(Unit* owner) : m_owner(owner)
+{ }
 
 SummonHandler::~SummonHandler()
 {
     removeAllSummons();
 }
 
-void SummonHandler::removeAllSummons(bool totemsOnly/* = false*/)
+// Needed to avoid implicit operator generation in header without knowing object size
+SummonHandler& SummonHandler::operator=(SummonHandler const&) = default;
+
+void SummonHandler::addSummonToHandler(Summon* summon)
 {
-    if (!m_Owner || !m_Owner->getWorldMap())
+    if (summon == nullptr || summon->getUnitOwner() != m_owner)
         return;
 
-    for (uint8 i = 0; i < MAX_SUMMON_SLOT; ++i)
+    if (summon->isPet())
     {
-        if (m_SummonSlot[i])
+        m_summons.push_back(summon);
+
+        // Check if current pet needs to be updated
+        if (m_pet == nullptr || (m_pet->isPermanentSummon() || summon->isPermanentSummon() || m_pet->getEntry() != summon->getEntry()))
         {
-            if (auto* const summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
+            m_pet = dynamic_cast<Pet*>(summon);
+            if (m_pet != nullptr)
             {
-                if (summon->isTotem())
-                    dynamic_cast<TotemSummon*>(summon)->unSummon();
-                else if (!totemsOnly)
-                    dynamic_cast<Summon*>(summon)->unSummon();
+                m_owner->setSummonGuid(m_pet->getGuid());
+                m_pet->SendSpellsToOwner();
             }
         }
+        return;
+    }
+
+    // Do not add scripted summons to handler
+    if (summon->getSummonProperties() == nullptr)
+        return;
+
+    switch (summon->getSummonProperties()->Slot)
+    {
+        // Not handled
+        case SUMMON_SLOT_NONE:
+            break;
+        case SUMMON_SLOT_TOTEM_FIRE:
+        case SUMMON_SLOT_TOTEM_EARTH:
+        case SUMMON_SLOT_TOTEM_WATER:
+        case SUMMON_SLOT_TOTEM_AIR:
+        case SUMMON_SLOT_MINIPET:
+        case SUMMON_SLOT_QUEST:
+        {
+            const uint8_t slot = summon->getSummonProperties()->Slot - 1;
+
+            // Send summon to totem bar
+            if (summon->getSummonProperties()->Slot != SUMMON_SLOT_MINIPET)
+            {
+                if (auto* const playerUnit = m_owner->isPlayer() ? dynamic_cast<Player*>(m_owner) : nullptr)
+                    playerUnit->sendTotemCreatedPacket(slot, summon->getGuid(), summon->getTimeLeft(), summon->getCreatedBySpellId());
+            }
+
+            // Remove old summon if exists
+            if (auto* const oldSummon = m_summonSlots[slot])
+                oldSummon->unSummon();
+
+            m_summonSlots[slot] = summon;
+        } break;
+        default:
+        {
+            sLogger.failure("SummonHandler::addSummonToHandler : Unknown pet slot {}", summon->getSummonProperties()->Slot);
+        } break;
+    }
+
+    m_summons.push_back(summon);
+}
+
+void SummonHandler::removeSummonFromHandler(Summon* summon)
+{
+    if (summon == nullptr || summon->getUnitOwner() != m_owner)
+        return;
+
+    if (summon->isPet())
+    {
+        std::erase(m_summons, summon);
+
+        if (m_pet != nullptr && m_pet->getGuid() == summon->getGuid())
+        {
+            // Current pet was removed, try find another controllable pet
+            auto foundControllablePet = false;
+            if (!m_summons.empty())
+            {
+                Summon* newCurrentPet = nullptr;
+                for (const auto& summon : m_summons)
+                {
+                    if (!summon->isPet() || !summon->isAlive())
+                        continue;
+
+                    if (summon->isPermanentSummon())
+                    {
+                        newCurrentPet = summon;
+                        break;
+                    }
+                    else if (newCurrentPet == nullptr)
+                    {
+                        // Use possibly this pet but try find permanent pet
+                        newCurrentPet = summon;
+                    }
+                }
+
+                if (newCurrentPet != nullptr)
+                {
+                    foundControllablePet = true;
+                    m_pet = dynamic_cast<Pet*>(newCurrentPet);
+                    if (m_pet != nullptr)
+                    {
+                        m_owner->setSummonGuid(m_pet->getGuid());
+                        m_pet->SendSpellsToOwner();
+                    }
+                }
+            }
+
+            if (!foundControllablePet)
+            {
+                m_pet = nullptr;
+                m_owner->setSummonGuid(0);
+                if (const auto plrOwner = m_owner->isPlayer() ? dynamic_cast<Player*>(m_owner) : nullptr)
+                    plrOwner->sendEmptyPetSpellList();
+            }
+        }
+        return;
+    }
+
+    if (summon->getSummonProperties() == nullptr)
+        return;
+
+    switch (summon->getSummonProperties()->Slot)
+    {
+        // Not handled
+        case SUMMON_SLOT_NONE:
+            break;
+        case SUMMON_SLOT_TOTEM_FIRE:
+        case SUMMON_SLOT_TOTEM_EARTH:
+        case SUMMON_SLOT_TOTEM_WATER:
+        case SUMMON_SLOT_TOTEM_AIR:
+        case SUMMON_SLOT_MINIPET:
+        case SUMMON_SLOT_QUEST:
+        {
+            const uint8_t slot = summon->getSummonProperties()->Slot - 1;
+            m_summonSlots[slot] = nullptr;
+        } break;
+        default:
+        {
+            sLogger.failure("SummonHandler::removeSummonFromHandler : Unknown pet slot {}", summon->getSummonProperties()->Slot);
+        } break;
+    }
+
+    std::erase(m_summons, summon);
+}
+
+Pet* SummonHandler::getPet() const
+{
+    return m_pet;
+}
+
+std::vector<Summon*> const& SummonHandler::getSummons() const
+{
+    return m_summons;
+}
+
+void SummonHandler::removeAllSummons()
+{
+    // Also removes m_pet and summons in m_summonSlots
+    for (auto itr = m_summons.cbegin(); itr != m_summons.cend();)
+    {
+        (*itr)->unSummon();
+        itr = m_summons.cbegin();
     }
 }
 
 void SummonHandler::setPvPFlags(bool set)
 {
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return;
-
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
+    for (const auto& summon : m_summons)
     {
-        if (Creature* summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
-        {
-            if (set)
-                summon->setPvpFlag();
-            else
-                summon->removePvpFlag();
-        }
+        if (set)
+            summon->setPvpFlag();
+        else
+            summon->removePvpFlag();
     }
 }
 
 void SummonHandler::setFFAPvPFlags(bool set)
 {
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return;
-
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
+    for (const auto& summon : m_summons)
     {
-        if (m_SummonSlot[i])
-        {
-            if (Creature* summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
-            {
-                if (set)
-                    summon->setFfaPvpFlag();
-                else
-                    summon->removeFfaPvpFlag();
-            }
-        }
+        if (set)
+            summon->setFfaPvpFlag();
+        else
+            summon->removeFfaPvpFlag();
     }
 }
 
 void SummonHandler::setSanctuaryFlags(bool set)
 {
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return;
-
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
+    for (const auto& summon : m_summons)
     {
-        if (m_SummonSlot[i])
+        if (set)
+            summon->setSanctuaryFlag();
+        else
+            summon->removeSanctuaryFlag();
+    }
+}
+
+void SummonHandler::setPhase(uint8_t command, uint32_t newPhase)
+{
+    for (const auto& summon : m_summons)
+        summon->setPhase(command, newPhase);
+}
+
+void SummonHandler::notifyOnOwnerSpeedChange(UnitSpeedType type, float_t rate, bool current)
+{
+    for (const auto& summon : m_summons)
+        summon->setSpeedRate(type, rate, current);
+}
+
+void SummonHandler::notifyOnOwnerAttacked(Unit* attacker)
+{
+    for (const auto& summon : m_summons)
+    {
+        if (summon->getAIInterface()->getReactState() != REACT_PASSIVE)
         {
-            if (Creature* summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
-            {
-                if (set)
-                    summon->setSanctuaryFlag();
-                else
-                    summon->removeSanctuaryFlag();
-            }
+            summon->getAIInterface()->onHostileAction(attacker);
+            // todo: handle this in pet system
+            if (auto* const pet = summon->isPet() ? dynamic_cast<Pet*>(summon) : nullptr)
+                pet->HandleAutoCastEvent(AUTOCAST_EVENT_OWNER_ATTACKED);
         }
     }
+}
+
+void SummonHandler::notifyOnPetDeath(Summon* pet)
+{
+    if (pet == nullptr || pet->getUnitOwner() != m_owner)
+        return;
+
+    if (m_pet != nullptr && m_pet != pet)
+        return;
+
+    // Some spells summon multiple pets like druid's Force of Nature
+    // If one of those pets die, summon guid should be updated to one that is alive
+    for (const auto& summon : m_summons)
+    {
+        if (!summon->isPet())
+            continue;
+
+        if (summon->getEntry() == pet->getEntry() && summon->isAlive())
+        {
+            m_pet = dynamic_cast<Pet*>(summon);
+            if (m_pet != nullptr)
+            {
+                m_owner->setSummonGuid(m_pet->getGuid());
+                m_pet->SendSpellsToOwner();
+            }
+            break;
+        }
+    }
+}
+
+Summon* SummonHandler::getSummonWithEntry(uint32_t entry) const
+{
+    for (const auto& summon : m_summons)
+    {
+        if (entry == summon->getEntry())
+            return summon;
+    }
+
+    return nullptr;
+}
+
+Summon* SummonHandler::getSummonInSlot(SummonSlot slot) const
+{
+    if (slot == SUMMON_SLOT_NONE || slot >= MAX_SUMMON_SLOT)
+        return nullptr;
+
+    const uint8_t summonSlot = slot - 1;
+    return m_summonSlots[summonSlot];
 }
 
 bool SummonHandler::hasTotemInSlot(SummonSlot slot) const
@@ -100,55 +299,18 @@ bool SummonHandler::hasTotemInSlot(SummonSlot slot) const
     if (slot < SUMMON_SLOT_TOTEM_FIRE || slot > SUMMON_SLOT_TOTEM_AIR)
         return false;
 
-    return m_SummonSlot[slot] != 0 ? true : false;
+    const auto* totem = getSummonInSlot(slot);
+    return totem != nullptr && totem->isTotem();
 }
 
-TotemSummon* SummonHandler::getTotemInSlot(SummonSlot slot) const
+void SummonHandler::killAllTotems() const
 {
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return nullptr;
-
-    if (slot < SUMMON_SLOT_TOTEM_FIRE || slot > SUMMON_SLOT_TOTEM_AIR)
-        return nullptr;
-
-    return static_cast<TotemSummon*>(m_Owner->getWorldMap()->getCreature(m_SummonSlot[slot]));
-}
-
-Summon* SummonHandler::getSummonWithEntry(uint32_t entry) const
-{
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return nullptr;
-
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
+    for (uint8_t i = SUMMON_SLOT_TOTEM_FIRE; i <= SUMMON_SLOT_TOTEM_AIR; ++i)
     {
-        if (Creature* summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
-        {
-            if (entry == summon->getEntry())
-                return static_cast<Summon*>(summon);
-        }
+        auto* const totem = getSummonInSlot(static_cast<SummonSlot>(i));
+        if (totem == nullptr || !totem->isTotem())
+            continue;
+
+        totem->dieAndDisappearOnExpire();
     }
-
-    return nullptr;
-}
-
-void SummonHandler::getTotemSpellIds(std::vector<uint32_t>& spellIds)
-{
-    if (!m_Owner || !m_Owner->getWorldMap())
-        return;
-
-    for (uint8_t i = 0; i < MAX_SUMMON_SLOT; ++i)
-    {
-        if (Creature* summon = m_Owner->getWorldMap()->getCreature(m_SummonSlot[i]))
-        {
-            if (summon->isTotem() && summon->getCreatedBySpellId())
-            {
-                spellIds.push_back(summon->getCreatedBySpellId());
-            }
-        }
-    }
-}
-
-void SummonHandler::setUnitOwner(Unit* owner)
-{
-    m_Owner = owner;
 }

--- a/src/world/Objects/Units/Creatures/Summons/SummonHandler.hpp
+++ b/src/world/Objects/Units/Creatures/Summons/SummonHandler.hpp
@@ -8,34 +8,63 @@ This file is released under the MIT license. See README-MIT for more information
 #include "CommonTypes.hpp"
 #include "SummonDefines.hpp"
 
+#include <array>
 #include <vector>
 
+class Pet;
 class Summon;
 class TotemSummon;
 class Unit;
+enum UnitSpeedType : uint8_t;
 
 class SERVER_DECL SummonHandler
 {
 public:
-    SummonHandler();
+    SummonHandler(Unit* owner);
     ~SummonHandler();
 
-    void removeAllSummons(bool totemsOnly = false);
+    SummonHandler& operator=(SummonHandler const&);
+
+    // Adds summon to interface
+    // Should only be called from Summon::OnPushToWorld
+    void addSummonToHandler(Summon* summon);
+    // Removes summon from interface
+    // Should only be called from Summon::unSummon
+    void removeSummonFromHandler(Summon* summon);
+
+    Pet* getPet() const;
+    std::vector<Summon*> const& getSummons() const;
+
+    // Unsummons all pets, guardians and totems
+    void removeAllSummons();
 
     void setPvPFlags(bool set);
     void setFFAPvPFlags(bool set);
     void setSanctuaryFlags(bool set);
 
-    bool hasTotemInSlot(SummonSlot slot) const;
-    TotemSummon* getTotemInSlot(SummonSlot slot) const;
+    void setPhase(uint8_t command, uint32_t newPhase);
+
+    void notifyOnOwnerSpeedChange(UnitSpeedType type, float_t rate, bool current);
+    void notifyOnOwnerAttacked(Unit* attacker);
+    void notifyOnPetDeath(Summon* pet);
+
     Summon* getSummonWithEntry(uint32_t entry) const;
+    Summon* getSummonInSlot(SummonSlot slot) const;
 
-    void getTotemSpellIds(std::vector<uint32_t> &spellIds);
+    bool hasTotemInSlot(SummonSlot slot) const;
+    void killAllTotems() const;
 
-    uint32_t m_SummonSlot[MAX_SUMMON_SLOT];
+private:
+    Unit* m_owner = nullptr;
 
-    void setUnitOwner(Unit* owner);
-
-protected:
-    Unit* m_Owner = nullptr;
+    // Current permanent pet
+    Pet* m_pet = nullptr;
+    // Summons with slot (i.e. totems)
+    // Skip SUMMON_SLOT_NONE
+    std::array<Summon*, (MAX_SUMMON_SLOT - 1)> m_summonSlots = { nullptr };
+    // All guardians, pets, totems, minipets etc
+    // Note; contains also current permanent pet and all summons from m_summonSlots
+    // TODO: minipet probably should not be in summons vector?
+    std::vector<Summon*> m_summons;
+    // TODO: unit summoned gameobjects
 };

--- a/src/world/Objects/Units/Creatures/Vehicle.cpp
+++ b/src/world/Objects/Units/Creatures/Vehicle.cpp
@@ -573,7 +573,7 @@ bool Vehicle::tryAddPassenger(Unit* passenger, SeatMap::iterator &Seat)
         if (!veSeat->hasFlag(WDB::Structures::VehicleSeatFlagsB::VEHICLE_SEAT_FLAG_B_KEEP_PET))
         {
             // Unsummon Pets
-            player->dismissActivePets();
+            player->unSummonPetTemporarily();
         }
     }
 

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -80,6 +80,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Server/Packets/SmsgLootReleaseResponse.h"
 #include "Server/Packets/SmsgLootRemoved.h"
 #include "Server/Packets/SmsgInstanceReset.h"
+#include "Server/Packets/SmsgStableResult.h"
 #include "Server/World.h"
 #include "Server/WorldSocket.h"
 #include "Server/Packets/SmsgContactList.h"
@@ -249,8 +250,6 @@ Player::~Player()
     if (Player* inviterPlayer = sObjectMgr.getPlayer(getGroupInviterId()))
         inviterPlayer->setGroupInviterId(0);
 
-    dismissActivePets();
-
     if (m_duelPlayer != nullptr)
         m_duelPlayer->m_duelPlayer = nullptr;
 
@@ -281,16 +280,13 @@ Player::~Player()
         delete _voidStorageItems[i];
 #endif
 
-    for (auto pet = m_pets.begin(); pet != m_pets.end(); ++pet)
-        delete pet->second;
-
     delete m_mailBox;
 #if VERSION_STRING > TBC
     delete m_achievementMgr;
 #endif
     delete m_taxi;
 
-    m_pets.clear();
+    m_cachedPets.clear();
     removeGarbageItems();
 }
 
@@ -453,10 +449,6 @@ void Player::Update(unsigned long time_passed)
     if (time_passed >= m_partyUpdateTimer)
     {
         sendUpdateToOutOfRangeGroupMembers();
-
-        // Remove also garbage items
-        removeGarbageItems();
-
         m_partyUpdateTimer = 1000;
     }
     else
@@ -467,6 +459,7 @@ void Player::Update(unsigned long time_passed)
     // Update items
     if (m_itemUpdateTimer >= 1000)
     {
+        removeGarbageItems();
         getItemInterface()->update(m_itemUpdateTimer);
         m_itemUpdateTimer = 0;
     }
@@ -688,6 +681,9 @@ void Player::OnPushToWorld()
         resetTalents();
         m_resetTalents = false;
     }
+
+    summonTemporarilyUnsummonedPet();
+
 #if VERSION_STRING == Mop
     updateVisibility();
 
@@ -735,9 +731,8 @@ void Player::removeFromWorld()
     //clear buyback
     getItemInterface()->EmptyBuyBack();
 
-    getSummonInterface()->removeAllSummons();
-    dismissActivePets();
-    removeFieldSummon();
+    // Keep current pet active, Unit::RemoveFromWorld removes other summons
+    unSummonPetTemporarily();
 
     if (m_summonedObject)
     {
@@ -2055,9 +2050,7 @@ void Player::setPhase(uint8_t command, uint32_t newPhase)
 #endif
     }
 
-    for (auto pet : getSummons())
-        if (pet)
-            pet->setPhase(command, newPhase);
+    getSummonInterface()->setPhase(command, newPhase);
 
     if (Unit* charm = m_WorldMap->getUnit(getCharmGuid()))
         charm->setPhase(command, newPhase);
@@ -2719,11 +2712,11 @@ void Player::applyLevelInfo(uint32_t newLevel)
 
     if (getClass() == WARLOCK)
     {
-        const auto pet = getFirstPetFromSummons();
+        const auto pet = getPet();
         if (pet != nullptr && pet->IsInWorld() && pet->isAlive())
         {
             pet->setLevel(newLevel);
-            pet->ApplyStatsForLevel();
+            pet->applyStatsForLevel();
             pet->UpdateSpellList();
         }
     }
@@ -2733,17 +2726,17 @@ void Player::applyLevelInfo(uint32_t newLevel)
     m_playedTime[0] = 0;
 }
 
-bool Player::isClassMage() { return false; }
-bool Player::isClassDeathKnight() { return false; }
-bool Player::isClassPriest() { return false; }
-bool Player::isClassRogue() { return false; }
-bool Player::isClassShaman() { return false; }
-bool Player::isClassHunter() { return false; }
-bool Player::isClassWarlock() { return false; }
-bool Player::isClassWarrior() { return false; }
-bool Player::isClassPaladin() { return false; }
-bool Player::isClassMonk() { return false; }
-bool Player::isClassDruid() { return false; }
+bool Player::isClassMage() const { return false; }
+bool Player::isClassDeathKnight() const { return false; }
+bool Player::isClassPriest() const { return false; }
+bool Player::isClassRogue() const { return false; }
+bool Player::isClassShaman() const { return false; }
+bool Player::isClassHunter() const { return false; }
+bool Player::isClassWarlock() const { return false; }
+bool Player::isClassWarrior() const { return false; }
+bool Player::isClassPaladin() const { return false; }
+bool Player::isClassMonk() const { return false; }
+bool Player::isClassDruid() const { return false; }
 
 PlayerTeam Player::getTeam() const { return m_team == TEAM_ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE; }
 PlayerTeam Player::getBgTeam() const { return m_bgTeam == TEAM_ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE; }
@@ -2769,7 +2762,23 @@ Unit* Player::getUnitOwner()
     return nullptr;
 }
 
+Unit const* Player::getUnitOwner() const
+{
+    if (getCharmedByGuid() != 0)
+        return getWorldMapUnit(getCharmedByGuid());
+
+    return nullptr;
+}
+
 Unit* Player::getUnitOwnerOrSelf()
+{
+    if (auto* const unitOwner = getUnitOwner())
+        return unitOwner;
+
+    return this;
+}
+
+Unit const* Player::getUnitOwnerOrSelf() const
 {
     if (auto* const unitOwner = getUnitOwner())
         return unitOwner;
@@ -2785,7 +2794,23 @@ Player* Player::getPlayerOwner()
     return nullptr;
 }
 
+Player const* Player::getPlayerOwner() const
+{
+    if (getCharmedByGuid() != 0)
+        return getWorldMapPlayer(getCharmedByGuid());
+
+    return nullptr;
+}
+
 Player* Player::getPlayerOwnerOrSelf()
+{
+    if (auto* const plrOwner = getPlayerOwner())
+        return plrOwner;
+
+    return this;
+}
+
+Player const* Player::getPlayerOwnerOrSelf() const
 {
     if (auto* const plrOwner = getPlayerOwner())
         return plrOwner;
@@ -5509,7 +5534,7 @@ void Player::_addSpell(uint32_t spellId, uint16_t fromSkill/* = 0*/, bool learni
                 (getShapeShiftMask() == 0 && (spellInfo->getAttributesExB() & ATTRIBUTESEXB_NOT_NEED_SHAPESHIFT)))
             {
                 // TODO: temporarily check for this custom flag, will be removed when spell system handles pets properly!
-                if (((spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET) == 0) || (spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET && getFirstPetFromSummons() != nullptr))
+                if (((spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET) == 0) || (spellInfo->custom_c_is_flags & SPELL_FLAG_IS_EXPIREING_WITH_PET && getPet() != nullptr))
                     castSpell(getGuid(), spellInfo, true);
             }
         }
@@ -5949,9 +5974,11 @@ void Player::resetTalents()
             _removeSpell(tmpTalent->RankID[rank], false, false, true, true);
     }
 
-    // Unsummon pet
-    if (getFirstPetFromSummons() != nullptr)
-        getFirstPetFromSummons()->Dismiss();
+    // Unsummon current pet or set temporarily unsummoned pet offline
+    if (getPet() != nullptr)
+        getPet()->unSummon();
+    else
+        setTemporarilyUnsummonedPetsOffline();
 
     // Check offhand
     unEquipOffHandIfRequired();
@@ -6132,8 +6159,8 @@ void Player::smsg_TalentsInfo([[maybe_unused]]bool SendPetTalents)
     data << uint8_t(SendPetTalents ? 1 : 0);
     if (SendPetTalents)
     {
-        if (getFirstPetFromSummons() != nullptr)
-            getFirstPetFromSummons()->SendTalentsToOwner();
+        if (getPet() != nullptr)
+            getPet()->SendTalentsToOwner();
         return;
     }
     else
@@ -6217,9 +6244,11 @@ void Player::activateTalentSpec([[maybe_unused]]uint8_t specId)
     if (specId >= MAX_SPEC_COUNT || m_talentActiveSpec >= MAX_SPEC_COUNT || m_talentActiveSpec == specId)
         return;
 
-    // Dismiss pet
-    if (getFirstPetFromSummons() != nullptr)
-        getFirstPetFromSummons()->Dismiss();
+    // Dismiss current pet or set temporarily unsummoned pet offline
+    if (getPet() != nullptr)
+        getPet()->unSummon();
+    else
+        setTemporarilyUnsummonedPetsOffline();
 
     // Reset action buttons on client
     sendActionBars(2);
@@ -7240,15 +7269,18 @@ uint8_t Player::getRaidDifficulty()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// Die, Kill, Corpse & Repop
+// Die, Corpse & Repop
 void Player::die(Unit* unitAttacker, uint32_t /*damage*/, uint32_t /*spellId*/)
 {
+    if (getDeathState() != ALIVE)
+        return;
+
 #ifdef FT_VEHICLES
     callExitVehicle();
 #endif
 
 #if VERSION_STRING > TBC
-    if (isPlayer())
+    if (unitAttacker != nullptr)
     {
         updateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_DEATH, 1, 0, 0);
         updateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_DEATH_AT_MAP, GetMapId(), 1, 0);
@@ -7260,11 +7292,14 @@ void Player::die(Unit* unitAttacker, uint32_t /*damage*/, uint32_t /*spellId*/)
     }
 #endif
 
-    if (!sHookInterface.OnPreUnitDie(unitAttacker, this))
+    if (unitAttacker != nullptr && !sHookInterface.OnPreUnitDie(unitAttacker, this))
         return;
 
-    if (!unitAttacker->isPlayer())
+    if (unitAttacker != nullptr && !unitAttacker->isPlayer())
         calcDeathDurabilityLoss(0.10);
+
+    setDeathState(JUST_DIED);
+    eventDeath();
 
     if (getChannelObjectGuid() != 0)
     {
@@ -7307,7 +7342,16 @@ void Player::die(Unit* unitAttacker, uint32_t /*damage*/, uint32_t /*spellId*/)
     smsg_AttackStop(unitAttacker);
     eventAttackStop();
 
-    if (m_WorldMap && m_WorldMap->getScript())
+    addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
+    setDynamicFlags(0);
+
+    m_session->SendPacket(SmsgCancelCombat().serialise().get());
+
+    WorldPacket data(SMSG_CANCEL_AUTO_REPEAT, 8);
+    data << GetNewGUID();
+    sendMessageToSet(&data, false);
+
+    if (unitAttacker != nullptr && m_WorldMap && m_WorldMap->getScript())
         m_WorldMap->getScript()->OnPlayerDeath(this, unitAttacker);
 
     uint32_t selfResSpellId = 0;
@@ -7330,19 +7374,30 @@ void Player::die(Unit* unitAttacker, uint32_t /*damage*/, uint32_t /*spellId*/)
     setSelfResurrectSpell(selfResSpellId);
     setMountDisplayId(0);
 
-    if (unitAttacker->IsInWorld() && unitAttacker->isCreature() && static_cast<Creature*>(unitAttacker)->GetScript())
-        static_cast<Creature*>(unitAttacker)->GetScript()->OnTargetDied(this);
+    if (unitAttacker != nullptr)
+    {
+        if (unitAttacker->IsInWorld() && unitAttacker->isCreature() && static_cast<Creature*>(unitAttacker)->GetScript())
+            static_cast<Creature*>(unitAttacker)->GetScript()->OnTargetDied(this);
 
-    unitAttacker->getAIInterface()->eventOnTargetDied(this);
-    unitAttacker->smsg_AttackStop(this);
+        unitAttacker->getAIInterface()->eventOnTargetDied(this);
+        unitAttacker->smsg_AttackStop(this);
+    }
 
     getCombatHandler().clearCombat();
 
     m_underwaterTime = 0;
     m_underwaterState = 0;
 
+    setMoveRoot(true);
+    sendStopMirrorTimerPacket(MIRROR_TYPE_FATIGUE);
+    sendStopMirrorTimerPacket(MIRROR_TYPE_BREATH);
+    sendStopMirrorTimerPacket(MIRROR_TYPE_FIRE);
+
     getSummonInterface()->removeAllSummons();
-    dismissActivePets();
+
+    // On player death set all pets offline
+    // If player was i.e. mounted with pet inactive when they died its possible to get pet stuck in weird state
+    setTemporarilyUnsummonedPetsOffline();
 
     setHealth(0);
 
@@ -7358,39 +7413,7 @@ void Player::die(Unit* unitAttacker, uint32_t /*damage*/, uint32_t /*spellId*/)
         }
     }
 
-    kill();
-
     clearHealthBatch();
-
-    if (m_WorldMap->getBaseMap()->isBattlegroundOrArena() && reinterpret_cast<BattlegroundMap*>(m_WorldMap)->getBattleground())
-        reinterpret_cast<BattlegroundMap*>(m_WorldMap)->getBattleground()->HookOnUnitDied(this);
-}
-
-void Player::kill()
-{
-    if (getDeathState() != ALIVE)
-        return;
-
-    setDeathState(JUST_DIED);
-
-    if (m_bg)
-        m_bg->HookOnPlayerDeath(this);
-
-    eventDeath();
-
-    m_session->SendPacket(SmsgCancelCombat().serialise().get());
-
-    WorldPacket data(SMSG_CANCEL_AUTO_REPEAT, 8);
-    data << GetNewGUID();
-    sendMessageToSet(&data, false);
-
-    setMoveRoot(true);
-    sendStopMirrorTimerPacket(MIRROR_TYPE_FATIGUE);
-    sendStopMirrorTimerPacket(MIRROR_TYPE_BREATH);
-    sendStopMirrorTimerPacket(MIRROR_TYPE_FIRE);
-
-    addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
-    setDynamicFlags(0);
 
     if (getClass() == WARRIOR)
         setPower(POWER_TYPE_RAGE, 0);
@@ -7399,12 +7422,11 @@ void Player::kill()
         setPower(POWER_TYPE_RUNIC_POWER, 0);
 #endif
 
-    getSummonInterface()->removeAllSummons();
-    dismissActivePets();
-
-#ifdef FT_VEHICLES
-    callExitVehicle();
-#endif
+    if (m_bg)
+    {
+        m_bg->HookOnUnitDied(this);
+        m_bg->HookOnPlayerDeath(this);
+    }
 
     sHookInterface.OnDeath(this);
 }
@@ -7697,8 +7719,6 @@ void Player::resurrect()
     for (uint8_t i = 0; i < 7; ++i)
         m_schoolImmunityList[i] = 0;
 
-    spawnActivePet();
-
     if (m_bg)
         m_bg->HookOnPlayerResurrect(this);
 }
@@ -7935,7 +7955,7 @@ void Player::sendUpdateToOutOfRangeGroupMembers()
 
     m_groupUpdateFlags = GROUP_UPDATE_FLAG_NONE;
 
-    if (Pet* pet = getFirstPetFromSummons())
+    if (Pet* pet = getPet())
         pet->resetAuraUpdateMaskForRaid();
 }
 
@@ -9534,10 +9554,14 @@ void Player::sendTalentResetConfirmPacket()
 
 void Player::sendPetUnlearnConfirmPacket()
 {
-    if (getFirstPetFromSummons() == nullptr)
+    if (getPet() == nullptr)
         return;
 
-    m_session->SendPacket(SmsgPetUnlearnConfirm(getFirstPetFromSummons()->getGuid(), getFirstPetFromSummons()->GetUntrainCost()).serialise().get());
+#if VERSION_STRING < Mop
+    m_session->SendPacket(SmsgPetUnlearnConfirm(getPet()->getGuid(), getPet()->getUntrainCost()).serialise().get());
+#else
+    m_session->SendPacket(SmsgPetUnlearnConfirm(getPet()->getGuid(), 0).serialise().get());
+#endif
 }
 
 void Player::sendDungeonDifficultyPacket()
@@ -9594,6 +9618,13 @@ void Player::sendEquipmentSetUseResultPacket(uint8_t result)
 void Player::sendTotemCreatedPacket(uint8_t slot, uint64_t guid, uint32_t duration, uint32_t spellId)
 {
     m_session->SendPacket(SmsgTotemCreated(slot, guid, duration, spellId).serialise().get());
+}
+
+void Player::sendPetTameFailure(uint8_t result) const
+{
+    WorldPacket data(SMSG_PET_TAME_FAILURE, 1);
+    data << uint8_t(result);
+    m_session->SendPacket(&data);
 }
 
 void Player::sendGossipPoiPacket(float posX, float posY, uint32_t icon, uint32_t flags, uint32_t data, std::string name)
@@ -9760,8 +9791,6 @@ void Player::setPvpFlag()
     addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
 
     getSummonInterface()->setPvPFlags(true);
-    for (auto& summon : getSummons())
-        summon->setPvpFlag();
 
     if (getCombatHandler().isInCombat())
         addPlayerFlags(PLAYER_FLAG_PVP_GUARD_ATTACKABLE);
@@ -9779,8 +9808,6 @@ void Player::removePvpFlag()
     removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
 
     getSummonInterface()->setPvPFlags(false);
-    for (auto& summon : getSummons())
-        summon->removePvpFlag();
 }
 
 bool Player::isFfaPvpFlagSet()
@@ -9795,8 +9822,6 @@ void Player::setFfaPvpFlag()
     addPlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
 
     getSummonInterface()->setFFAPvPFlags(true);
-    for (auto& summon : getSummons())
-        summon->setFfaPvpFlag();
 }
 
 void Player::removeFfaPvpFlag()
@@ -9806,8 +9831,6 @@ void Player::removeFfaPvpFlag()
     removePlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
 
     getSummonInterface()->setFFAPvPFlags(false);
-    for (auto& summon : getSummons())
-        summon->removeFfaPvpFlag();
 }
 
 bool Player::isSanctuaryFlagSet()
@@ -9821,8 +9844,6 @@ void Player::setSanctuaryFlag()
     addPlayerFlags(PLAYER_FLAG_SANCTUARY);
 
     getSummonInterface()->setSanctuaryFlags(true);
-    for (auto& summon : getSummons())
-        summon->setSanctuaryFlag();
 }
 
 void Player::removeSanctuaryFlag()
@@ -9831,8 +9852,6 @@ void Player::removeSanctuaryFlag()
     removePlayerFlags(PLAYER_FLAG_SANCTUARY);
 
     getSummonInterface()->setSanctuaryFlags(false);
-    for (auto& summon : getSummons())
-        summon->removeSanctuaryFlag();
 }
 
 void Player::sendPvpCredit(uint32_t honor, uint64_t victimGuid, uint32_t victimRank)
@@ -11994,7 +12013,7 @@ void Player::endDuel(uint8_t condition)
     eventAttackStop();
     m_duelPlayer->eventAttackStop();
 
-    for (auto& summon : getSummons())
+    for (auto& summon : getSummonInterface()->getSummons())
     {
         summon->getCombatHandler().clearCombat();
         summon->getAIInterface()->setPetOwner(this);
@@ -12003,7 +12022,7 @@ void Player::endDuel(uint8_t condition)
         summon->getThreatManager().removeMeFromThreatLists();
     }
 
-    for (auto& duelingWithSummon : m_duelPlayer->getSummons())
+    for (auto& duelingWithSummon : m_duelPlayer->getSummonInterface()->getSummons())
     {
         duelingWithSummon->getCombatHandler().clearCombat();
         duelingWithSummon->getAIInterface()->setPetOwner(this);
@@ -12048,12 +12067,6 @@ void Player::cancelDuel()
 
     m_duelPlayer->m_duelPlayer = nullptr;
     m_duelPlayer = nullptr;
-
-    for (const auto& summonedPet : getSummons())
-    {
-        if (summonedPet && summonedPet->isAlive())
-            summonedPet->SetPetAction(PET_ACTION_STAY);
-    }
 }
 
 void Player::handleDuelCountdown()
@@ -12232,147 +12245,395 @@ void Player::updateRestState()
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // Pets/Summons
-std::list<Pet*> Player::getSummons() { return m_summons; }
-void Player::addPetToSummons(Pet* pet) { m_summons.push_front(pet); }
 
-void Player::removePetFromSummons(Pet* pet)
+PetCache const* Player::getPetCache(uint8_t petId) const
 {
-    for (auto itr = m_summons.begin(); itr != m_summons.end(); ++itr)
-    {
-        if ((*itr)->getGuid() == pet->getGuid())
-        {
-            m_summons.erase(itr);
-            break;
-        }
-    }
-}
-
-Pet* Player::getFirstPetFromSummons() const
-{
-    if (!m_summons.empty())
-        return m_summons.front();
+    const auto itr = m_cachedPets.find(petId);
+    if (itr != m_cachedPets.cend())
+        return itr->second.get();
 
     return nullptr;
 }
 
-PlayerPet* Player::getPlayerPet(uint32_t petId)
+PetCache* Player::getModifiablePetCache(uint8_t petId) const
 {
-    const auto itr = m_pets.find(petId);
-    if (itr != m_pets.end())
-        return itr->second;
+    const auto itr = m_cachedPets.find(petId);
+    if (itr != m_cachedPets.cend())
+        return itr->second.get();
 
     return nullptr;
 }
 
-void Player::addPlayerPet(PlayerPet* pet, uint32_t index) { m_pets[index] = pet; }
-
-void Player::removePlayerPet(uint32_t petId)
+PetCacheMap const& Player::getPetCacheMap() const
 {
-    const auto itr = m_pets.find(petId);
-    if (itr != m_pets.end())
+    return m_cachedPets;
+}
+
+std::map<uint8_t, uint8_t> const& Player::getPetCachedSlotMap() const
+{
+    return m_cachedPetSlots;
+}
+
+void Player::addPetCache(std::unique_ptr<PetCache> pet, uint8_t index)
+{
+    m_cachedPetSlots.emplace(pet->slot, index);
+    m_cachedPets.emplace(index, std::move(pet));
+}
+
+void Player::removePetCache(uint8_t petId)
+{
+    const auto itr = std::as_const(m_cachedPets).find(petId);
+    if (itr != m_cachedPets.cend())
     {
-        delete itr->second;
-        m_pets.erase(itr);
+        std::erase_if(m_cachedPetSlots, [petId](const auto& slotItr) { return slotItr.second == petId; });
+        m_cachedPets.erase(itr);
     }
+
+    // Pet will be deleted from playerpets table when player is saved
     CharacterDatabase.Execute("DELETE FROM playerpetspells WHERE ownerguid=%u AND petnumber=%u", getGuidLow(), petId);
 }
 
-uint8_t Player::getPetCount() const { return static_cast<uint8_t>(m_pets.size()); }
+uint8_t Player::getPetCount() const { return static_cast<uint8_t>(m_cachedPets.size()); }
 
-uint32_t Player::getFreePetNumber() const
+uint8_t Player::getFreePetNumber()
 {
-    const uint32_t newMax = m_maxPetNumber + 1;
-    for (uint32_t i = 1; i < m_maxPetNumber; ++i)
-        if (!m_pets.contains(i))
+    for (uint8_t i = 1; i < m_maxPetNumber; ++i)
+        if (!m_cachedPets.contains(i))
             return i;
 
-    return newMax;
+    m_maxPetNumber += 1;
+    return m_maxPetNumber;
 }
 
-void Player::spawnPet(uint32_t petId)
+std::optional<uint8_t> Player::getPetIdFromSlot(uint8_t slot) const
 {
-    const auto itr = m_pets.find(petId);
-    if (itr == m_pets.end())
-    {
-        sLogger.failure("PET SYSTEM: {} Tried to load invalid pet {}", std::to_string(getGuid()), petId);
-        return;
-    }
+    const auto itr = m_cachedPetSlots.find(slot);
+    if (itr != m_cachedPetSlots.cend())
+        return itr->second;
 
-    const auto pet = sObjectMgr.createPet(itr->second->entry);
-    pet->LoadFromDB(this, itr->second);
-
-    if (this->isPvpFlagSet())
-        pet->setPvpFlag();
-    else
-        pet->removePvpFlag();
-
-    if (this->isFfaPvpFlagSet())
-        pet->setFfaPvpFlag();
-    else
-        pet->removeFfaPvpFlag();
-
-    if (this->isSanctuaryFlagSet())
-        pet->setSanctuaryFlag();
-    else
-        pet->removeSanctuaryFlag();
-
-    pet->setFaction(this->getFactionTemplate());
-
-    if (itr->second->spellid)
-    {
-        removeAllAurasById(18789);
-        removeAllAurasById(18790);
-        removeAllAurasById(18791);
-        removeAllAurasById(18792);
-        removeAllAurasById(35701);
-    }
+    return std::nullopt;
 }
 
-void Player::spawnActivePet()
+bool Player::hasPetInSlot(uint8_t slot) const
 {
-    if (getFirstPetFromSummons() != nullptr || !isAlive() || !IsInWorld())   //\todo  only hunters for now
-        return;
+    return m_cachedPetSlots.contains(slot);
+}
 
-    for (auto& pet : m_pets)
+std::optional<uint8_t> Player::findFreeActivePetSlot() const
+{
+    std::optional<uint8_t> foundSlot = std::nullopt;
+    for (uint8_t i = PET_SLOT_FIRST_ACTIVE_SLOT; i < PET_SLOT_MAX_ACTIVE_SLOT; ++i)
     {
-        if (pet.second->stablestate == STABLE_STATE_ACTIVE && pet.second->active)
+        if (!hasPetInSlot(i))
         {
-            if (pet.second->alive)
-                spawnPet(pet.first);
+            foundSlot = i;
+            break;
+        }
+    }
+    return foundSlot;
+}
+
+std::optional<uint8_t> Player::findFreeStablePetSlot() const
+{
+    std::optional<uint8_t> foundSlot = std::nullopt;
+    for (uint8_t i = PET_SLOT_FIRST_STABLE_SLOT; i < PET_SLOT_LAST_STABLE_SLOT; ++i)
+    {
+        if (m_stableSlotCount <= (i - PET_SLOT_FIRST_STABLE_SLOT))
+            break;
+
+        if (!hasPetInSlot(i))
+        {
+            foundSlot = i;
+            break;
+        }
+    }
+    return foundSlot;
+}
+
+bool Player::tryPutPetToSlot(uint8_t petId, uint8_t newSlot, bool sendErrors/* = true*/)
+{
+    const auto petItr = std::as_const(m_cachedPets).find(petId);
+    if (petItr == m_cachedPets.cend())
+    {
+        if (sendErrors)
+            sendPacket(SmsgStableResult(PetStableResult::Error).serialise().get());
+
+        return false;
+    }
+
+    // Check if pet is being tried to move to same slot where it is already
+    if (petItr->second->slot == newSlot)
+    {
+        if (sendErrors)
+            sendPacket(SmsgStableResult(PetStableResult::Error).serialise().get());
+
+        return false;
+    }
+
+    auto* oldSlotPet = petItr->second.get();
+    // Pet that possibly exists in new slot
+    PetCache* newSlotPet = nullptr;
+
+    const auto slotItr = std::as_const(m_cachedPetSlots).find(newSlot);
+    if (slotItr != m_cachedPetSlots.cend())
+    {
+        const auto existingPetItr = std::as_const(m_cachedPets).find(slotItr->second);
+        if (existingPetItr != m_cachedPets.cend())
+            newSlotPet = existingPetItr->second.get();
+    }
+
+    const auto isOldSlotActiveSlot = oldSlotPet->slot < PET_SLOT_MAX_ACTIVE_SLOT;
+    const auto isNewSlotActiveSlot = newSlot < PET_SLOT_MAX_ACTIVE_SLOT;
+
+#if VERSION_STRING >= WotLK
+    if (isNewSlotActiveSlot)
+    {
+        // Check if player can have exotic pets when taking pet from stables
+        if (const auto creatureProperties = sMySQLStore.getCreatureProperties(oldSlotPet->entry))
+        {
+            if (creatureProperties->isExotic() && !hasAuraWithAuraEffect(SPELL_AURA_ALLOW_TAME_PET_TYPE))
+            {
+                if (sendErrors)
+                    sendPacket(SmsgStableResult(PetStableResult::ExoticNotAvailable).serialise().get());
+
+                return false;
+            }
+        }
+    }
+
+    if (isOldSlotActiveSlot && !isNewSlotActiveSlot && newSlotPet != nullptr)
+    {
+        // Check also if pet in new slot is exotic if player is swapping pet slots
+        if (const auto creatureProperties = sMySQLStore.getCreatureProperties(newSlotPet->entry))
+        {
+            if (creatureProperties->isExotic() && !hasAuraWithAuraEffect(SPELL_AURA_ALLOW_TAME_PET_TYPE))
+            {
+                if (sendErrors)
+                    sendPacket(SmsgStableResult(PetStableResult::ExoticNotAvailable).serialise().get());
+
+                return false;
+            }
+        }
+    }
+#endif
+
+    if (!isNewSlotActiveSlot)
+    {
+        // Must be hunter pet
+        if (oldSlotPet->type != PET_TYPE_HUNTER)
+        {
+            if (sendErrors)
+                sendPacket(SmsgStableResult(PetStableResult::Error).serialise().get());
+
+            return false;
+        }
+    }
+
+    m_cachedPetSlots.insert_or_assign(newSlot, petId);
+    if (newSlotPet != nullptr)
+        m_cachedPetSlots.insert_or_assign(oldSlotPet->slot, newSlotPet->number);
+    else
+        m_cachedPetSlots.erase(oldSlotPet->slot);
+
+    // Update only slot in pet cache, full update is done in possible summon/unsummon
+    if (newSlotPet != nullptr)
+        newSlotPet->slot = oldSlotPet->slot;
+    oldSlotPet->slot = newSlot;
+
+    auto requiresPetSave = false;
+    if (isOldSlotActiveSlot && !isNewSlotActiveSlot)
+    {
+        // Active pet is put to stables
+        auto* const currentPet = getPet();
+        if (currentPet != nullptr && currentPet->getPetId() == petId)
+        {
+            currentPet->unSummon();
+            if (newSlotPet != nullptr && !isPetRequiringTemporaryUnsummon() && newSlotPet->alive)
+                _spawnPet(newSlotPet);
+        }
+        else
+        {
+            // If this pet was temporary unsummoned make the other pet active as well
+            if (newSlotPet != nullptr)
+                newSlotPet->active = oldSlotPet->active;
+            oldSlotPet->active = false;
+            requiresPetSave = true;
+        }
+    }
+    else if (!isOldSlotActiveSlot && isNewSlotActiveSlot)
+    {
+        // Pet is taken from stables
+        if (newSlotPet != nullptr)
+        {
+            auto* const currentPet = getPet();
+            // Only summon it if it's put to same slot as current summoned pet
+            if (currentPet != nullptr && currentPet->getPetId() == newSlotPet->number)
+            {
+                currentPet->unSummon();
+                if (!isPetRequiringTemporaryUnsummon() && oldSlotPet->alive)
+                    _spawnPet(oldSlotPet);
+            }
+            else
+            {
+                // If pet from new slot was temporary unsummoned make this pet active as well
+                oldSlotPet->active = newSlotPet->active;
+                newSlotPet->active = false;
+                requiresPetSave = true;
+            }
+        }
+        else
+        {
+            requiresPetSave = true;
+        }
+    }
+    else if ((!isOldSlotActiveSlot && !isNewSlotActiveSlot) || (isOldSlotActiveSlot && isNewSlotActiveSlot))
+    {
+        // Pet is either moved inside stables or its active slot was changed
+        // In either case unsummon is not required, just save pets to database
+        requiresPetSave = true;
+    }
+
+    if (requiresPetSave)
+    {
+        // Save only slot and active fields
+        CharacterDatabase.Execute("UPDATE playerpets SET slot = %u, active = %u WHERE ownerguid = %u AND petnumber = %u",
+            oldSlotPet->slot, oldSlotPet->active, getGuidLow(), oldSlotPet->number);
+        if (newSlotPet != nullptr)
+        {
+            CharacterDatabase.Execute("UPDATE playerpets SET slot = %u, active = %u WHERE ownerguid = %u AND petnumber = %u",
+                newSlotPet->slot, newSlotPet->active, getGuidLow(), newSlotPet->number);
+        }
+    }
+
+    return true;
+}
+
+void Player::spawnPet(uint8_t petId)
+{
+    const auto itr = m_cachedPets.find(petId);
+    if (itr == m_cachedPets.cend())
+    {
+        sLogger.failure("Player::spawnPet : {} tried to load invalid pet {}", std::to_string(getGuid()), petId);
+        return;
+    }
+
+    if (itr->second.get()->slot >= PET_SLOT_MAX_ACTIVE_SLOT)
+    {
+        sLogger.debug("Player::spawnPet : {} tried to spawn pet from stable slot {}", std::to_string(getGuid()), std::to_string(itr->second.get()->slot));
+        return;
+    }
+
+    _spawnPet(itr->second.get());
+}
+
+void Player::summonTemporarilyUnsummonedPet()
+{
+    if (getPet() != nullptr)
+        return;
+
+    if (isPetRequiringTemporaryUnsummon())
+        return;
+
+    for (const auto& [slot, petId] : std::as_const(m_cachedPetSlots))
+    {
+        // Just check active slots
+        if (slot >= PET_SLOT_MAX_ACTIVE_SLOT)
+            break;
+
+        auto* const petCache = getModifiablePetCache(petId);
+        if (petCache != nullptr && petCache->active)
+        {
+            // If active pet is not alive it cant be summoned now
+            // Player must explicitly summon and revive it
+            if (petCache->alive)
+                _spawnPet(petCache);
+            else
+                petCache->active = false;
 
             return;
         }
     }
 }
 
-void Player::dismissActivePets()
+void Player::unSummonPetTemporarily()
 {
-    for (auto itr = m_summons.rbegin(); itr != m_summons.rend();)
+    if (getPet() == nullptr)
+        return;
+
+    getPet()->unSummonTemporarily();
+}
+
+bool Player::isPetRequiringTemporaryUnsummon() const
+{
+    if (!IsInWorld() || !isAlive())
+        return true;
+
+    if (isOnTaxi())
+        return true;
+
+    // In classic pets were not despawned when mounted
+    // In tbc and wotlk they despawned, but this was again changed around patch 4.1
+#if VERSION_STRING == TBC || VERSION_STRING == WotLK
+#ifdef FT_VEHICLES
+    if (isMounted() || isOnVehicle())
+#else
+    if (isMounted())
+#endif
     {
-        if (Pet* summon = *itr)
+        if (const auto* const pet = getPet())
         {
-            if (summon->IsSummonedPet())
-                summon->Dismiss();
+            if (!pet->isAlive())
+                return false;
+
+            if (!pet->isPermanentSummon())
+                return false;
+
+            if (m_bg != nullptr && m_bg->isArena())
+                return false;
+
+            // For some reason permanent water elemental is not despawned
+            if (pet->getEntry() == PET_WATER_ELEMENTAL_NEW)
+                return false;
+        }
+
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+void Player::setTemporarilyUnsummonedPetsOffline()
+{
+    const auto copiedCachedSlots = m_cachedPetSlots;
+    for (const auto& [slot, petId] : std::as_const(copiedCachedSlots))
+    {
+        // Just check active slots
+        if (slot >= PET_SLOT_MAX_ACTIVE_SLOT)
+            break;
+
+        auto* const petCache = getModifiablePetCache(petId);
+        if (petCache == nullptr)
+            continue;
+
+        if (petCache->active)
+        {
+            // Summoned pets can be completely deleted since they can be resummoned anyway
+            if (petCache->type == PET_TYPE_HUNTER)
+                petCache->active = false;
             else
-                summon->Remove(true, false);
+                removePetCache(petCache->number);
         }
     }
 }
 
+void Player::setLastBattlegroundPetId(uint8_t petId) { m_battlegroundLastPetId = petId; }
+uint8_t Player::getLastBattlegroundPetId() const { return m_battlegroundLastPetId; }
+void Player::setLastBattlegroundPetSpell(uint32_t petSpell) { m_battlegroundLastPetSpell = petSpell; }
+uint32_t Player::getLastBattlegroundPetSpell() const { return m_battlegroundLastPetSpell; }
+
 void Player::setStableSlotCount(uint8_t count) { m_stableSlotCount = count; }
 uint8_t Player::getStableSlotCount() const { return m_stableSlotCount; }
-
-uint32_t Player::getUnstabledPetNumber() const
-{
-    if (m_pets.empty())
-        return 0;
-
-    for (const auto& petMap : m_pets)
-        if (petMap.second->stablestate == STABLE_STATE_ACTIVE)
-            return petMap.first;
-
-    return 0;
-}
 
 void Player::eventSummonPet(Pet* summonPet)
 {
@@ -12415,6 +12676,26 @@ void Player::eventDismissPet()
 
 Object* Player::getSummonedObject() const { return m_summonedObject; }
 void Player::setSummonedObject(Object* summonedObject) { m_summonedObject = summonedObject; }
+
+void Player::_spawnPet(PetCache const* petCache)
+{
+    const auto pet = sObjectMgr.createPet(petCache->entry, nullptr);
+    if (!pet->loadFromDB(this, petCache))
+    {
+        pet->DeleteMe();
+        return;
+    }
+
+    // TODO: find a better way to handle these -Appled
+    if (petCache->spellid)
+    {
+        removeAllAurasById(18789);
+        removeAllAurasById(18790);
+        removeAllAurasById(18791);
+        removeAllAurasById(18792);
+        removeAllAurasById(35701);
+    }
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Misc
@@ -13487,7 +13768,7 @@ void Player::eventDeath()
     setServersideDrunkValue(0);
 }
 
-void Player::_savePet(QueryBuffer* buf)
+void Player::_savePet(QueryBuffer* buf, bool updateCurrentPetCache/* = false*/, Pet* currentPet/* = nullptr*/)
 {
     // Remove any existing m_playerCreateInfo
     if (buf == nullptr)
@@ -13495,30 +13776,33 @@ void Player::_savePet(QueryBuffer* buf)
     else
         buf->AddQuery("DELETE FROM playerpets WHERE ownerguid = %u", getGuidLow());
 
-    Pet* summon = getFirstPetFromSummons();
-    if (summon && summon->IsInWorld() && summon->getPlayerOwner() == this)    // update PlayerPets array with current pet's m_playerCreateInfo
+    const auto* summon = currentPet != nullptr ? currentPet : getPet();
+    if (summon && summon->IsInWorld())    // update PlayerPets array with current pet's m_playerCreateInfo
     {
-        PlayerPet* pPet = getPlayerPet(summon->m_PetNumber);
-        if (!pPet || pPet->active == false)
-            summon->UpdatePetInfo(true);
-        else
-            summon->UpdatePetInfo(false);
+        if (updateCurrentPetCache)
+        {
+            const auto playerPetCache = getPetCache(summon->getPetId());
+            if (playerPetCache != nullptr && playerPetCache->active)
+                summon->updatePetInfo(false);
+            else
+                summon->updatePetInfo(true);
+        }
 
-        if (!summon->Summon)       // is a pet
+        if (summon->isHunterPet())       // is a pet
         {
             // save pet spellz
-            uint32_t pn = summon->m_PetNumber;
+            auto pn = summon->getPetId();
             if (buf == nullptr)
                 CharacterDatabase.Execute("DELETE FROM playerpetspells WHERE ownerguid=%u AND petnumber=%u", getGuidLow(), pn);
             else
                 buf->AddQuery("DELETE FROM playerpetspells WHERE ownerguid=%u AND petnumber=%u", getGuidLow(), pn);
 
-            for (PetSpellMap::iterator itr = summon->mSpells.begin(); itr != summon->mSpells.end(); ++itr)
+            for (const auto& [spell, state] : summon->getSpellMap())
             {
                 if (buf == nullptr)
-                    CharacterDatabase.Execute("INSERT INTO playerpetspells VALUES(%u, %u, %u, %u)", getGuidLow(), pn, itr->first->getId(), itr->second);
+                    CharacterDatabase.Execute("INSERT INTO playerpetspells VALUES(%u, %u, %u, %u)", getGuidLow(), pn, spell->getId(), state);
                 else
-                    buf->AddQuery("INSERT INTO playerpetspells VALUES(%u, %u, %u, %u)", getGuidLow(), pn, itr->first->getId(), itr->second);
+                    buf->AddQuery("INSERT INTO playerpetspells VALUES(%u, %u, %u, %u)", getGuidLow(), pn, spell->getId(), state);
             }
         }
     }
@@ -13527,37 +13811,115 @@ void Player::_savePet(QueryBuffer* buf)
 
     ss.rdbuf()->str("");
 
-    for (std::map<uint32_t, PlayerPet*>::iterator itr = m_pets.begin(); itr != m_pets.end(); ++itr)
+    std::optional<uint8_t> currentPetId = std::nullopt;
+    if (getPet() != nullptr && getPet()->isPermanentSummon())
+        currentPetId = getPet()->getPetId();
+
+    std::vector<uint8_t> savedPetIds;
+    savedPetIds.reserve(m_cachedPets.size());
+
+    auto foundActivePet = false;
+    for (auto itr = m_cachedPets.cbegin(); itr != m_cachedPets.cend();)
     {
+        auto* petCache = itr->second.get();
+
+        // Do some clean up to pet cache before save
+        if (currentPetId.has_value())
+        {
+            // Set all other pets expect current pet to offline
+            if (petCache->active && petCache->number != currentPetId.value())
+                petCache->active = false;
+
+            // Remove all other cached pets from non-hunters expect current pet
+            if (!isClassHunter() && getPetCount() > 1)
+            {
+                if (petCache->number != currentPetId.value())
+                {
+                    std::erase_if(m_cachedPetSlots, [&petCache](const auto& slotItr) { return slotItr.second == petCache->number; });
+                    itr = m_cachedPets.erase(itr);
+                    continue;
+                }
+            }
+        }
+        else
+        {
+            // There can be only one active pet
+            if (petCache->active)
+            {
+                if (petCache->slot >= PET_SLOT_FIRST_STABLE_SLOT)
+                    petCache->active = false;
+                else if (foundActivePet)
+                    petCache->active = false;
+                else
+                    foundActivePet = true;
+            }
+
+            // Only hunters can have multiple pets saved
+            if (!isClassHunter() && getPetCount() > 1)
+            {
+                if (!petCache->active)
+                {
+                    std::erase_if(m_cachedPetSlots, [&petCache](const auto& slotItr) { return slotItr.second == petCache->number; });
+                    itr = m_cachedPets.erase(itr);
+                    continue;
+                }
+            }
+        }
+
         ss.rdbuf()->str("");
 
         ss << "REPLACE INTO playerpets VALUES('"
             << getGuidLow() << "','"
-            << itr->second->number << "','"
-            << itr->second->name << "','"
-            << itr->second->entry << "','"
-            << itr->second->xp << "','"
-            << (itr->second->active ? 1 : 0) + itr->second->stablestate * 10 << "','"
-            << itr->second->level << "','"
-            << itr->second->actionbar << "','"
-            << itr->second->happinessupdate << "','"
-            << (long)itr->second->reset_time << "','"
-            << itr->second->reset_cost << "','"
-            << itr->second->spellid << "','"
-            << itr->second->petstate << "','"
-            << itr->second->alive << "','"
-            << itr->second->talentpoints << "','"
-            << itr->second->current_power << "','"
-            << itr->second->current_hp << "','"
-            << itr->second->current_happiness << "','"
-            << itr->second->renamable << "','"
-            << itr->second->type << "')";
+            << std::to_string(petCache->number) << "','"
+            << std::to_string(petCache->type) << "','"
+            << petCache->name << "','"
+            << petCache->entry << "','"
+            << petCache->model << "','"
+            << petCache->level << "','"
+            << petCache->xp << "','"
+            << std::to_string(petCache->slot) << "','"
+            << petCache->active << "','"
+            << petCache->alive << "','"
+            << petCache->actionbar << "','"
+            << static_cast<long>(petCache->reset_time) << "','"
+            << petCache->reset_cost << "','"
+            << petCache->spellid << "','"
+            << std::to_string(petCache->petstate) << "','"
+            << petCache->talentpoints << "','"
+            << petCache->current_power << "','"
+            << petCache->current_hp << "','"
+            << petCache->current_happiness << "','"
+            << petCache->renamable << "')";
 
         if (buf == nullptr)
             CharacterDatabase.ExecuteNA(ss.str().c_str());
         else
             buf->AddQueryStr(ss.str());
+
+        savedPetIds.push_back(petCache->number);
+        ++itr;
     }
+
+    // Cleanup as well pet spell table by removing spells from non existant pets
+    ss.rdbuf()->str("");
+    ss << "DELETE FROM playerpetspells WHERE ownerguid=" << getGuidLow();
+    if (!savedPetIds.empty())
+    {
+        ss << " AND petnumber NOT IN (";
+        for (auto itr = savedPetIds.cbegin(); itr != savedPetIds.cend();)
+        {
+            ss << std::to_string(*itr);
+            if (++itr != savedPetIds.cend())
+                ss << ", ";
+            else
+                ss << ")";
+        }
+    }
+
+    if (buf == nullptr)
+        CharacterDatabase.ExecuteNA(ss.str().c_str());
+    else
+        buf->AddQueryStr(ss.str());
 }
 
 void Player::_savePetSpells(QueryBuffer* buf)
@@ -13639,33 +14001,94 @@ void Player::_loadPet(QueryResult* result)
     {
         Field* fields = result->Fetch();
 
-        PlayerPet* pet = new PlayerPet;
-        pet->number = fields[1].asUint32();
-        pet->name = fields[2].asCString();
-        pet->entry = fields[3].asUint32();
+        auto pet = std::make_unique<PetCache>();
+        pet->number = fields[1].asUint8();
+        pet->type = fields[2].asUint8();
+        pet->name = fields[3].asCString();
+        pet->entry = fields[4].asUint32();
 
-        pet->xp = fields[4].asUint32();
-        pet->active = fields[5].asInt8() % 10 > 0 ? true : false;
-        pet->stablestate = fields[5].asInt8() / 10;
+        // Check that creature properties exist
+        const auto creatureProperties = sMySQLStore.getCreatureProperties(pet->entry);
+        if (creatureProperties == nullptr)
+            continue;
+
+        pet->model = fields[5].asUint32();
         pet->level = fields[6].asUint32();
-        pet->actionbar = fields[7].asCString();
-        pet->happinessupdate = fields[8].asUint32();
-        pet->reset_time = fields[9].asUint32();
-        pet->reset_cost = fields[10].asUint32();
-        pet->spellid = fields[11].asUint32();
-        pet->petstate = fields[12].asUint32();
-        pet->alive = fields[13].asBool();
-        pet->talentpoints = fields[14].asUint32();
-        pet->current_power = fields[15].asUint32();
-        pet->current_hp = fields[16].asUint32();
-        pet->current_happiness = fields[17].asUint32();
-        pet->renamable = fields[18].asUint32();
-        pet->type = fields[19].asUint32();
+        pet->xp = fields[7].asUint32();
+        pet->slot = fields[8].asUint8();
+        pet->active = fields[9].asBool();
+        pet->alive = fields[10].asBool();
+        pet->actionbar = fields[11].asCString();
+        pet->reset_time = fields[12].asUint32();
+        pet->reset_cost = fields[13].asUint32();
+        pet->spellid = fields[14].asUint32();
+        pet->petstate = fields[15].asUint8();
+        pet->talentpoints = fields[16].asUint32();
+        pet->current_power = fields[17].asUint32();
+        pet->current_hp = fields[18].asUint32();
+        pet->current_happiness = fields[19].asUint32();
+        pet->renamable = fields[20].asBool();
 
-        m_pets[pet->number] = pet;
+        // Check if there are pets using same slot
+        // Also check for invalid pet slot in classic - wotlk
+        // Could happen when server changes from cata to wotlk
+        if (m_cachedPetSlots.contains(pet->slot)
+#if VERSION_STRING < Cata
+            || (pet->slot >= PET_SLOT_MAX_ACTIVE_SLOT && pet->slot < PET_SLOT_FIRST_STABLE_SLOT)
+#endif
+            )
+        {
+            if (pet->type != PET_TYPE_HUNTER)
+            {
+                // If other than hunter pet has invalid slot or is in duplicate slot, just remove it
+                // They can be resummoned anyway
+                continue;
+            }
+
+#if VERSION_STRING >= Cata
+            auto foundNewSlot = false;
+            if (pet->slot < PET_SLOT_FIRST_STABLE_SLOT)
+            {
+                // Pet is in active slot, try find another active slot
+                const auto freeActiveSlot = findFreeActivePetSlot();
+                if (freeActiveSlot.has_value())
+                {
+                    pet->slot = freeActiveSlot.value();
+                    foundNewSlot = true;
+                }
+            }
+
+            if (!foundNewSlot)
+#endif
+            {
+                // Next try find free stable slot
+                const auto freeStableSlot = findFreeStablePetSlot();
+                if (!freeStableSlot.has_value())
+                {
+                    // There were no free slots left, remove pet
+                    continue;
+                }
+
+                pet->slot = freeStableSlot.value();
+            }
+        }
+
+        if (pet->type != PET_TYPE_HUNTER)
+        {
+            // Skip dead or inactive summoned pets
+            // They should not be saved anyway
+            if (!pet->active || !pet->alive)
+                continue;
+        }
+
+        // Pet in stables cannot be active
+        if (pet->slot >= PET_SLOT_FIRST_STABLE_SLOT && pet->active)
+            pet->active = false;
 
         if (pet->number > m_maxPetNumber)
             m_maxPetNumber = pet->number;
+
+        addPetCache(std::move(pet), pet->number);
     } while (result->NextRow());
 }
 
@@ -14004,7 +14427,7 @@ void Player::saveToDB(bool newCharacter /* =false */)
     // Pets
     if (getClass() == HUNTER || getClass() == WARLOCK)
     {
-        _savePet(buf);
+        _savePet(buf, true);
         _savePetSpells(buf);
     }
     m_nextSave = Util::getMSTime() + worldConfig.getIntRate(INTRATE_SAVE);
@@ -14695,11 +15118,15 @@ void Player::loadFromDBProc(QueryResultVector& results)
     //class fixes
     switch (getClass())
     {
-    case WARLOCK:
-    case HUNTER:
-        _loadPet(results[PlayerQuery::Pets].result);
-        _loadPetSpells(results[PlayerQuery::SummonSpells].result);
-        break;
+        case WARLOCK:
+        case HUNTER:
+#if VERSION_STRING >= WotLK
+        case DEATHKNIGHT:
+        case MAGE:
+#endif
+            _loadPet(results[PlayerQuery::Pets].result);
+            _loadPetSpells(results[PlayerQuery::SummonSpells].result);
+            break;
     }
 
     if (getGuildId())
@@ -15338,22 +15765,6 @@ void Player::onRemoveInRangeObject(Object* object)
 
         setCharmGuid(0);
     }
-
-    // We've just gone out of range of our pet :(
-    std::list<Pet*> summons = getSummons();
-    for (std::list<Pet*>::iterator summon = summons.begin(); summon != summons.end();)
-    {
-        Pet* summonPet = (*summon);
-        ++summon;
-        if (object == summonPet)
-        {
-            summonPet->DelayedRemove(false, false, 1);//delayed otherwise Object::RemoveInRangeObject() will remove twice the Pet from inrangeset. Refer to r3199
-            return;
-        }
-    }
-
-    if (object->getGuid() == getSummonGuid())
-        sEventMgr.AddEvent(static_cast<Unit*>(this), &Unit::removeFieldSummon, EVENT_SUMMON_EXPIRE, 1, 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);//otherwise Creature::Update() will access free'd memory
 }
 
 void Player::clearInRangeSets()
@@ -15429,9 +15840,8 @@ void Player::calcResistance(uint8_t type)
 #endif
         setResistance(type, res > 0 ? res : 0);
 
-        std::list<Pet*> summons = getSummons();
-        for (std::list<Pet*>::iterator itr = summons.begin(); itr != summons.end(); ++itr)
-            (*itr)->CalcResistance(type);  //Re-calculate pet's too.
+        if (auto* const pet = getPet())
+            pet->CalcResistance(type);  //Re-calculate pet's too.
 
 #if VERSION_STRING >= WotLK
         // Dynamic aura 285 application, adding bonus
@@ -15475,9 +15885,8 @@ void Player::calcStat(uint8_t type)
 
         if (type == STAT_STAMINA || type == STAT_INTELLECT)
         {
-            std::list<Pet*> summons = getSummons();
-            for (std::list<Pet*>::iterator summon = summons.begin(); summon != summons.end(); ++summon)
-                (*summon)->CalcStat(type);  //Re-calculate pet's too
+            if (auto* const pet = getPet())
+                pet->CalcStat(type);  //Re-calculate pet's too
         }
     }
 }
@@ -15513,7 +15922,7 @@ void Player::_Relocate(uint32_t mapid, const LocationVector& v, bool sendpending
     bool sendpacket = (mapid == m_mapId);
     // Dismount before teleport and before being removed from world,
     // otherwise we may spawn the active pet while not being in world.
-    dismount();
+    dismount(false);
 
     MySQLStructure::AreaTrigger const* areaTrigger = nullptr;
     bool check = false;
@@ -15827,9 +16236,6 @@ void Player::completeLoading()
             getSession()->SendPacket(SmsgCorpseReclaimDelay(CORPSE_RECLAIM_TIME_MS).serialise().get());
         }
     }
-
-    if (!isMounted())
-        spawnActivePet();
 
 #if VERSION_STRING > TBC
     // useless logon spell
@@ -16384,9 +16790,8 @@ void Player::calculateDamage()
     setCombatRating(CR_WEAPON_SKILL_RANGED, cr);
 #endif
     // Ranged END
-    std::list<Pet*> summons = getSummons();
-    for (std::list<Pet*>::iterator itr = summons.begin(); itr != summons.end(); ++itr)
-        (*itr)->calculateDamage();//Re-calculate pet's too
+    if (auto* const pet = getPet())
+        pet->calculateDamage();//Re-calculate pet's too
 }
 
 uint32_t Player::getMainMeleeDamage(uint32_t attackPowerOverride)

--- a/src/world/Objects/Units/Players/Player.hpp
+++ b/src/world/Objects/Units/Players/Player.hpp
@@ -636,17 +636,17 @@ public:
 
     void applyLevelInfo(uint32_t newLevel);
 
-    virtual bool isClassMage();
-    virtual bool isClassDeathKnight();
-    virtual bool isClassPriest();
-    virtual bool isClassRogue();
-    virtual bool isClassShaman();
-    virtual bool isClassHunter();
-    virtual bool isClassWarlock();
-    virtual bool isClassWarrior();
-    virtual bool isClassPaladin();
-    virtual bool isClassMonk();
-    virtual bool isClassDruid();
+    virtual bool isClassMage() const;
+    virtual bool isClassDeathKnight() const;
+    virtual bool isClassPriest() const;
+    virtual bool isClassRogue() const;
+    virtual bool isClassShaman() const;
+    virtual bool isClassHunter() const;
+    virtual bool isClassWarlock() const;
+    virtual bool isClassWarrior() const;
+    virtual bool isClassPaladin() const;
+    virtual bool isClassMonk() const;
+    virtual bool isClassDruid() const;
 
     PlayerTeam getTeam() const;
     PlayerTeam getBgTeam() const;
@@ -659,10 +659,22 @@ public:
     bool isTeamHorde() const;
     bool isTeamAlliance() const;
 
+    // Returns unit charmer
     Unit* getUnitOwner() override;
+    // Returns unit charmer
+    Unit const* getUnitOwner() const override;
+    // Returns unit charmer or self
     Unit* getUnitOwnerOrSelf() override;
+    // Returns unit charmer or self
+    Unit const* getUnitOwnerOrSelf() const override;
+    // Returns player charmer
     Player* getPlayerOwner() override;
+    // Returns player charmer
+    Player const* getPlayerOwner() const override;
+    // Returns player charmer or self
     Player* getPlayerOwnerOrSelf() override;
+    // Returns player charmer or self
+    Player const* getPlayerOwnerOrSelf() const override;
 
     void toggleAfk();
     void toggleDnd();
@@ -1122,10 +1134,9 @@ private:
     uint8_t m_raidDifficulty = 0;
 
     //////////////////////////////////////////////////////////////////////////////////////////
-    // Die, Kill, Corpse & Repop
+    // Die, Corpse & Repop
 public:
     void die(Unit* unitAttacker, uint32_t damage, uint32_t spellId) override;
-    void kill();
 
     void setCorpseData(LocationVector position, int32_t instanceId);
     LocationVector getCorpseLocation() const;
@@ -1707,26 +1718,41 @@ private:
     /////////////////////////////////////////////////////////////////////////////////////////
     // Pets/Summons
 public:
-    std::list<Pet*> getSummons();
-    void addPetToSummons(Pet* pet);
-    void removePetFromSummons(Pet* pet);
-    Pet* getFirstPetFromSummons() const;
-
-    PlayerPet* getPlayerPet(uint32_t petId);
-    void addPlayerPet(PlayerPet* pet, uint32_t index);
-    void removePlayerPet(uint32_t petId);
+    PetCache const* getPetCache(uint8_t petId) const;
+    PetCache* getModifiablePetCache(uint8_t petId) const;
+    PetCacheMap const& getPetCacheMap() const;
+    // <Slot, pet id>
+    std::map<uint8_t, uint8_t> const& getPetCachedSlotMap() const;
+    void addPetCache(std::unique_ptr<PetCache> petCache, uint8_t index);
+    void removePetCache(uint8_t petId);
     uint8_t getPetCount() const;
 
-    uint32_t getFreePetNumber() const;
+    uint8_t getFreePetNumber();
+    std::optional<uint8_t> getPetIdFromSlot(uint8_t slot) const;
+    bool hasPetInSlot(uint8_t slot) const;
+    std::optional<uint8_t> findFreeActivePetSlot() const;
+    std::optional<uint8_t> findFreeStablePetSlot() const;
 
-    void spawnPet(uint32_t petId);
-    void spawnActivePet();
-    void dismissActivePets();
+    bool tryPutPetToSlot(uint8_t petId, uint8_t newSlot, bool sendErrors = true);
+
+    // Summons existing pet from PetCache map
+    // Pet must be in active slot
+    void spawnPet(uint8_t petId);
+    // Summons temporarily unsummoned pet if one exists
+    void summonTemporarilyUnsummonedPet();
+    // Unsummons current pet and saves it id for quick re-summon
+    // Used i.e. when entering vehicle, mounting or using taxi
+    void unSummonPetTemporarily();
+    bool isPetRequiringTemporaryUnsummon() const;
+    void setTemporarilyUnsummonedPetsOffline();
+
+    void setLastBattlegroundPetId(uint8_t petId);
+    uint8_t getLastBattlegroundPetId() const;
+    void setLastBattlegroundPetSpell(uint32_t petSpell);
+    uint32_t getLastBattlegroundPetSpell() const;
 
     void setStableSlotCount(uint8_t count);
     uint8_t getStableSlotCount() const;
-
-    uint32_t getUnstabledPetNumber() const;
 
     void eventSummonPet(Pet* summonPet);
     void eventDismissPet();
@@ -1735,11 +1761,17 @@ public:
     void setSummonedObject(Object* summonedObject);
 
 private:
-    std::list<Pet*> m_summons;
-    std::map<uint32_t, PlayerPet*> m_pets;
+    void _spawnPet(PetCache const* petCache);
+
+    PetCacheMap m_cachedPets;
+    // <Slot, pet id>
+    std::map<uint8_t, uint8_t> m_cachedPetSlots;
+
+    uint8_t m_battlegroundLastPetId = 0;
+    uint32_t m_battlegroundLastPetSpell = 0;
 
     uint8_t m_stableSlotCount = 0;
-    uint32_t m_maxPetNumber = 0;
+    uint8_t m_maxPetNumber = 0;
 
     Object* m_summonedObject = nullptr;
 
@@ -1769,6 +1801,7 @@ public:
     void sendDestroyObjectPacket(uint64_t destroyedGuid);
     void sendEquipmentSetUseResultPacket(uint8_t result);
     void sendTotemCreatedPacket(uint8_t slot, uint64_t guid, uint32_t duration, uint32_t spellId);
+    void sendPetTameFailure(uint8_t result) const;
 
     void sendGossipPoiPacket(float posX, float posY, uint32_t icon, uint32_t flags, uint32_t data, std::string name);
     void sendPoiById(uint32_t id);
@@ -2129,7 +2162,7 @@ protected:
 
     void _loadPet(QueryResult* result);
     void _loadPetSpells(QueryResult* result);
-    void _savePet(QueryBuffer* buf);
+    void _savePet(QueryBuffer* buf, bool updateCurrentPetCache = false, Pet* currentPet = nullptr);
     void _savePetSpells(QueryBuffer* buf);
 
     void _eventAttack(bool offhand);

--- a/src/world/Objects/Units/Players/PlayerClasses.hpp
+++ b/src/world/Objects/Units/Players/PlayerClasses.hpp
@@ -44,7 +44,7 @@ public:
         }
     }
 
-    bool isClassDeathKnight() override { return true; }
+    bool isClassDeathKnight() const override { return true; }
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Runes
@@ -66,7 +66,7 @@ class Druid : public Player
 public:
     explicit Druid(uint32_t guid) : Player(guid) {}
 
-    bool isClassDruid() override { return true; }
+    bool isClassDruid() const override { return true; }
 };
 
 class Rogue : public Player
@@ -74,7 +74,7 @@ class Rogue : public Player
 public:
     explicit Rogue(uint32_t guid) : Player(guid) {}
 
-    bool isClassRogue() override { return true; }
+    bool isClassRogue() const override { return true; }
 };
 
 class Priest : public Player
@@ -82,7 +82,7 @@ class Priest : public Player
 public:
     explicit Priest(uint32_t guid) : Player(guid) {}
 
-    bool isClassPriest() override { return true; }
+    bool isClassPriest() const override { return true; }
 };
 
 class Paladin : public Player
@@ -90,7 +90,7 @@ class Paladin : public Player
 public:
     explicit Paladin(uint32_t guid) : Player(guid) {}
 
-    bool isClassPaladin() override { return true; }
+    bool isClassPaladin() const override { return true; }
 };
 
 class Warrior : public Player
@@ -98,7 +98,7 @@ class Warrior : public Player
 public:
     explicit Warrior(uint32_t guid) : Player(guid) {}
 
-    bool isClassWarrior() override { return true; }
+    bool isClassWarrior() const override { return true; }
 };
 
 class Warlock : public Player
@@ -106,7 +106,7 @@ class Warlock : public Player
 public:
     explicit Warlock(uint32_t guid) : Player(guid) {}
 
-    bool isClassWarlock() override { return true; }
+    bool isClassWarlock() const override { return true; }
 };
 
 class Mage : public Player
@@ -114,7 +114,7 @@ class Mage : public Player
 public:
     explicit Mage(uint32_t guid) : Player(guid) {}
 
-    bool isClassMage() override { return true; }
+    bool isClassMage() const override { return true; }
 };
 
 class Monk : public Player
@@ -122,7 +122,7 @@ class Monk : public Player
 public:
     explicit Monk(uint32_t guid) : Player(guid) {}
 
-    bool isClassMonk() override { return true; }
+    bool isClassMonk() const override { return true; }
 };
 
 class Hunter : public Player
@@ -130,7 +130,7 @@ class Hunter : public Player
 public:
     explicit Hunter(uint32_t guid) : Player(guid) {}
 
-    bool isClassHunter() override { return true; }
+    bool isClassHunter() const override { return true; }
 };
 
 class Shaman : public Player
@@ -138,5 +138,5 @@ class Shaman : public Player
 public:
     explicit Shaman(uint32_t guid) : Player(guid) {}
 
-    bool isClassShaman() override { return true; }
+    bool isClassShaman() const override { return true; }
 };

--- a/src/world/Objects/Units/Players/PlayerDefines.hpp
+++ b/src/world/Objects/Units/Players/PlayerDefines.hpp
@@ -1007,29 +1007,30 @@ struct FactionReputation
     bool Positive() { return standing >= 0; }
 };
 
-struct PlayerPet
+struct PetCache
 {
-    std::string name;
+    uint8_t number = 0; // Refers to Pet::m_petId
+    uint8_t type = 0;
+    utf8_string name;
     uint32_t entry = 0;
+    uint32_t model = 0;
+    uint32_t level = 0;
     uint32_t xp = 0;
+    uint8_t slot = 0;
     bool active = false;
     bool alive = false;
-    char stablestate = 0;
-    uint32_t number = 0;
-    uint32_t level = 0;
-    uint32_t happinessupdate = 0;
     std::string actionbar;
     time_t reset_time = 0;
     uint32_t reset_cost = 0;
     uint32_t spellid = 0;
-    uint32_t petstate = 0;
+    uint8_t petstate = 0;
     uint32_t talentpoints = 0;
     uint32_t current_power = 0;
     uint32_t current_hp = 0;
     uint32_t current_happiness = 0;
-    uint32_t renamable = 0;
-    uint32_t type = 0;
+    bool renamable = false;
 };
+typedef std::map<uint8_t, std::unique_ptr<PetCache>> PetCacheMap;
 
 struct WeaponModifier
 {

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -69,7 +69,7 @@
 #include "Utilities/Benchmark.hpp"
 
 // DB version
-static const char* REQUIRED_CHAR_DB_VERSION = "20230710-00_characters_taxi";
+static const char* REQUIRED_CHAR_DB_VERSION = "20241206-00_playerpets";
 static const char* REQUIRED_WORLD_DB_VERSION = "20240904-00_misc";
 
 volatile bool Master::m_stopEvent = false;

--- a/src/world/Server/Packets/Handlers/ChatHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ChatHandler.cpp
@@ -418,7 +418,7 @@ void WorldSession::handleTextEmoteOpcode(WorldPacket& recvPacket)
         if (unit->isPlayer())
             unitName = dynamic_cast<Player*>(unit)->getName();
         else if (unit->isPet())
-            unitName = dynamic_cast<Pet*>(unit)->GetName();
+            unitName = dynamic_cast<Pet*>(unit)->getName();
         else
             unitName = dynamic_cast<Creature*>(unit)->GetCreatureProperties()->Name;
 
@@ -483,7 +483,7 @@ void WorldSession::handleTextEmoteOpcode(WorldPacket& recvPacket)
         }
         else if (unit->isPet())
         {
-            unitName = dynamic_cast<Pet*>(unit)->GetName().c_str();
+            unitName = dynamic_cast<Pet*>(unit)->getName().c_str();
             nameLength = static_cast<uint32_t>(strlen(unitName)) + 1;
         }
         else

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -322,7 +322,7 @@ void WorldSession::handleUseItemOpcode(WorldPacket& recvPacket)
         }
         else
         {
-            if (!_player->getFirstPetFromSummons() || _player->getFirstPetFromSummons()->getEntry() != static_cast<uint32_t>(itemProto->ForcedPetId))
+            if (!_player->getPet() || _player->getPet()->getEntry() != static_cast<uint32_t>(itemProto->ForcedPetId))
             {
                 _player->sendCastFailedPacket(spellInfo->getId(), SPELL_FAILED_BAD_TARGETS, srlPacket.castCount, 0);
                 return;

--- a/src/world/Server/Packets/Handlers/MovementHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MovementHandler.cpp
@@ -635,8 +635,11 @@ void WorldSession::handleMoveTeleportAckOpcode(WorldPacket& recvPacket)
         _player->setTransferStatus(TRANSFER_NONE);
         _player->speedCheatReset();
 
-        for (auto summon : _player->getSummons())
-            summon->SetPosition(_player->GetPositionX() + 2, _player->GetPositionY() + 2, _player->GetPositionZ(), M_PI_FLOAT);
+        for (const auto& summon : _player->getSummonInterface()->getSummons())
+        {
+            if (!summon->isTotem())
+                summon->SetPosition(_player->GetPositionX() + 2, _player->GetPositionY() + 2, _player->GetPositionZ(), M_PI_FLOAT);
+        }
 
         if (_player->m_sentTeleportPosition.x != 999999.0f)
         {

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -380,24 +380,24 @@ void WorldSession::handleStabledPetList(WorldPacket& recvPacket)
 
 void WorldSession::sendStabledPetList(uint64_t npcguid)
 {
-    std::vector<PlayerStablePetList> stableList;
-    PlayerStablePetList stablePet;
+    std::map<uint8_t, PlayerStablePet> stableList;
+    PlayerStablePet stablePet;
 
-    for (const auto itr : _player->m_pets)
+    for (const auto& [petId, cachedPet] : _player->getPetCacheMap())
     {
-        stablePet.petNumber = itr.first;
-        stablePet.entry = itr.second->entry;
-        stablePet.level = itr.second->level;
-        stablePet.name = itr.second->name;
-        if (itr.second->stablestate == STABLE_STATE_ACTIVE)
-            stablePet.stableState = STABLE_STATE_ACTIVE;
-        else
-            stablePet.stableState = STABLE_STATE_PASSIVE + 1;
-
-        stableList.push_back(stablePet);
+        stablePet.petNumber = petId;
+        stablePet.entry = cachedPet->entry;
+        stablePet.level = cachedPet->level;
+        stablePet.name.assign(cachedPet->name);
+        stableList.emplace(cachedPet->slot, stablePet);
     }
 
-    SendPacket(MsgListStabledPets(npcguid, static_cast<uint8_t>(_player->m_pets.size()), _player->m_stableSlotCount, stableList).serialise().get());
+#if VERSION_STRING >= Cata
+    // Since cata all stable slots are automatically unlocked
+    SendPacket(MsgListStabledPets(npcguid, PET_SLOT_MAX_STABLE_SLOT, stableList).serialise().get());
+#else
+    SendPacket(MsgListStabledPets(npcguid, _player->m_stableSlotCount, stableList).serialise().get());
+#endif
 }
 
 void WorldSession::sendTrainerList(Creature* creature)

--- a/src/world/Server/Packets/Handlers/SpellHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SpellHandler.cpp
@@ -248,7 +248,7 @@ void WorldSession::handlePetCastSpell(WorldPacket& recvPacket)
     if (spellInfo == nullptr)
         return;
 
-    if (_player->getFirstPetFromSummons() == nullptr && _player->getCharmGuid() == 0)
+    if (_player->getPet() == nullptr && _player->getCharmGuid() == 0)
     {
         sLogger.failure("Received opcode but player {} has no pet.", _player->getGuidLow());
         return;
@@ -265,7 +265,7 @@ void WorldSession::handlePetCastSpell(WorldPacket& recvPacket)
         return;
 
     // If pet is summoned by player
-    if (_player->getFirstPetFromSummons() == petUnit)
+    if (_player->getPet() == petUnit)
     {
         // Check does the pet have the spell
         if (!dynamic_cast<Pet*>(petUnit)->HasSpell(srlPacket.spellId))
@@ -365,15 +365,17 @@ void WorldSession::handleCancelTotem(WorldPacket& recvPacket)
     uint8_t totemSlot;
     recvPacket >> totemSlot;
 
-    if (totemSlot >= SUMMON_SLOT_MINIPET)
+    // Clientside slot is zero indexed
+    totemSlot += 1;
+    if (totemSlot >= MAX_SUMMON_SLOT)
     {
         sLogger.failure("Player {} tried to cancel totem from out of range slot {}, ignored.", _player->getGuidLow(), totemSlot);
         return;
     }
 
-    const auto totem = _player->getTotem(SummonSlot(totemSlot + 1));
-    if (totem != nullptr)
-        totem->unSummon();
+    const auto summon = _player->getSummonInterface()->getSummonInSlot(static_cast<SummonSlot>(totemSlot));
+    if (summon != nullptr)
+        summon->unSummon();
 }
 
 void WorldSession::handleUpdateProjectilePosition(WorldPacket& recvPacket)

--- a/src/world/Server/Packets/MsgListStabledPets.h
+++ b/src/world/Server/Packets/MsgListStabledPets.h
@@ -7,15 +7,15 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 #include "WorldPacket.h"
 
-struct PlayerStablePetList
+struct PlayerStablePet
 {
     uint32_t petNumber;
     uint32_t entry;
     uint32_t level;
-    uint8_t stableState;
     utf8_string name;
 };
 
@@ -25,29 +25,44 @@ namespace AscEmu::Packets
     {
     public:
         WoWGuid guid;
-        uint8_t listSize;
         uint8_t slotCount;
-        std::vector<PlayerStablePetList> stableList;
+        std::map<uint8_t, PlayerStablePet> const& stableList;
 
-        MsgListStabledPets() : MsgListStabledPets(0, 0, 0, {})
+        MsgListStabledPets() : MsgListStabledPets(0, 0, {})
         {
         }
 
-        MsgListStabledPets(uint64_t guid, uint8_t listSize, uint8_t slotCount, std::vector<PlayerStablePetList> stableList) :
-            ManagedPacket(MSG_LIST_STABLED_PETS, 10 + listSize * 25),
+        MsgListStabledPets(uint64_t guid, uint8_t slotCount, std::map<uint8_t, PlayerStablePet> const& stableList) :
+            ManagedPacket(MSG_LIST_STABLED_PETS, 8),
             guid(guid),
-            listSize(listSize),
             slotCount(slotCount),
             stableList(stableList)
         {
         }
 
     protected:
+#if VERSION_STRING >= Cata
+        size_t expectedSize() const override { return 10 + (stableList.size() * 29); }
+#else
+        size_t expectedSize() const override { return 10 + (stableList.size() * 25); }
+#endif
+
         bool internalSerialise(WorldPacket& packet) override
         {
-            packet << guid.getRawGuid() << listSize << slotCount;
-            for (const auto& stablePet : stableList)
-                packet << stablePet.petNumber << stablePet.entry << stablePet.level << stablePet.name << stablePet.stableState;
+            packet << guid.getRawGuid() << uint8_t(stableList.size()) << slotCount;
+            for (const auto& [slot, stablePet] : stableList)
+            {
+#if VERSION_STRING >= Cata
+                packet << int32_t(slot);
+#endif
+                packet << stablePet.petNumber;
+                packet << stablePet.entry;
+                packet << stablePet.level;
+                packet << stablePet.name;
+                // Seems to be some kind of flag; 1 for active pet, 2 or 3 for stabled pet. Any other value breaks the stable window.
+                // TODO: verify values for cata
+                packet << uint8_t(slot < PET_SLOT_MAX_ACTIVE_SLOT ? 1 : 2);
+            }
 
             return true;
         }

--- a/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
+++ b/src/world/Server/Packets/SmsgPartyMemberStatsFull.h
@@ -46,7 +46,7 @@ namespace AscEmu::Packets
             {
                 packet << player->getGuid();
 
-                auto playerPet = player->getFirstPetFromSummons();
+                auto playerPet = player->getPet();
                 if (playerPet)
                     packet << uint32_t(0x7FFFFFFF);
                 else
@@ -81,7 +81,7 @@ namespace AscEmu::Packets
                 {
                     const auto petPowerType = playerPet->getPowerType();
                     packet << uint64_t(playerPet->getGuid());
-                    packet << playerPet->GetName();
+                    packet << playerPet->getName();
                     packet << uint16_t(playerPet->getDisplayId());
                     packet << uint32_t(playerPet->getHealth());
                     packet << uint32_t(playerPet->getMaxHealth());

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -801,7 +801,7 @@ void CreatureAIScript::setZoneWideCombat(Creature* creature)
     if (!map->hasPlayers())
         return;
 
-    for (auto player : map->getPlayers())
+    for (const auto& player : map->getPlayers())
     {
         if (Player* plr = player.second)
         {
@@ -810,8 +810,8 @@ void CreatureAIScript::setZoneWideCombat(Creature* creature)
 
             creature->getAIInterface()->onHostileAction(plr);
 
-            for (auto pet : plr->getSummons())
-                creature->getAIInterface()->onHostileAction(pet->ToCreature());
+            for (const auto& summon : plr->getSummonInterface()->getSummons())
+                creature->getAIInterface()->onHostileAction(summon);
 
 #ifdef FT_VEHICLES
             if (Unit* vehicle = plr->getVehicleBase())

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -696,6 +696,8 @@ bool World::setInitialWorldSettings()
     auto localeString = Util::getLanguagesStringFromId(mDbcLocaleId);
     if (mDbcLocaleId == 0)
         localeString.append("/enUS");
+    else if (mDbcLocaleId == 10)
+        localeString.append("/ptPT");
 
     sLogger.info("World : Using {} DBC locale", localeString);
 #endif

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -325,15 +325,15 @@ void WorldSession::LogoutPlayer(bool Save)
         _player->m_loadHealth = _player->getHealth();
         _player->m_loadMana = _player->getPower(POWER_TYPE_MANA);
 
-
-        _player->getSummonInterface()->removeAllSummons();
-
-        _player->dismissActivePets();
-
         // _player->SaveAuras();
 
         if (Save)
             _player->saveToDB(false);
+
+        // Remove pet/summons after save so current pet is properly saved
+        // Keep pet active so it will be summoned again when player logs in
+        _player->unSummonPetTemporarily();
+        _player->getSummonInterface()->removeAllSummons();
 
         // Dismounting with removeAllAuras may in certain cases add a player
         // aura,
@@ -1096,8 +1096,8 @@ void WorldSession::registerOpcodeHandler()
     // Pets
     registry.registerOpcode(MSG_LIST_STABLED_PETS, &WorldSession::handleStabledPetList, true, true, true, false, false);
 
-    registry.registerOpcode(CMSG_PET_ACTION, &WorldSession::handlePetAction, true, true, true, false, false);
-    registry.registerOpcode(CMSG_PET_NAME_QUERY, &WorldSession::handlePetNameQuery, true, true, true, false, false);
+    registry.registerOpcode(CMSG_PET_ACTION, &WorldSession::handlePetAction, true, true, true, true, false);
+    registry.registerOpcode(CMSG_PET_NAME_QUERY, &WorldSession::handlePetNameQuery, true, true, true, true, false);
     registry.registerOpcode(CMSG_BUY_STABLE_SLOT, &WorldSession::handleBuyStableSlot, true, true, true, false, false);
     registry.registerOpcode(CMSG_STABLE_PET, &WorldSession::handleStablePet, true, true, true, false, false);
     registry.registerOpcode(CMSG_UNSTABLE_PET, &WorldSession::handleUnstablePet, true, true, true, false, false);

--- a/src/world/Spell/Definitions/AuraEffects.hpp
+++ b/src/world/Spell/Definitions/AuraEffects.hpp
@@ -157,7 +157,11 @@ enum AuraEffect : uint32_t
     SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE = 143,                          // Mod Resistance Exclusive
     SPELL_AURA_SAFE_FALL = 144,                                         // Safe Fall
     SPELL_AURA_CHARISMA = 145,                                          // Charisma
+#if VERSION_STRING < WotLK
     SPELL_AURA_PERSUADED = 146,                                         // Persuaded
+#else
+    SPELL_AURA_ALLOW_TAME_PET_TYPE = 146,                               // Allow tame pet type
+#endif
     SPELL_AURA_MECHANIC_IMMUNITY_MASK = 147,                            // Mechanic Immunity Mask
     SPELL_AURA_RETAIN_COMBO_POINTS = 148,                               // Retain Combo Points
     SPELL_AURA_RESIST_PUSHBACK = 149,                                   // Resist Pushback

--- a/src/world/Spell/Definitions/PowerType.hpp
+++ b/src/world/Spell/Definitions/PowerType.hpp
@@ -14,7 +14,11 @@ enum PowerType : int16_t
     POWER_TYPE_RAGE             = 1,
     POWER_TYPE_FOCUS            = 2,
     POWER_TYPE_ENERGY           = 3,
+#if VERSION_STRING < Cata
     POWER_TYPE_HAPPINESS        = 4,
+#else
+    POWER_TYPE_UNK4             = 4,
+#endif
 #if VERSION_STRING >= WotLK
     POWER_TYPE_RUNES            = 5,
     POWER_TYPE_RUNIC_POWER      = 6,

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -1237,11 +1237,7 @@ void Spell::SendResurrectRequest(Player* target)
 void Spell::SendTameFailure(uint8 result)
 {
     if (p_caster != nullptr)
-    {
-        WorldPacket data(SMSG_PET_TAME_FAILURE, 1);
-        data << uint8(result);
-        p_caster->getSession()->SendPacket(&data);
-    }
+        p_caster->sendPetTameFailure(result);
 }
 
 void Spell::HandleAddAura(uint64 guid)

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -1860,7 +1860,7 @@ void Aura::spellAuraEffectAddModifier(AuraEffectModifier* aurEff, bool apply)
     // Hunter's beastmastery talents
     if (aurEff->getAuraEffectType() == SPELL_AURA_ADD_FLAT_MODIFIER)
     {
-        const auto pet = getPlayerOwner()->getFirstPetFromSummons();
+        const auto pet = getPlayerOwner()->getPet();
         if (pet != nullptr)
         {
             switch (getSpellInfo()->getId())

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -440,46 +440,23 @@ void Aura::EventUpdateRaidAA(AuraEffectModifier* /*aurEff*/, float r)
 
 void Aura::EventUpdatePetAA(AuraEffectModifier* aurEff, float r)
 {
-    Player* p = nullptr;
-
-    if (m_target->isPlayer())
-        p = static_cast<Player*>(m_target);
-    else
+    const auto pet = m_target->getPet();
+    if (pet == nullptr)
         return;
 
-    std::list< Pet* > pl = p->getSummons();
-    for (std::list< Pet* >::iterator itr = pl.begin(); itr != pl.end(); ++itr)
+    if (m_target->getDistanceSq(pet) > r)
     {
-        Pet* pet = *itr;
-
-        if (p->getDistanceSq(pet) > r)
-            continue;
-
-        if (!pet->isAlive())
-            continue;
-
-        if (pet->hasAurasWithId(m_spellInfo->getId()))
-            continue;
-
+        pet->removeAllAurasByIdForGuid(m_spellInfo->getId(), m_target->getGuid());
+    }
+    else
+    {
+        if (pet->isAlive() && pet->getAuraWithIdForGuid(m_spellInfo->getId(), m_target->getGuid()) == nullptr)
         {
-            Aura* a = sSpellMgr.newAura(m_spellInfo, getTimeLeft(), p, pet, true);
+            Aura* a = sSpellMgr.newAura(m_spellInfo, getTimeLeft(), m_target, pet, true);
             a->m_areaAura = true;
             a->addAuraEffect(aurEff->getAuraEffectType(), aurEff->getEffectDamage(), aurEff->getEffectMiscValue(), aurEff->getEffectPercentModifier(), true, aurEff->getEffectIndex());
             pet->addAura(a);
         }
-    }
-
-    for (std::list< Pet* >::iterator itr = pl.begin(); itr != pl.end();)
-    {
-        std::list< Pet* >::iterator itr2 = itr;
-
-        Pet* pet = *itr2;
-        ++itr;
-
-        if (p->getDistanceSq(pet) <= r)
-            continue;
-
-        pet->removeAllAurasById(m_spellInfo->getId());
     }
 }
 
@@ -742,17 +719,10 @@ void Aura::ClearAATargets()
     }
     targets.clear();
 
-    if (m_target->isPlayer() && m_spellInfo->hasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA))
+    if (m_spellInfo->hasEffect(SPELL_EFFECT_APPLY_PET_AREA_AURA))
     {
-        Player* p = static_cast<Player*>(m_target);
-
-        std::list< Pet* > pl = p->getSummons();
-        for (std::list< Pet* >::iterator itr = pl.begin(); itr != pl.end(); ++itr)
-        {
-            Pet* pet = *itr;
-
-            pet->removeAllAurasById(spellid);
-        }
+        if (auto* const pet = m_target->getPet())
+            pet->removeAllAurasByIdForGuid(spellid, m_target->getGuid());
     }
 
 #if VERSION_STRING >= TBC
@@ -3204,28 +3174,12 @@ void Aura::SpellAuraMounted(AuraEffectModifier* aurEff, bool apply)
     }
     else
     {
-        p_target->removeUnitFlags(UNIT_FLAG_MOUNT);
-
-#if VERSION_STRING > TBC
-        if (p_target->getVehicleKit())
-        {
-            // Send other players that we are no longer a vehicle
-            p_target->sendMessageToSet(SmsgPlayerVehicleData(p_target->GetNewGUID(), 0).serialise().get(), true);
-
-            // Remove vehicle from player
-            p_target->removeVehicleKit();
-        }
-#endif
-
         p_target->setMountVehicleId(0);
         p_target->setMountSpellId(0);
         p_target->m_flyingAura = 0;
-        m_target->setMountDisplayId(0);
-        //m_target->removeUnitFlags(UNIT_FLAG_MOUNTED_TAXI);
 
-        //if we had pet then respawn
-        p_target->spawnActivePet();
-        p_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_DISMOUNT);
+        p_target->dismount();
+
 #if VERSION_STRING > WotLK
         uint32_t amount = 0;
         if (WDB::Structures::MountCapabilityEntry const* mountCapability = m_target->getMountCapability(uint32(getSpellInfo()->getEffectMiscValueB(0))))
@@ -5713,26 +5667,17 @@ void Aura::SpellAuraModPossessPet(AuraEffectModifier* /*aurEff*/, bool apply)
     if (pCaster == nullptr || !pCaster->IsInWorld())
         return;
 
-    if (!m_target->isPet())
+    if (!m_target->isPet() || m_target->getPlayerOwner() != pCaster)
         return;
 
-    std::list<Pet*> summons = pCaster->getSummons();
-    for (std::list<Pet*>::iterator itr = summons.begin(); itr != summons.end(); ++itr)
+    if (apply)
     {
-        if (*itr == m_target)
-        {
-            if (apply)
-            {
-                pCaster->possess(m_target);
-                pCaster->speedCheatDelay(getTimeLeft());
-            }
-            else
-            {
-                pCaster->unPossess();
-            }
-            break;
-        }
-
+        pCaster->possess(m_target);
+        pCaster->speedCheatDelay(getTimeLeft());
+    }
+    else
+    {
+        pCaster->unPossess();
     }
 }
 

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -530,7 +530,7 @@ void Spell::spellEffectSummonTotem(uint8_t /*effIndex*/, WDB::Structures::Summon
     const auto totemSlot = static_cast<SummonSlot>(spe->Slot);
 
     // Generate spawn point
-    const float_t angle = totemSlot > SUMMON_SLOT_PET && totemSlot < SUMMON_SLOT_MINIPET
+    const float_t angle = totemSlot > SUMMON_SLOT_NONE && totemSlot < SUMMON_SLOT_MINIPET
         ? M_PI_FLOAT / static_cast<float>(SUMMON_SLOT_TOTEM_AIR) - (totemSlot * 2 * M_PI_FLOAT / static_cast<float>(SUMMON_SLOT_TOTEM_AIR))
         : 0.0f;
     u_caster->GetPoint(u_caster->GetOrientation() + angle, 3.5f, v.x, v.y, v.z, false);
@@ -3043,13 +3043,13 @@ void Spell::SpellEffectSummonGuardian(uint32 /*i*/, WDB::Structures::SummonPrope
     }
 }
 
-void Spell::SpellEffectSummonTemporaryPet(uint32 /*i*/, WDB::Structures::SummonPropertiesEntry const* spe, CreatureProperties const* properties_, LocationVector & v)
+void Spell::SpellEffectSummonTemporaryPet(uint32 i, WDB::Structures::SummonPropertiesEntry const* spe, CreatureProperties const* properties_, LocationVector & v)
 {
     if (p_caster == nullptr)
         return;
 
-    p_caster->dismissActivePets();
-    p_caster->removeFieldSummon();
+    if (p_caster->getPet() != nullptr)
+        p_caster->getPet()->unSummon();
 
     int32 count = 0;
 
@@ -3074,9 +3074,8 @@ void Spell::SpellEffectSummonTemporaryPet(uint32 /*i*/, WDB::Structures::SummonP
         v.x += x;
         v.y += y;
 
-        const auto pet = sObjectMgr.createPet(properties_->Id);
-
-        if (!pet->CreateAsSummon(properties_->Id, ci, nullptr, p_caster, m_spellInfo, 1, static_cast<uint32_t>(getDuration()), &v, false))
+        const auto pet = sObjectMgr.createPet(properties_->Id, spe);
+        if (!pet->createAsSummon(ci, nullptr, p_caster, v, static_cast<uint32_t>(getDuration()), m_spellInfo, i, PET_TYPE_SUMMON))
         {
             pet->DeleteMe();
             break;
@@ -3092,8 +3091,8 @@ void Spell::SpellEffectSummonPossessed(uint32 /*i*/, WDB::Structures::SummonProp
     if (p_caster == nullptr)
         return;
 
-    p_caster->dismissActivePets();
-    p_caster->removeFieldSummon();
+    if (p_caster->getPet() != nullptr)
+        p_caster->getPet()->unSummon();
 
     v.x += (3 * cos(M_PI_FLOAT / 2 + v.o));
     v.y += (3 * cos(M_PI_FLOAT / 2 + v.o));
@@ -4169,16 +4168,18 @@ void Spell::SpellEffectEnchantItemTemporary(uint8_t effectIndex)  // Enchant Ite
         DetermineSkillUp(static_cast<uint16_t>(skill_line_ability->skilline), m_itemTarget->getItemProperties()->ItemLevel);
 }
 
-void Spell::SpellEffectTameCreature(uint8_t /*effectIndex*/)
+void Spell::SpellEffectTameCreature(uint8_t effectIndex)
 {
     if (m_unitTarget == nullptr || !m_unitTarget->isCreature())
+        return;
+    if (p_caster == nullptr || p_caster->getPet() != nullptr)
         return;
     Creature* tame = static_cast<Creature*>(m_unitTarget);
 
     // Remove target
     tame->getAIInterface()->handleEvent(EVENT_LEAVECOMBAT, p_caster, 0);
-    const auto pet = sObjectMgr.createPet(tame->getEntry());
-    if (!pet->CreateAsSummon(tame->getEntry(), tame->GetCreatureProperties(), tame, p_caster, nullptr, 2, 0))
+    const auto pet = sObjectMgr.createPet(tame->getEntry(), nullptr);
+    if (!pet->createAsSummon(tame->GetCreatureProperties(), tame, p_caster, p_caster->GetPosition(), 0, nullptr, effectIndex, PET_TYPE_HUNTER))
     {
         pet->DeleteMe();//CreateAsSummon() returns false if an error occurred.
     }
@@ -4191,22 +4192,33 @@ void Spell::SpellEffectSummonPet(uint8_t effectIndex) //summon - pet
 
     if (getSpellInfo()->getId() == 883)  // "Call Pet" spell
     {
-        if (p_caster->getFirstPetFromSummons())
+        if (p_caster->getPet() != nullptr)
         {
             sendCastResult(SPELL_FAILED_ALREADY_HAVE_SUMMON);
             return;
         }
 
-        uint32 petno = p_caster->getUnstabledPetNumber();
-        if (petno)
+        const auto foundPetId = p_caster->getPetIdFromSlot(PET_SLOT_FIRST_ACTIVE_SLOT);
+        if (foundPetId.has_value())
         {
-            if (p_caster->getPlayerPet(petno) == nullptr)
+            const auto petno = foundPetId.value();
+            if (p_caster->isPetRequiringTemporaryUnsummon())
+            {
+#if VERSION_STRING < WotLK
+                sendCastResult(SPELL_FAILED_TRY_AGAIN);
+#else
+                sendCastResult(SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW);
+#endif
+                return;
+            }
+
+            if (p_caster->getPetCache(petno) == nullptr)
             {
                 sendCastResult(SPELL_FAILED_ALREADY_HAVE_SUMMON);
                 return;
             }
 
-            if (p_caster->getPlayerPet(petno)->alive)
+            if (p_caster->getPetCache(petno)->alive)
             {
                 p_caster->spawnPet(petno);
             }
@@ -4229,9 +4241,9 @@ void Spell::SpellEffectSummonPet(uint8_t effectIndex) //summon - pet
     //felhunter:     Devour Magic,Paranoia,Spell Lock,  Tainted Blood
 
     // remove old pet
-    Pet* old = static_cast< Player* >(m_caster)->getFirstPetFromSummons();
+    Pet* old = p_caster->getPet();
     if (old)
-        old->Dismiss();
+        old->unSummon();
 
     CreatureProperties const* ci = sMySQLStore.getCreatureProperties(getSpellInfo()->getEffectMiscValue(effectIndex));
     if (ci)
@@ -4246,8 +4258,8 @@ void Spell::SpellEffectSummonPet(uint8_t effectIndex) //summon - pet
             p_caster->removeAllAurasById(35701);
         }
 
-        const auto pet = sObjectMgr.createPet(getSpellInfo()->getEffectMiscValue(effectIndex));
-        if (!pet->CreateAsSummon(getSpellInfo()->getEffectMiscValue(effectIndex), ci, nullptr, p_caster, getSpellInfo(), 2, 0))
+        const auto pet = sObjectMgr.createPet(getSpellInfo()->getEffectMiscValue(effectIndex), nullptr);
+        if (!pet->createAsSummon(ci, nullptr, u_caster, u_caster->GetPosition(), 0, m_spellInfo, effectIndex, PET_TYPE_SUMMON))
         {
             pet->DeleteMe();//CreateAsSummon() returns false if an error occurred.
         }
@@ -4267,7 +4279,7 @@ void Spell::SpellEffectLearnPetSpell(uint8_t effectIndex)
     if (m_unitTarget && m_unitTarget->isPet() && p_caster)
     {
         Pet* pPet = static_cast< Pet* >(m_unitTarget);
-        if (pPet->IsSummonedPet())
+        if (!pPet->isHunterPet())
             p_caster->addSummonSpell(m_unitTarget->getEntry(), getSpellInfo()->getEffectTriggerSpell(effectIndex));
 
         pPet->AddSpell(sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(effectIndex)), true);
@@ -5129,7 +5141,7 @@ void Spell::SpellEffectFeedPet(uint8_t effectIndex)  // Feed Pet
     if (!m_itemTarget || !p_caster)
         return;
 
-    Pet* pPet = p_caster->getFirstPetFromSummons();
+    Pet* pPet = p_caster->getPet();
     if (!pPet)
         return;
 
@@ -5164,9 +5176,9 @@ void Spell::SpellEffectDismissPet(uint8_t /*effectIndex*/)
     // remove pet.. but don't delete so it can be called later
     if (!p_caster) return;
 
-    Pet* pPet = p_caster->getFirstPetFromSummons();
+    Pet* pPet = p_caster->getPet();
     if (!pPet) return;
-    pPet->Remove(true, true);
+    pPet->unSummon();
 }
 
 void Spell::SpellEffectReputation(uint8_t effectIndex)
@@ -5255,22 +5267,47 @@ void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
     //this is pet resurrect
     if (!p_caster)
         return;
-    Pet* pPet = p_caster->getFirstPetFromSummons();
+    Pet* pPet = p_caster->getPet();
     if (pPet)
     {
+        // Pet should teleport to owner's position
+        HandleTeleport(p_caster->GetPosition(), p_caster->GetMapId(), pPet);
         //\note remove all dynamic flags
         pPet->setDynamicFlags(0);
         pPet->setHealth(pPet->getMaxHealth() * damage / 100);
         pPet->setDeathState(ALIVE);
         pPet->getAIInterface()->handleEvent(EVENT_FOLLOWOWNER, pPet, 0);
-        sEventMgr.RemoveEvents(pPet, EVENT_PET_DELAYED_REMOVE);
         pPet->SendSpellsToOwner();
+
+        // Restore unit and pvp flags that were resetted on death
+        if (p_caster->isPvpFlagSet())
+            pPet->setPvpFlag();
+        else
+            pPet->removePvpFlag();
+
+        if (p_caster->isFfaPvpFlagSet())
+            pPet->setFfaPvpFlag();
+        else
+            pPet->removeFfaPvpFlag();
+
+        if (p_caster->isSanctuaryFlagSet())
+            pPet->setSanctuaryFlag();
+        else
+            pPet->removeSanctuaryFlag();
+
+        if (p_caster->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
+            pPet->addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
     }
     else
     {
+        // This was set in canCast so it should exist at this point
+        if (add_damage == 0)
+            return;
 
-        p_caster->spawnPet(p_caster->getUnstabledPetNumber());
-        pPet = p_caster->getFirstPetFromSummons();
+        if (!p_caster->isPetRequiringTemporaryUnsummon())
+            p_caster->spawnPet(static_cast<uint8_t>(add_damage));
+
+        pPet = p_caster->getPet();
         if (pPet == nullptr)//no pets to Revive
             return;
 
@@ -5294,13 +5331,13 @@ void Spell::SpellEffectDestroyAllTotems(uint8_t effectIndex)
     uint32 RetreivedMana = 0;
     uint32 refundpercent = m_spellInfo->getEffectBasePoints(effectIndex) + 1;
 
-    std::vector< uint32 > spellids;
-
-    p_caster->getSummonInterface()->getTotemSpellIds(spellids);
-
-    for (std::vector< uint32 >::iterator itr = spellids.begin(); itr != spellids.end(); ++itr)
+    for (uint8_t i = SUMMON_SLOT_TOTEM_FIRE; i <= SUMMON_SLOT_TOTEM_AIR; ++i)
     {
-        uint32 spellid = *itr;
+        const auto* totem = p_caster->getSummonInterface()->getSummonInSlot(static_cast<SummonSlot>(i));
+        if (totem == nullptr || !totem->isTotem())
+            continue;
+
+        const auto spellid = totem->getCreatedBySpellId();
         SpellInfo const* sp = sSpellMgr.getSpellInfo(spellid);
 
         if (sp != nullptr)
@@ -5316,7 +5353,7 @@ void Spell::SpellEffectDestroyAllTotems(uint8_t effectIndex)
         }
     }
 
-    p_caster->getSummonInterface()->removeAllSummons(true);
+    p_caster->getSummonInterface()->killAllTotems();
     p_caster->energize(p_caster, getSpellInfo()->getId(), RetreivedMana, POWER_TYPE_MANA);
 }
 
@@ -6005,14 +6042,14 @@ void Spell::SpellEffectCreatePet(uint8_t effectIndex)
     if (!m_playerTarget)
         return;
 
-    if (m_playerTarget->getFirstPetFromSummons())
-        m_playerTarget->getFirstPetFromSummons()->Remove(true, true);
+    if (m_playerTarget->getPet())
+        m_playerTarget->getPet()->unSummon();
 
     CreatureProperties const* ci = sMySQLStore.getCreatureProperties(getSpellInfo()->getEffectMiscValue(effectIndex));
     if (ci)
     {
-        const auto pet = sObjectMgr.createPet(getSpellInfo()->getEffectMiscValue(effectIndex));
-        if (!pet->CreateAsSummon(getSpellInfo()->getEffectMiscValue(effectIndex), ci, nullptr, m_playerTarget, getSpellInfo(), 1, 0))
+        const auto pet = sObjectMgr.createPet(getSpellInfo()->getEffectMiscValue(effectIndex), nullptr);
+        if (!pet->createAsSummon(ci, nullptr, m_playerTarget, m_playerTarget->GetPosition(), 0, m_spellInfo, effectIndex, PET_TYPE_HUNTER))
         {
             pet->DeleteMe();//CreateAsSummon() returns false if an error occurred.
         }
@@ -6125,7 +6162,7 @@ void Spell::SpellEffectRenamePet(uint8_t /*effectIndex*/)
         !static_cast< Pet* >(m_unitTarget)->getPlayerOwner() || static_cast< Pet* >(m_unitTarget)->getPlayerOwner()->getClass() != HUNTER)
         return;
 
-    m_unitTarget->setPetFlags(m_unitTarget->getPetFlags() | PET_RENAME_ALLOWED);
+    m_unitTarget->addPetFlags(UNIT_CAN_BE_RENAMED);
 }
 
 void Spell::SpellEffectRestoreHealthPct(uint8_t /*effectIndex*/)

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -412,7 +412,9 @@ int32_t SpellInfo::getBasePowerCost(Unit* caster) const
                 case POWER_TYPE_RAGE:
                 case POWER_TYPE_FOCUS:
                 case POWER_TYPE_ENERGY:
+#if VERSION_STRING < Cata
                 case POWER_TYPE_HAPPINESS:
+#endif
                     powerCost += static_cast<int32_t>(caster->getMaxPower(getPowerType()) * getManaCostPercentage() / 100);
                     break;
 #if VERSION_STRING >= WotLK
@@ -643,7 +645,9 @@ uint32_t SpellInfo::getRequiredTargetMaskForEffectTarget(uint32_t implicitTarget
     switch (implicitTarget)
     {
         case EFF_TARGET_NONE:
-            targetMask = SPELL_TARGET_REQUIRE_ITEM | SPELL_TARGET_REQUIRE_GAMEOBJECT;
+            // TODO: this needs more investigation but lots of spells with learn effect, add glyph, enchants,
+            // quest spells etc have this target type, so adding mask for all object types -Appled
+            targetMask = SPELL_TARGET_REQUIRE_ITEM | SPELL_TARGET_REQUIRE_GAMEOBJECT | SPELL_TARGET_REQUIRE_FRIENDLY;
             break;
         case EFF_TARGET_SELF:
             targetMask = SPELL_TARGET_OBJECT_SELF;

--- a/src/world/Spell/SpellTarget.Legacy.cpp
+++ b/src/world/Spell/SpellTarget.Legacy.cpp
@@ -77,8 +77,8 @@ void Spell::FillTargetMap(uint32 i)
     /*if (TargetType & SPELL_TARGET_OBJECT_CURTOTEMS && u_caster != NULL)
         for (uint32 i=1; i<5; ++i) //totem slots are 1, 2, 3, 4
         AddTarget(i, TargetType, u_caster->m_summonslot[i]);*/
-    if (TargetType & SPELL_TARGET_OBJECT_CURPET && p_caster != nullptr)
-        AddTarget(i, TargetType, p_caster->getFirstPetFromSummons());
+    if (TargetType & SPELL_TARGET_OBJECT_CURPET && u_caster != nullptr)
+        AddTarget(i, TargetType, u_caster->getPet());
     if (TargetType & SPELL_TARGET_OBJECT_PETOWNER)
     {
         WoWGuid wowGuid;

--- a/src/world/Spell/Spell_ClassScripts.cpp
+++ b/src/world/Spell/Spell_ClassScripts.cpp
@@ -91,30 +91,12 @@ public:
         {
             if (u_caster)
             {
-                // If someone has a better solutionen, your welcome :-)
-                int totem_ids[32] = {
-                    //Searing Totems
-                    2523, 3902, 3903, 3904, 7400, 7402, 15480, 31162, 31164, 31165,
-                    //Magma Totems
-                    8929, 7464, 7435, 7466, 15484, 31166, 31167,
-                    //Fire Elementel
-                    15439,
-                    //Flametongue Totems
-                    5950, 6012, 7423, 10557, 15485, 31132, 31158, 31133,
-                    //Frost Resistance Totems
-                    5926, 7412, 7413, 15486, 31171, 31172
-                };
-                Unit* totem;
-                for (uint8 i = 0; i < 32; i++)
+                auto* totem = u_caster->getTotem(SUMMON_SLOT_TOTEM_FIRE);
+                if (totem != nullptr)
                 {
-                    totem = u_caster->getSummonInterface()->getSummonWithEntry(totem_ids[i]);   // Get possible firetotem
-                    if (totem != NULL)
-                    {
-                        HasFireTotem = true;
-                        CastSpell(totem);
-                    }
+                    CastSpell(totem);
                 }
-                if (!HasFireTotem)
+                else
                 {
                     *parameter1 = SPELL_EXTRA_ERROR_MUST_HAVE_FIRE_TOTEM;
                     result = SPELL_FAILED_CUSTOM_ERROR;


### PR DESCRIPTION
**Description**
Pets: Start rewriting pet files
- Pets are now derived from Summon rather than directly from Creature
- Also fix stable master and pet stabling in classic - wotlk

Summons: Refactor Summon class
Units: Refactor also SummonInterface class to support different kind of summons
- Store all unit summons in the interface

Spells: Fix target issues in some spells that require gameobject, item or pet target
Misc: Fix nonpch build

Closes https://github.com/AscEmu/AscEmu/issues/1184 https://github.com/AscEmu/AscEmu/issues/337

Known bugs:
Pet AI is still a mess but that is in another pr 😉 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [x] TBC
- [x] WotLK
- [x] Cata
