### PR TITLE
Some Minor Crash Fixes

### DIFF
--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Raid_IceCrownCitadel.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Raid_IceCrownCitadel.cpp
@@ -543,14 +543,14 @@ void IceCrownCitadelScript::OnPlayerEnter(Player* /*player*/)
 
     // Spawning the Gunships at the same moment a player enters causes them to bug the npcs sometimes
     if (!isPrepared)
-        scriptEvents->addEvent(EVENT_SPAWN_GUNSHIPS, 5000);
+        scriptEvents.addEvent(EVENT_SPAWN_GUNSHIPS, 5000);
 }    
 
 void IceCrownCitadelScript::UpdateEvent()
 {
-    scriptEvents->updateEvents(getUpdateFrequency(), 0);
+    scriptEvents.updateEvents(getUpdateFrequency(), 0);
 
-    while (uint32_t eventId = scriptEvents->getFinishedEvent())
+    while (uint32_t eventId = scriptEvents.getFinishedEvent())
     {
         switch (eventId)
         {
@@ -583,7 +583,7 @@ void IceCrownCitadelScript::UpdateEvent()
                 {
                     DoCheckFallingPlayer(GetCreatureByGuid(MuradinBronzebeardGbGUID));
                     if (DoWipeCheck(skybreaker))
-                        scriptEvents->addEvent(EVENT_WIPE_CHECK, 3000);
+                        scriptEvents.addEvent(EVENT_WIPE_CHECK, 3000);
                     else
                         DoAction(ACTION_FAIL);
                 }
@@ -591,7 +591,7 @@ void IceCrownCitadelScript::UpdateEvent()
                 {
                     DoCheckFallingPlayer(GetCreatureByGuid(DeathbringerSaurfangGbGUID));
                     if (DoWipeCheck(orgrimmar))
-                        scriptEvents->addEvent(EVENT_WIPE_CHECK, 3000);
+                        scriptEvents.addEvent(EVENT_WIPE_CHECK, 3000);
                     else
                         DoAction(ACTION_FAIL);
                 }
@@ -663,12 +663,12 @@ void IceCrownCitadelScript::DoAction(int32_t const action)
         }   
         case ACTION_INTRO_START:
         {
-            scriptEvents->addEvent(EVENT_START_FLY, 2500);
+            scriptEvents.addEvent(EVENT_START_FLY, 2500);
             break;
         }
         case ACTION_BATTLE_EVENT:
         {
-            scriptEvents->addEvent(EVENT_WIPE_CHECK, 5000);
+            scriptEvents.addEvent(EVENT_WIPE_CHECK, 5000);
             setBossState(DATA_ICECROWN_GUNSHIP_BATTLE, InProgress);
             break;
         }
@@ -703,7 +703,7 @@ void IceCrownCitadelScript::DoAction(int32_t const action)
         {
             if (getInstance()->getTeamIdInInstance() == TEAM_ALLIANCE)
             {
-                scriptEvents->addEvent(EVENT_SPAWN_ZEPPELIN_ALLIANCE, 1);
+                scriptEvents.addEvent(EVENT_SPAWN_ZEPPELIN_ALLIANCE, 1);
             }
             break;
         }

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Instance_TheVioletHold.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Instance_TheVioletHold.cpp
@@ -149,7 +149,7 @@ void TheVioletHoldScript::UpdateEvent()
     }
 
     // Update Event Timers
-    scriptEvents->updateEvents(getUpdateFrequency(), 0);
+    scriptEvents.updateEvents(getUpdateFrequency(), 0);
 
     // Check Door Integrety
     if (EventState == EncounterStates::InProgress)
@@ -160,7 +160,7 @@ void TheVioletHoldScript::UpdateEvent()
     }
 
     // Events
-    while (uint32_t eventId = scriptEvents->getFinishedEvent())
+    while (uint32_t eventId = scriptEvents.getFinishedEvent())
     {
         switch (eventId)
         {
@@ -214,7 +214,7 @@ void TheVioletHoldScript::UpdateEvent()
             case EVENT_STATE_CHECK:
             {
                 StateCheck();
-                scriptEvents->addEvent(EVENT_STATE_CHECK, 3 * TimeVarsMs::Second);
+                scriptEvents.addEvent(EVENT_STATE_CHECK, 3 * TimeVarsMs::Second);
             } break;
             case EVENT_TIMER1:
             {
@@ -258,7 +258,7 @@ void TheVioletHoldScript::UpdateEvent()
                     }
                 }
 
-                scriptEvents->addEvent(EVENT_TIMER2, 5 * TimeVarsMs::Second);
+                scriptEvents.addEvent(EVENT_TIMER2, 5 * TimeVarsMs::Second);
             } break;
             case EVENT_TIMER2:
             {
@@ -306,7 +306,7 @@ void TheVioletHoldScript::UpdateEvent()
                     }
                 }
 
-                scriptEvents->addEvent(EVENT_TIMER3, 8 * TimeVarsMs::Second);
+                scriptEvents.addEvent(EVENT_TIMER3, 8 * TimeVarsMs::Second);
             } break;
             case EVENT_TIMER3:
             {
@@ -384,7 +384,7 @@ void TheVioletHoldScript::setLocalData(uint32_t type, uint32_t data)
             if (WaveCount)
             {
                 // Add Next Wave
-                scriptEvents->addEvent(EVENT_NEXT_WAVE, (isBossWave(WaveCount - 1) ? 45 : 5) * TimeVarsMs::Second);
+                scriptEvents.addEvent(EVENT_NEXT_WAVE, (isBossWave(WaveCount - 1) ? 45 : 5) * TimeVarsMs::Second);
             }
         } break;
         case DATA_DOOR_INTEGRITY:
@@ -425,8 +425,8 @@ void TheVioletHoldScript::setLocalData(uint32_t type, uint32_t data)
                     getInstance()->getWorldStatesHandler().SetWorldStateForZone(4415, 0, WORLD_STATE_VH_SHOW, 1);
 
                     WaveCount = 1;
-                    scriptEvents->addEvent(EVENT_NEXT_WAVE, 1 * TimeVarsMs::Second);
-                    scriptEvents->addEvent(EVENT_STATE_CHECK, 3 * TimeVarsMs::Second);
+                    scriptEvents.addEvent(EVENT_NEXT_WAVE, 1 * TimeVarsMs::Second);
+                    scriptEvents.addEvent(EVENT_STATE_CHECK, 3 * TimeVarsMs::Second);
 
                     for (uint8_t i = 0; i < ActivationCrystalCount; ++i)
                         if (GameObject* crystal = GetGameObjectByGuid(ActivationCrystalGUIDs[i]))
@@ -519,9 +519,9 @@ void TheVioletHoldScript::spawnPortal()
 
 void TheVioletHoldScript::startCyanigosaIntro()
 {
-    scriptEvents->addEvent(EVENT_CYANIGOSA_INTRO1, 2 * TimeVarsMs::Second);
-    scriptEvents->addEvent(EVENT_CYANIGOSA_INTRO2, 6 * TimeVarsMs::Second);
-    scriptEvents->addEvent(EVENT_CYANIGOSA_INTRO3, 7 * TimeVarsMs::Second);
+    scriptEvents.addEvent(EVENT_CYANIGOSA_INTRO1, 2 * TimeVarsMs::Second);
+    scriptEvents.addEvent(EVENT_CYANIGOSA_INTRO2, 6 * TimeVarsMs::Second);
+    scriptEvents.addEvent(EVENT_CYANIGOSA_INTRO3, 7 * TimeVarsMs::Second);
 }
 
 void TheVioletHoldScript::StateCheck()
@@ -538,7 +538,7 @@ void TheVioletHoldScript::StateCheck()
         Defenseless = true;
         setLocalData(DATA_MAIN_EVENT_STATE, EncounterStates::NotStarted);
 
-        scriptEvents->resetEvents();
+        scriptEvents.resetEvents();
 
         if (Creature* sinclari = getCreatureFromData(DATA_SINCLARI))
         {
@@ -568,7 +568,7 @@ bool TheVioletHoldScript::WipeCheck()
 
 void TheVioletHoldScript::startBossEncounter(uint8_t bossId)
 {
-    scriptEvents->addEvent(EVENT_TIMER1, 3 * TimeVarsMs::Second);
+    scriptEvents.addEvent(EVENT_TIMER1, 3 * TimeVarsMs::Second);
     handleCells(bossId);
 }
 

--- a/src/world/Server/Script/InstanceScript.hpp
+++ b/src/world/Server/Script/InstanceScript.hpp
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "CommonTypes.hpp"
 #include "AEVersion.hpp"
+#include "ScriptEvent.hpp"
 
 #include <map>
 #include <set>
@@ -197,7 +198,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////
     // script events
 protected:
-    scriptEventMap* scriptEvents;
+    scriptEventMap scriptEvents;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // misc

--- a/src/world/Server/Script/ScriptMgr.cpp
+++ b/src/world/Server/Script/ScriptMgr.cpp
@@ -807,7 +807,6 @@ CreatureAIScript* ScriptMgr::CreateAIScriptClassForEntry(Creature* pCreature)
 {
     uint32_t entry = pCreature->getEntry();
 
-    std::lock_guard lock(m_creaturesMutex);
     CreatureCreateMap::iterator itr = _creatures.find(entry);
     if (itr == _creatures.end())
         return nullptr;


### PR DESCRIPTION
Fixed Mutex Loop in certain conditions. And fixed scriptEvents being Invalid.

**Description**
Fixed some minor Mistakes in Instances where a Mutex Loop would crash the server. And scriptEvents not beeing Initialised and being invalid.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [x] Classic
- [x] TBC
- [x] WotLK
- [x] Cata
-->
