### PR TITLE
Fix database updater

### DIFF
--- a/sql/world/updates/20230727-00_trialofcrusader.sql
+++ b/sql/world/updates/20230727-00_trialofcrusader.sql
@@ -2091,4 +2091,4 @@ INSERT INTO `script_spline_chain_waypoints` VALUES ('39814', '2', '0', '14', '30
 INSERT INTO `script_spline_chain_waypoints` VALUES ('39814', '2', '0', '15', '3008.66', '500.079', '89.6627');
 INSERT INTO `script_spline_chain_waypoints` VALUES ('39814', '2', '0', '16', '3003.83', '501.25', '89.4507');
 
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('136', '20230727-00_trialofcrusader');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('135', '20230727-00_trialofcrusader');

--- a/sql/world/updates/20231123-00_creature_properties.sql
+++ b/sql/world/updates/20231123-00_creature_properties.sql
@@ -176,4 +176,4 @@ DELETE FROM `creature_spawns` WHERE  `id`=460380;
 
 DELETE FROM `creature_spawns` WHERE  `id`=476817;
 
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('137', '20231123-00_creature_properties');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('136', '20231123-00_creature_properties');

--- a/sql/world/updates/20240309-00_spell_ranks.sql
+++ b/sql/world/updates/20240309-00_spell_ranks.sql
@@ -9,7 +9,7 @@ AND `proc_effect_trigger_spell_1` IS NULL AND `proc_effect_trigger_spell_2` IS N
 UPDATE `trainer_properties_spellset` SET `deletespell`='0';
 
 -- Update world db version
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('138', '20240309-00_spell_ranks');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('137', '20240309-00_spell_ranks');
 
 -- Create and populate new spell ranks table
 DROP TABLE IF EXISTS `spell_ranks`;

--- a/sql/world/updates/20240511-00_creature_properties.sql
+++ b/sql/world/updates/20240511-00_creature_properties.sql
@@ -1,4 +1,4 @@
 UPDATE `creature_properties` SET `info_str`='Repair' WHERE  `entry`=43421 AND `build`=15595;
 
 -- Update world db version
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('139', '20240511-00_creature_properties');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('138', '20240511-00_creature_properties');

--- a/sql/world/updates/20240511-01_creature_properties.sql
+++ b/sql/world/updates/20240511-01_creature_properties.sql
@@ -2,4 +2,4 @@ ALTER TABLE `creature_properties`
 	CHANGE COLUMN `info_str` `icon_name` VARCHAR(100) NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci' AFTER `subname`;
 
 -- Update world db version
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('140', '20240511-01_creature_properties');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('139', '20240511-01_creature_properties');

--- a/sql/world/updates/20240904-00_misc.sql
+++ b/sql/world/updates/20240904-00_misc.sql
@@ -6,4 +6,4 @@ UPDATE item_properties SET spellid_3 = 0 WHERE spellid_3 = -1;
 UPDATE reputation_creature_onkill SET rep_limit = 21000 WHERE creature_id = 23051;
 
 -- Update world db version
-INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('141', '20240904-00_misc');
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('140', '20240904-00_misc');

--- a/sql/world/updates/20250112-00_world_db_version.sql
+++ b/sql/world/updates/20250112-00_world_db_version.sql
@@ -1,0 +1,8 @@
+UPDATE `world_db_version` SET `id`='135' WHERE `LastUpdate`='20230727-00_trialofcrusader';
+UPDATE `world_db_version` SET `id`='136' WHERE `LastUpdate`='20231123-00_creature_properties';
+UPDATE `world_db_version` SET `id`='137' WHERE `LastUpdate`='20240309-00_spell_ranks';
+UPDATE `world_db_version` SET `id`='138' WHERE `LastUpdate`='20240511-00_creature_properties';
+UPDATE `world_db_version` SET `id`='139' WHERE `LastUpdate`='20240511-01_creature_properties';
+UPDATE `world_db_version` SET `id`='140' WHERE `LastUpdate`='20240904-00_misc';
+
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('141', '20250112-00_world_db_version');

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -70,7 +70,7 @@
 
 // DB version
 static const char* REQUIRED_CHAR_DB_VERSION = "20241206-00_playerpets";
-static const char* REQUIRED_WORLD_DB_VERSION = "20240904-00_misc";
+static const char* REQUIRED_WORLD_DB_VERSION = "20250112-00_world_db_version";
 
 volatile bool Master::m_stopEvent = false;
 


### PR DESCRIPTION
**Description**
- Use regex to ensure unix newlines in database update files.
- Correct world db version ids. Apparently we have skipped id 135.

Closes https://github.com/AscEmu/AscEmu/issues/1214 https://github.com/AscEmu/AscEmu/issues/1209

Tested by having clean new databases and let auto update setup base files and apply all updates.
Tested with Debian and MariaDB, Ubuntu and MySQL, Windows and MySQL.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [x] TBC
- [x] WotLK
- [ ] Cata
