### PR TITLE
Fix worldserver register timeout

### DIFF
--- a/src/logonserver/LogonCommServer/LogonCommServer.cpp
+++ b/src/logonserver/LogonCommServer/LogonCommServer.cpp
@@ -283,14 +283,14 @@ void LogonCommServerSocket::SendPacket(WorldPacket* data)
     byteSwapUInt32(&header.size);
 
     if (use_crypto)
-        _rwCrypto.process((unsigned char*)&header, (unsigned char*)&header, 6);
+        _sendCrypto.process((unsigned char*)&header, (unsigned char*)&header, 6);
 
     rv = BurstSend((uint8*)&header, 6);
 
     if (data->size() > 0 && rv)
     {
         if (use_crypto)
-            _rwCrypto.process((unsigned char*)data->contents(), (unsigned char*)data->contents(), (uint32)data->size());
+            _sendCrypto.process((unsigned char*)data->contents(), (unsigned char*)data->contents(), (uint32)data->size());
 
         rv = BurstSend(data->contents(), (uint32)data->size());
     }
@@ -337,7 +337,7 @@ void LogonCommServerSocket::HandleAuthChallenge(WorldPacket & recvData)
     //sLogger.info(sstext); FIX fmt
 
     _rwCrypto.setup(key, 20);
-
+    _sendCrypto.setup(key, 20);
 
     // packets are encrypted from now on
     use_crypto = true;

--- a/src/logonserver/LogonCommServer/LogonCommServer.h
+++ b/src/logonserver/LogonCommServer/LogonCommServer.h
@@ -31,6 +31,7 @@ class LogonCommServerSocket : public Socket
     uint16 opcode;
     uint32 seed;
 
+    AscEmu::RC4Engine _sendCrypto;
     AscEmu::RC4Engine _rwCrypto;
 
     public:

--- a/src/world/Server/LogonCommClient/LogonCommClient.cpp
+++ b/src/world/Server/LogonCommClient/LogonCommClient.cpp
@@ -222,14 +222,14 @@ void LogonCommClientSocket::SendPacket(WorldPacket* data, bool no_crypto)
     byteSwapUInt32(&header.size);
 
     if (use_crypto && !no_crypto)
-        _rwCrypto.process((unsigned char*)&header, (unsigned char*)&header, 6);
+        _sendCrypto.process((unsigned char*)&header, (unsigned char*)&header, 6);
 
     bool rv = BurstSend((const uint8*)&header, 6);
 
     if (data->size() > 0 && rv)
     {
         if (use_crypto && !no_crypto)
-            _rwCrypto.process(data->contents(), data->contents(), (unsigned int)data->size());
+            _sendCrypto.process(data->contents(), data->contents(), (unsigned int)data->size());
 
         rv = BurstSend(data->contents(), (uint32)data->size());
     }
@@ -255,6 +255,7 @@ void LogonCommClientSocket::SendChallenge()
     uint8* key = sLogonCommHandler.sql_passhash;
 
     _rwCrypto.setup(key, 20);
+    _sendCrypto.setup(key, 20);
 
     // packets are encrypted from now on
     use_crypto = true;

--- a/src/world/Server/LogonCommClient/LogonCommClient.h
+++ b/src/world/Server/LogonCommClient/LogonCommClient.h
@@ -33,6 +33,7 @@ class LogonCommClientSocket : public Socket
     uint16 opcode;
 
     AscEmu::RC4Engine _rwCrypto;
+    AscEmu::RC4Engine _sendCrypto;
 
     public:
         LogonCommClientSocket(SOCKET fd);


### PR DESCRIPTION
**Description**
LogonComm: Use additional RC4Engine for packet send
@Zyres I have no idea what I am doing XD but now worldserver instantly registers with logonserver.
I knew that https://github.com/AscEmu/AscEmu/commit/1dcaf276ccf4b2d1b27c0d953198964a9773aaa3 caused the issue so I added sendCrypto back to LogonCommClient/Server.
Tested on Ubuntu and Windows.

Closes https://github.com/AscEmu/AscEmu/issues/1211

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.


**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [ ] TBC
- [x] WotLK
- [ ] Cata

