### PR TITLE
Spells: Set implicit target based on effect if it's not existing

### DIFF
--- a/src/world/Server/Packets/MsgAuctionHello.h
+++ b/src/world/Server/Packets/MsgAuctionHello.h
@@ -32,6 +32,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4 + 1); }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << guid.getRawGuid() << auctionHouseId << isAuctionHouseEnabled;

--- a/src/world/Server/Packets/MsgChannelStart.h
+++ b/src/world/Server/Packets/MsgChannelStart.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 
 namespace AscEmu::Packets
@@ -23,7 +24,7 @@ namespace AscEmu::Packets
         }
 
         MsgChannelStart(WoWGuid casterGuid, uint32_t spellId, uint32_t duration) :
-            ManagedPacket(MSG_CHANNEL_START, 8),
+            ManagedPacket(MSG_CHANNEL_START, 0),
             casterGuid(casterGuid),
             spellId(spellId),
             duration(duration)
@@ -31,6 +32,14 @@ namespace AscEmu::Packets
         }
 
     protected:
+#if VERSION_STRING == Classic
+        size_t expectedSize() const override { return static_cast<size_t>(4 + 4); }
+#elif VERSION_STRING >= TBC
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4 + 4); }
+#elif VERSION_STRING >= Cata
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4 + 4 + 1 + 1); }
+#endif
+
         bool internalSerialise(WorldPacket& packet) override
         {
 #if VERSION_STRING >= TBC

--- a/src/world/Server/Packets/MsgChannelUpdate.h
+++ b/src/world/Server/Packets/MsgChannelUpdate.h
@@ -22,13 +22,15 @@ namespace AscEmu::Packets
         }
 
         MsgChannelUpdate(WoWGuid casterGuid, uint32_t time) :
-            ManagedPacket(MSG_CHANNEL_UPDATE, 8 + 4),
+            ManagedPacket(MSG_CHANNEL_UPDATE, 0),
             casterGuid(casterGuid),
             time(time)
         {
         }
 
     protected:
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4); }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << casterGuid << time;

--- a/src/world/Server/Packets/MsgCorpseQuery.h
+++ b/src/world/Server/Packets/MsgCorpseQuery.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 #include "WorldPacket.h"
 
@@ -27,7 +28,7 @@ namespace AscEmu::Packets
         }
 
         MsgCorspeQuery(uint8_t isFound, uint32_t mapId = 0, LocationVector position = {}, uint32_t corpseMapId = 0, uint32_t unknown = 0, WoWGuid guid = uint64_t(0)) :
-            ManagedPacket(MSG_CORPSE_QUERY, isFound ? 1 + 5 * 4 : 1),
+            ManagedPacket(MSG_CORPSE_QUERY, 0),
             isFound(isFound),
             mapId(mapId),
             position(position),
@@ -36,6 +37,15 @@ namespace AscEmu::Packets
             guid(guid)
         {
         }
+
+    protected:
+#if VERSION_STRING > TBC
+        size_t expectedSize() const override { return isFound ? static_cast<size_t>(1 + 4 + 4 + 4 + 4 + 4 + 4) : 1; }
+#elif VERSION_STRING < Mop
+        size_t expectedSize() const override { return isFound ? static_cast<size_t>(1 + 4 + 4 + 4 + 4 + 4) : 1; }
+#else
+        size_t expectedSize() const override { return isFound ? static_cast<size_t>(1 + 8 + 4 + 4 + 4 + 4 + 4) : static_cast<size_t>(9 + (5 * 4)); }
+#endif
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/MsgInspectArenaTeams.h
+++ b/src/world/Server/Packets/MsgInspectArenaTeams.h
@@ -33,16 +33,18 @@ namespace AscEmu::Packets
         }
 
         MsgInspectArenaTeams(uint64_t guid, std::vector<ArenaTeamsList> arenaTeams) :
-            ManagedPacket(MSG_INSPECT_ARENA_TEAMS, 65),
+            ManagedPacket(MSG_INSPECT_ARENA_TEAMS, 8),
             guid(guid),
             arenaTeams(arenaTeams)
         {
         }
 
     protected:
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 2 + 4 + 4 + 4 + 4 + 4) * arenaTeams.size(); }
+
         bool internalSerialise(WorldPacket& packet) override
         {
-            for (const auto teamMembers : arenaTeams)
+            for (const auto& teamMembers : arenaTeams)
             {
                 packet << teamMembers.playerGuid << teamMembers.teamType << teamMembers.teamId << 
                     teamMembers.teamRating << teamMembers.playedWeek << teamMembers.wonWeek << teamMembers.playedSeason;

--- a/src/world/Server/Packets/MsgInspectHonorStats.h
+++ b/src/world/Server/Packets/MsgInspectHonorStats.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 
 namespace AscEmu::Packets
@@ -26,7 +27,7 @@ namespace AscEmu::Packets
         }
 
         MsgInspectHonorStats(uint64_t guid, uint8_t honnorCurrency, uint32_t kills, uint32_t todayContrib, uint32_t yesterdayContrib, uint32_t lifetimeHonorKills) :
-            ManagedPacket(MSG_INSPECT_HONOR_STATS, 13),
+            ManagedPacket(MSG_INSPECT_HONOR_STATS, 8),
             guid(guid),
             honnorCurrency(honnorCurrency),
             kills(kills),
@@ -37,6 +38,14 @@ namespace AscEmu::Packets
         }
 
     protected:
+#if VERSION_STRING == Classic
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 1 + 4); }
+#elif VERSION_STRING < Cata
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 1 + 4 + 4 + 4 + 4); }
+#else
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 1 + 4 + 4); }
+#endif
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << guid << honnorCurrency;

--- a/src/world/Server/Packets/MsgMinimapPing.h
+++ b/src/world/Server/Packets/MsgMinimapPing.h
@@ -31,6 +31,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4 + 4); }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << guid << posX << posY;

--- a/src/world/Server/Packets/MsgMoveTeleportAck.h
+++ b/src/world/Server/Packets/MsgMoveTeleportAck.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 #include "WorldPacket.h"
 
@@ -24,7 +25,11 @@ namespace AscEmu::Packets
         }
 
         MsgMoveTeleportAck(uint32_t flags, uint32_t time) :
+#if VERSION_STRING >= Cata
+            ManagedPacket(MSG_MOVE_TELEPORT_ACK, 4 + 4 + 8),
+#else
             ManagedPacket(MSG_MOVE_TELEPORT_ACK, 8),
+#endif
             flags(flags),
             time(time)
         {

--- a/src/world/Server/Packets/MsgPetitionDecline.h
+++ b/src/world/Server/Packets/MsgPetitionDecline.h
@@ -28,6 +28,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return 8; }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << playerGuid;

--- a/src/world/Server/Packets/MsgQuestPushResult.h
+++ b/src/world/Server/Packets/MsgQuestPushResult.h
@@ -31,7 +31,8 @@ namespace AscEmu::Packets
         {
         }
 
-        size_t expectedSize() const { return 9; }
+    protected:
+        size_t expectedSize() const override { return 9; }
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/MsgRaidReadyCheck.h
+++ b/src/world/Server/Packets/MsgRaidReadyCheck.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
         }
 
         MsgRaidReadyCheck(uint64_t guid, uint8_t isReady, bool isRequest) :
-            ManagedPacket(MSG_RAID_READY_CHECK, 9),
+            ManagedPacket(MSG_RAID_READY_CHECK, 1),
             isReady(isReady),
             guid(guid),
             isRequest(isRequest)
@@ -32,6 +32,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return isRequest ? 8 : 9; }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             if (isRequest)

--- a/src/world/Server/Packets/MsgRandomRoll.h
+++ b/src/world/Server/Packets/MsgRandomRoll.h
@@ -24,7 +24,7 @@ namespace AscEmu::Packets
         }
 
         MsgRandomRoll(uint32_t min, uint32_t max, uint32_t roll, uint64_t guid) :
-            ManagedPacket(MSG_RANDOM_ROLL, 20),
+            ManagedPacket(MSG_RANDOM_ROLL, 8),
             min(min),
             max(max),
             roll(roll),
@@ -33,6 +33,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return static_cast<size_t>(4 + 4 + 4 + 8); }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << min << max << roll << guid;

--- a/src/world/Server/Packets/MsgSetDungeonDifficulty.h
+++ b/src/world/Server/Packets/MsgSetDungeonDifficulty.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 
 namespace AscEmu::Packets
@@ -23,7 +24,7 @@ namespace AscEmu::Packets
         }
 
         MsgSetDungeonDifficulty(uint8_t difficulty, uint32_t unknown, bool isInGroup) :
-            ManagedPacket(MSG_SET_DUNGEON_DIFFICULTY, 0),
+            ManagedPacket(MSG_SET_DUNGEON_DIFFICULTY, 1),
             difficulty(difficulty),
             unknown(unknown),
             isInGroup(isInGroup)
@@ -31,10 +32,11 @@ namespace AscEmu::Packets
         }
 
     protected:
-        size_t expectedSize() const override
-        {
-            return 12;
-        }
+#if VERSION_STRING == Mop
+        size_t expectedSize() const override { return 4; }
+#else
+        size_t expectedSize() const override { return 12; }
+#endif
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/MsgSetRaidDifficulty.h
+++ b/src/world/Server/Packets/MsgSetRaidDifficulty.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include <cstdint>
 
+#include "AEVersion.hpp"
 #include "ManagedPacket.h"
 
 namespace AscEmu::Packets
@@ -24,7 +25,7 @@ namespace AscEmu::Packets
         }
 
         MsgSetRaidDifficulty(uint8_t difficulty, uint32_t unknown, bool isInGroup) :
-            ManagedPacket(MSG_SET_RAID_DIFFICULTY, 0),
+            ManagedPacket(MSG_SET_RAID_DIFFICULTY, 4),
             difficulty(difficulty),
             unknown(unknown),
             isInGroup(isInGroup)
@@ -32,10 +33,11 @@ namespace AscEmu::Packets
         }
 
     protected:
-        size_t expectedSize() const override
-        {
-            return 12;
-        }
+#if VERSION_STRING == Mop
+        size_t expectedSize() const override { return 4; }
+#else
+        size_t expectedSize() const override { return 12; }
+#endif
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Server/Packets/MsgTabardvendorActivate.h
+++ b/src/world/Server/Packets/MsgTabardvendorActivate.h
@@ -28,6 +28,8 @@ namespace AscEmu::Packets
         }
 
     protected:
+        size_t expectedSize() const override { return 8; }
+
         bool internalSerialise(WorldPacket& packet) override
         {
             packet << guid.getRawGuid();

--- a/src/world/Server/Packets/MsgTalentWipeConfirm.h
+++ b/src/world/Server/Packets/MsgTalentWipeConfirm.h
@@ -29,10 +29,7 @@ namespace AscEmu::Packets
         }
 
     protected:
-        size_t expectedSize() const override
-        {
-            return 8 + 4;
-        }
+        size_t expectedSize() const override { return static_cast<size_t>(8 + 4); }
 
         bool internalSerialise(WorldPacket& packet) override
         {

--- a/src/world/Spell/Definitions/SpellCastTargetFlags.hpp
+++ b/src/world/Spell/Definitions/SpellCastTargetFlags.hpp
@@ -15,7 +15,7 @@ enum SpellCastTargetFlags
     TARGET_FLAG_ITEM            = 0x00010,
     TARGET_FLAG_SOURCE_LOCATION = 0x00020,
     TARGET_FLAG_DEST_LOCATION   = 0x00040,
-    TARGET_FLAG_OBJECT_CASTER   = 0x00080,
+    TARGET_FLAG_UNK8            = 0x00080, // used in 7 spells
     TARGET_FLAG_UNIT_CASTER     = 0x00100,
     TARGET_FLAG_CORPSE          = 0x00200, // PvP Corpse
     TARGET_FLAG_UNIT_CORPSE     = 0x00400, // Gathering Corpse

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -2587,7 +2587,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                     if (lockInfo->locktype[x] == LOCK_KEY_ITEM)
                     {
                         if (i_caster == nullptr || lockInfo->lockmisc[x] == 0)
-                            return SPELL_FAILED_BAD_TARGETS;
+                            continue;
                         // No need to check further on a successful match
                         if (i_caster->getEntry() == lockInfo->lockmisc[x])
                         {

--- a/src/world/Spell/SpellCastTargets.cpp
+++ b/src/world/Spell/SpellCastTargets.cpp
@@ -68,7 +68,7 @@ void SpellCastTargets::read(WorldPacket& data, uint64_t caster)
         return;
     }
 
-    if (m_targetMask & (TARGET_FLAG_OBJECT | TARGET_FLAG_OBJECT_CASTER))
+    if (m_targetMask & (TARGET_FLAG_OBJECT | TARGET_FLAG_OPEN_LOCK))
     {
         WoWGuid guid;
         data >> guid;
@@ -135,7 +135,7 @@ void SpellCastTargets::write(WorldPacket& data) const
 {
     data << m_targetMask;
 
-    if (m_targetMask & (TARGET_FLAG_OBJECT | TARGET_FLAG_OBJECT_CASTER))
+    if (m_targetMask & (TARGET_FLAG_OBJECT | TARGET_FLAG_OPEN_LOCK))
     {
         FastGUIDPack(data, m_gameObjectTargetGuid);
     }

--- a/src/world/Spell/SpellInfo.hpp
+++ b/src/world/Spell/SpellInfo.hpp
@@ -198,7 +198,7 @@ public:
 
     uint32_t getRequiredShapeShift() const { return Shapeshifts; }
     uint32_t getShapeshiftExclude() const { return ShapeshiftsExcluded; }
-    uint32_t getTargets() const { return Targets; } // not used!
+    uint32_t getTargets() const { return Targets; }
     uint32_t getTargetCreatureType() const { return TargetCreatureType; }
     uint32_t getRequiresSpellFocus() const { return RequiresSpellFocus; }
     uint32_t getFacingCasterFlags() const { return FacingCasterFlags; }


### PR DESCRIPTION
**Description**
Spells: Set implicit target based on effect if it's not existing
Packets: Correct packet sizes in all Msg packets

Closes https://github.com/AscEmu/AscEmu/issues/1210

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

