### PR TITLE
fix clang build raspberry pi

### DIFF
--- a/cmake/Compilers/clang.cmake
+++ b/cmake/Compilers/clang.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2025 AscEmu Team <http://www.ascemu.org>
 
-# Clang >= 16.0.0
-set(CLANG_SUPPORTS_VERSION 16.0.0)
+# Clang >= 14.0.6
+set(CLANG_SUPPORTS_VERSION 14.0.6)
 # TODO change to 18 when Debian 13 is released
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS CLANG_SUPPORTS_VERSION)


### PR DESCRIPTION
**Description**

added support arm
fix build raspberry pi

![image](https://github.com/user-attachments/assets/797b8347-df8e-4a29-a9e7-2a6b5c99be08)

test pi 5 8gb
Operating System: Debian GNU/Linux 12 (bookworm)  
Kernel: Linux 6.1.0-rpi8-rpi-2712
Architecture: arm64

clang version 14.0.6
gcc    version 12.2.0 (Debian 12.2.0-14) 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.

**Multiversion Ingame Tests Performed:**
- [x] Classic
- [x] TBC
- [x] WotLK
- [x] Cata
