### PR TITLE
Latest version of actions/checkout is 4.2.2. 

### DIFF
--- a/.github/workflows/clang-linux-test-x64.yml
+++ b/.github/workflows/clang-linux-test-x64.yml
@@ -11,7 +11,7 @@ jobs:
   Classic:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -34,7 +34,7 @@ jobs:
   TBC:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -57,7 +57,7 @@ jobs:
   WotLK:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -80,7 +80,7 @@ jobs:
   Cata:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -103,7 +103,7 @@ jobs:
   Mop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev

--- a/.github/workflows/gcc-linux-test-x64.yml
+++ b/.github/workflows/gcc-linux-test-x64.yml
@@ -11,7 +11,7 @@ jobs:
   Classic:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -34,7 +34,7 @@ jobs:
   TBC:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -57,7 +57,7 @@ jobs:
   WotLK:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -80,7 +80,7 @@ jobs:
   Cata:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev
@@ -103,7 +103,7 @@ jobs:
   Mop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Setup Environment
       run: |
         sudo apt-get update && sudo apt-get install -y zlib1g-dev


### PR DESCRIPTION
**Description**

Latest version of actions/checkout is 4.2.2. Update our github actions to use it.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
