### PR TITLE
Sort out multiversion WoWData byte fields and unit/player flags

### DIFF
--- a/sql/character/updates/20250516-00_characters.sql
+++ b/sql/character/updates/20250516-00_characters.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `characters` ADD COLUMN `enabled_actionbars` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `player_flags`;
+UPDATE `characters` SET `enabled_actionbars`=(player_bytes >> 16) & 0xFF;
+ALTER TABLE `characters` DROP COLUMN `player_bytes`;
+
+-- Remove problematic version specific player flags
+UPDATE `characters` SET `player_flags` = `player_flags` & ~(0x00000080 | 0x00008000 | 0x00010000 | 0x00040000);
+
+INSERT INTO `character_db_version` (`id`, `LastUpdate`) VALUES ('14', '20250516-00_characters');

--- a/sql/world/updates/20250516-00_creature_spawns.sql
+++ b/sql/world/updates/20250516-00_creature_spawns.sql
@@ -1,0 +1,8 @@
+UPDATE `creature_spawns` SET `standstate`=(bytes1) & 0xFF WHERE `standstate`='0';
+ALTER TABLE `creature_spawns` ADD COLUMN `sheath_state` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `mountdisplayid`;
+UPDATE `creature_spawns` SET `sheath_state`=(bytes2) & 0xFF;
+ALTER TABLE `creature_spawns` ADD COLUMN `pvp_flagged` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `flags`;
+UPDATE `creature_spawns` SET `pvp_flagged`=((bytes2 >> 8) & 0xFF) & 0x1;
+ALTER TABLE `creature_spawns` DROP COLUMN `bytes1`, DROP COLUMN `bytes2`;
+
+INSERT INTO `world_db_version` (`id`, `LastUpdate`) VALUES ('142', '20250516-00_creature_spawns');

--- a/src/scripts/InstanceScripts/Wotlk/CrusadersColiseum/TrialOfTheCrusader/Lord_Jaraxxus.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/CrusadersColiseum/TrialOfTheCrusader/Lord_Jaraxxus.cpp
@@ -19,7 +19,7 @@ JaraxxusAI::JaraxxusAI(Creature* pCreature) : CreatureAIScript(pCreature)
     // Add Boundary
     pCreature->getAIInterface()->addBoundary(std::make_unique<CircleBoundary>(LocationVector(563.26f, 139.6f), 75.0));
 
-    setUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_PLUS_MOB);
+    setUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_PLUS_MOB);
 
     addEmoteForEventByIndex(Event_OnCombatStart, jaraxxus::SAY_AGGRO);
     addEmoteForEventByIndex(Event_OnTargetDied, jaraxxus::SAY_KILL_PLAYER);

--- a/src/scripts/InstanceScripts/Wotlk/CrusadersColiseum/TrialOfTheCrusader/Northrend_Beasts.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/CrusadersColiseum/TrialOfTheCrusader/Northrend_Beasts.cpp
@@ -212,7 +212,7 @@ void NorthrendBeastsAI::initialMove(CreatureAIFunc pThis)
 ///  Gormok
 GormokAI::GormokAI(Creature* pCreature) : NorthrendBeastsAI(pCreature)
 {
-    setUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_PLUS_MOB);
+    setUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_PLUS_MOB);
     getCreature()->setAItoUse(true);
     _setWieldWeapon(true);
 }

--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Saurfang.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Saurfang.cpp
@@ -153,7 +153,7 @@ void MuradinSaurfangEvent::AIUpdate(unsigned long time_passed)
                 if (outroNpc && outroNpc->GetScript())
                 {
                     outroNpc->GetScript()->setCanEnterCombat(false);
-                    outroNpc->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                    outroNpc->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                     outroNpc->GetScript()->DoAction(ACTION_START_OUTRO);
                 }
 
@@ -852,7 +852,7 @@ void DeathbringerSaurfangAI::Reset()
     _dead = false;
 
     setCanEnterCombat(false);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 
     getCreature()->setPower(POWER_TYPE_ENERGY, 0);
     _castAISpell(ZeroPowerSpell);
@@ -899,7 +899,7 @@ void DeathbringerSaurfangAI::AIUpdate(unsigned long time_passed)
                 sendDBChatMessage(SAY_DEATHBRINGER_INTRO_ALLIANCE_7);
                 _castAISpell(GripOfAgonySpell);
                 setCanEnterCombat(true);
-                getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                 break;
             }
             case EVENT_INTRO_HORDE_2_SE:
@@ -919,7 +919,7 @@ void DeathbringerSaurfangAI::AIUpdate(unsigned long time_passed)
                 sendDBChatMessage(SAY_DEATHBRINGER_INTRO_HORDE_9);
                 _castAISpell(GripOfAgonySpell);
                 setCanEnterCombat(true);
-                getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                getCreature()->removeUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                 break;
             }
             case EVENT_INTRO_FINISH_SE:
@@ -1001,7 +1001,7 @@ void DeathbringerSaurfangAI::DamageTaken(Unit* _attacker, uint32_t* damage)
 
         // Prepare for Outro
         getCreature()->addUnitFlags(UNIT_FLAG_NOT_SELECTABLE);
-        getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+        getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 
         Creature* Commander = mInstance->getInstance()->getInterface()->findNearestCreature(getCreature(), mInstance->getInstance()->getTeamIdInInstance() ? NPC_SE_HIGH_OVERLORD_SAURFANG : NPC_SE_MURADIN_BRONZEBEARD, 250.0f);
         if (Commander)

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Erekem.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Erekem.cpp
@@ -54,7 +54,7 @@ void ErekemAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 }
 
 void ErekemAI::AIUpdate(unsigned long /*time_passed*/)

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Ichron.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Ichron.cpp
@@ -41,7 +41,7 @@ void IchronAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 
     /// for some reason ichoron can't walk back to it's water basin on evade
     getCreature()->addUnitStateFlag(UNIT_STATE_IGNORE_PATHFINDING);

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Instance_TheVioletHold.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Instance_TheVioletHold.cpp
@@ -321,7 +321,7 @@ void TheVioletHoldScript::UpdateEvent()
                 {
                     boss->getAIInterface()->setImmuneToNPC(false);
                     boss->getAIInterface()->setImmuneToPC(false);
-                    boss->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                    boss->removeUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 
                     switch (bossId)
                     {
@@ -335,7 +335,7 @@ void TheVioletHoldScript::UpdateEvent()
                                 {
                                     guard->getAIInterface()->setImmuneToNPC(false);
                                     guard->getAIInterface()->setImmuneToPC(false);
-                                    guard->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                                    guard->removeUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                                 }
                             }
                         } break;
@@ -365,7 +365,7 @@ void TheVioletHoldScript::UpdateEvent()
                     cyanigosa->castSpell(cyanigosa, SPELL_CYANIGOSA_TRANSFORM, true);
                     cyanigosa->getAIInterface()->setImmuneToNPC(false);
                     cyanigosa->getAIInterface()->setImmuneToPC(false);
-                    cyanigosa->removeUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                    cyanigosa->removeUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                 }
             } break;
             default:
@@ -605,7 +605,7 @@ void TheVioletHoldScript::resetBossEncounter(uint8_t bossId)
                     guard->getMovementManager()->moveTargetedHome();
                     guard->getAIInterface()->setImmuneToNPC(true);
                     guard->getAIInterface()->setImmuneToPC(true);
-                    guard->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+                    guard->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
                 }
             }
         } [[fallthrough]];

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Lavanthor.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Lavanthor.cpp
@@ -30,7 +30,7 @@ void LavanthorAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 }
 
 void LavanthorAI::OnDied(Unit* /*_killer*/)

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Moragg.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Moragg.cpp
@@ -30,7 +30,7 @@ void MoraggAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 }
 
 void MoraggAI::OnDied(Unit* /*_killer*/)

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Xevozz.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Xevozz.cpp
@@ -37,7 +37,7 @@ void XevozzAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 }
 
 void XevozzAI::OnCombatStart(Unit* /*_target*/)

--- a/src/scripts/InstanceScripts/Wotlk/VioletHold/Zuramat.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/VioletHold/Zuramat.cpp
@@ -35,7 +35,7 @@ void ZuramatAI::OnLoad()
     getCreature()->getMovementManager()->moveTargetedHome();
     getCreature()->getAIInterface()->setImmuneToNPC(true);
     getCreature()->getAIInterface()->setImmuneToPC(true);
-    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_PLAYER_NPC);
+    getCreature()->addUnitFlags(UNIT_FLAG_IGNORE_CREATURE_COMBAT);
 }
 
 void ZuramatAI::OnCombatStop(Unit* /*_target*/)

--- a/src/scripts/LuaEngine/LuaUnit.cpp
+++ b/src/scripts/LuaEngine/LuaUnit.cpp
@@ -5971,8 +5971,10 @@ int LuaUnit::ResetPetTalents(lua_State* /*L*/, Unit* ptr)
     if (pet != nullptr)
     {
         pet->WipeTalents();
+#if VERSION_STRING == WotLK || VERSION_STRING == Cata
         pet->setPetTalentPoints(pet->GetTPsForLevel(pet->getLevel()));
         pet->SendTalentsToOwner();
+#endif
     }
     return 0;
 }

--- a/src/scripts/SpellHandlers/LegacyFiles/PetAISpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/PetAISpells.cpp
@@ -312,10 +312,12 @@ public:
     static CreatureAIScript* Create(Creature* c) { return new FrostBroodVanquisherAI(c); }
     explicit FrostBroodVanquisherAI(Creature* pCreature) : CreatureAIScript(pCreature) {}
 
+#if VERSION_STRING >= TBC
     void OnLoad() override
     {
-        getCreature()->setAnimationTier(AnimationTier::Hover);
+        getCreature()->setAnimationFlags(ANIMATION_FLAG_HOVER);
     }
+#endif
 
     void OnRemovePassenger(Unit* _passenger) override
     {

--- a/src/shared/Utilities/Util.hpp
+++ b/src/shared/Utilities/Util.hpp
@@ -10,6 +10,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include <map>
 #include <filesystem>
 #include <locale>
+#include <type_traits>
 
 namespace Util
 {
@@ -84,6 +85,36 @@ namespace Util
     uint32_t readMajorVersionFromString(const std::string& fileName);
 
     uint32_t readMinorVersionFromString(const std::string& fileName);
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // std::is_specialization_of_v implementation
+
+    // Primary template - not a specialization
+    template <template <typename, typename...> class Template, typename>
+    struct is_specialization_of : std::false_type {};
+
+    // Partial specialization for types with a second parameter as a pack
+    template <template <typename, typename...> class Template, typename T1, typename... Args>
+    struct is_specialization_of<Template, Template<T1, Args...>> : std::true_type {};
+
+    // Helper variable template for convenience
+    template <typename T, template <typename, typename...> class Template>
+    concept is_specialization_of_v = is_specialization_of<Template, T>::value;
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // std::is_specialization_of_v implementation for e.g. std::arrays
+
+    // Primary template for types with size_t as the second parameter - not a specialization
+    template <template <typename, size_t> class Template, typename>
+    struct is_size_based_specialization_of : std::false_type {};
+
+    // Partial specialization for types with size_t as the second parameter
+    template <template <typename, size_t> class Template, typename T1, size_t N>
+    struct is_size_based_specialization_of<Template, Template<T1, N>> : std::true_type {};
+
+    // Helper variable template for types with size_t as the second parameter for convenience
+    template <typename T, template <typename, size_t> class Template>
+    concept is_size_based_specialization_of_v = is_size_based_specialization_of<Template, T>::value;
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // Misc

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -84,14 +84,14 @@ bool ChatHandler::HandleMoveHardcodedScriptsToDBCommand(const char* args, WorldS
         creature_spawn->o = session->GetPlayer()->GetOrientation();
         creature_spawn->emote_state = 0;
         creature_spawn->flags = creature_properties->NPCFLags;
+        creature_spawn->pvp_flagged = 0;
         creature_spawn->factionid = creature_properties->Faction;
         creature_spawn->bytes0 = creature_spawn->setbyte(0, 2, gender);
-        creature_spawn->bytes1 = 0;
-        creature_spawn->bytes2 = 0;
         creature_spawn->stand_state = 0;
         creature_spawn->death_state = 0;
         creature_spawn->channel_target_creature = creature_spawn->channel_target_go = creature_spawn->channel_spell = 0;
         creature_spawn->MountedDisplayID = 0;
+        creature_spawn->sheath_state = 0;
 
         creature_spawn->Item1SlotEntry = creature_properties->itemslot_1;
         creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;

--- a/src/world/Chat/Commands/GameMasterCommands.cpp
+++ b/src/world/Chat/Commands/GameMasterCommands.cpp
@@ -32,8 +32,10 @@ bool ChatHandler::HandleGMActiveCommand(const char* args, WorldSession* m_sessio
     }
     else
     {
+#if VERSION_STRING >= WotLK
         if (player->hasPlayerFlags(PLAYER_FLAG_DEVELOPER))
             HandleGMDevTagCommand("no_notice", m_session);
+#endif
 
         SystemMessage(m_session, "GM Flag set.");
         BlueSystemMessage(m_session, "<GM> will now appear above your name and in chat messages until you use this command again.");
@@ -120,6 +122,7 @@ bool ChatHandler::HandleGMDevTagCommand(const char* args, WorldSession* m_sessio
     auto player = m_session->GetPlayer();
     bool toggle_no_notice = std::string(args) == "no_notice" ? true : false;
 
+#if VERSION_STRING >= WotLK
     if (player->hasPlayerFlags(PLAYER_FLAG_DEVELOPER))
     {
         if (!toggle_no_notice)
@@ -138,6 +141,7 @@ bool ChatHandler::HandleGMDevTagCommand(const char* args, WorldSession* m_sessio
         BlueSystemMessage(m_session, "<DEV> will now appear above your name and in chat messages until you use this command again.");
         player->addPlayerFlags(PLAYER_FLAG_DEVELOPER);
     }
+#endif
 
     return true;
 }

--- a/src/world/Chat/Commands/NpcCommands.cpp
+++ b/src/world/Chat/Commands/NpcCommands.cpp
@@ -774,14 +774,14 @@ bool ChatHandler::HandleNpcSpawnCommand(const char* args, WorldSession* m_sessio
     creature_spawn->o = m_session->GetPlayer()->GetOrientation();
     creature_spawn->emote_state = 0;
     creature_spawn->flags = creature_properties->NPCFLags;
+    creature_spawn->pvp_flagged = 0;
     creature_spawn->factionid = creature_properties->Faction;
     creature_spawn->bytes0 = creature_spawn->setbyte(0, 2, gender);
-    creature_spawn->bytes1 = 0;
-    creature_spawn->bytes2 = 0;
     creature_spawn->stand_state = 0;
     creature_spawn->death_state = 0;
     creature_spawn->channel_target_creature = creature_spawn->channel_target_go = creature_spawn->channel_spell = 0;
     creature_spawn->MountedDisplayID = 0;
+    creature_spawn->sheath_state = 0;
 
     creature_spawn->Item1SlotEntry = creature_properties->itemslot_1;
     creature_spawn->Item2SlotEntry = creature_properties->itemslot_2;

--- a/src/world/Data/Flags.hpp
+++ b/src/world/Data/Flags.hpp
@@ -7,8 +7,10 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "AEVersion.hpp"
 
+#include <cstdint>
+
 #if VERSION_STRING == Classic
-enum TrainerSpellState
+enum TrainerSpellState : uint8_t
 {
     TRAINER_SPELL_GREEN                 = 0,
     TRAINER_SPELL_RED                   = 1,
@@ -16,7 +18,7 @@ enum TrainerSpellState
     TRAINER_SPELL_GREEN_DISABLED        = 10
 };
 
-enum ObjectUpdateFlags
+enum ObjectUpdateFlags : uint16_t
 {
     UPDATEFLAG_NONE                     = 0x0000,
     UPDATEFLAG_SELF                     = 0x0001,
@@ -31,7 +33,7 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == TBC
-enum TrainerSpellState
+enum TrainerSpellState : uint8_t
 {
     TRAINER_SPELL_GREEN                 = 0,
     TRAINER_SPELL_RED                   = 1,
@@ -39,7 +41,7 @@ enum TrainerSpellState
     TRAINER_SPELL_GREEN_DISABLED        = 10
 };
 
-enum ObjectUpdateFlags
+enum ObjectUpdateFlags : uint16_t
 {
     UPDATEFLAG_NONE                     = 0x0000,
     UPDATEFLAG_SELF                     = 0x0001,
@@ -54,7 +56,7 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == WotLK
-enum TrainerSpellState
+enum TrainerSpellState : uint8_t
 {
     TRAINER_SPELL_GREEN                 = 0,
     TRAINER_SPELL_RED                   = 1,
@@ -62,7 +64,7 @@ enum TrainerSpellState
     TRAINER_SPELL_GREEN_DISABLED        = 10
 };
 
-enum ObjectUpdateFlags
+enum ObjectUpdateFlags : uint16_t
 {
     UPDATEFLAG_NONE                     = 0x0000,
     UPDATEFLAG_SELF                     = 0x0001,
@@ -84,7 +86,7 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == Cata
-enum TrainerSpellState
+enum TrainerSpellState : uint8_t
 {
     TRAINER_SPELL_GRAY                  = 0,
     TRAINER_SPELL_GREEN                 = 1,
@@ -92,7 +94,7 @@ enum TrainerSpellState
     TRAINER_SPELL_GREEN_DISABLED        = 10
 };
 
-enum ObjectUpdateFlags
+enum ObjectUpdateFlags : uint32_t
 {
     UPDATEFLAG_NONE                     = 0x00000,
     UPDATEFLAG_SELF                     = 0x00001,
@@ -117,7 +119,7 @@ enum ObjectUpdateFlags
 #endif
 
 #if VERSION_STRING == Mop
-enum TrainerSpellState
+enum TrainerSpellState : uint8_t
 {
     TRAINER_SPELL_GRAY                  = 0,
     TRAINER_SPELL_GREEN                 = 1,
@@ -125,7 +127,7 @@ enum TrainerSpellState
     TRAINER_SPELL_GREEN_DISABLED        = 10
 };
 
-enum ObjectUpdateFlags
+enum ObjectUpdateFlags : uint16_t
 {
     UPDATEFLAG_NONE                     = 0x0000,
     UPDATEFLAG_SELF                     = 0x0001,

--- a/src/world/Data/GuidData.hpp
+++ b/src/world/Data/GuidData.hpp
@@ -8,13 +8,13 @@ This file is released under the MIT license. See README-MIT for more information
 #include <cstdint>
 
 #pragma pack(push, 1)
-union
+union guid_union
 {
     uint64_t guid;
-    struct
+    struct parts
     {
         uint32_t low;
         uint32_t high;
     } parts;
-} typedef guid_union;
+};
 #pragma pack(pop)

--- a/src/world/Data/WoWAreaTrigger.hpp
+++ b/src/world/Data/WoWAreaTrigger.hpp
@@ -17,8 +17,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma pack(push, 1)
 
-#if VERSION_STRING >= Cata
-#if VERSION_STRING < Mop
+#if VERSION_STRING == Cata
 struct WoWAreaTrigger : WoWObject
 {
     uint32_t spell_id;
@@ -28,7 +27,7 @@ struct WoWAreaTrigger : WoWObject
     float pos_y;
     float pos_z;
 };
-#else
+#elif VERSION_STRING == Mop
 struct WoWAreaTrigger : WoWObject
 {
     guid_union caster_guid;
@@ -37,7 +36,6 @@ struct WoWAreaTrigger : WoWObject
     uint32_t spell_visual_id;
     float scale;
 };
-#endif
 #endif
 
 #pragma pack(pop)

--- a/src/world/Data/WoWContainer.hpp
+++ b/src/world/Data/WoWContainer.hpp
@@ -20,59 +20,59 @@ This file is released under the MIT license. See README-MIT for more information
 #if VERSION_STRING == Classic
 
 //todo verify - descriptor is 72, enum 58.
-#define WOWCONTAINER_ITEM_SLOT_COUNT 29
+static inline constexpr uint8_t WOWCONTAINER_ITEM_SLOT_COUNT = 29;
 
 struct WoWContainer : WoWItem
 {
     uint32_t slot_count;
     uint32_t padding_container;
-    guid_union item_slot[WOWCONTAINER_ITEM_SLOT_COUNT];
+    std::array<guid_union, WOWCONTAINER_ITEM_SLOT_COUNT> item_slot;
 };
 #endif
 
 #if VERSION_STRING == TBC
 
-#define WOWCONTAINER_ITEM_SLOT_COUNT 36
+static inline constexpr uint8_t WOWCONTAINER_ITEM_SLOT_COUNT = 36;
 
 struct WoWContainer : WoWItem
 {
     uint32_t slot_count;
     uint32_t padding_container;
-    guid_union item_slot[WOWCONTAINER_ITEM_SLOT_COUNT];
+    std::array<guid_union, WOWCONTAINER_ITEM_SLOT_COUNT> item_slot;
 };
 #endif
 
 #if VERSION_STRING == WotLK
 
-#define WOWCONTAINER_ITEM_SLOT_COUNT 36
+static inline constexpr uint8_t WOWCONTAINER_ITEM_SLOT_COUNT = 36;
 
 struct WoWContainer : WoWItem
 {
     uint32_t slot_count;
     uint32_t padding_container;
-    guid_union item_slot[WOWCONTAINER_ITEM_SLOT_COUNT];
+    std::array<guid_union, WOWCONTAINER_ITEM_SLOT_COUNT> item_slot;
 };
 #endif
 
 #if VERSION_STRING == Cata
 
-#define WOWCONTAINER_ITEM_SLOT_COUNT 36
+static inline constexpr uint8_t WOWCONTAINER_ITEM_SLOT_COUNT = 36;
 
 struct WoWContainer : WoWItem
 {
     uint32_t slot_count;
     uint32_t container_padding_0;
-    guid_union item_slot[WOWCONTAINER_ITEM_SLOT_COUNT];
+    std::array<guid_union, WOWCONTAINER_ITEM_SLOT_COUNT> item_slot;
 };
 #endif
 
 #if VERSION_STRING == Mop
 
-#define WOWCONTAINER_ITEM_SLOT_COUNT 36
+static inline constexpr uint8_t WOWCONTAINER_ITEM_SLOT_COUNT = 36;
 
 struct WoWContainer : WoWItem
 {
-    guid_union item_slot[WOWCONTAINER_ITEM_SLOT_COUNT];
+    std::array<guid_union, WOWCONTAINER_ITEM_SLOT_COUNT> item_slot;
     uint32_t slot_count;
 };
 #endif

--- a/src/world/Data/WoWCorpse.hpp
+++ b/src/world/Data/WoWCorpse.hpp
@@ -15,11 +15,13 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "WoWObject.hpp"
 
+#include <array>
+
 #pragma pack(push, 1)
 
-union
+union corpse_bytes_1_union
 {
-    struct
+    struct parts
     {
         uint8_t unk1;
         uint8_t race;
@@ -27,11 +29,11 @@ union
         uint8_t skin_color;
     } s;
     uint32_t raw;
-} typedef corpse_bytes_1_union;
+};
 
-union
+union corpse_bytes_2_union
 {
-    struct
+    struct parts
     {
         uint8_t face;
         uint8_t hair_style;
@@ -39,11 +41,11 @@ union
         uint8_t facial_hair;
     } s;
     uint32_t raw;
-} typedef corpse_bytes_2_union;
+};
 
 #if VERSION_STRING == Classic
 
-#define WOWCORPSE_ITEM_COUNT 19
+static inline constexpr uint8_t WOWCORPSE_ITEM_COUNT = 19;
 
 struct WoWCorpse : WoWObject
 {
@@ -54,7 +56,7 @@ struct WoWCorpse : WoWObject
     float y;
     float z;
     uint32_t display_id;
-    uint32_t item[WOWCORPSE_ITEM_COUNT];
+    std::array<uint32_t, WOWCORPSE_ITEM_COUNT> item;
     corpse_bytes_1_union corpse_bytes_1;
     corpse_bytes_2_union corpse_bytes_2;
     uint32_t guild;
@@ -66,7 +68,7 @@ struct WoWCorpse : WoWObject
 
 #if VERSION_STRING == TBC
 
-#define WOWCORPSE_ITEM_COUNT 19
+static inline constexpr uint8_t WOWCORPSE_ITEM_COUNT = 19;
 
 struct WoWCorpse : WoWObject
 {
@@ -77,7 +79,7 @@ struct WoWCorpse : WoWObject
     float y;
     float z;
     uint32_t display_id;
-    uint32_t item[WOWCORPSE_ITEM_COUNT];
+    std::array<uint32_t, WOWCORPSE_ITEM_COUNT> item;
     corpse_bytes_1_union corpse_bytes_1;
     corpse_bytes_2_union corpse_bytes_2;
     uint32_t guild;
@@ -89,14 +91,14 @@ struct WoWCorpse : WoWObject
 
 #if VERSION_STRING == WotLK
 
-#define WOWCORPSE_ITEM_COUNT 19
+static inline constexpr uint8_t WOWCORPSE_ITEM_COUNT = 19;
 
 struct WoWCorpse : WoWObject
 {
     uint64_t owner_guid;
     uint64_t party_guid;
     uint32_t display_id;
-    uint32_t item[WOWCORPSE_ITEM_COUNT];
+    std::array<uint32_t, WOWCORPSE_ITEM_COUNT> item;
     corpse_bytes_1_union corpse_bytes_1;
     corpse_bytes_2_union corpse_bytes_2;
     uint32_t guild;
@@ -108,14 +110,14 @@ struct WoWCorpse : WoWObject
 
 #if VERSION_STRING == Cata
 
-#define WOWCORPSE_ITEM_COUNT 19
+static inline constexpr uint8_t WOWCORPSE_ITEM_COUNT = 19;
 
 struct WoWCorpse : WoWObject
 {
     uint64_t owner_guid;
     uint64_t party_guid;
     uint32_t display_id;
-    uint32_t item[WOWCORPSE_ITEM_COUNT];
+    std::array<uint32_t, WOWCORPSE_ITEM_COUNT> item;
     corpse_bytes_1_union corpse_bytes_1;
     corpse_bytes_2_union corpse_bytes_2;
     uint32_t corpse_flags;
@@ -125,14 +127,14 @@ struct WoWCorpse : WoWObject
 
 #if VERSION_STRING == Mop
 
-#define WOWCORPSE_ITEM_COUNT 19
+static inline constexpr uint8_t WOWCORPSE_ITEM_COUNT = 19;
 
 struct WoWCorpse : WoWObject
 {
     uint64_t owner_guid;
     uint64_t party_guid;
     uint32_t display_id;
-    uint32_t item[WOWCORPSE_ITEM_COUNT];
+    std::array<uint32_t, WOWCORPSE_ITEM_COUNT> item;
     corpse_bytes_1_union corpse_bytes_1;
     corpse_bytes_2_union corpse_bytes_2;
     uint32_t corpse_flags;

--- a/src/world/Data/WoWDynamicObject.hpp
+++ b/src/world/Data/WoWDynamicObject.hpp
@@ -17,9 +17,10 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma pack(push, 1)
 
-union
+#if VERSION_STRING == Classic
+union dynamic_bytes_union
 {
-    struct
+    struct parts
     {
         uint8_t type;
         uint8_t unk1;
@@ -27,9 +28,8 @@ union
         uint8_t unk3;
     } s;
     uint32_t raw;
-} typedef dynamic_bytes_union;
+};
 
-#if VERSION_STRING == Classic
 struct WoWDynamicObject : WoWObject
 {
     uint64_t caster_guid;
@@ -45,6 +45,18 @@ struct WoWDynamicObject : WoWObject
 #endif
 
 #if VERSION_STRING == TBC
+union dynamic_bytes_union
+{
+    struct parts
+    {
+        uint8_t type;
+        uint8_t unk1;
+        uint8_t unk2;
+        uint8_t unk3;
+    } s;
+    uint32_t raw;
+};
+
 struct WoWDynamicObject : WoWObject
 {
     uint64_t caster_guid;
@@ -60,6 +72,18 @@ struct WoWDynamicObject : WoWObject
 #endif
 
 #if VERSION_STRING == WotLK
+union dynamic_bytes_union
+{
+    struct parts
+    {
+        uint8_t type;
+        uint8_t unk1;
+        uint8_t unk2;
+        uint8_t unk3;
+    } s;
+    uint32_t raw;
+};
+
 struct WoWDynamicObject : WoWObject
 {
     uint64_t caster_guid;
@@ -71,6 +95,17 @@ struct WoWDynamicObject : WoWObject
 #endif
 
 #if VERSION_STRING == Cata
+union dynamic_bytes_union
+{
+    // todo: verify bits
+    struct parts
+    {
+        uint32_t spell_visual_id : 28; // not used
+        uint32_t type : 4;
+    } s;
+    uint32_t raw;
+};
+
 struct WoWDynamicObject : WoWObject
 {
     uint64_t caster_guid;
@@ -82,6 +117,17 @@ struct WoWDynamicObject : WoWObject
 #endif
 
 #if VERSION_STRING == Mop
+union dynamic_bytes_union
+{
+    // todo: verify bits
+    struct parts
+    {
+        uint32_t spell_visual_id : 28; // not used
+        uint32_t type : 4;
+    } s;
+    uint32_t raw;
+};
+
 struct WoWDynamicObject : WoWObject
 {
     uint64_t caster_guid;

--- a/src/world/Data/WoWGameObject.hpp
+++ b/src/world/Data/WoWGameObject.hpp
@@ -14,20 +14,21 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "WoWObject.hpp"
-#include "GuidData.hpp"
+
+#include <array>
 
 #pragma pack(push, 1)
 
 #if VERSION_STRING == Classic
 
-#define GAMEOBJECT_ROTATION_COUNT 4
+static inline constexpr uint8_t GAMEOBJECT_ROTATION_COUNT = 4;
 
 struct WoWGameObject : WoWObject
 {
     guid_union object_field_created_by;
     uint32_t display_id;
     uint32_t flags;
-    float rotation[GAMEOBJECT_ROTATION_COUNT];
+    std::array<float, GAMEOBJECT_ROTATION_COUNT> rotation;
     uint32_t state;
     float x;
     float y;
@@ -45,14 +46,14 @@ struct WoWGameObject : WoWObject
 
 #if VERSION_STRING == TBC
 
-#define GAMEOBJECT_ROTATION_COUNT 4
+static inline constexpr uint8_t GAMEOBJECT_ROTATION_COUNT = 4;
 
 struct WoWGameObject : WoWObject
 {
     guid_union object_field_created_by;
     uint32_t display_id;
     uint32_t flags;
-    float rotation[GAMEOBJECT_ROTATION_COUNT];
+    std::array<float, GAMEOBJECT_ROTATION_COUNT> rotation;
     uint32_t state;
     float x;
     float y;
@@ -70,110 +71,110 @@ struct WoWGameObject : WoWObject
 
 #if VERSION_STRING == WotLK
 
-#define GAMEOBJECT_ROTATION_COUNT 4
+static inline constexpr uint8_t GAMEOBJECT_ROTATION_COUNT = 4;
 
 struct WoWGameObject : WoWObject
 {
     guid_union object_field_created_by;
     uint32_t display_id;
     uint32_t flags;
-    float rotation[GAMEOBJECT_ROTATION_COUNT];
-    union
+    std::array<float, GAMEOBJECT_ROTATION_COUNT> rotation;
+    union field_dynamic_union
     {
-        struct
+        struct parts
         {
             uint16_t dyn_flag;
             int16_t path_progress;
         } dynamic_field_parts;
-        uint32_t dynamic;
-    };
+        uint32_t raw;
+    } dynamic;
     uint32_t faction_template;
     uint32_t level;
-    union
+    union gameobject_bytes_union
     {
-        struct
+        struct parts
         {
             uint8_t state;
             uint8_t type;
             uint8_t art_kit;
             uint8_t animation_progress;
         } bytes_1_gameobject;
-        uint32_t bytes_1;
-    };
+        uint32_t raw;
+    } bytes_1;
 };
 #endif
 
 #if VERSION_STRING == Cata
 
-#define GAMEOBJECT_ROTATION_COUNT 4
+static inline constexpr uint8_t GAMEOBJECT_ROTATION_COUNT = 4;
 
 struct WoWGameObject : WoWObject
 {
     guid_union object_field_created_by;
     uint32_t display_id;
     uint32_t flags;
-    float rotation[GAMEOBJECT_ROTATION_COUNT];
-    union
+    std::array<float, GAMEOBJECT_ROTATION_COUNT> rotation;
+    union field_dynamic_union
     {
-        struct
+        struct parts
         {
             uint16_t dyn_flag;
             int16_t path_progress;
         } dynamic_field_parts;
-        uint32_t dynamic;
-    };
+        uint32_t raw;
+    } dynamic;
     uint32_t faction_template;
     uint32_t level;
-    union
+    union gameobject_bytes_union
     {
-        struct
+        struct parts
         {
             uint8_t state;
             uint8_t type;
             uint8_t art_kit;
             uint8_t animation_progress;
         } bytes_1_gameobject;
-        uint32_t bytes_1;
-    };
+        uint32_t raw;
+    } bytes_1;
 };
 #endif
 
 #if VERSION_STRING == Mop
 
-#define GAMEOBJECT_ROTATION_COUNT 4
+static inline constexpr uint8_t GAMEOBJECT_ROTATION_COUNT = 4;
 
 struct WoWGameObject : WoWObject
 {
     guid_union object_field_created_by;
     uint32_t display_id;
     uint32_t flags;
-    float rotation[GAMEOBJECT_ROTATION_COUNT];
+    std::array<float, GAMEOBJECT_ROTATION_COUNT> rotation;
     uint32_t faction_template;
     uint32_t level;
     
-    union
+    union gameobject_bytes_union
     {
-        struct
+        struct parts
         {
             uint8_t state;
             uint8_t type;
             uint8_t unk;
             uint8_t health;
         } bytes_1_gameobject;
-        uint32_t bytes_1;
-    };
+        uint32_t raw;
+    } bytes_1;
 
-    union
+    union gameobject_bytes_2_union
     {
-        struct
+        struct parts
         {
             uint8_t transparency;
             uint8_t art_kit;
             uint8_t unk2;
             uint8_t animation_progress;
         } bytes_2_gameobject;
-        uint32_t bytes_2;
-    };
+        uint32_t raw;
+    } bytes_2;
 };
 #endif
 

--- a/src/world/Data/WoWItem.hpp
+++ b/src/world/Data/WoWItem.hpp
@@ -14,14 +14,15 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "WoWObject.hpp"
-#include "GuidData.hpp"
+
+#include <array>
 
 #pragma pack(push, 1)
 
 #if VERSION_STRING == Classic
 
-#define WOWITEM_SPELL_CHARGES_COUNT 5
-#define WOWITEM_ENCHANTMENT_COUNT 7
+static inline constexpr uint8_t WOWITEM_SPELL_CHARGES_COUNT = 5;
+static inline constexpr uint8_t WOWITEM_ENCHANTMENT_COUNT = 7;
 
 //\todo verify this
 struct WoWItem_Enchantment
@@ -39,9 +40,9 @@ struct WoWItem : WoWObject
     guid_union gift_creator_guid;
     uint32_t stack_count;
     uint32_t duration;
-    int32_t spell_charges[WOWITEM_SPELL_CHARGES_COUNT];
+    std::array<int32_t, WOWITEM_SPELL_CHARGES_COUNT> spell_charges;
     uint32_t flags;
-    WoWItem_Enchantment enchantment[WOWITEM_ENCHANTMENT_COUNT];
+    std::array<WoWItem_Enchantment, WOWITEM_ENCHANTMENT_COUNT> enchantment;
     uint32_t property_seed;
     uint32_t random_properties_id;
     uint32_t item_text_id;
@@ -52,8 +53,8 @@ struct WoWItem : WoWObject
 
 #if VERSION_STRING == TBC
 
-#define WOWITEM_SPELL_CHARGES_COUNT 5
-#define WOWITEM_ENCHANTMENT_COUNT 11
+static inline constexpr uint8_t WOWITEM_SPELL_CHARGES_COUNT = 5;
+static inline constexpr uint8_t WOWITEM_ENCHANTMENT_COUNT = 11;
 
 //\todo verify this
 struct WoWItem_Enchantment
@@ -71,9 +72,9 @@ struct WoWItem : WoWObject
     guid_union gift_creator_guid;
     uint32_t stack_count;
     uint32_t duration;
-    int32_t spell_charges[WOWITEM_SPELL_CHARGES_COUNT];
+    std::array<int32_t, WOWITEM_SPELL_CHARGES_COUNT> spell_charges;
     uint32_t flags;
-    WoWItem_Enchantment enchantment[WOWITEM_ENCHANTMENT_COUNT];
+    std::array<WoWItem_Enchantment, WOWITEM_ENCHANTMENT_COUNT> enchantment;
     uint32_t property_seed;
     uint32_t random_properties_id;
     uint32_t item_text_id;
@@ -84,8 +85,8 @@ struct WoWItem : WoWObject
 
 #if VERSION_STRING == WotLK
 
-#define WOWITEM_SPELL_CHARGES_COUNT 5
-#define WOWITEM_ENCHANTMENT_COUNT 12
+static inline constexpr uint8_t WOWITEM_SPELL_CHARGES_COUNT = 5;
+static inline constexpr uint8_t WOWITEM_ENCHANTMENT_COUNT = 12;
 
 struct WoWItem_Enchantment
 {
@@ -102,9 +103,9 @@ struct WoWItem : WoWObject
     guid_union gift_creator_guid;
     uint32_t stack_count;
     uint32_t duration;
-    int32_t spell_charges[WOWITEM_SPELL_CHARGES_COUNT];
+    std::array<int32_t, WOWITEM_SPELL_CHARGES_COUNT> spell_charges;
     uint32_t flags;
-    WoWItem_Enchantment enchantment[WOWITEM_ENCHANTMENT_COUNT];
+    std::array<WoWItem_Enchantment, WOWITEM_ENCHANTMENT_COUNT> enchantment;
     uint32_t property_seed;
     uint32_t random_properties_id;
     uint32_t durability;
@@ -116,8 +117,8 @@ struct WoWItem : WoWObject
 
 #if VERSION_STRING == Cata
 
-#define WOWITEM_SPELL_CHARGES_COUNT 5
-#define WOWITEM_ENCHANTMENT_COUNT 15
+static inline constexpr uint8_t WOWITEM_SPELL_CHARGES_COUNT = 5;
+static inline constexpr uint8_t WOWITEM_ENCHANTMENT_COUNT = 15;
 
 struct WoWItem_Enchantment
 {
@@ -134,9 +135,9 @@ struct WoWItem : WoWObject
     guid_union gift_creator_guid;
     uint32_t stack_count;
     uint32_t duration;
-    int32_t spell_charges[WOWITEM_SPELL_CHARGES_COUNT];
+    std::array<int32_t, WOWITEM_SPELL_CHARGES_COUNT> spell_charges;
     uint32_t flags;
-    WoWItem_Enchantment enchantment[WOWITEM_ENCHANTMENT_COUNT];
+    std::array<WoWItem_Enchantment, WOWITEM_ENCHANTMENT_COUNT> enchantment;
     uint32_t property_seed;
     uint32_t random_properties_id;
     uint32_t durability;
@@ -147,8 +148,8 @@ struct WoWItem : WoWObject
 
 #if VERSION_STRING == Mop
 
-#define WOWITEM_SPELL_CHARGES_COUNT 5
-#define WOWITEM_ENCHANTMENT_COUNT 13
+static inline constexpr uint8_t WOWITEM_SPELL_CHARGES_COUNT = 5;
+static inline constexpr uint8_t WOWITEM_ENCHANTMENT_COUNT = 13;
 
 struct WoWItem_Enchantment
 {
@@ -165,9 +166,9 @@ struct WoWItem : WoWObject
     guid_union gift_creator_guid;
     uint32_t stack_count;
     uint32_t duration;
-    int32_t spell_charges[WOWITEM_SPELL_CHARGES_COUNT];
+    std::array<int32_t, WOWITEM_SPELL_CHARGES_COUNT> spell_charges;
     uint32_t flags;
-    WoWItem_Enchantment enchantment[WOWITEM_ENCHANTMENT_COUNT];
+    std::array<WoWItem_Enchantment, WOWITEM_ENCHANTMENT_COUNT> enchantment;
     uint32_t property_seed;
     uint32_t random_properties_id;
     uint32_t durability;

--- a/src/world/Data/WoWObject.hpp
+++ b/src/world/Data/WoWObject.hpp
@@ -14,6 +14,7 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "AEVersion.hpp"
+#include "GuidData.hpp"
 
 #include <cstdint>
 
@@ -22,16 +23,7 @@ This file is released under the MIT license. See README-MIT for more information
 #if VERSION_STRING < Cata
 struct WoWObject
 {
-    union
-    {
-        struct
-        {
-            uint32_t low;
-            uint32_t high;
-        } guid_parts;
-        uint64_t guid;
-    };
-
+    guid_union guid;
     uint32_t type;
     uint32_t entry;
     float scale_x;
@@ -50,27 +42,18 @@ struct WoWObject
 #elif VERSION_STRING == Cata
 struct WoWObject
 {
-    union
-    {
-        struct
-        {
-            uint32_t low;
-            uint32_t high;
-        } guid_parts;
-        uint64_t guid;
-    };
-
+    guid_union guid;
     uint64_t data;
 
-    union
+    union field_type_union
     {
-        struct
+        struct parts
         {
             uint16_t type;
             uint16_t guild_id;
         } parts;
-        uint32_t raw_parts;
-    };
+        uint32_t raw;
+    } field_type;
 
     uint32_t entry;
     float scale_x;
@@ -89,38 +72,29 @@ struct WoWObject
 #elif VERSION_STRING == Mop
 struct WoWObject
 {
-    union
-    {
-        struct
-        {
-            uint32_t low;
-            uint32_t high;
-        } guid_parts;
-        uint64_t guid;
-    };
-
+    guid_union guid;
     uint64_t data;
 
-    union
+    union field_type_union
     {
-        struct
+        struct parts
         {
             uint16_t type;
             uint16_t guild_id;
         } parts;
-        uint32_t raw_parts;
-    };
+        uint32_t raw;
+    } field_type;
 
     uint32_t entry;
-    union
+    union field_dynamic_union
     {
-        struct
+        struct parts
         {
             uint16_t dynamic_flags;
             int16_t path_progress;
         } dynamic_field_parts;
-        uint32_t dynamic_field;
-    };
+        uint32_t raw;
+    } dynamic_field;
     float scale_x;
 
     void setLowGuid(uint32_t val)

--- a/src/world/Data/WoWPlayer.hpp
+++ b/src/world/Data/WoWPlayer.hpp
@@ -17,9 +17,9 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma pack(push, 1)
 
-union
+union player_bytes_union
 {
-    struct
+    struct parts
     {
         uint8_t skin_color;
         uint8_t face;
@@ -35,11 +35,11 @@ union
         };
     } s;
     uint32_t raw;
-} typedef player_bytes_union;
+};
 
-union
+union player_bytes_2_union
 {
-    struct
+    struct parts
     {
         union
         {
@@ -58,61 +58,60 @@ union
         uint8_t rest_state;
     } s;
     uint32_t raw;
-} typedef player_bytes_2_union;
-
-union
-{
-    struct
-    {
-        uint8_t gender;
-        uint8_t drunk_value;
-        uint8_t pvp_rank;
-        uint8_t arena_faction;
-    } s;
-    uint32_t raw;
-} typedef player_bytes_3_union;
-
-union
-{
-    struct
-    {
-        uint8_t flags; // not used
-        uint8_t rafLevel; // not used
-        uint8_t actionBarId;
-        uint8_t maxPvpRank; // not used
-    } s;
-    uint32_t raw;
-} typedef player_field_bytes_union;
-
-union
-{
-    struct
-    {
-        uint16_t overrideSpellId;
-        uint8_t ignorePowerRegenPredictionMask; // not used
-        uint8_t auraVision; //not used
-    } s;
-    uint32_t raw;
-} typedef player_field_bytes_2_union;
+};
 
 // Adjusted values.
 #if VERSION_STRING == Classic
-#define WOWPLAYER_QUEST_COUNT 20
-#define WOWPLAYER_VISIBLE_ITEM_COUNT 19
-#define WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT 7
+static inline constexpr uint8_t WOWPLAYER_QUEST_COUNT = 20;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_COUNT = 19;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_INVENTORY_SLOT_COUNT = 23;
+static inline constexpr uint8_t WOWPLAYER_PACK_SLOT_COUNT = 16;
+static inline constexpr uint8_t WOWPLAYER_BANK_SLOT_COUNT = 24;
+static inline constexpr uint8_t WOWPLAYER_BANK_BAG_SLOT_COUNT = 6;
+static inline constexpr uint8_t WOWPLAYER_BUY_BACK_COUNT = 12;
+static inline constexpr uint8_t WOWPLAYER_KEYRING_SLOT_COUNT = 20;
+static inline constexpr uint8_t WOWPLAYER_SKILL_INFO_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_EXPLORED_ZONES_COUNT = 64;
+static inline constexpr uint8_t WOWPLAYER_STAT_COUNT = 5;
+static inline constexpr uint8_t WOWPLAYER_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_COMBAT_RATING_COUNT = 20;
 
-#define WOWPLAYER_INVENTORY_SLOT_COUNT 23
-#define WOWPLAYER_PACK_SLOT_COUNT 16
-// WOWPLAYER_BANK_SLOT_COUNT and WOWPLAYER_BANK_BAG_SLOT_COUNT are different to TBC. TODO: Verify
-#define WOWPLAYER_BANK_SLOT_COUNT 24
-#define WOWPLAYER_BANK_BAG_SLOT_COUNT 6
-#define WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT 12
-#define WOWPLAYER_KEYRING_SLOT_COUNT 20
-#define WOWPLAYER_SKILL_INFO_COUNT 128
-#define WOWPLAYER_EXPLORED_ZONES_COUNT 64
-#define WOWPLAYER_STAT_COUNT 5
-#define WOWPLAYER_SPELL_SCHOOL_COUNT 7
-#define WOWPLAYER_COMBAT_RATING_COUNT 20
+union player_bytes_3_union
+{
+    struct parts
+    {
+        uint8_t gender;
+        uint8_t drunk_value;
+        uint8_t pvp_city_protector_rank; // not used
+        uint8_t pvp_rank;
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_union
+{
+    struct parts
+    {
+        uint8_t misc_flags;
+        uint8_t combo_points; // not used
+        uint8_t enabled_action_bars;
+        uint8_t max_pvp_rank; // not used
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t unk0; // related to pvp
+        uint8_t aura_vision;
+        uint8_t unk2;
+        uint8_t unk3;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWPlayer_Quest
 {
@@ -125,7 +124,7 @@ struct WoWPlayer_VisibleItem
 {
     uint64_t creator;
     uint32_t entry;
-    uint32_t enchantment[WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT];
+    std::array<uint32_t, WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT> enchantment;
     uint32_t properties;
     uint32_t padding;
 };
@@ -151,20 +150,20 @@ struct WoWPlayer : WoWUnit
     player_bytes_3_union player_bytes_3;
     uint32_t duel_team;
     uint32_t guild_timestamp;
-    WoWPlayer_Quest quests[WOWPLAYER_QUEST_COUNT];
-    WoWPlayer_VisibleItem visible_items[WOWPLAYER_VISIBLE_ITEM_COUNT];
+    std::array<WoWPlayer_Quest, WOWPLAYER_QUEST_COUNT> quests;
+    std::array<WoWPlayer_VisibleItem, WOWPLAYER_VISIBLE_ITEM_COUNT> visible_items;
     // Current player fields say long - client memory dump says int.
-    uint64_t inventory_slot[WOWPLAYER_INVENTORY_SLOT_COUNT];
-    uint64_t pack_slot[WOWPLAYER_PACK_SLOT_COUNT];
-    uint64_t bank_slot[WOWPLAYER_BANK_SLOT_COUNT];
-    uint64_t bank_bag_slot[WOWPLAYER_BANK_BAG_SLOT_COUNT];
-    uint64_t vendor_buy_back_slot[WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT];
-    uint64_t key_ring_slot[WOWPLAYER_KEYRING_SLOT_COUNT];
+    std::array<uint64_t, WOWPLAYER_INVENTORY_SLOT_COUNT> inventory_slot;
+    std::array<uint64_t, WOWPLAYER_PACK_SLOT_COUNT> pack_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_SLOT_COUNT> bank_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_BAG_SLOT_COUNT> bank_bag_slot;
+    std::array<uint64_t, WOWPLAYER_BUY_BACK_COUNT> vendor_buy_back_slot;
+    std::array<uint64_t, WOWPLAYER_KEYRING_SLOT_COUNT> key_ring_slot;
     uint64_t farsight_guid;
     uint64_t field_combo_target;
     uint32_t xp;
     uint32_t next_level_xp;
-    WoWPlayer_SkillInfo skill_info[WOWPLAYER_SKILL_INFO_COUNT];
+    std::array<WoWPlayer_SkillInfo, WOWPLAYER_SKILL_INFO_COUNT> skill_info;
     uint32_t character_points_1;
     uint32_t character_points_2;
     uint32_t track_creatures;
@@ -174,22 +173,22 @@ struct WoWPlayer : WoWUnit
     float parry_pct;
     float crit_pct;
     float ranged_crit_pct;
-    uint32_t explored_zones[WOWPLAYER_EXPLORED_ZONES_COUNT];
+    std::array<uint32_t, WOWPLAYER_EXPLORED_ZONES_COUNT> explored_zones;
     uint32_t rest_state_xp;
     uint32_t field_coinage;
-    uint32_t pos_stat[WOWPLAYER_STAT_COUNT];
-    uint32_t neg_stat[WOWPLAYER_STAT_COUNT];
-    uint32_t resistance_buff_mod_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t resistance_buff_mod_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    float field_mod_damage_done_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<uint32_t, WOWPLAYER_STAT_COUNT> pos_stat;
+    std::array<uint32_t, WOWPLAYER_STAT_COUNT> neg_stat;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> resistance_buff_mod_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> resistance_buff_mod_negative;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_negative;
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_pct;
     player_field_bytes_union player_field_bytes;
     uint32_t ammo_id;
     uint32_t self_resurrection_spell;
     uint32_t field_pvp_medals;
-    uint32_t field_buy_back_price[WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT];
-    uint32_t field_buy_back_timestamp[WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT];
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_price;
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_timestamp;
     uint32_t field_session_kills;
     uint32_t field_yesterday_kills;
     uint32_t field_last_week_kills;
@@ -202,27 +201,62 @@ struct WoWPlayer : WoWUnit
     uint32_t field_last_week_rank;
     player_field_bytes_2_union player_field_bytes_2;
     uint32_t field_watched_faction_idx;
-    uint32_t field_combat_rating[WOWPLAYER_COMBAT_RATING_COUNT];
+    std::array<uint32_t, WOWPLAYER_COMBAT_RATING_COUNT> field_combat_rating;
 };
 #elif VERSION_STRING == TBC
-#define WOWPLAYER_QUEST_COUNT 25
-#define WOWPLAYER_VISIBLE_ITEM_COUNT 19
-#define WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT 11
-#define WOWPLAYER_INVENTORY_SLOT_COUNT 23
-#define WOWPLAYER_PACK_SLOT_COUNT 16
-#define WOWPLAYER_BANK_SLOT_COUNT 28
-#define WOWPLAYER_BANK_BAG_SLOT_COUNT 7
-#define WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT 12
-#define WOWPLAYER_KEYRING_SLOT_COUNT 32
-#define WOWPLAYER_VANITY_PET_SLOT_COUNT 18
-#define WOWPLAYER_SKILL_INFO_COUNT 128
-#define WOWPLAYER_SPELL_SCHOOL_COUNT 7
-#define WOWPLAYER_EXPLORED_ZONES_COUNT 128
-#define WOWPLAYER_BUY_BACK_COUNT 12
-#define WOWPLAYER_COMBAT_RATING_COUNT 24
-#define WOWPLAYER_ARENA_TEAM_SLOTS 3
-#define WOWPLAYER_DAILY_QUESTS_COUNT 25
-#define WOWPLAYER_KNOWN_TITLES_SIZE 1
+static inline constexpr uint8_t WOWPLAYER_QUEST_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_COUNT = 19;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT = 11;
+static inline constexpr uint8_t WOWPLAYER_INVENTORY_SLOT_COUNT = 23;
+static inline constexpr uint8_t WOWPLAYER_PACK_SLOT_COUNT = 16;
+static inline constexpr uint8_t WOWPLAYER_BANK_SLOT_COUNT = 28;
+static inline constexpr uint8_t WOWPLAYER_BANK_BAG_SLOT_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_KEYRING_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_VANITY_PET_SLOT_COUNT = 18;
+static inline constexpr uint8_t WOWPLAYER_SKILL_INFO_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_EXPLORED_ZONES_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_BUY_BACK_COUNT = 12;
+static inline constexpr uint8_t WOWPLAYER_COMBAT_RATING_COUNT = 24;
+static inline constexpr uint8_t WOWPLAYER_ARENA_TEAM_SLOTS = 3;
+static inline constexpr uint8_t WOWPLAYER_DAILY_QUESTS_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_KNOWN_TITLES_SIZE = 1;
+
+union player_bytes_3_union
+{
+    struct parts
+    {
+        uint8_t gender;
+        uint8_t drunk_value;
+        uint8_t pvp_rank;
+        uint8_t arena_faction;
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_union
+{
+    struct parts
+    {
+        uint8_t misc_flags;
+        uint8_t raf_level; // not used
+        uint8_t enabled_action_bars;
+        uint8_t max_pvp_rank; // not used
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t unk0; // same as classic?
+        uint8_t aura_vision;
+        uint8_t unk2;
+        uint8_t unk3;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWPlayer_Quest
 {
@@ -236,7 +270,7 @@ struct WoWPlayer_VisibleItem
 {
     uint64_t creator;
     uint32_t entry;
-    uint32_t enchantment[WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT];
+    std::array<uint32_t, WOWPLAYER_VISIBLE_ITEM_UNK0_COUNT> enchantment;
     uint32_t properties;
     uint32_t padding;
 };
@@ -272,23 +306,23 @@ struct WoWPlayer : WoWUnit
     player_bytes_3_union player_bytes_3;
     uint32_t duel_team;
     uint32_t guild_timestamp;
-    WoWPlayer_Quest quests[WOWPLAYER_QUEST_COUNT];
-    WoWPlayer_VisibleItem visible_items[WOWPLAYER_VISIBLE_ITEM_COUNT];
+    std::array<WoWPlayer_Quest, WOWPLAYER_QUEST_COUNT> quests;
+    std::array<WoWPlayer_VisibleItem, WOWPLAYER_VISIBLE_ITEM_COUNT> visible_items;
     uint32_t chosen_title;
     uint32_t player_padding_0;
     // Current player fields say long - client memory dump says int.
-    uint64_t inventory_slot[WOWPLAYER_INVENTORY_SLOT_COUNT];
-    uint64_t pack_slot[WOWPLAYER_PACK_SLOT_COUNT];
-    uint64_t bank_slot[WOWPLAYER_BANK_SLOT_COUNT];
-    uint64_t bank_bag_slot[WOWPLAYER_BANK_BAG_SLOT_COUNT];
-    uint64_t vendor_buy_back_slot[WOWPLAYER_VENDOR_BUY_BACK_SLOT_COUNT];
-    uint64_t key_ring_slot[WOWPLAYER_KEYRING_SLOT_COUNT];
-    uint64_t vanity_pet_slot[WOWPLAYER_VANITY_PET_SLOT_COUNT];
+    std::array<uint64_t, WOWPLAYER_INVENTORY_SLOT_COUNT> inventory_slot;
+    std::array<uint64_t, WOWPLAYER_PACK_SLOT_COUNT> pack_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_SLOT_COUNT> bank_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_BAG_SLOT_COUNT> bank_bag_slot;
+    std::array<uint64_t, WOWPLAYER_BUY_BACK_COUNT> vendor_buy_back_slot;
+    std::array<uint64_t, WOWPLAYER_KEYRING_SLOT_COUNT> key_ring_slot;
+    std::array<uint64_t, WOWPLAYER_VANITY_PET_SLOT_COUNT> vanity_pet_slot;
     uint64_t farsight_guid;
-    uint64_t field_known_titles[WOWPLAYER_KNOWN_TITLES_SIZE];
+    std::array<uint64_t, WOWPLAYER_KNOWN_TITLES_SIZE> field_known_titles;
     uint32_t xp;
     uint32_t next_level_xp;
-    WoWPlayer_SkillInfo skill_info[WOWPLAYER_SKILL_INFO_COUNT];
+    std::array<WoWPlayer_SkillInfo, WOWPLAYER_SKILL_INFO_COUNT> skill_info;
     uint32_t character_points_1;
     uint32_t character_points_2;
     uint32_t track_creatures;
@@ -301,14 +335,14 @@ struct WoWPlayer : WoWUnit
     float crit_pct;
     float ranged_crit_pct;
     float offhand_crit_pct;
-    float spell_crit_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> spell_crit_pct;
     uint32_t shield_block;
-    uint32_t explored_zones[WOWPLAYER_EXPLORED_ZONES_COUNT];
+    std::array<uint32_t, WOWPLAYER_EXPLORED_ZONES_COUNT> explored_zones;
     uint32_t rest_state_xp;
     uint32_t field_coinage;
-    uint32_t field_mod_damage_done_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    float field_mod_damage_done_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_negative;
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_pct;
     uint32_t field_mod_healing_done;
     uint32_t field_mod_target_resistance;
     uint32_t field_mod_target_physical_resistance;
@@ -316,51 +350,86 @@ struct WoWPlayer : WoWUnit
     uint32_t ammo_id;
     uint32_t self_resurrection_spell;
     uint32_t field_pvp_medals;
-    uint32_t field_buy_back_price[WOWPLAYER_BUY_BACK_COUNT];
-    uint32_t field_buy_back_timestamp[WOWPLAYER_BUY_BACK_COUNT];
-    union
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_price;
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_timestamp;
+    union field_kills_union
     {
-        struct
+        struct parts
         {
             uint16_t kills_today;
             uint16_t kills_yesterday;
         } kills_field_parts;
-        uint32_t field_kills;
-    };
+        uint32_t raw;
+    } field_kills;
     uint32_t field_contribution_today;
     uint32_t field_contribution_yesterday;
     uint32_t field_lifetime_honorable_kills;
     player_field_bytes_2_union player_field_bytes_2;
     uint32_t field_watched_faction_idx;
-    uint32_t field_combat_rating[WOWPLAYER_COMBAT_RATING_COUNT];
-    WoWPlayer_ArenaTeamInfo field_arena_team_info[WOWPLAYER_ARENA_TEAM_SLOTS];
+    std::array<uint32_t, WOWPLAYER_COMBAT_RATING_COUNT> field_combat_rating;
+    std::array<WoWPlayer_ArenaTeamInfo, WOWPLAYER_ARENA_TEAM_SLOTS> field_arena_team_info;
     uint32_t field_honor_currency;
     uint32_t field_arena_currency;
     float field_mod_mana_regen;
     float field_mod_mana_regen_interrupt;
     uint32_t field_max_level;
-    uint32_t field_daily_quests[WOWPLAYER_DAILY_QUESTS_COUNT];
+    std::array<uint32_t, WOWPLAYER_DAILY_QUESTS_COUNT> field_daily_quests;
 };
 #elif VERSION_STRING == WotLK
-#define WOWPLAYER_QUEST_COUNT 25
-#define WOWPLAYER_VISIBLE_ITEM_COUNT 19
-#define WOWPLAYER_EXPLORED_ZONES_COUNT 128
-#define WOWPLAYER_INVENTORY_SLOT_COUNT 23
-#define WOWPLAYER_PACK_SLOT_COUNT 16
-#define WOWPLAYER_BANK_SLOT_COUNT 28
-#define WOWPLAYER_BANK_BAG_SLOT_COUNT 7
-#define WOWPLAYER_KEYRING_SLOT_COUNT 32
-#define WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT 32
-#define WOWPLAYER_SKILL_INFO_COUNT 128
-#define WOWPLAYER_SPELL_SCHOOL_COUNT 7
-#define WOWPLAYER_BUY_BACK_COUNT 12
-#define WOWPLAYER_COMBAT_RATING_COUNT 25
-#define WOWPLAYER_ARENA_TEAM_SLOTS 3
-#define WOWPLAYER_DAILY_QUESTS_COUNT 25
-#define WOWPLAYER_RUNE_REGEN_COUNT 4
-#define WOWPLAYER_NO_REAGENT_COST_COUNT 3
-#define WOWPLAYER_GLYPH_SLOT_COUNT 6
-#define WOWPLAYER_KNOWN_TITLES_SIZE 3
+static inline constexpr uint8_t WOWPLAYER_QUEST_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_COUNT = 19;
+static inline constexpr uint8_t WOWPLAYER_EXPLORED_ZONES_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_INVENTORY_SLOT_COUNT = 23;
+static inline constexpr uint8_t WOWPLAYER_PACK_SLOT_COUNT = 16;
+static inline constexpr uint8_t WOWPLAYER_BANK_SLOT_COUNT = 28;
+static inline constexpr uint8_t WOWPLAYER_BANK_BAG_SLOT_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_KEYRING_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_SKILL_INFO_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_BUY_BACK_COUNT = 12;
+static inline constexpr uint8_t WOWPLAYER_COMBAT_RATING_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_ARENA_TEAM_SLOTS = 3;
+static inline constexpr uint8_t WOWPLAYER_DAILY_QUESTS_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_RUNE_REGEN_COUNT = 4;
+static inline constexpr uint8_t WOWPLAYER_NO_REAGENT_COST_COUNT = 3;
+static inline constexpr uint8_t WOWPLAYER_GLYPH_SLOT_COUNT = 6;
+static inline constexpr uint8_t WOWPLAYER_KNOWN_TITLES_SIZE = 3;
+
+union player_bytes_3_union
+{
+    struct parts
+    {
+        uint8_t gender;
+        uint8_t drunk_value;
+        uint8_t pvp_rank;
+        uint8_t arena_faction;
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_union
+{
+    struct parts
+    {
+        uint8_t misc_flags;
+        uint8_t raf_level; // not used
+        uint8_t enabled_action_bars;
+        uint8_t max_pvp_rank; // not used
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_2_union
+{
+    struct parts
+    {
+        uint16_t override_spell_id; // not used
+        uint8_t ignore_power_regen_prediction_mask; // not used
+        uint8_t aura_vision;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWPlayer_Quest
 {
@@ -373,15 +442,15 @@ struct WoWPlayer_Quest
 struct WoWPlayer_VisibleItem
 {
     uint32_t entry;
-    union
+    union enchantment_union
     {
-        struct
+        struct parts
         {
             uint16_t perm_enchantment;
             uint16_t temp_enchantment;
         } enchantment_field_parts;
-        uint16_t enchantment[2];
-    };
+        std::array<uint16_t, 2> raw;
+    } enchantment;
 };
 
 struct WoWPlayer_ArenaTeamInfo
@@ -416,24 +485,24 @@ struct WoWPlayer : WoWUnit
     player_bytes_3_union player_bytes_3;
     uint32_t duel_team;
     uint32_t guild_timestamp;
-    WoWPlayer_Quest quests[WOWPLAYER_QUEST_COUNT];
-    WoWPlayer_VisibleItem visible_items[WOWPLAYER_VISIBLE_ITEM_COUNT];
+    std::array<WoWPlayer_Quest, WOWPLAYER_QUEST_COUNT> quests;
+    std::array<WoWPlayer_VisibleItem, WOWPLAYER_VISIBLE_ITEM_COUNT> visible_items;
     uint32_t chosen_title;
     uint32_t inebriation;
     uint32_t player_padding_0;
-    uint64_t inventory_slot[WOWPLAYER_INVENTORY_SLOT_COUNT];
-    uint64_t pack_slot[WOWPLAYER_PACK_SLOT_COUNT];
-    uint64_t bank_slot[WOWPLAYER_BANK_SLOT_COUNT];
-    uint64_t bank_bag_slot[WOWPLAYER_BANK_BAG_SLOT_COUNT];
-    uint64_t vendor_buy_back_slot[WOWPLAYER_BUY_BACK_COUNT];
-    uint64_t key_ring_slot[WOWPLAYER_KEYRING_SLOT_COUNT];
-    uint64_t currencytoken_slot[WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT];
+    std::array<uint64_t, WOWPLAYER_INVENTORY_SLOT_COUNT> inventory_slot;
+    std::array<uint64_t, WOWPLAYER_PACK_SLOT_COUNT> pack_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_SLOT_COUNT> bank_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_BAG_SLOT_COUNT> bank_bag_slot;
+    std::array<uint64_t, WOWPLAYER_BUY_BACK_COUNT> vendor_buy_back_slot;
+    std::array<uint64_t, WOWPLAYER_KEYRING_SLOT_COUNT> key_ring_slot;
+    std::array<uint64_t, WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT> currencytoken_slot;
     uint64_t farsight_guid;
-    uint64_t field_known_titles[WOWPLAYER_KNOWN_TITLES_SIZE];
+    std::array<uint64_t, WOWPLAYER_KNOWN_TITLES_SIZE> field_known_titles;
     uint64_t field_known_currencies;
     uint32_t xp;
     uint32_t next_level_xp;
-    WoWPlayer_SkillInfo skill_info[WOWPLAYER_SKILL_INFO_COUNT];
+    std::array<WoWPlayer_SkillInfo, WOWPLAYER_SKILL_INFO_COUNT> skill_info;
     uint32_t character_points_1;
     uint32_t character_points_2;
     uint32_t track_creatures;
@@ -446,15 +515,15 @@ struct WoWPlayer : WoWUnit
     float crit_pct;
     float ranged_crit_pct;
     float offhand_crit_pct;
-    float spell_crit_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> spell_crit_pct;
     uint32_t shield_block;
     float shield_block_crit_pct;
-    uint32_t explored_zones[WOWPLAYER_EXPLORED_ZONES_COUNT];
+    std::array<uint32_t, WOWPLAYER_EXPLORED_ZONES_COUNT> explored_zones;
     uint32_t rest_state_xp;
     uint32_t field_coinage;
-    uint32_t field_mod_damage_done_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    float field_mod_damage_done_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_negative;
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_pct;
     uint32_t field_mod_healing_done;
     uint32_t field_mod_healing_pct;
     uint32_t field_mod_healing_done_pct;
@@ -464,53 +533,93 @@ struct WoWPlayer : WoWUnit
     uint32_t ammo_id;
     uint32_t self_resurrection_spell;
     uint32_t field_pvp_medals;
-    uint32_t field_buy_back_price[WOWPLAYER_BUY_BACK_COUNT];
-    uint32_t field_buy_back_timestamp[WOWPLAYER_BUY_BACK_COUNT];
-    union
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_price;
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_timestamp;
+    union field_kills_union
     {
-        struct
+        struct parts
         {
             uint16_t kills_today;
             uint16_t kills_yesterday;
         } kills_field_parts;
-        uint32_t field_kills;
-    };
+        uint32_t raw;
+    } field_kills;
     uint32_t field_contribution_today;
     uint32_t field_contribution_yesterday;
     uint32_t field_lifetime_honorable_kills;
     player_field_bytes_2_union player_field_bytes_2;
     uint32_t field_watched_faction_idx;
-    uint32_t field_combat_rating[WOWPLAYER_COMBAT_RATING_COUNT];
-    WoWPlayer_ArenaTeamInfo field_arena_team_info[WOWPLAYER_ARENA_TEAM_SLOTS];
+    std::array<uint32_t, WOWPLAYER_COMBAT_RATING_COUNT> field_combat_rating;
+    std::array<WoWPlayer_ArenaTeamInfo, WOWPLAYER_ARENA_TEAM_SLOTS> field_arena_team_info;
     uint32_t field_honor_currency;
     uint32_t field_arena_currency;
     uint32_t field_max_level;
-    uint32_t field_daily_quests[WOWPLAYER_DAILY_QUESTS_COUNT];
-    float rune_regen[WOWPLAYER_RUNE_REGEN_COUNT];
-    uint32_t no_reagent_cost[WOWPLAYER_NO_REAGENT_COST_COUNT];
-    uint32_t field_glyph_slots[WOWPLAYER_GLYPH_SLOT_COUNT];
-    uint32_t field_glyphs[WOWPLAYER_GLYPH_SLOT_COUNT];
+    std::array<uint32_t, WOWPLAYER_DAILY_QUESTS_COUNT> field_daily_quests;
+    std::array<float, WOWPLAYER_RUNE_REGEN_COUNT> rune_regen;
+    std::array<uint32_t, WOWPLAYER_NO_REAGENT_COST_COUNT> no_reagent_cost;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyph_slots;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyphs;
     uint32_t glyphs_enabled;
     uint32_t pet_spell_power;
 };
 #elif VERSION_STRING == Cata
-#define WOWPLAYER_EXPLORED_ZONES_COUNT 156
-#define WOWPLAYER_SPELL_SCHOOL_COUNT 7
-#define WOWPLAYER_BUY_BACK_COUNT 12
-#define WOWPLAYER_ARENA_TEAM_SLOTS 3
-#define WOWPLAYER_DAILY_QUESTS_COUNT 25
-#define WOWPLAYER_QUEST_COUNT 50
-#define WOWPLAYER_VISIBLE_ITEM_COUNT 19
-#define WOWPLAYER_INVENTORY_SLOT_COUNT 23
-#define WOWPLAYER_PACK_SLOT_COUNT 16
-#define WOWPLAYER_BANK_SLOT_COUNT 28
-#define WOWPLAYER_BANK_BAG_SLOT_COUNT 7
-#define WOWPLAYER_KEYRING_SLOT_COUNT 32
-#define WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT 32
-#define WOWPLAYER_NO_REAGENT_COST_COUNT 3
-#define WOWPLAYER_GLYPH_SLOT_COUNT 9
-#define WOWPLAYER_KNOWN_TITLES_SIZE 4
-#define WOWPLAYER_SKILL_INFO_COUNT 128
+static inline constexpr uint8_t WOWPLAYER_EXPLORED_ZONES_COUNT = 156;
+static inline constexpr uint8_t WOWPLAYER_WEAPON_DMG_MULTIPLIER_COUNT = 3;
+static inline constexpr uint8_t WOWPLAYER_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_BUY_BACK_COUNT = 12;
+static inline constexpr uint8_t WOWPLAYER_ARENA_TEAM_SLOTS = 3;
+static inline constexpr uint8_t WOWPLAYER_DAILY_QUESTS_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_QUEST_COUNT = 50;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_COUNT = 19;
+static inline constexpr uint8_t WOWPLAYER_INVENTORY_SLOT_COUNT = 23;
+static inline constexpr uint8_t WOWPLAYER_PACK_SLOT_COUNT = 16;
+static inline constexpr uint8_t WOWPLAYER_BANK_SLOT_COUNT = 28;
+static inline constexpr uint8_t WOWPLAYER_BANK_BAG_SLOT_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_KEYRING_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_COMBAT_RATING_COUNT = 26;
+static inline constexpr uint8_t WOWPLAYER_RUNE_REGEN_COUNT = 4;
+static inline constexpr uint8_t WOWPLAYER_NO_REAGENT_COST_COUNT = 3;
+static inline constexpr uint8_t WOWPLAYER_GLYPH_SLOT_COUNT = 9;
+static inline constexpr uint8_t WOWPLAYER_KNOWN_TITLES_SIZE = 4;
+static inline constexpr uint8_t WOWPLAYER_SKILL_INFO_COUNT = 128;
+static inline constexpr uint8_t WOWPLAYER_RESEARCHING_COUNT = 8;
+static inline constexpr uint8_t WOWPLAYER_PROFESSION_SKILL_COUNT = 2;
+
+union player_bytes_3_union
+{
+    struct parts
+    {
+        uint8_t gender;
+        uint8_t drunk_value;
+        uint8_t pvp_rank;
+        uint8_t arena_faction;
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_union
+{
+    struct parts
+    {
+        uint8_t misc_flags;
+        uint8_t raf_level; // not used
+        uint8_t enabled_action_bars;
+        uint8_t max_pvp_rank; // not used
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_2_union
+{
+    struct parts
+    {
+        uint16_t override_spell_id; // not used
+        uint8_t ignore_power_regen_prediction_mask; // not used
+        uint8_t aura_vision;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWPlayer_Quest
 {
@@ -523,15 +632,15 @@ struct WoWPlayer_Quest
 struct WoWPlayer_VisibleItem
 {
     uint32_t entry;
-    union
+    union enchantment_union
     {
-        struct
+        struct parts
         {
             uint16_t perm_enchantment;
             uint16_t temp_enchantment;
         } enchantment_field_parts;
-        uint16_t enchantment[2];
-    };
+        std::array<uint16_t, 2> raw;
+    } enchantment;
 };
 
 struct WoWPlayer_ArenaTeamInfo
@@ -557,33 +666,33 @@ struct WoWPlayer : WoWUnit
     player_bytes_3_union player_bytes_3;
     uint32_t duel_team;
     uint32_t guild_timestamp;
-    WoWPlayer_Quest quests[WOWPLAYER_QUEST_COUNT];
-    WoWPlayer_VisibleItem visible_items[WOWPLAYER_VISIBLE_ITEM_COUNT];
+    std::array<WoWPlayer_Quest, WOWPLAYER_QUEST_COUNT> quests;
+    std::array<WoWPlayer_VisibleItem, WOWPLAYER_VISIBLE_ITEM_COUNT> visible_items;
     uint32_t chosen_title;
     uint32_t inebriation;
     uint32_t player_padding_0;
-    uint64_t inventory_slot[WOWPLAYER_INVENTORY_SLOT_COUNT];
-    uint64_t pack_slot[WOWPLAYER_PACK_SLOT_COUNT];
-    uint64_t bank_slot[WOWPLAYER_BANK_SLOT_COUNT];
-    uint64_t bank_bag_slot[WOWPLAYER_BANK_BAG_SLOT_COUNT];
-    uint64_t vendor_buy_back_slot[WOWPLAYER_BUY_BACK_COUNT];
+    std::array<uint64_t, WOWPLAYER_INVENTORY_SLOT_COUNT> inventory_slot;
+    std::array<uint64_t, WOWPLAYER_PACK_SLOT_COUNT> pack_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_SLOT_COUNT> bank_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_BAG_SLOT_COUNT> bank_bag_slot;
+    std::array<uint64_t, WOWPLAYER_BUY_BACK_COUNT> vendor_buy_back_slot;
     uint64_t farsight_guid;
-    uint64_t field_known_titles[WOWPLAYER_KNOWN_TITLES_SIZE];
+    std::array<uint64_t, WOWPLAYER_KNOWN_TITLES_SIZE> field_known_titles;
     uint32_t xp;
     uint32_t next_level_xp;
 
-    union
+    union skill_info_union
     {
-        struct
+        struct parts
         {
-            uint32_t skill_line[64];
-            uint32_t skill_step[64];
-            uint32_t skill_rank[64];
-            uint32_t skill_max_rank[64];
-            uint32_t skill_mod[64];
-            uint32_t skill_talent[64];
+            std::array<uint32_t, 64> skill_line;
+            std::array<uint32_t, 64> skill_step;
+            std::array<uint32_t, 64> skill_rank;
+            std::array<uint32_t, 64> skill_max_rank;
+            std::array<uint32_t, 64> skill_mod;
+            std::array<uint32_t, 64> skill_talent;
         } skill_info_parts;
-    };
+    } field_skill_info;
 
     uint32_t character_points_1;
     uint32_t track_creatures;
@@ -596,20 +705,20 @@ struct WoWPlayer : WoWUnit
     float crit_pct;
     float ranged_crit_pct;
     float offhand_crit_pct;
-    float spell_crit_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> spell_crit_pct;
     uint32_t shield_block;
     float shield_block_crit_pct;
     uint32_t mastery;
-    uint32_t explored_zones[WOWPLAYER_EXPLORED_ZONES_COUNT];
+    std::array<uint32_t, WOWPLAYER_EXPLORED_ZONES_COUNT> explored_zones;
     uint32_t rest_state_xp;
     uint64_t field_coinage;
-    uint32_t field_mod_damage_done_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    float field_mod_damage_done_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_negative;
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_pct;
     uint32_t field_mod_healing_done;
     float field_mod_healing_pct;
     float field_mod_healing_done_pct;
-    float weapon_dmg_multiplier[3];
+    std::array<float, WOWPLAYER_WEAPON_DMG_MULTIPLIER_COUNT> weapon_dmg_multiplier;
     float mod_spell_power_pct;
     float override_spell_power_by_ap_pct;
     uint32_t field_mod_target_resistance;
@@ -617,34 +726,34 @@ struct WoWPlayer : WoWUnit
     player_field_bytes_union player_field_bytes;
     uint32_t self_resurrection_spell;
     uint32_t field_pvp_medals;
-    uint32_t field_buy_back_price[WOWPLAYER_BUY_BACK_COUNT];
-    uint32_t field_buy_back_timestamp[WOWPLAYER_BUY_BACK_COUNT];
-    union
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_price;
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_timestamp;
+    union field_kills_union
     {
-        struct
+        struct parts
         {
             uint16_t kills_today;
             uint16_t kills_yesterday;
         } kills_field_parts;
-        uint32_t field_kills;
-    };
+        uint32_t raw;
+    } field_kills;
     uint32_t field_lifetime_honorable_kills;
     player_field_bytes_2_union player_field_bytes_2;
     uint32_t field_watched_faction_idx;
-    uint32_t field_combat_rating[26];
-    WoWPlayer_ArenaTeamInfo field_arena_team_info[WOWPLAYER_ARENA_TEAM_SLOTS];
+    std::array<uint32_t, WOWPLAYER_COMBAT_RATING_COUNT> field_combat_rating;
+    std::array<WoWPlayer_ArenaTeamInfo, WOWPLAYER_ARENA_TEAM_SLOTS> field_arena_team_info;
     uint32_t battleground_rating;
     uint32_t field_max_level;
-    uint32_t field_daily_quests[WOWPLAYER_DAILY_QUESTS_COUNT];
-    float rune_regen[4];
-    uint32_t no_reagent_cost[WOWPLAYER_NO_REAGENT_COST_COUNT];
-    uint32_t field_glyph_slots[WOWPLAYER_GLYPH_SLOT_COUNT];
-    uint32_t field_glyphs[WOWPLAYER_GLYPH_SLOT_COUNT];
+    std::array<uint32_t, WOWPLAYER_DAILY_QUESTS_COUNT> field_daily_quests;
+    std::array<float, WOWPLAYER_RUNE_REGEN_COUNT> rune_regen;
+    std::array<uint32_t, WOWPLAYER_NO_REAGENT_COST_COUNT> no_reagent_cost;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyph_slots;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyphs;
     uint32_t glyphs_enabled;
     uint32_t pet_spell_power;
-    uint32_t researching[8];
-    uint32_t research_site[8];
-    uint32_t profession_skill_line[2];
+    std::array<uint32_t, WOWPLAYER_RESEARCHING_COUNT> researching;
+    std::array<uint32_t, WOWPLAYER_RESEARCHING_COUNT> research_site;
+    std::array<uint32_t, WOWPLAYER_PROFESSION_SKILL_COUNT> profession_skill_line;
     float ui_hit_mod;
     float ui_hit_spell_mod;
     uint32_t ui_home_realm_time_offset;
@@ -654,22 +763,52 @@ struct WoWPlayer : WoWUnit
     float mod_haste_regen;
 };
 #elif VERSION_STRING == Mop
-#define WOWPLAYER_EXPLORED_ZONES_COUNT 200
-#define WOWPLAYER_SPELL_SCHOOL_COUNT 7
-#define WOWPLAYER_BUY_BACK_COUNT 12
-#define WOWPLAYER_ARENA_TEAM_SLOTS 3
-#define WOWPLAYER_DAILY_QUESTS_COUNT 25
-#define WOWPLAYER_QUEST_COUNT 150
-#define WOWPLAYER_VISIBLE_ITEM_COUNT 19
-#define WOWPLAYER_INVENTORY_SLOT_COUNT 23
-#define WOWPLAYER_PACK_SLOT_COUNT 16
-#define WOWPLAYER_BANK_SLOT_COUNT 28
-#define WOWPLAYER_BANK_BAG_SLOT_COUNT 7
-#define WOWPLAYER_KEYRING_SLOT_COUNT 32
-#define WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT 32
-#define WOWPLAYER_KNOWN_TITLES_SIZE 5
-#define WOWPLAYER_SKILL_INFO_COUNT 448
-#define WOWPLAYER_NO_REAGENT_COST_COUNT 4
+static inline constexpr uint8_t WOWPLAYER_EXPLORED_ZONES_COUNT = 200;
+static inline constexpr uint8_t WOWPLAYER_WEAPON_DMG_MULTIPLIER_COUNT = 3;
+static inline constexpr uint8_t WOWPLAYER_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_BUY_BACK_COUNT = 12;
+static inline constexpr uint8_t WOWPLAYER_ARENA_TEAM_SLOTS = 3;
+static inline constexpr uint8_t WOWPLAYER_DAILY_QUESTS_COUNT = 25;
+static inline constexpr uint8_t WOWPLAYER_QUEST_COUNT = 150;
+static inline constexpr uint8_t WOWPLAYER_VISIBLE_ITEM_COUNT = 19;
+static inline constexpr uint8_t WOWPLAYER_INVENTORY_SLOT_COUNT = 23;
+static inline constexpr uint8_t WOWPLAYER_PACK_SLOT_COUNT = 16;
+static inline constexpr uint8_t WOWPLAYER_BANK_SLOT_COUNT = 28;
+static inline constexpr uint8_t WOWPLAYER_BANK_BAG_SLOT_COUNT = 7;
+static inline constexpr uint8_t WOWPLAYER_KEYRING_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_CURRENCY_TOKEN_SLOT_COUNT = 32;
+static inline constexpr uint8_t WOWPLAYER_KNOWN_TITLES_SIZE = 5;
+static inline constexpr uint16_t WOWPLAYER_SKILL_INFO_COUNT = 448;
+static inline constexpr uint8_t WOWPLAYER_COMBAT_RATING_COUNT = 27;
+static inline constexpr uint8_t WOWPLAYER_RUNE_REGEN_COUNT = 4;
+static inline constexpr uint8_t WOWPLAYER_NO_REAGENT_COST_COUNT = 4;
+static inline constexpr uint8_t WOWPLAYER_GLYPH_SLOT_COUNT = 6;
+static inline constexpr uint8_t WOWPLAYER_RESEARCHING_COUNT = 8;
+static inline constexpr uint8_t WOWPLAYER_PROFESSION_SKILL_COUNT = 2;
+
+union player_bytes_3_union
+{
+    struct parts
+    {
+        uint8_t gender;
+        uint8_t drunk_value;
+        uint8_t pvp_rank;
+        uint8_t arena_faction;
+    } s;
+    uint32_t raw;
+};
+
+union player_field_bytes_union
+{
+    struct parts
+    {
+        uint8_t misc_flags;
+        uint8_t raf_level; // not used
+        uint8_t enabled_action_bars;
+        uint8_t max_pvp_rank; // not used
+    } s;
+    uint32_t raw;
+};
 
 struct WoWPlayer_Quest
 {
@@ -682,15 +821,15 @@ struct WoWPlayer_Quest
 struct WoWPlayer_VisibleItem
 {
     uint32_t entry;
-    union
+    union enchantment_union
     {
-        struct
+        struct parts
         {
             uint16_t perm_enchantment;
             uint16_t temp_enchantment;
         } enchantment_field_parts;
-        uint16_t enchantment[2];
-    };
+        std::array<uint16_t, 2> raw;
+    } enchantment;
 };
 
 //\todo: guessed structure
@@ -718,39 +857,39 @@ struct WoWPlayer : WoWUnit
     player_bytes_3_union player_bytes_3;
     uint32_t duel_team;
     uint32_t guild_timestamp;
-    WoWPlayer_Quest quests[WOWPLAYER_QUEST_COUNT];
-    WoWPlayer_VisibleItem visible_items[WOWPLAYER_VISIBLE_ITEM_COUNT];
+    std::array<WoWPlayer_Quest, WOWPLAYER_QUEST_COUNT> quests;
+    std::array<WoWPlayer_VisibleItem, WOWPLAYER_VISIBLE_ITEM_COUNT> visible_items;
     uint32_t chosen_title;
     uint32_t inebriation;
     uint32_t virtual_player_realm;
     uint32_t current_spec_id;
     uint32_t taxi_mount_anim_kit_id;
     uint32_t current_battle_pet_breed_quality;
-    uint64_t inventory_slot[WOWPLAYER_INVENTORY_SLOT_COUNT];
-    uint64_t pack_slot[WOWPLAYER_PACK_SLOT_COUNT];
-    uint64_t bank_slot[WOWPLAYER_BANK_SLOT_COUNT];
-    uint64_t bank_bag_slot[WOWPLAYER_BANK_BAG_SLOT_COUNT];
-    uint64_t vendor_buy_back_slot[WOWPLAYER_BUY_BACK_COUNT];
+    std::array<uint64_t, WOWPLAYER_INVENTORY_SLOT_COUNT> inventory_slot;
+    std::array<uint64_t, WOWPLAYER_PACK_SLOT_COUNT> pack_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_SLOT_COUNT> bank_slot;
+    std::array<uint64_t, WOWPLAYER_BANK_BAG_SLOT_COUNT> bank_bag_slot;
+    std::array<uint64_t, WOWPLAYER_BUY_BACK_COUNT> vendor_buy_back_slot;
     uint64_t farsight_guid;
-    uint64_t field_known_titles[WOWPLAYER_KNOWN_TITLES_SIZE];
+    std::array<uint64_t, WOWPLAYER_KNOWN_TITLES_SIZE> field_known_titles;
     uint64_t field_coinage;
     uint32_t xp;
     uint32_t next_level_xp;
 
-    union
+    union skill_info_union
     {
-        struct
+        struct parts
         {
-            uint32_t skill_line[64];
-            uint32_t skill_step[64];
-            uint32_t skill_rank[64];
-            uint32_t skill_starting_rank[64];
-            uint32_t skill_max_rank[64];
-            uint32_t skill_mod[64];
-            uint32_t skill_talent[64];
+            std::array<uint32_t, 64> skill_line;
+            std::array<uint32_t, 64> skill_step;
+            std::array<uint32_t, 64> skill_rank;
+            std::array<uint32_t, 64> skill_starting_rank;
+            std::array<uint32_t, 64> skill_max_rank;
+            std::array<uint32_t, 64> skill_mod;
+            std::array<uint32_t, 64> skill_talent;
         } skill_info_parts;
-        uint32_t skill_info[WOWPLAYER_SKILL_INFO_COUNT];
-    };
+        std::array<uint32_t, WOWPLAYER_SKILL_INFO_COUNT> skill_info;
+    } field_skill_info;
 
     uint32_t character_points_1;
     uint32_t max_talent_tiers;
@@ -766,22 +905,22 @@ struct WoWPlayer : WoWUnit
     float crit_pct;
     float ranged_crit_pct;
     float offhand_crit_pct;
-    float spell_crit_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> spell_crit_pct;
     uint32_t shield_block;
     float shield_block_crit_pct;
     uint32_t mastery;
     uint32_t pvp_power_damage;
     uint32_t pvp_power_healing;
-    uint32_t explored_zones[WOWPLAYER_EXPLORED_ZONES_COUNT];
+    std::array<uint32_t, WOWPLAYER_EXPLORED_ZONES_COUNT> explored_zones;
     uint32_t rest_state_xp;
-    uint32_t field_mod_damage_done_positive[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    uint32_t field_mod_damage_done_negative[WOWPLAYER_SPELL_SCHOOL_COUNT];
-    float field_mod_damage_done_pct[WOWPLAYER_SPELL_SCHOOL_COUNT];
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_positive;
+    std::array<uint32_t, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_negative;
+    std::array<float, WOWPLAYER_SPELL_SCHOOL_COUNT> field_mod_damage_done_pct;
     uint32_t field_mod_healing_done;
     float field_mod_healing_pct;
     float field_mod_healing_done_pct;
     float field_mod_periodic_healing_done_pct;
-    float weapon_dmg_multiplier[3];
+    std::array<float, WOWPLAYER_WEAPON_DMG_MULTIPLIER_COUNT> weapon_dmg_multiplier;
     float mod_spell_power_pct;
     float mod_resilience_pct;
     float override_spell_power_by_ap_pct;
@@ -791,30 +930,30 @@ struct WoWPlayer : WoWUnit
     player_field_bytes_union player_field_bytes;
     uint32_t self_resurrection_spell;
     uint32_t field_pvp_medals;
-    uint32_t field_buy_back_price[WOWPLAYER_BUY_BACK_COUNT];
-    uint32_t field_buy_back_timestamp[WOWPLAYER_BUY_BACK_COUNT];
-    union
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_price;
+    std::array<uint32_t, WOWPLAYER_BUY_BACK_COUNT> field_buy_back_timestamp;
+    union field_kills_union
     {
-        struct
+        struct parts
         {
             uint16_t kills_today;
             uint16_t kills_yesterday;
         } kills_field_parts;
-        uint32_t field_kills;
-    };
+        uint32_t raw;
+    } field_kills;
     uint32_t field_lifetime_honorable_kills;
     uint32_t field_watched_faction_idx;
-    uint32_t field_combat_rating[27];
-    WoWPlayer_ArenaTeamInfo field_arena_team_info[WOWPLAYER_ARENA_TEAM_SLOTS];
+    std::array<uint32_t, WOWPLAYER_COMBAT_RATING_COUNT> field_combat_rating;
+    std::array<WoWPlayer_ArenaTeamInfo, WOWPLAYER_ARENA_TEAM_SLOTS> field_arena_team_info;
     uint32_t field_max_level;
-    float rune_regen[4];
-    uint32_t no_reagent_cost[WOWPLAYER_NO_REAGENT_COST_COUNT];
-    uint32_t field_glyph_slots[6];
-    uint32_t field_glyphs[6];
+    std::array<float, WOWPLAYER_RUNE_REGEN_COUNT> rune_regen;
+    std::array<uint32_t, WOWPLAYER_NO_REAGENT_COST_COUNT> no_reagent_cost;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyph_slots;
+    std::array<uint32_t, WOWPLAYER_GLYPH_SLOT_COUNT> field_glyphs;
     uint32_t glyphs_enabled;
     uint32_t pet_spell_power;
-    uint32_t researching[8];
-    uint32_t profession_skill_line[2];
+    std::array<uint32_t, WOWPLAYER_RESEARCHING_COUNT> researching;
+    std::array<uint32_t, WOWPLAYER_PROFESSION_SKILL_COUNT> profession_skill_line;
     float ui_hit_mod;
     float ui_hit_spell_mod;
     uint32_t ui_home_realm_time_offset;

--- a/src/world/Data/WoWUnit.hpp
+++ b/src/world/Data/WoWUnit.hpp
@@ -14,13 +14,14 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "WoWObject.hpp"
-#include "GuidData.hpp"
+
+#include <array>
 
 #pragma pack(push, 1)
 
-union
+union field_bytes_0_union
 {
-    struct
+    struct parts
     {
         uint8_t race;
         uint8_t unit_class;
@@ -28,25 +29,250 @@ union
         uint8_t power_type;
     } s;
     uint32_t raw;
-} typedef field_bytes_0_union;
+};
 
-union
+union unit_virtual_item_info
 {
-    struct
+    struct parts
     {
-        uint8_t itemClass;
-        uint8_t itemSubClass;
+        uint8_t item_class;
+        uint8_t item_subclass;
         int8_t unk0;
         uint8_t material;
-        uint8_t inventoryType;
+        uint8_t inventory_type;
         uint8_t sheath;
     } fields;
     uint64_t raw;
-} typedef unit_virtual_item_info;
+};
 
-union
+#if VERSION_STRING == Classic
+static inline constexpr uint8_t WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_AURA_COUNT = 48;
+static inline constexpr uint8_t WOWUNIT_AURA_FLAGS_COUNT = 6;
+static inline constexpr uint8_t WOWUNIT_AURA_LEVELS_COUNT = 12;
+static inline constexpr uint8_t WOWUNIT_AURA_APPLICATIONS_COUNT = 12;
+static inline constexpr uint8_t WOWUNIT_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_ATTACK_TIME_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_STAT_COUNT = 5;
+
+union field_bytes_1_union
 {
-    struct
+    struct parts
+    {
+        uint8_t stand_state;
+        uint8_t pet_loyalty; // 0 for non pet creature
+        uint8_t shape_shift_form;
+        uint8_t stand_state_flag;
+    } s;
+    uint32_t raw;
+};
+
+union field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t sheath_type;
+        uint8_t unk1; // some sort of flag
+        uint8_t unk2;
+        uint8_t unk3;
+    } s;
+    uint32_t raw;
+};
+
+struct WoWUnit : WoWObject
+{
+    guid_union charm_guid;
+    guid_union summon_guid;
+    guid_union charmed_by_guid;
+    guid_union summoned_by_guid;
+    guid_union created_by_guid;
+    guid_union target_guid;
+    guid_union persuaded_guid;
+    guid_union channel_object_guid;
+    uint32_t health;
+    uint32_t power_1;
+    uint32_t power_2;
+    uint32_t power_3;
+    uint32_t power_4;
+    uint32_t power_5;
+    uint32_t max_health;
+    uint32_t max_power_1;
+    uint32_t max_power_2;
+    uint32_t max_power_3;
+    uint32_t max_power_4;
+    uint32_t max_power_5;
+    uint32_t level;
+    uint32_t faction_template;
+    field_bytes_0_union field_bytes_0;
+    std::array<uint32_t, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_slot_display;       //0 = melee, 1 = offhand, 2 = ranged
+    std::array<unit_virtual_item_info, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_info; //0 = melee, 1 = offhand, 2 = ranged
+    uint32_t unit_flags;
+    std::array<uint32_t, WOWUNIT_AURA_COUNT> aura;
+    std::array<uint32_t, WOWUNIT_AURA_FLAGS_COUNT> aura_flags;
+    std::array<uint32_t, WOWUNIT_AURA_LEVELS_COUNT> aura_levels;
+    std::array<uint32_t, WOWUNIT_AURA_APPLICATIONS_COUNT> aura_applications;
+    uint32_t aura_state;
+    std::array<uint32_t, WOWUNIT_ATTACK_TIME_COUNT> base_attack_time;  //0 = melee, 1 = offhand, 2 = ranged
+    float bounding_radius;
+    float combat_reach;
+    uint32_t display_id;
+    uint32_t native_display_id;
+    uint32_t mount_display_id;
+    float minimum_damage;
+    float maximum_damage;
+    float minimum_offhand_damage;
+    float maximum_offhand_damage;
+    field_bytes_1_union field_bytes_1;
+    uint32_t pet_number;
+    uint32_t pet_name_timestamp;
+    uint32_t pet_experience;
+    uint32_t pet_next_level_experience;
+    uint32_t dynamic_flags;
+    uint32_t channel_spell;
+    float mod_cast_speed;
+    uint32_t created_by_spell_id;
+    uint32_t npc_flags;
+    uint32_t npc_emote_state;
+    uint32_t training_points;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> stat;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance;
+    uint32_t base_mana;
+    uint32_t base_health;
+    field_bytes_2_union field_bytes_2;
+    uint32_t attack_power;
+    int32_t attack_power_mods;
+    float attack_power_multiplier;
+    int32_t ranged_attack_power;
+    int32_t ranged_attack_power_mods;
+    float ranged_attack_power_multiplier;
+    float minimum_ranged_damage;
+    float maximum_ranged_ddamage;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_modifier;
+    std::array<float, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_multiplier;
+    uint32_t unit_padding;
+};
+#elif VERSION_STRING == TBC
+static inline constexpr uint8_t WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_AURA_COUNT = 56;
+static inline constexpr uint8_t WOWUNIT_AURA_FLAGS_COUNT = 14;
+static inline constexpr uint8_t WOWUNIT_AURA_LEVELS_COUNT = 14;
+static inline constexpr uint8_t WOWUNIT_AURA_APPLICATIONS_COUNT = 14;
+static inline constexpr uint8_t WOWUNIT_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_ATTACK_TIME_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_STAT_COUNT = 5;
+
+union field_bytes_1_union
+{
+    struct parts
+    {
+        uint8_t stand_state;
+        uint8_t pet_loyalty; // 0 for non pet creature
+        uint8_t stand_state_flag;
+        uint8_t animation_flag;
+    } s;
+    uint32_t raw;
+};
+
+union field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t sheath_type;
+        uint8_t positive_aura_limit;
+        uint8_t pet_flag;
+        uint8_t shape_shift_form;
+    } s;
+    uint32_t raw;
+};
+
+struct WoWUnit : WoWObject
+{
+    guid_union charm_guid;
+    guid_union summon_guid;
+    guid_union charmed_by_guid;
+    guid_union summoned_by_guid;
+    guid_union created_by_guid;
+    guid_union target_guid;
+    guid_union persuaded_guid;
+    guid_union channel_object_guid;
+    uint32_t health;
+    uint32_t power_1;
+    uint32_t power_2;
+    uint32_t power_3;
+    uint32_t power_4;
+    uint32_t power_5;
+    uint32_t max_health;
+    uint32_t max_power_1;
+    uint32_t max_power_2;
+    uint32_t max_power_3;
+    uint32_t max_power_4;
+    uint32_t max_power_5;
+    uint32_t level;
+    uint32_t faction_template;
+    field_bytes_0_union field_bytes_0;
+    std::array<uint32_t, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_slot_display;       //0 = melee, 1 = offhand, 2 = ranged
+    std::array<unit_virtual_item_info, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_info; //0 = melee, 1 = offhand, 2 = ranged
+    uint32_t unit_flags;
+    uint32_t unit_flags_2;
+    std::array<uint32_t, WOWUNIT_AURA_COUNT> aura;
+    std::array<uint32_t, WOWUNIT_AURA_FLAGS_COUNT> aura_flags;
+    std::array<uint32_t, WOWUNIT_AURA_LEVELS_COUNT> aura_levels;
+    std::array<uint32_t, WOWUNIT_AURA_APPLICATIONS_COUNT> aura_applications;
+    uint32_t aura_state;
+    std::array<uint32_t, WOWUNIT_ATTACK_TIME_COUNT> base_attack_time;  //0 = melee, 1 = offhand, 2 = ranged
+    float bounding_radius;
+    float combat_reach;
+    uint32_t display_id;
+    uint32_t native_display_id;
+    uint32_t mount_display_id;
+    float minimum_damage;
+    float maximum_damage;
+    float minimum_offhand_damage;
+    float maximum_offhand_damage;
+    field_bytes_1_union field_bytes_1;
+    uint32_t pet_number;
+    uint32_t pet_name_timestamp;
+    uint32_t pet_experience;
+    uint32_t pet_next_level_experience;
+    uint32_t dynamic_flags;
+    uint32_t channel_spell;
+    float mod_cast_speed;
+    uint32_t created_by_spell_id;
+    uint32_t npc_flags;
+    uint32_t npc_emote_state;
+    uint32_t training_points;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> positive_stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> negative_stat;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_positive;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_negative;
+    uint32_t base_mana;
+    uint32_t base_health;
+    field_bytes_2_union field_bytes_2;
+    uint32_t attack_power;
+    int32_t attack_power_mods;
+    float attack_power_multiplier;
+    int32_t ranged_attack_power;
+    int32_t ranged_attack_power_mods;
+    float ranged_attack_power_multiplier;
+    float minimum_ranged_damage;
+    float maximum_ranged_ddamage;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_modifier;
+    std::array<float, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_multiplier;
+    float max_health_modifier;    // not used
+    uint32_t unit_padding;
+};
+#elif VERSION_STRING == WotLK
+static inline constexpr uint8_t WOWUNIT_POWER_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_ATTACK_TIME_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_STAT_COUNT = 5;
+
+union field_bytes_1_union
+{
+    struct parts
     {
         uint8_t stand_state;
         uint8_t pet_talent_points; // 0 for non pet creature
@@ -54,11 +280,11 @@ union
         uint8_t animation_flag;
     } s;
     uint32_t raw;
-} typedef field_bytes_1_union;
+};
 
-union
+union field_bytes_2_union
 {
-    struct
+    struct parts
     {
         uint8_t sheath_type;
         uint8_t pvp_flag;
@@ -66,190 +292,7 @@ union
         uint8_t shape_shift_form;
     } s;
     uint32_t raw;
-} typedef field_bytes_2_union;
-
-#if VERSION_STRING == Classic
-#define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_AURA_COUNT 48
-#define WOWUNIT_AURA_FLAGS_COUNT 6
-#define WOWUNIT_AURA_LEVELS_COUNT 12
-#define WOWUNIT_AURA_APPLICATIONS_COUNT 12
-#define WOWUNIT_RESISTANCE_COUNT 7
-#define WOWUNIT_POWER_COST_MODIFIER 7
-#define WOWUNIT_POWER_COST_MULTIPLIER 7
-#define WOWUNIT_ATTACK_TIME_COUNT 3
-#define WOWUNIT_STAT_COUNT 5
-
-struct WoWUnit : WoWObject
-{
-    guid_union charm_guid;
-    guid_union summon_guid;
-    guid_union charmed_by_guid;
-    guid_union summoned_by_guid;
-    guid_union created_by_guid;
-    guid_union target_guid;
-    guid_union persuaded_guid;
-    guid_union channel_object_guid;
-    uint32_t health;
-    uint32_t power_1;
-    uint32_t power_2;
-    uint32_t power_3;
-    uint32_t power_4;
-    uint32_t power_5;
-    uint32_t max_health;
-    uint32_t max_power_1;
-    uint32_t max_power_2;
-    uint32_t max_power_3;
-    uint32_t max_power_4;
-    uint32_t max_power_5;
-    uint32_t level;
-    uint32_t faction_template;
-    field_bytes_0_union field_bytes_0;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];       //0 = melee, 1 = offhand, 2 = ranged
-    unit_virtual_item_info virtual_item_info[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT]; //0 = melee, 1 = offhand, 2 = ranged
-    uint32_t unit_flags;
-    uint32_t aura[WOWUNIT_AURA_COUNT];
-    uint32_t aura_flags[WOWUNIT_AURA_FLAGS_COUNT];
-    uint32_t aura_levels[WOWUNIT_AURA_LEVELS_COUNT];
-    uint32_t aura_applications[WOWUNIT_AURA_APPLICATIONS_COUNT];
-    uint32_t aura_state;
-    uint32_t base_attack_time[WOWUNIT_ATTACK_TIME_COUNT];  //0 = melee, 1 = offhand, 2 = ranged
-    float bounding_radius;
-    float combat_reach;
-    uint32_t display_id;
-    uint32_t native_display_id;
-    uint32_t mount_display_id;
-    float minimum_damage;
-    float maximum_damage;
-    float minimum_offhand_damage;
-    float maximum_offhand_damage;
-    field_bytes_1_union field_bytes_1;
-    uint32_t pet_number;
-    uint32_t pet_name_timestamp;
-    uint32_t pet_experience;
-    uint32_t pet_next_level_experience;
-    uint32_t dynamic_flags;
-    uint32_t channel_spell;
-    float mod_cast_speed;
-    uint32_t created_by_spell_id;
-    uint32_t npc_flags;
-    uint32_t npc_emote_state;
-    uint32_t training_points;
-    uint32_t stat[WOWUNIT_STAT_COUNT];
-    uint32_t resistance[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t base_mana;
-    uint32_t base_health;
-    field_bytes_2_union field_bytes_2;
-    uint32_t attack_power;
-    int32_t attack_power_mods;
-    float attack_power_multiplier;
-    int32_t ranged_attack_power;
-    int32_t ranged_attack_power_mods;
-    float ranged_attack_power_multiplier;
-    float minimum_ranged_damage;
-    float maximum_ranged_ddamage;
-    uint32_t power_cost_modifier[WOWUNIT_POWER_COST_MODIFIER];
-    float power_cost_multiplier[WOWUNIT_POWER_COST_MULTIPLIER];
-    uint32_t unit_padding;
 };
-#elif VERSION_STRING == TBC
-#define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_AURA_COUNT 56
-#define WOWUNIT_AURA_FLAGS_COUNT 14
-#define WOWUNIT_AURA_LEVELS_COUNT 14
-#define WOWUNIT_AURA_APPLICATIONS_COUNT 14
-#define WOWUNIT_RESISTANCE_COUNT 7                      //school?
-#define WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT 7    //school?
-#define WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT 7    //school?
-#define WOWUNIT_POWER_COST_MODIFIER 7                   //school?
-#define WOWUNIT_POWER_COST_MULTIPLIER 7                 //school?
-#define WOWUNIT_ATTACK_TIME_COUNT 3
-#define WOWUNIT_STAT_COUNT 5
-
-struct WoWUnit : WoWObject
-{
-    guid_union charm_guid;
-    guid_union summon_guid;
-    guid_union charmed_by_guid;
-    guid_union summoned_by_guid;
-    guid_union created_by_guid;
-    guid_union target_guid;
-    guid_union persuaded_guid;
-    guid_union channel_object_guid;
-    uint32_t health;
-    uint32_t power_1;
-    uint32_t power_2;
-    uint32_t power_3;
-    uint32_t power_4;
-    uint32_t power_5;
-    uint32_t max_health;
-    uint32_t max_power_1;
-    uint32_t max_power_2;
-    uint32_t max_power_3;
-    uint32_t max_power_4;
-    uint32_t max_power_5;
-    uint32_t level;
-    uint32_t faction_template;
-    field_bytes_0_union field_bytes_0;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];       //0 = melee, 1 = offhand, 2 = ranged
-    unit_virtual_item_info virtual_item_info[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT]; //0 = melee, 1 = offhand, 2 = ranged
-    uint32_t unit_flags;
-    uint32_t unit_flags_2;
-    uint32_t aura[WOWUNIT_AURA_COUNT];
-    uint32_t aura_flags[WOWUNIT_AURA_FLAGS_COUNT];
-    uint32_t aura_levels[WOWUNIT_AURA_LEVELS_COUNT];
-    uint32_t aura_applications[WOWUNIT_AURA_APPLICATIONS_COUNT];
-    uint32_t aura_state;
-    uint32_t base_attack_time[WOWUNIT_ATTACK_TIME_COUNT];  //0 = melee, 1 = offhand, 2 = ranged
-    float bounding_radius;
-    float combat_reach;
-    uint32_t display_id;
-    uint32_t native_display_id;
-    uint32_t mount_display_id;
-    float minimum_damage;
-    float maximum_damage;
-    float minimum_offhand_damage;
-    float maximum_offhand_damage;
-    field_bytes_1_union field_bytes_1;
-    uint32_t pet_number;
-    uint32_t pet_name_timestamp;
-    uint32_t pet_experience;
-    uint32_t pet_next_level_experience;
-    uint32_t dynamic_flags;
-    uint32_t channel_spell;
-    float mod_cast_speed;
-    uint32_t created_by_spell_id;
-    uint32_t npc_flags;
-    uint32_t npc_emote_state;
-    uint32_t training_points;
-    uint32_t stat[WOWUNIT_STAT_COUNT];
-    uint32_t positive_stat[WOWUNIT_STAT_COUNT];
-    uint32_t negative_stat[WOWUNIT_STAT_COUNT];
-    uint32_t resistance[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t resistance_buff_mod_positive[WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT];
-    uint32_t resistance_buff_mod_negative[WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT];
-    uint32_t base_mana;
-    uint32_t base_health;
-    field_bytes_2_union field_bytes_2;
-    uint32_t attack_power;
-    int32_t attack_power_mods;
-    float attack_power_multiplier;
-    int32_t ranged_attack_power;
-    int32_t ranged_attack_power_mods;
-    float ranged_attack_power_multiplier;
-    float minimum_ranged_damage;
-    float maximum_ranged_ddamage;
-    uint32_t power_cost_modifier[WOWUNIT_POWER_COST_MODIFIER];
-    float power_cost_multiplier[WOWUNIT_POWER_COST_MULTIPLIER];
-    float max_health_modifier;    // not used
-    uint32_t unit_padding;
-};
-#elif VERSION_STRING == WotLK
-#define WOWUNIT_POWER_COUNT 7
-#define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_RESISTANCE_COUNT 7
-#define WOWUNIT_ATTACK_TIME_COUNT 3
-#define WOWUNIT_STAT_COUNT 5
 
 struct WoWUnit : WoWObject
 {
@@ -279,15 +322,15 @@ struct WoWUnit : WoWObject
     uint32_t max_power_5;
     uint32_t max_power_6;
     uint32_t max_power_7;
-    float power_regen_flat_modifier[WOWUNIT_POWER_COUNT];
-    float power_regen_interrupted_flat_modifier[WOWUNIT_POWER_COUNT];
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_flat_modifier;
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_interrupted_flat_modifier;
     uint32_t level;
     uint32_t faction_template;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];    //0 = melee, 1 = offhand, 2 = ranged
+    std::array<uint32_t, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_slot_display;    //0 = melee, 1 = offhand, 2 = ranged
     uint32_t unit_flags;
     uint32_t unit_flags_2;
     uint32_t aura_state;
-    uint32_t base_attack_time[WOWUNIT_ATTACK_TIME_COUNT];  //0 = melee, 1 = offhand, 2 = ranged
+    std::array<uint32_t, WOWUNIT_ATTACK_TIME_COUNT> base_attack_time;  //0 = melee, 1 = offhand, 2 = ranged
     float bounding_radius;
     float combat_reach;
     uint32_t display_id;
@@ -307,12 +350,12 @@ struct WoWUnit : WoWObject
     uint32_t created_by_spell_id;
     uint32_t npc_flags;
     uint32_t npc_emote_state;
-    uint32_t stat[WOWUNIT_STAT_COUNT];
-    uint32_t positive_stat[WOWUNIT_STAT_COUNT];
-    uint32_t negative_stat[WOWUNIT_STAT_COUNT];
-    uint32_t resistance[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t resistance_buff_mod_positive[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t resistance_buff_mod_negative[WOWUNIT_RESISTANCE_COUNT];
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> positive_stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> negative_stat;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_positive;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_negative;
     uint32_t base_mana;
     uint32_t base_health;
     field_bytes_2_union field_bytes_2;
@@ -324,19 +367,42 @@ struct WoWUnit : WoWObject
     float ranged_attack_power_multiplier;
     float minimum_ranged_damage;
     float maximum_ranged_ddamage;
-    uint32_t power_cost_modifier[WOWUNIT_POWER_COUNT];
-    float power_cost_multiplier[WOWUNIT_POWER_COUNT];
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_modifier;
+    std::array<float, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_multiplier;
     float max_health_modifier;
     float hover_height;
     uint32_t unit_padding;
 };
 #elif VERSION_STRING == Cata
-#define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_RESISTANCE_COUNT 7
-#define WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT 7
-#define WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT 7
-#define WOWUNIT_ATTACK_TIME_COUNT 3
-#define WOWUNIT_STAT_COUNT 5
+static inline constexpr uint8_t WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_POWER_COUNT = 5;
+static inline constexpr uint8_t WOWUNIT_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_ATTACK_TIME_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_STAT_COUNT = 5;
+
+union field_bytes_1_union
+{
+    struct parts
+    {
+        uint8_t stand_state;
+        uint8_t pet_talent_points; // 0 for non pet creature
+        uint8_t stand_state_flag;
+        uint8_t animation_flag;
+    } s;
+    uint32_t raw;
+};
+
+union field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t sheath_type;
+        uint8_t pvp_flag;
+        uint8_t pet_flag;
+        uint8_t shape_shift_form;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWUnit : WoWObject
 {
@@ -362,15 +428,15 @@ struct WoWUnit : WoWObject
     uint32_t max_power_3;
     uint32_t max_power_4;
     uint32_t max_power_5;
-    float power_regen_flat_modifier[5];
-    float power_regen_interrupted_flat_modifier[5];
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_flat_modifier;
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_interrupted_flat_modifier;
     uint32_t level;
     uint32_t faction_template;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];    //0 = melee, 1 = offhand, 2 = ranged
+    std::array<uint32_t, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_slot_display;    //0 = melee, 1 = offhand, 2 = ranged
     uint32_t unit_flags;
     uint32_t unit_flags_2;
     uint32_t aura_state;
-    uint32_t base_attack_time[WOWUNIT_ATTACK_TIME_COUNT];  //0 = melee, 1 = offhand, 2 = ranged
+    std::array<uint32_t, WOWUNIT_ATTACK_TIME_COUNT> base_attack_time;  //0 = melee, 1 = offhand, 2 = ranged
     float bounding_radius;
     float combat_reach;
     uint32_t display_id;
@@ -391,12 +457,12 @@ struct WoWUnit : WoWObject
     uint32_t created_by_spell_id;
     uint32_t npc_flags;
     uint32_t npc_emote_state;
-    uint32_t stat[WOWUNIT_STAT_COUNT];
-    uint32_t positive_stat[WOWUNIT_STAT_COUNT];
-    uint32_t negative_stat[WOWUNIT_STAT_COUNT];
-    uint32_t resistance[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t resistance_buff_mod_positive[WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT];
-    uint32_t resistance_buff_mod_negative[WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT];
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> positive_stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> negative_stat;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_positive;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_negative;
     uint32_t base_mana;
     uint32_t base_health;
     field_bytes_2_union field_bytes_2;
@@ -410,20 +476,43 @@ struct WoWUnit : WoWObject
     float ranged_attack_power_multiplier;
     float minimum_ranged_damage;
     float maximum_ranged_ddamage;
-    uint32_t power_cost_modifier[7];
-    float power_cost_multiplier[7];
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_modifier;
+    std::array<float, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_multiplier;
     float max_health_modifier;
     float hover_height;
     uint32_t max_item_level;
     uint32_t unit_padding;
 };
 #elif VERSION_STRING == Mop
-#define WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT 3
-#define WOWUNIT_RESISTANCE_COUNT 7
-#define WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT 7
-#define WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT 7
-#define WOWUNIT_ATTACK_TIME_COUNT 2
-#define WOWUNIT_STAT_COUNT 5
+static inline constexpr uint8_t WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT = 3;
+static inline constexpr uint8_t WOWUNIT_POWER_COUNT = 5;
+static inline constexpr uint8_t WOWUNIT_SPELL_SCHOOL_COUNT = 7;
+static inline constexpr uint8_t WOWUNIT_ATTACK_TIME_COUNT = 2;
+static inline constexpr uint8_t WOWUNIT_STAT_COUNT = 5;
+
+union field_bytes_1_union
+{
+    struct parts
+    {
+        uint8_t stand_state;
+        uint8_t unk1; // possibly pet specialization
+        uint8_t stand_state_flag;
+        uint8_t animation_flag;
+    } s;
+    uint32_t raw;
+};
+
+union field_bytes_2_union
+{
+    struct parts
+    {
+        uint8_t sheath_type;
+        uint8_t pvp_flag;
+        uint8_t pet_flag;
+        uint8_t shape_shift_form;
+    } s;
+    uint32_t raw;
+};
 
 struct WoWUnit : WoWObject
 {
@@ -454,16 +543,16 @@ struct WoWUnit : WoWObject
     uint32_t max_power_3;
     uint32_t max_power_4;
     uint32_t max_power_5;
-    float power_regen_flat_modifier[5];
-    float power_regen_interrupted_flat_modifier[5];
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_flat_modifier;
+    std::array<float, WOWUNIT_POWER_COUNT> power_regen_interrupted_flat_modifier;
     uint32_t level;
     uint32_t effective_level;
     uint32_t faction_template;
-    uint32_t virtual_item_slot_display[WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT];    //0 = melee, 1 = offhand, 2 = ranged
+    std::array<uint32_t, WOWUNIT_VIRTUAL_ITEM_SLOT_DISPLAY_COUNT> virtual_item_slot_display;    //0 = melee, 1 = offhand, 2 = ranged
     uint32_t unit_flags;
     uint32_t unit_flags_2;
     uint32_t aura_state;
-    uint32_t base_attack_time[WOWUNIT_ATTACK_TIME_COUNT];  //0 = melee, 1 = offhand
+    std::array<uint32_t, WOWUNIT_ATTACK_TIME_COUNT> base_attack_time;  //0 = melee, 1 = offhand
     uint32_t ranged_attack_time;
     float bounding_radius;
     float combat_reach;
@@ -487,12 +576,12 @@ struct WoWUnit : WoWObject
     uint32_t created_by_spell_id;
     uint64_t npc_flags;
     uint32_t npc_emote_state;
-    uint32_t stat[WOWUNIT_STAT_COUNT];
-    uint32_t positive_stat[WOWUNIT_STAT_COUNT];
-    uint32_t negative_stat[WOWUNIT_STAT_COUNT];
-    uint32_t resistance[WOWUNIT_RESISTANCE_COUNT];
-    uint32_t resistance_buff_mod_positive[WOWUNIT_RESISTANCE_BUFF_MOD_POSITIVE_COUNT];
-    uint32_t resistance_buff_mod_negative[WOWUNIT_RESISTANCE_BUFF_MOD_NEGATIVE_COUNT];
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> positive_stat;
+    std::array<uint32_t, WOWUNIT_STAT_COUNT> negative_stat;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_positive;
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> resistance_buff_mod_negative;
     uint32_t base_mana;
     uint32_t base_health;
     field_bytes_2_union field_bytes_2;
@@ -506,8 +595,8 @@ struct WoWUnit : WoWObject
     float ranged_attack_power_multiplier;
     float minimum_ranged_damage;
     float maximum_ranged_ddamage;
-    uint32_t power_cost_modifier[7];
-    float power_cost_multiplier[7];
+    std::array<uint32_t, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_modifier;
+    std::array<float, WOWUNIT_SPELL_SCHOOL_COUNT> power_cost_multiplier;
     float max_health_modifier;
     float hover_height;
     uint32_t min_item_level;

--- a/src/world/Management/Battleground/Battleground.cpp
+++ b/src/world/Management/Battleground/Battleground.cpp
@@ -817,7 +817,8 @@ Creature* Battleground::spawnSpiritGuide(float x, float y, float z, float o, uin
 
     pCreature->setVirtualItemSlotId(MELEE, 22802);
 
-    pCreature->setUnitFlags(UNIT_FLAG_PLUS_MOB | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_IGNORE_PLAYER_NPC | UNIT_FLAG_PVP); // 4928
+    pCreature->setUnitFlags(UNIT_FLAG_PLUS_MOB | UNIT_FLAG_IGNORE_PLAYER_COMBAT | UNIT_FLAG_IGNORE_CREATURE_COMBAT); // 832
+    pCreature->setPvpFlag();
 
     pCreature->setBaseAttackTime(MELEE, 2000);
     pCreature->setBaseAttackTime(OFFHAND, 2000);
@@ -832,7 +833,9 @@ Creature* Battleground::spawnSpiritGuide(float x, float y, float z, float o, uin
 
     pCreature->setNpcFlags(UNIT_NPC_FLAG_SPIRITGUIDE);
     pCreature->setSheathType(SHEATH_STATE_MELEE);
-    pCreature->setPvpFlags(U_FIELD_BYTES_FLAG_AURAS);
+#if VERSION_STRING == TBC
+    pCreature->setPositiveAuraLimit(POS_AURA_LIMIT_CREATURE);
+#endif
 
     pCreature->setAItoUse(false);
 
@@ -932,6 +935,7 @@ void Battleground::eventResurrectPlayers()
                 plr->setPower(POWER_TYPE_ENERGY, plr->getMaxPower(POWER_TYPE_ENERGY));
                 plr->castSpell(plr, BattlegroundDef::REVIVE_PREPARATION, true);
 
+#if VERSION_STRING >= TBC
                 // Spawn last active pet
                 if (plr->getLastBattlegroundPetId() != 0)
                 {
@@ -946,6 +950,7 @@ void Battleground::eventResurrectPlayers()
                     plr->castSpell(plr, plr->getLastBattlegroundPetSpell(), true);
                     plr->removeUnitFlags(UNIT_FLAG_NO_REAGANT_COST);
                 }
+#endif
 
                 plr->setLastBattlegroundPetId(0);
                 plr->setLastBattlegroundPetSpell(0);

--- a/src/world/Management/GameEventDefines.hpp
+++ b/src/world/Management/GameEventDefines.hpp
@@ -97,9 +97,8 @@ struct EventCreatureSpawnsQueryResult
     uint32_t displayid;
     uint32_t faction;
     uint32_t flags;
+    uint8_t pvp_flagged;
     uint32_t bytes0;
-    uint32_t bytes1;
-    uint32_t bytes2;
     uint16_t emote_state;
     uint32_t npc_respawn_link;
     uint32_t channel_spell;
@@ -108,6 +107,7 @@ struct EventCreatureSpawnsQueryResult
     uint8_t standstate;
     uint8_t death_state;
     uint32_t mountdisplayid;
+    uint8_t sheath_state;
     uint32_t slot1item;
     uint32_t slot2item;
     uint32_t slot3item;

--- a/src/world/Management/GameEventMgr.cpp
+++ b/src/world/Management/GameEventMgr.cpp
@@ -145,9 +145,9 @@ void GameEventMgr::LoadFromDB()
     sLogger.info("GameEventMgr : Start loading game event creature spawns");
     {
         const char* loadEventCreatureSpawnsQuery = "SELECT id, entry, map, position_x, position_y, position_z, \
-                                                    orientation, movetype, displayid, faction, flags, bytes0, bytes1, bytes2, \
+                                                    orientation, movetype, displayid, faction, flags, pvp_flagged, bytes0, \
                                                     emote_state, npc_respawn_link, channel_spell, channel_target_sqlid, \
-                                                    channel_target_sqlid_creature, standstate, death_state, mountdisplayid, \
+                                                    channel_target_sqlid_creature, standstate, death_state, mountdisplayid, sheath_state, \
                                                     slot1item, slot2item, slot3item, CanFly, phase, waypoint_group, event_entry \
                                                     FROM creature_spawns WHERE min_build <= %u AND max_build >= %u AND event_entry > 0";
         bool success = false;
@@ -193,17 +193,17 @@ void GameEventMgr::LoadFromDB()
                 dbResult.displayid = field[8].asUint32();
                 dbResult.faction = field[9].asUint32();
                 dbResult.flags = field[10].asUint32();
-                dbResult.bytes0 = field[11].asUint32();
-                dbResult.bytes1 = field[12].asUint32();
-                dbResult.bytes2 = field[13].asUint32();
-                dbResult.emote_state = field[14].asUint16();
-                dbResult.npc_respawn_link = field[15].asUint32();
-                dbResult.channel_spell = field[16].asUint32();
-                dbResult.channel_target_sqlid = field[17].asUint32();
-                dbResult.channel_target_sqlid_creature = field[18].asUint32();
-                dbResult.standstate = field[19].asUint8();
-                dbResult.death_state = field[20].asUint8();
-                dbResult.mountdisplayid = field[21].asUint32();
+                dbResult.pvp_flagged = field[11].asUint8();
+                dbResult.bytes0 = field[12].asUint32();
+                dbResult.emote_state = field[13].asUint16();
+                dbResult.npc_respawn_link = field[14].asUint32();
+                dbResult.channel_spell = field[15].asUint32();
+                dbResult.channel_target_sqlid = field[16].asUint32();
+                dbResult.channel_target_sqlid_creature = field[17].asUint32();
+                dbResult.standstate = field[18].asUint8();
+                dbResult.death_state = field[19].asUint8();
+                dbResult.mountdisplayid = field[20].asUint32();
+                dbResult.sheath_state = field[21].asUint8();
                 dbResult.slot1item = field[22].asUint32();
                 dbResult.slot2item = field[23].asUint32();
                 dbResult.slot3item = field[24].asUint32();

--- a/src/world/Management/ItemInterface.h
+++ b/src/world/Management/ItemInterface.h
@@ -123,6 +123,8 @@ public:
     // Inventory error report
     void buildInventoryChangeError(Item const* srcItem, Item const* dstItem, uint8_t inventoryError, uint32_t srcItemId = 0);
 
+    void setOwnerInventoryItem(uint8_t slot, uint64_t guid);
+
     void update(uint32_t timePassed);
 
 private:

--- a/src/world/Management/Loot/LootRoll.hpp
+++ b/src/world/Management/Loot/LootRoll.hpp
@@ -7,7 +7,6 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "Server/EventableObject.h"
 
-struct LootItem;
 class Player;
 class WorldMap;
 

--- a/src/world/Map/Maps/MapScriptInterface.cpp
+++ b/src/world/Map/Maps/MapScriptInterface.cpp
@@ -345,16 +345,16 @@ Creature* MapScriptInterface::spawnCreature(uint32_t Entry, LocationVector pos, 
     spawn->o = pos.o;
     spawn->emote_state = 0;
     spawn->flags = 0;
+    spawn->pvp_flagged = 0;
     spawn->factionid = creature_properties->Faction;
     spawn->bytes0 = 0;
-    spawn->bytes1 = 0;
-    spawn->bytes2 = 0;
     spawn->stand_state = 0;
     spawn->death_state = 0;
     spawn->channel_target_creature = 0;
     spawn->channel_target_go = 0;
     spawn->channel_spell = 0;
     spawn->MountedDisplayID = 0;
+    spawn->sheath_state = 0;
 
     spawn->Item1SlotEntry = creature_properties->itemslot_1;
     spawn->Item2SlotEntry = creature_properties->itemslot_2;

--- a/src/world/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/world/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -116,7 +116,9 @@ void FlightPathMovementGenerator::doFinalize(Player* player, bool active, bool /
         player->safeTeleport(_path[getCurrentNode()]->mapid, 0, LocationVector(_path[getCurrentNode()]->x, _path[getCurrentNode()]->y, mapHeight, player->GetOrientation()));
     }
 
-    player->removePlayerFlags(PLAYER_FLAG_UNK2);
+#if VERSION_STRING >= TBC
+    player->removePlayerFlags(PLAYER_FLAG_TAXI_TIME_TEST);
+#endif
 }
 
 void FlightPathMovementGenerator::doReset(Player* player)

--- a/src/world/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/world/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -341,10 +341,10 @@ void WaypointMovementGenerator<Creature>::startMove(Creature* owner, bool relaun
     {
 #if VERSION_STRING >= WotLK
         case WAYPOINT_MOVE_TYPE_LAND:
-            init.SetAnimation(AnimationTier::Ground);
+            init.SetAnimation(ANIMATION_FLAG_GROUND);
             break;
         case WAYPOINT_MOVE_TYPE_TAKEOFF:
-            init.SetAnimation(AnimationTier::Hover);
+            init.SetAnimation(ANIMATION_FLAG_HOVER);
             break;
 #endif
         case WAYPOINT_MOVE_TYPE_RUN:

--- a/src/world/Movement/MovementManager.cpp
+++ b/src/world/Movement/MovementManager.cpp
@@ -671,7 +671,7 @@ void MovementManager::moveLand(uint32_t id, LocationVector const& pos, Optional<
     MovementMgr::MoveSplineInit init(_owner);
     init.MoveTo(positionToVector3(pos), false);
 #if VERSION_STRING >= WotLK
-    init.SetAnimation(AnimationTier::Ground);
+    init.SetAnimation(ANIMATION_FLAG_GROUND);
 #endif
     if (velocity)
         init.SetVelocity(*velocity);
@@ -683,7 +683,7 @@ void MovementManager::moveTakeoff(uint32_t id, LocationVector const& pos, Option
     MovementMgr::MoveSplineInit init(_owner);
     init.MoveTo(positionToVector3(pos), false);
 #if VERSION_STRING >= WotLK
-    init.SetAnimation(AnimationTier::Hover);
+    init.SetAnimation(ANIMATION_FLAG_HOVER);
 #endif
     if (velocity)
         init.SetVelocity(*velocity);
@@ -831,7 +831,7 @@ void MovementManager::moveCirclePath(float x, float y, float z, float radius, bo
         init.SetFly();
         init.SetCyclic();
 #if VERSION_STRING >= WotLK
-        init.SetAnimation(AnimationTier::Hover);
+        init.SetAnimation(ANIMATION_FLAG_HOVER);
 #endif
     }
     else

--- a/src/world/Movement/Spline/MoveSpline.h
+++ b/src/world/Movement/Spline/MoveSpline.h
@@ -120,7 +120,7 @@ public:
 
 #if VERSION_STRING >= WotLK
     bool HasAnimation() const { return splineflags.animation; }
-    AnimationTier GetAnimationTier() const { return static_cast<AnimationTier>(splineflags.animTier); }
+    UnitBytes1_AnimationFlag GetAnimationTier() const { return static_cast<UnitBytes1_AnimationFlag>(splineflags.animTier); }
 #endif
 
     bool onTransport;

--- a/src/world/Movement/Spline/MoveSplineInit.h
+++ b/src/world/Movement/Spline/MoveSplineInit.h
@@ -52,7 +52,7 @@ public:
 #if VERSION_STRING >= WotLK
     // Plays animation after movement done
     // can't be combined with parabolic movement
-    void SetAnimation(AnimationTier anim);
+    void SetAnimation(UnitBytes1_AnimationFlag anim);
 #endif
 
     // Adds final facing animation
@@ -188,7 +188,7 @@ inline void MoveSplineInit::SetParabolic(float amplitude, float time_shift)
 }
 
 #if VERSION_STRING >= WotLK
-inline void MoveSplineInit::SetAnimation(AnimationTier anim)
+inline void MoveSplineInit::SetAnimation(UnitBytes1_AnimationFlag anim)
 {
     args.time_perc = 0.f;
     args.flags.EnableAnimation(static_cast<uint8_t>(anim));

--- a/src/world/Objects/Container.cpp
+++ b/src/world/Objects/Container.cpp
@@ -321,6 +321,5 @@ bool Container::safeFullRemoveItemFromSlot(int16_t slot)
 uint32_t Container::getSlotCount() const { return containerData()->slot_count; }
 void Container::setSlotCount(uint32_t count) { write(containerData()->slot_count, count); }
 
-//\todo not used. is it really uint64_t (guid) or is it another value we want to send to the client?
 uint64_t Container::getSlot(uint16_t slot) const { return containerData()->item_slot[slot].guid; }
 void Container::setSlot(uint16_t slot, uint64_t guid) { write(containerData()->item_slot[slot].guid, guid); }

--- a/src/world/Objects/DynamicObject.cpp
+++ b/src/world/Objects/DynamicObject.cpp
@@ -223,7 +223,11 @@ void DynamicObject::setCasterGuid(uint64_t guid) { write(dynamicObjectData()->ca
 
 //bytes start
 uint8_t DynamicObject::getDynamicType() const { return dynamicObjectData()->dynamicobject_bytes.s.type; }
+#if VERSION_STRING < Cata
 void DynamicObject::setDynamicType(uint8_t type) { write(dynamicObjectData()->dynamicobject_bytes.s.type, type); }
+#else
+void DynamicObject::setDynamicType(uint8_t type) { write(dynamicObjectData()->dynamicobject_bytes.s.type, static_cast<uint32_t>(type)); }
+#endif
 //bytes end
 
 uint32_t DynamicObject::getSpellId() const { return dynamicObjectData()->spell_id; }

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -172,13 +172,10 @@ int64_t GameObject::getPackedLocalRotation() const { return m_packedRotation; }
 uint32_t GameObject::getDynamicFlags() const { return gameObjectData()->dynamic; }
 void GameObject::setDynamicFlags(uint32_t dynamicFlags) { write(gameObjectData()->dynamic, dynamicFlags); }
 #elif VERSION_STRING < Mop
-uint32_t GameObject::getDynamicField() const { return gameObjectData()->dynamic; }
-uint16_t GameObject::getDynamicFlags() const { return gameObjectData()->dynamic_field_parts.dyn_flag; }
-int16_t GameObject::getDynamicPathProgress() const { return gameObjectData()->dynamic_field_parts.path_progress; }
-void GameObject::setDynamicField(uint32_t dynamic) { write(gameObjectData()->dynamic, dynamic); }
-void GameObject::setDynamicField(uint16_t dynamicFlags, int16_t pathProgress) { setDynamicField(static_cast<uint32_t>(pathProgress) << 16 | dynamicFlags); }
-void GameObject::setDynamicFlags(uint16_t dynamicFlags) { setDynamicField(dynamicFlags, getDynamicPathProgress()); }
-void GameObject::setDynamicPathProgress(int16_t pathProgress) { setDynamicField(getDynamicFlags(), pathProgress); }
+uint16_t GameObject::getDynamicFlags() const { return gameObjectData()->dynamic.dynamic_field_parts.dyn_flag; }
+int16_t GameObject::getDynamicPathProgress() const { return gameObjectData()->dynamic.dynamic_field_parts.path_progress; }
+void GameObject::setDynamicFlags(uint16_t dynamicFlags) { write(gameObjectData()->dynamic.dynamic_field_parts.dyn_flag, dynamicFlags); }
+void GameObject::setDynamicPathProgress(int16_t pathProgress) { write(gameObjectData()->dynamic.dynamic_field_parts.path_progress, pathProgress); }
 #endif
 
 uint32_t GameObject::getFactionTemplate() const { return gameObjectData()->faction_template; }
@@ -193,7 +190,7 @@ uint8_t GameObject::getState() const
 #if VERSION_STRING <= TBC
     return gameObjectData()->state;
 #elif VERSION_STRING >= WotLK
-    return gameObjectData()->bytes_1_gameobject.state;
+    return gameObjectData()->bytes_1.bytes_1_gameobject.state;
 #endif
 }
 void GameObject::setState(uint8_t state)
@@ -201,7 +198,7 @@ void GameObject::setState(uint8_t state)
 #if VERSION_STRING <= TBC
     write(gameObjectData()->state, static_cast<uint32_t>(state));
 #elif VERSION_STRING >= WotLK
-    write(gameObjectData()->bytes_1_gameobject.state, state);
+    write(gameObjectData()->bytes_1.bytes_1_gameobject.state, state);
 #endif
 }
 
@@ -210,7 +207,7 @@ uint8_t GameObject::getGoType() const
 #if VERSION_STRING <= TBC
     return gameObjectData()->type;
 #elif VERSION_STRING >= WotLK
-    return gameObjectData()->bytes_1_gameobject.type;
+    return gameObjectData()->bytes_1.bytes_1_gameobject.type;
 #endif
 }
 void GameObject::setGoType(uint8_t type)
@@ -218,7 +215,7 @@ void GameObject::setGoType(uint8_t type)
 #if VERSION_STRING <= TBC
     write(gameObjectData()->type, static_cast<uint32_t>(type));
 #elif VERSION_STRING >= WotLK
-    write(gameObjectData()->bytes_1_gameobject.type, type);
+    write(gameObjectData()->bytes_1.bytes_1_gameobject.type, type);
 #endif
 }
 
@@ -228,7 +225,7 @@ uint8_t GameObject::getArtKit() const
 #if VERSION_STRING <= TBC
     return gameObjectData()->art_kit;
 #elif VERSION_STRING >= WotLK
-    return gameObjectData()->bytes_1_gameobject.art_kit;
+    return gameObjectData()->bytes_1.bytes_1_gameobject.art_kit;
 #endif
 }
 void GameObject::setArtKit(uint8_t artkit)
@@ -236,17 +233,17 @@ void GameObject::setArtKit(uint8_t artkit)
 #if VERSION_STRING <= TBC
     write(gameObjectData()->art_kit, static_cast<uint32_t>(artkit));
 #elif VERSION_STRING >= WotLK
-    write(gameObjectData()->bytes_1_gameobject.art_kit, artkit);
+    write(gameObjectData()->bytes_1.bytes_1_gameobject.art_kit, artkit);
 #endif
 }
 #else
 uint8_t GameObject::getArtKit() const
 {
-    return gameObjectData()->bytes_2_gameobject.art_kit;
+    return gameObjectData()->bytes_2.bytes_2_gameobject.art_kit;
 }
 void GameObject::setArtKit(uint8_t artkit)
 {
-    write(gameObjectData()->bytes_2_gameobject.art_kit, artkit);
+    write(gameObjectData()->bytes_2.bytes_2_gameobject.art_kit, artkit);
 }
 #endif
 
@@ -256,7 +253,7 @@ uint8_t GameObject::getAnimationProgress() const
 #if VERSION_STRING <= TBC
     return gameObjectData()->animation_progress;
 #elif VERSION_STRING >= WotLK
-    return gameObjectData()->bytes_1_gameobject.animation_progress;
+    return gameObjectData()->bytes_1.bytes_1_gameobject.animation_progress;
 #endif
 }
 void GameObject::setAnimationProgress(uint8_t progress)
@@ -264,17 +261,17 @@ void GameObject::setAnimationProgress(uint8_t progress)
 #if VERSION_STRING <= TBC
     write(gameObjectData()->animation_progress, static_cast<uint32_t>(progress));
 #elif VERSION_STRING >= WotLK
-    write(gameObjectData()->bytes_1_gameobject.animation_progress, progress);
+    write(gameObjectData()->bytes_1.bytes_1_gameobject.animation_progress, progress);
 #endif
 }
 #else
 uint8_t GameObject::getAnimationProgress() const
 {
-    return gameObjectData()->bytes_2_gameobject.animation_progress;
+    return gameObjectData()->bytes_2.bytes_2_gameobject.animation_progress;
 }
 void GameObject::setAnimationProgress(uint8_t progress)
 {
-    write(gameObjectData()->bytes_2_gameobject.animation_progress, progress);
+    write(gameObjectData()->bytes_2.bytes_2_gameobject.animation_progress, progress);
 }
 #endif
 

--- a/src/world/Objects/GameObject.h
+++ b/src/world/Objects/GameObject.h
@@ -146,11 +146,8 @@ public:
     uint32_t getDynamicFlags() const;
     void setDynamicFlags(uint32_t dynamicFlags);
 #elif VERSION_STRING < Mop
-    uint32_t getDynamicField() const;
     uint16_t getDynamicFlags() const;
     int16_t getDynamicPathProgress() const;
-    void setDynamicField(uint32_t dynamic);
-    void setDynamicField(uint16_t dynamicFlags, int16_t pathProgress);
     void setDynamicFlags(uint16_t dynamicFlags);
     void setDynamicPathProgress(int16_t pathProgress);
 #endif

--- a/src/world/Objects/Object.hpp
+++ b/src/world/Objects/Object.hpp
@@ -160,11 +160,8 @@ public:
     uint32_t getEntry() const;
 
 #if VERSION_STRING >= Mop
-    uint32_t getDynamicField() const;
     uint16_t getDynamicFlags() const;
     int16_t getDynamicPathProgress() const;
-    void setDynamicField(uint32_t dynamic);
-    void setDynamicField(uint16_t dynamicFlags, int16_t pathProgress);
     void setDynamicFlags(uint16_t dynamicFlags);
     void addDynamicFlags(uint16_t dynamicFlags);
     void removeDynamicFlags(uint16_t dynamicFlags);

--- a/src/world/Objects/Units/Creatures/AIInterface.cpp
+++ b/src/world/Objects/Units/Creatures/AIInterface.cpp
@@ -3112,10 +3112,10 @@ void AIInterface::setWayPointToMove(uint32_t waypointId)
     {
 #if VERSION_STRING >= WotLK
     case WAYPOINT_MOVE_TYPE_LAND:
-        init.SetAnimation(AnimationTier::Ground);
+        init.SetAnimation(ANIMATION_FLAG_GROUND);
         break;
     case WAYPOINT_MOVE_TYPE_TAKEOFF:
-        init.SetAnimation(AnimationTier::Hover);
+        init.SetAnimation(ANIMATION_FLAG_HOVER);
         break;
 #endif
     case WAYPOINT_MOVE_TYPE_RUN:

--- a/src/world/Objects/Units/Creatures/Creature.cpp
+++ b/src/world/Objects/Units/Creatures/Creature.cpp
@@ -200,8 +200,8 @@ bool Creature::isClassTrainer() const { return getNpcFlags() & UNIT_NPC_FLAG_TRA
 bool Creature::isProfessionTrainer() const { return getNpcFlags() & UNIT_NPC_FLAG_TRAINER_PROFESSION; }
 bool Creature::isQuestGiver() const { return getNpcFlags() & UNIT_NPC_FLAG_QUESTGIVER; }
 bool Creature::isGossip() const{ return getNpcFlags() & UNIT_NPC_FLAG_GOSSIP; }
-bool Creature::isTaxi() const { return getNpcFlags() & UNIT_NPC_FLAG_FLIGHTMASTER; }
-bool Creature::isCharterGiver() const { return getNpcFlags() & UNIT_NPC_FLAG_PETITIONER; }
+bool Creature::isTaxi() const { return getNpcFlags() & UNIT_NPC_FLAG_TAXI; }
+bool Creature::isCharterGiver() const { return getNpcFlags() & UNIT_NPC_FLAG_CHARTERGIVER; }
 bool Creature::isGuildBank() const { return getNpcFlags() & UNIT_NPC_FLAG_GUILD_BANKER; }
 bool Creature::isBattleMaster() const { return getNpcFlags() & UNIT_NPC_FLAG_BATTLEMASTER; }
 bool Creature::isBanker() const { return getNpcFlags() & UNIT_NPC_FLAG_BANKER; }
@@ -210,11 +210,11 @@ bool Creature::isSpiritHealer() const { return getNpcFlags() & UNIT_NPC_FLAG_SPI
 bool Creature::isTabardDesigner() const { return getNpcFlags() & UNIT_NPC_FLAG_TABARDDESIGNER; }
 bool Creature::isAuctioneer() const { return getNpcFlags() & UNIT_NPC_FLAG_AUCTIONEER; }
 bool Creature::isStableMaster() const { return getNpcFlags() & UNIT_NPC_FLAG_STABLEMASTER; }
-bool Creature::isArmorer() const { return getNpcFlags() & UNIT_NPC_FLAG_REPAIR; }
+bool Creature::isArmorer() const { return getNpcFlags() & UNIT_NPC_FLAG_ARMORER; }
 #if VERSION_STRING >= Cata
 bool Creature::isTransmog() const { return getNpcFlags() & UNIT_NPC_FLAG_TRANSMOGRIFIER; }
 bool Creature::isReforger() const { return getNpcFlags() & UNIT_NPC_FLAG_REFORGER; }
-bool Creature::isVoidStorage() const { return getNpcFlags() & UNIT_NPC_FLAG_VAULTKEEPER; }
+bool Creature::isVoidStorage() const { return getNpcFlags() & UNIT_NPC_FLAG_VOID_STORAGE; }
 #endif
 
 bool Creature::isVehicle() const
@@ -227,54 +227,82 @@ bool Creature::isTrainingDummy()
     return creature_properties->isTrainingDummy;
 }
 
-bool Creature::isPvpFlagSet()
+bool Creature::isPvpFlagSet() const
 {
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_PVP;
+#if VERSION_STRING > TBC
+    return getPvpFlags() & PVP_STATE_FLAG_PVP;
+#else
+    return getUnitFlags() & UNIT_FLAG_PVP;
+#endif
 }
 
 void Creature::setPvpFlag()
 {
-    addPvpFlags(U_FIELD_BYTES_FLAG_PVP);
+#if VERSION_STRING > TBC
+    addPvpFlags(PVP_STATE_FLAG_PVP);
+#else
+    addUnitFlags(UNIT_FLAG_PVP);
+#endif
     getSummonInterface()->setPvPFlags(true);
 }
 
 void Creature::removePvpFlag()
 {
-    removePvpFlags(U_FIELD_BYTES_FLAG_PVP);
+#if VERSION_STRING > TBC
+    removePvpFlags(PVP_STATE_FLAG_PVP);
+#else
+    removeUnitFlags(UNIT_FLAG_PVP);
+#endif
     getSummonInterface()->setPvPFlags(false);
 }
 
-bool Creature::isFfaPvpFlagSet()
+bool Creature::isFfaPvpFlagSet() const
 {
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_FFA_PVP;
+#if VERSION_STRING > TBC
+    return getPvpFlags() & PVP_STATE_FLAG_FFA_PVP;
+#else
+    return false;
+#endif
 }
 
 void Creature::setFfaPvpFlag()
 {
-    addPvpFlags(U_FIELD_BYTES_FLAG_FFA_PVP);
+#if VERSION_STRING > TBC
+    addPvpFlags(PVP_STATE_FLAG_FFA_PVP);
+#endif
     getSummonInterface()->setFFAPvPFlags(true);
 }
 
 void Creature::removeFfaPvpFlag()
 {
-    removePvpFlags(U_FIELD_BYTES_FLAG_FFA_PVP);
+#if VERSION_STRING > TBC
+    removePvpFlags(PVP_STATE_FLAG_FFA_PVP);
+#endif
     getSummonInterface()->setFFAPvPFlags(false);
 }
 
-bool Creature::isSanctuaryFlagSet()
+bool Creature::isSanctuaryFlagSet() const
 {
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_SANCTUARY;
+#if VERSION_STRING > TBC
+    return getPvpFlags() & PVP_STATE_FLAG_SANCTUARY;
+#else
+    return false;
+#endif
 }
 
 void Creature::setSanctuaryFlag()
 {
-    addPvpFlags(U_FIELD_BYTES_FLAG_SANCTUARY);
+#if VERSION_STRING > TBC
+    addPvpFlags(PVP_STATE_FLAG_SANCTUARY);
+#endif
     getSummonInterface()->setSanctuaryFlags(true);
 }
 
 void Creature::removeSanctuaryFlag()
 {
-    removePvpFlags(U_FIELD_BYTES_FLAG_SANCTUARY);
+#if VERSION_STRING > TBC
+    removePvpFlags(PVP_STATE_FLAG_SANCTUARY);
+#endif
     getSummonInterface()->setSanctuaryFlags(false);
 }
 
@@ -1647,6 +1675,12 @@ bool Creature::Load(MySQLStructure::CreatureSpawn* spawn, uint8_t mode, MySQLStr
     setCombatReach(creature_properties->CombatReach);
     original_emotestate = spawn->emote_state;
 
+#if VERSION_STRING == TBC
+    // Summons are set in Summon::load
+    if (!isSummon())
+        setPositiveAuraLimit(POS_AURA_LIMIT_CREATURE);
+#endif
+
     // set position
     m_position.ChangeCoords({ spawn->x, spawn->y, spawn->z, spawn->o });
     m_spawnLocation.ChangeCoords({ spawn->x, spawn->y, spawn->z, spawn->o });
@@ -1710,10 +1744,7 @@ bool Creature::Load(MySQLStructure::CreatureSpawn* spawn, uint8_t mode, MySQLStr
     setBytes0(spawn->bytes0);
 
     // Bytes 1
-    setStandState(static_cast<uint8_t>((spawn->bytes1) & 0xFF));
-    setPetTalentPoints(static_cast<uint8_t>((spawn->bytes1 >> 8) & 0xFF));
-    setStandStateFlags(static_cast<uint8_t>((spawn->bytes1 >> 16) & 0xFF));
-    setAnimationTier(static_cast<AnimationTier>((spawn->bytes1 >> 24) & 0xFF));
+    setBytes1(spawn->bytes1);
 
     // Bytes 2
     setBytes2(spawn->bytes2);
@@ -1876,10 +1907,15 @@ void Creature::Load(CreatureProperties const* properties_, float x, float y, flo
     setMinDamage(creature_properties->MinDamage);
     setMaxDamage(creature_properties->MaxDamage);
 
-
     setFaction(creature_properties->Faction);
     setBoundingRadius(creature_properties->BoundingRadius);
     setCombatReach(creature_properties->CombatReach);
+
+#if VERSION_STRING == TBC
+    // Summons are set in Summon::load
+    if (!isSummon())
+        setPositiveAuraLimit(POS_AURA_LIMIT_CREATURE);
+#endif
 
     original_emotestate = 0;
 

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -88,15 +88,15 @@ public:
     bool isTrainingDummy() override;
 
     //pvp helper
-    bool isPvpFlagSet() override;
+    bool isPvpFlagSet() const override;
     void setPvpFlag() override;
     void removePvpFlag() override;
 
-    bool isFfaPvpFlagSet() override;
+    bool isFfaPvpFlagSet() const override;
     void setFfaPvpFlag() override;
     void removeFfaPvpFlag() override;
 
-    bool isSanctuaryFlagSet() override;
+    bool isSanctuaryFlagSet() const override;
     void setSanctuaryFlag() override;
     void removeSanctuaryFlag() override;
 

--- a/src/world/Objects/Units/Creatures/CreatureDefines.hpp
+++ b/src/world/Objects/Units/Creatures/CreatureDefines.hpp
@@ -282,38 +282,45 @@ enum UNIT_TYPE
     UNIT_TYPE_NUM               = 14
 };
 
+// TODO: confirm flags introduced in tbc
 enum NPCFlags : uint32_t
 {
     UNIT_NPC_FLAG_NONE                  = 0x00000000,
-    UNIT_NPC_FLAG_GOSSIP                = 0x00000001,       // 100%
-    UNIT_NPC_FLAG_QUESTGIVER            = 0x00000002,       // 100%
+    UNIT_NPC_FLAG_GOSSIP                = 0x00000001,
+    UNIT_NPC_FLAG_QUESTGIVER            = 0x00000002,
     UNIT_NPC_FLAG_UNK1                  = 0x00000004,
     UNIT_NPC_FLAG_UNK2                  = 0x00000008,
-    UNIT_NPC_FLAG_TRAINER               = 0x00000010,       // 100%
-    UNIT_NPC_FLAG_TRAINER_CLASS         = 0x00000020,       // 100%
-    UNIT_NPC_FLAG_TRAINER_PROFESSION    = 0x00000040,       // 100%
-    UNIT_NPC_FLAG_VENDOR                = 0x00000080,       // 100%
-    UNIT_NPC_FLAG_VENDOR_AMMO           = 0x00000100,       // 100%, general goods vendor
-    UNIT_NPC_FLAG_VENDOR_FOOD           = 0x00000200,       // 100%
-    UNIT_NPC_FLAG_VENDOR_POISON         = 0x00000400,       // guessed
-    UNIT_NPC_FLAG_VENDOR_REAGENT        = 0x00000800,       // 100%
-    UNIT_NPC_FLAG_REPAIR                = 0x00001000,       // 100%
-    UNIT_NPC_FLAG_FLIGHTMASTER          = 0x00002000,       // 100%
-    UNIT_NPC_FLAG_SPIRITHEALER          = 0x00004000,       // guessed
-    UNIT_NPC_FLAG_SPIRITGUIDE           = 0x00008000,       // guessed
-    UNIT_NPC_FLAG_INNKEEPER             = 0x00010000,       // 100%
-    UNIT_NPC_FLAG_BANKER                = 0x00020000,       // 100%
-    UNIT_NPC_FLAG_PETITIONER            = 0x00040000,       // 100% 0xC0000 = guild petitions, 0x40000 = arena team petitions
-    UNIT_NPC_FLAG_TABARDDESIGNER        = 0x00080000,       // 100%
-    UNIT_NPC_FLAG_BATTLEMASTER          = 0x00100000,       // 100%
-    UNIT_NPC_FLAG_AUCTIONEER            = 0x00200000,       // 100%
-    UNIT_NPC_FLAG_STABLEMASTER          = 0x00400000,       // 100%
-    UNIT_NPC_FLAG_GUILD_BANKER          = 0x00800000,       // cause client to send 997 opcode
-    UNIT_NPC_FLAG_SPELLCLICK            = 0x01000000,       // cause client to send 1015 opcode (spell click)
-    UNIT_NPC_FLAG_PLAYER_VEHICLE        = 0x02000000,       // players with mounts that have vehicle data should have it set
-    UNIT_NPC_FLAG_REFORGER              = 0x08000000,       // reforging
-    UNIT_NPC_FLAG_TRANSMOGRIFIER        = 0x10000000,       // transmogrification
-    UNIT_NPC_FLAG_VAULTKEEPER           = 0x20000000,       // void storage
+    UNIT_NPC_FLAG_TRAINER               = 0x00000010,
+    UNIT_NPC_FLAG_TRAINER_CLASS         = 0x00000020,
+    UNIT_NPC_FLAG_TRAINER_PROFESSION    = 0x00000040,
+    UNIT_NPC_FLAG_VENDOR                = 0x00000080,
+    UNIT_NPC_FLAG_VENDOR_AMMO           = 0x00000100,
+    UNIT_NPC_FLAG_VENDOR_FOOD           = 0x00000200,
+    UNIT_NPC_FLAG_VENDOR_POISON         = 0x00000400,
+    UNIT_NPC_FLAG_VENDOR_REAGENT        = 0x00000800,
+    UNIT_NPC_FLAG_ARMORER               = 0x00001000,
+    UNIT_NPC_FLAG_TAXI                  = 0x00002000,
+    UNIT_NPC_FLAG_SPIRITHEALER          = 0x00004000,
+    UNIT_NPC_FLAG_SPIRITGUIDE           = 0x00008000,
+    UNIT_NPC_FLAG_INNKEEPER             = 0x00010000,
+    UNIT_NPC_FLAG_BANKER                = 0x00020000,
+    UNIT_NPC_FLAG_CHARTERGIVER          = 0x00040000,
+    UNIT_NPC_FLAG_TABARDDESIGNER        = 0x00080000,
+    UNIT_NPC_FLAG_BATTLEMASTER          = 0x00100000,
+    UNIT_NPC_FLAG_AUCTIONEER            = 0x00200000,
+    UNIT_NPC_FLAG_STABLEMASTER          = 0x00400000,
+    UNIT_NPC_FLAG_GUILD_BANKER          = 0x00800000,
+    UNIT_NPC_FLAG_SPELLCLICK            = 0x01000000,
+#if VERSION_STRING >= WotLK
+    UNIT_NPC_FLAG_PLAYER_VEHICLE        = 0x02000000,
+    UNIT_NPC_FLAG_MAILBOX               = 0x04000000,
+#endif
+#if VERSION_STRING >= Cata
+    UNIT_NPC_FLAG_REFORGER              = 0x08000000,
+    UNIT_NPC_FLAG_TRANSMOGRIFIER        = 0x10000000,
+    UNIT_NPC_FLAG_VOID_STORAGE          = 0x20000000,
+#endif
+    // TODO: move these flags elsewhere, mop+ flags will collide with these
     UNIT_NPC_FLAG_DISABLE_REGEN         = 0x40000000,       // custom Disable Creature Health reg
     UNIT_NPC_FLAG_DISABLE_PWREGEN       = 0x80000000,       // custom Disable Creature Power reg
 };

--- a/src/world/Objects/Units/Creatures/Pet.h
+++ b/src/world/Objects/Units/Creatures/Pet.h
@@ -204,10 +204,12 @@ public:
         uint32_t CanLearnSpell(SpellInfo const* sp);
         void UpdateSpellList(bool showLearnSpells = true);
 
+#if VERSION_STRING == WotLK || VERSION_STRING == Cata
         // talents
         void SendTalentsToOwner();                                                                              // Send talentpoints and talent spells to owner
         inline uint8_t GetTPsForLevel(uint32_t level) { return (level >= 20) ? uint8_t(level - 16) >> 2 : 0; }  // pet gain first talent point at lvl 20, then every 4 lvls another point
         inline uint8_t GetSpentTPs() { return GetTPsForLevel(getLevel()) - this->getPetTalentPoints(); }        // returns amount of spent talent points
+#endif
 
         void HandleAutoCastEvent(AutoCastEvents Type);
         AI_Spell* HandleAutoCastEvent();

--- a/src/world/Objects/Units/Creatures/Summons/Summon.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/Summon.cpp
@@ -90,6 +90,13 @@ void Summon::load(CreatureProperties const* creatureProperties, Unit* unitOwner,
     if (unitOwner->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
         addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
 
+#if VERSION_STRING == TBC
+    if (unitOwner->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
+        setPositiveAuraLimit(POS_AURA_LIMIT_PVP_ATTACKABLE);
+    else
+        setPositiveAuraLimit(POS_AURA_LIMIT_CREATURE);
+#endif
+
     m_unitOwner = unitOwner;
 
     // Non-scripted summons

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -14272,7 +14272,7 @@ void Player::saveToDB(bool newCharacter /* =false */)
         removePlayerFlags(PLAYER_FLAG_SANCTUARY);
 #endif
 
-    ss << getPlayerFlags() << ", " << getPlayerFieldBytes() << ", ";
+    ss << getPlayerFlags() << ", " << std::to_string(getEnabledActionBars()) << ", ";
 
     // if its an arena, save the entry coords instead of the normal position
     if (in_arena)
@@ -14752,7 +14752,7 @@ void Player::loadFromDBProc(QueryResultVector& results)
     setPlayerGender(getGender());
 
     setPlayerFlags(field[24].asUint32());
-    setPlayerFieldBytes(field[25].asUint32());
+    setEnabledActionBars(field[25].asUint8());
 
     m_position.x = field[26].asFloat();
     m_position.y = field[27].asFloat();

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -574,7 +574,6 @@ void Player::OnPushToWorld()
 
     // Update PVP Situation
     setupPvPOnLogin();
-    removePvpFlags(U_FIELD_BYTES_FLAG_UNK2 | U_FIELD_BYTES_FLAG_SANCTUARY);
 
     if (m_playerInfo->lastOnline + 900 < UNIXTIME)    // did we logged out for more than 15 minutes?
         getItemInterface()->RemoveAllConjured();
@@ -802,11 +801,11 @@ void Player::setGuildId(uint32_t guildId)
     write(objectData()->data, WoWGuid(guildId, 0, HIGHGUID_TYPE_GUILD).getRawGuid());
 
     if (guildId)
-        addPlayerFlags(PLAYER_FLAGS_GUILD_LVL_ENABLED);
+        addPlayerFlags(PLAYER_FLAG_GUILD_LVL_ENABLED);
     else
-        removePlayerFlags(PLAYER_FLAGS_GUILD_LVL_ENABLED);
+        removePlayerFlags(PLAYER_FLAG_GUILD_LVL_ENABLED);
 
-    write(objectData()->parts.guild_id, static_cast<uint16_t>(guildId != 0 ? 1 : 0));
+    write(objectData()->field_type.parts.guild_id, static_cast<uint16_t>(guildId != 0 ? 1 : 0));
 #endif
 }
 
@@ -842,9 +841,6 @@ void Player::setPlayerBytes2(uint32_t bytes2) { write(playerData()->player_bytes
 uint8_t Player::getFacialFeatures() const { return playerData()->player_bytes_2.s.facial_hair; }
 void Player::setFacialFeatures(uint8_t feature) { write(playerData()->player_bytes_2.s.facial_hair, feature); }
 
-uint8_t Player::getBytes2UnknownField() const { return playerData()->player_bytes_2.s.unk1; }
-void Player::setBytes2UnknownField(uint8_t value) { write(playerData()->player_bytes_2.s.unk1, value); }
-
 uint8_t Player::getBankSlots() const { return playerData()->player_bytes_2.s.bank_slots; }
 void Player::setBankSlots(uint8_t slots) { write(playerData()->player_bytes_2.s.bank_slots, slots); }
 
@@ -865,8 +861,10 @@ void Player::setDrunkValue(uint8_t value) { write(playerData()->player_bytes_3.s
 uint8_t Player::getPvpRank() const { return playerData()->player_bytes_3.s.pvp_rank; }
 void Player::setPvpRank(uint8_t rank) { write(playerData()->player_bytes_3.s.pvp_rank, rank); }
 
+#if VERSION_STRING >= TBC
 uint8_t Player::getArenaFaction() const { return playerData()->player_bytes_3.s.arena_faction; }
 void Player::setArenaFaction(uint8_t faction) { write(playerData()->player_bytes_3.s.arena_faction, faction); }
+#endif
 //bytes3 end
 
 uint32_t Player::getDuelTeam() const { return playerData()->duel_team; }
@@ -929,14 +927,14 @@ uint16_t Player::getVisibleItemEnchantment(uint32_t slot, uint8_t pos) const
     if (pos > TEMP_ENCHANTMENT_SLOT)
         return 0;
 
-    return playerData()->visible_items[slot].enchantment[pos];
+    return playerData()->visible_items[slot].enchantment.raw[pos];
 }
 void Player::setVisibleItemEnchantment(uint32_t slot, uint8_t pos, uint16_t enchantment)
 {
     if (pos > TEMP_ENCHANTMENT_SLOT)
         return;
 
-    write(playerData()->visible_items[slot].enchantment[pos], enchantment);
+    write(playerData()->visible_items[slot].enchantment.raw[pos], enchantment);
 }
 #else
 uint32_t Player::getVisibleItemEnchantment(uint32_t slot, uint8_t pos) const { return playerData()->visible_items[slot].enchantment[pos]; }
@@ -944,8 +942,35 @@ void Player::setVisibleItemEnchantment(uint32_t slot, uint8_t pos, uint32_t ench
 #endif
 //VisibleItem end
 
+uint64_t Player::getInventorySlotItemGuid(uint8_t slot) const { return playerData()->inventory_slot[slot]; }
+void Player::setInventorySlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->inventory_slot[slot], guid); }
+
+uint64_t Player::getPackSlotItemGuid(uint8_t slot) const { return playerData()->pack_slot[slot]; }
+void Player::setPackSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->pack_slot[slot], guid); }
+
+uint64_t Player::getBankSlotItemGuid(uint8_t slot) const { return playerData()->bank_slot[slot]; }
+void Player::setBankSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->bank_slot[slot], guid); }
+
+uint64_t Player::getBankBagSlotItemGuid(uint8_t slot) const { return playerData()->bank_bag_slot[slot]; }
+void Player::setBankBagSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->bank_bag_slot[slot], guid); }
+
 uint64_t Player::getVendorBuybackSlot(uint8_t slot) const { return playerData()->vendor_buy_back_slot[slot]; }
 void Player::setVendorBuybackSlot(uint8_t slot, uint64_t guid) { write(playerData()->vendor_buy_back_slot[slot], guid); }
+
+#if VERSION_STRING < Cata
+uint64_t Player::getKeyRingSlotItemGuid(uint8_t slot) const { return playerData()->key_ring_slot[slot]; }
+void Player::setKeyRingSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->key_ring_slot[slot], guid); }
+#endif
+
+#if VERSION_STRING == TBC
+uint64_t Player::getVanityPetSlotItemGuid(uint8_t slot) const { return playerData()->vanity_pet_slot[slot]; }
+void Player::setVanityPetSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->vanity_pet_slot[slot], guid); }
+#endif
+
+#if VERSION_STRING == WotLK
+uint64_t Player::getCurrencyTokenSlotItemGuid(uint8_t slot) const { return playerData()->currencytoken_slot[slot]; }
+void Player::setCurrencyTokenSlotItemGuid(uint8_t slot, uint64_t guid) { write(playerData()->currencytoken_slot[slot], guid); }
+#endif
 
 uint64_t Player::getFarsightGuid() const { return playerData()->farsight_guid; }
 void Player::setFarsightGuid(uint64_t farsightGuid) { write(playerData()->farsight_guid, farsightGuid); }
@@ -986,19 +1011,19 @@ void Player::setSkillInfoMaxValue(uint32_t index, uint16_t max) { write(playerDa
 void Player::setSkillInfoBonusTemporary(uint32_t index, uint16_t bonus) { write(playerData()->skill_info[index].bonus_temporary, bonus); }
 void Player::setSkillInfoBonusPermanent(uint32_t index, uint16_t bonus) { write(playerData()->skill_info[index].bonus_permanent, bonus); }
 #else
-uint16_t Player::getSkillInfoId(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_line[index]) + offset); }
-uint16_t Player::getSkillInfoStep(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_step[index]) + offset); }
-uint16_t Player::getSkillInfoCurrentValue(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_rank[index]) + offset); }
-uint16_t Player::getSkillInfoMaxValue(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_max_rank[index]) + offset); }
-uint16_t Player::getSkillInfoBonusTemporary(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_mod[index]) + offset); }
-uint16_t Player::getSkillInfoBonusPermanent(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->skill_info_parts.skill_talent[index]) + offset); }
+uint16_t Player::getSkillInfoId(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_line[index]) + offset); }
+uint16_t Player::getSkillInfoStep(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_step[index]) + offset); }
+uint16_t Player::getSkillInfoCurrentValue(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_rank[index]) + offset); }
+uint16_t Player::getSkillInfoMaxValue(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_max_rank[index]) + offset); }
+uint16_t Player::getSkillInfoBonusTemporary(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_mod[index]) + offset); }
+uint16_t Player::getSkillInfoBonusPermanent(uint32_t index, uint8_t offset) const { return *(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_talent[index]) + offset); }
 uint32_t Player::getProfessionSkillLine(uint32_t index) const { return playerData()->profession_skill_line[index]; }
-void Player::setSkillInfoId(uint32_t index, uint8_t offset, uint16_t id) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_line[index]) + offset), id); }
-void Player::setSkillInfoStep(uint32_t index, uint8_t offset, uint16_t step) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_step[index]) + offset), step); }
-void Player::setSkillInfoCurrentValue(uint32_t index, uint8_t offset, uint16_t current) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_rank[index]) + offset), current); }
-void Player::setSkillInfoMaxValue(uint32_t index, uint8_t offset, uint16_t max) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_max_rank[index]) + offset), max); }
-void Player::setSkillInfoBonusTemporary(uint32_t index, uint8_t offset, uint16_t bonus) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_mod[index]) + offset), bonus); }
-void Player::setSkillInfoBonusPermanent(uint32_t index, uint8_t offset, uint16_t bonus) { write(*(((uint16_t*)&playerData()->skill_info_parts.skill_talent[index]) + offset), bonus); }
+void Player::setSkillInfoId(uint32_t index, uint8_t offset, uint16_t id) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_line[index]) + offset), id); }
+void Player::setSkillInfoStep(uint32_t index, uint8_t offset, uint16_t step) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_step[index]) + offset), step); }
+void Player::setSkillInfoCurrentValue(uint32_t index, uint8_t offset, uint16_t current) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_rank[index]) + offset), current); }
+void Player::setSkillInfoMaxValue(uint32_t index, uint8_t offset, uint16_t max) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_max_rank[index]) + offset), max); }
+void Player::setSkillInfoBonusTemporary(uint32_t index, uint8_t offset, uint16_t bonus) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_mod[index]) + offset), bonus); }
+void Player::setSkillInfoBonusPermanent(uint32_t index, uint8_t offset, uint16_t bonus) { write(*(((uint16_t*)&playerData()->field_skill_info.skill_info_parts.skill_talent[index]) + offset), bonus); }
 void Player::setProfessionSkillLine(uint32_t index, uint32_t value) { write(playerData()->profession_skill_line[index], value); }
 #endif
 
@@ -1201,8 +1226,13 @@ void Player::modModTargetPhysicalResistance(int32_t value) { setModTargetPhysica
 uint32_t Player::getPlayerFieldBytes() const { return playerData()->player_field_bytes.raw; }
 void Player::setPlayerFieldBytes(uint32_t bytes) { write(playerData()->player_field_bytes.raw, bytes); }
 
-uint8_t Player::getActionBarId() const { return playerData()->player_field_bytes.s.actionBarId; }
-void Player::setActionBarId(uint8_t actionBarId) { write(playerData()->player_field_bytes.s.actionBarId, actionBarId); }
+uint8_t Player::getPlayerFieldBytesMiscFlag() const { return playerData()->player_field_bytes.s.misc_flags; }
+void Player::setPlayerFieldBytesMiscFlag(uint8_t miscFlag) { write(playerData()->player_field_bytes.s.misc_flags, miscFlag); }
+void Player::addPlayerFieldBytesMiscFlag(uint8_t miscFlag) { setPlayerFieldBytesMiscFlag(getPlayerFieldBytesMiscFlag() | miscFlag); }
+void Player::removePlayerFieldBytesMiscFlag(uint8_t miscFlag) { setPlayerFieldBytesMiscFlag(getPlayerFieldBytesMiscFlag() & ~miscFlag); }
+
+uint8_t Player::getEnabledActionBars() const { return playerData()->player_field_bytes.s.enabled_action_bars; }
+void Player::setEnabledActionBars(uint8_t actionBarId) { write(playerData()->player_field_bytes.s.enabled_action_bars, actionBarId); }
 
 #if VERSION_STRING < Cata
 uint32_t Player::getAmmoId() const { return playerData()->ammo_id; }
@@ -1216,8 +1246,8 @@ uint32_t Player::getBuybackTimestampSlot(uint8_t slot) const { return playerData
 void Player::setBuybackTimestampSlot(uint8_t slot, uint32_t timestamp) { write(playerData()->field_buy_back_timestamp[slot], timestamp); }
 
 #if VERSION_STRING > Classic
-uint32_t Player::getFieldKills() const { return playerData()->field_kills; }
-void Player::setFieldKills(uint32_t kills) { write(playerData()->field_kills, kills); }
+uint32_t Player::getFieldKills() const { return playerData()->field_kills.raw; }
+void Player::setFieldKills(uint32_t kills) { write(playerData()->field_kills.raw, kills); }
 #endif
 
 #if VERSION_STRING > Classic
@@ -1236,6 +1266,11 @@ void Player::setLifetimeHonorableKills(uint32_t kills) { write(playerData()->fie
 #if VERSION_STRING != Mop
 uint32_t Player::getPlayerFieldBytes2() const { return playerData()->player_field_bytes_2.raw; }
 void Player::setPlayerFieldBytes2(uint32_t bytes) { write(playerData()->player_field_bytes_2.raw, bytes); }
+
+uint8_t Player::getAuraVision() const { return playerData()->player_field_bytes_2.s.aura_vision; }
+void Player::setAuraVision(uint8_t auraVision) { write(playerData()->player_field_bytes_2.s.aura_vision, auraVision); }
+void Player::addAuraVision(uint8_t auraVision) { setAuraVision(getAuraVision() | auraVision); }
+void Player::removeAuraVision(uint8_t auraVision) { setAuraVision(getAuraVision() & ~auraVision); }
 #endif
 
 uint32_t Player::getCombatRating(uint8_t combatRating) const { return playerData()->field_combat_rating[combatRating]; }
@@ -1251,9 +1286,6 @@ uint32_t Player::getArenaTeamMemberRank(uint8_t teamSlot) const { return playerD
 void Player::setArenaTeamMemberRank(uint8_t teamSlot, uint32_t rank) { write(playerData()->field_arena_team_info[teamSlot].member_rank, rank); }
     // field_arena_team_info end
 #endif
-
-uint64_t Player::getInventorySlotItemGuid(uint8_t index) const { return playerData()->inventory_slot[index]; }
-void Player::setInventorySlotItemGuid(uint8_t index, uint64_t guid) { write(playerData()->inventory_slot[index], guid); }
 
 #if VERSION_STRING > Classic
 #if VERSION_STRING < Cata
@@ -2495,18 +2527,15 @@ bool Player::create(CharCreate& charCreateContent)
     setHairColor(charCreateContent.hairColor);
 
     // PLAYER_BYTES_2
+    setPlayerBytes2(0);
     setFacialFeatures(charCreateContent.facialHair);
-    setBytes2UnknownField(0);
-    setBankSlots(0);
     setRestState(RESTSTATE_NORMAL);
 
     // PLAYER_BYTES_3
+    setPlayerBytes3(0);
     setPlayerGender(charCreateContent.gender);
-    setDrunkValue(0);
-    setPvpRank(0);
-    setArenaFaction(0);
 
-    setPlayerFieldBytes(0x08);
+    addPlayerFieldBytesMiscFlag(PLAYER_MISC_FLAG_SHOW_RELEASE_TIME);
 
     // Gold Starting Amount
     setCoinage(worldConfig.player.startGoldAmount);
@@ -3295,7 +3324,7 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, guid) + 1);
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, data));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, data) + 1);
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, raw_parts));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, field_type.raw));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, entry));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, dynamic_field));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, scale_x));
@@ -3329,9 +3358,9 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, max_power_4));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, max_power_5));
 
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[0]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[1]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[2]));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 0));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 1));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 2));
 
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, level));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, faction_template));
@@ -3339,8 +3368,8 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, unit_flags));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, unit_flags_2));
 
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, base_attack_time[0]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, base_attack_time[1]) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, base_attack_time, 0));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, base_attack_time, 1) + 1);
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, bounding_radius));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, combat_reach));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, display_id));
@@ -3392,7 +3421,7 @@ void Player::initVisibleUpdateBits()
 #if VERSION_STRING < Cata
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, type));
 #else
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, raw_parts));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, field_type.raw));
 #endif
 
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWObject, entry));
@@ -3426,17 +3455,17 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, max_power_7));
 #endif
 
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[0]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[1]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_slot_display[2]));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 0));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 1));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_slot_display, 2));
 
 #if VERSION_STRING <= TBC
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[0]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[0]) + 1);
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[1]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[1]) + 1);
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[2]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, virtual_item_info[2]) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 0));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 0) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 1));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 1) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 2));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, virtual_item_info, 2) + 1);
 #endif
 
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, level));
@@ -3447,8 +3476,8 @@ void Player::initVisibleUpdateBits()
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, unit_flags_2));
 #endif
 
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, base_attack_time[0]));
-    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, base_attack_time[1]) + 1);
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, base_attack_time, 0));
+    Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredArrayField(WoWUnit, base_attack_time, 1) + 1);
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, bounding_radius));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, combat_reach));
     Player::m_visibleUpdateMask.SetBit(getOffsetForStructuredField(WoWUnit, display_id));
@@ -3732,9 +3761,10 @@ void Player::setInitialPlayerData()
 
     setMaxLevel(worldConfig.player.playerLevelCap);
 
-    addPvpFlags(U_FIELD_BYTES_FLAG_PVP);
     addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
-#if VERSION_STRING >= TBC
+#if VERSION_STRING == TBC
+    setPositiveAuraLimit(POS_AURA_LIMIT_PVP_ATTACKABLE);
+#elif VERSION_STRING >= WotLK
     addUnitFlags2(UNIT_FLAG2_ENABLE_POWER_REGEN);
 #endif
 
@@ -4105,7 +4135,7 @@ bool Player::isInFeralForm()
 #if VERSION_STRING >= TBC
 bool Player::isInDisallowedMountForm() const
 {
-    if (ShapeshiftForm form = ShapeshiftForm(getShapeShiftForm()))
+    if (auto form = UnitBytes_ShapeshiftForm(getShapeShiftForm()))
     {
         WDB::Structures::SpellShapeshiftFormEntry const* shapeshift = sSpellShapeshiftFormStore.lookupEntry(form);
         if (!shapeshift)
@@ -4138,7 +4168,7 @@ bool Player::isInDisallowedMountForm() const
 #else
 bool Player::isInDisallowedMountForm() const
 {
-    ShapeshiftForm form = ShapeshiftForm(getShapeShiftForm());
+    auto form = UnitBytes_ShapeshiftForm(getShapeShiftForm());
     return form != FORM_NORMAL && form != FORM_BATTLESTANCE && form != FORM_BERSERKERSTANCE && form != FORM_DEFENSIVESTANCE &&
         form != FORM_SHADOW && form != FORM_STEALTH;
 }
@@ -8334,7 +8364,9 @@ void Player::togglePvP()
             stopPvPTimer();
 
             addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
             removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
             if (!isPvpFlagSet())
                 setPvpFlag();
@@ -8360,12 +8392,16 @@ void Player::togglePvP()
                 }
 
                 removePlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                 addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
             }
             else
             {
                 addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                 removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
                 stopPvPTimer();
                 setPvpFlag();
@@ -8387,7 +8423,9 @@ void Player::togglePvP()
                 stopPvPTimer();
 
                 addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                 removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
                 if (!isPvpFlagSet())
                     setPvpFlag();
@@ -8400,13 +8438,17 @@ void Player::togglePvP()
                     resetPvPTimer();
 
                     removePlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                     addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
                 }
                 else
                 {
                     // Move into PvP state.
                     addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                     removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
                     stopPvPTimer();
                     setPvpFlag();
@@ -8426,7 +8468,9 @@ void Player::togglePvP()
                         stopPvPTimer();
 
                         addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                         removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
                         if (!isPvpFlagSet())
                             setPvpFlag();
@@ -8439,13 +8483,17 @@ void Player::togglePvP()
                             resetPvPTimer();
 
                             removePlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                             addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
                         }
                         else
                         {
                             // Move into PvP state.
                             addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                             removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
 
                             stopPvPTimer();
                             setPvpFlag();
@@ -8458,12 +8506,16 @@ void Player::togglePvP()
             if (!hasPlayerFlags(PLAYER_FLAG_PVP_TOGGLE))
             {
                 addPlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                 removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
             }
             else
             {
                 removePlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
+#if VERSION_STRING >= WotLK
                 addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
+#endif
             }
         }
     }
@@ -9744,10 +9796,10 @@ void Player::sendInitialWorldstates()
 #endif
 }
 
-bool Player::isPvpFlagSet() 
+bool Player::isPvpFlagSet() const
 {
 #if VERSION_STRING > TBC
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_PVP;
+    return getPvpFlags() & PVP_STATE_FLAG_PVP;
 #else
     return getUnitFlags() & UNIT_FLAG_PVP;
 #endif
@@ -9757,12 +9809,11 @@ void Player::setPvpFlag()
 {
     stopPvPTimer();
 #if VERSION_STRING > TBC
-    addPvpFlags(U_FIELD_BYTES_FLAG_PVP);
+    addPvpFlags(PVP_STATE_FLAG_PVP);
+    addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
 #else
     addUnitFlags(UNIT_FLAG_PVP);
 #endif
-
-    addPlayerFlags(PLAYER_FLAG_PVP_TIMER);
 
     getSummonInterface()->setPvPFlags(true);
 
@@ -9774,26 +9825,32 @@ void Player::removePvpFlag()
 {
     stopPvPTimer();
 #if VERSION_STRING > TBC
-    removePvpFlags(U_FIELD_BYTES_FLAG_PVP);
+    removePvpFlags(PVP_STATE_FLAG_PVP);
+    removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
 #else
     removeUnitFlags(UNIT_FLAG_PVP);
 #endif
 
-    removePlayerFlags(PLAYER_FLAG_PVP_TIMER);
-
     getSummonInterface()->setPvPFlags(false);
 }
 
-bool Player::isFfaPvpFlagSet()
+bool Player::isFfaPvpFlagSet() const
 {
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_FFA_PVP;
+#if VERSION_STRING > TBC
+    return getPvpFlags() & PVP_STATE_FLAG_FFA_PVP;
+#else
+    return hasPlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
+#endif
 }
 
 void Player::setFfaPvpFlag()
 {
     stopPvPTimer();
-    addPvpFlags(U_FIELD_BYTES_FLAG_FFA_PVP);
+#if VERSION_STRING > TBC
+    addPvpFlags(PVP_STATE_FLAG_FFA_PVP);
+#else
     addPlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
+#endif
 
     getSummonInterface()->setFFAPvPFlags(true);
 }
@@ -9801,29 +9858,44 @@ void Player::setFfaPvpFlag()
 void Player::removeFfaPvpFlag()
 {
     stopPvPTimer();
-    removePvpFlags(U_FIELD_BYTES_FLAG_FFA_PVP);
+#if VERSION_STRING > TBC
+    removePvpFlags(PVP_STATE_FLAG_FFA_PVP);
+#else
     removePlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
+#endif
 
     getSummonInterface()->setFFAPvPFlags(false);
 }
 
-bool Player::isSanctuaryFlagSet()
+bool Player::isSanctuaryFlagSet() const
 {
-    return getPvpFlags() & U_FIELD_BYTES_FLAG_SANCTUARY;
+#if VERSION_STRING > TBC
+    return getPvpFlags() & PVP_STATE_FLAG_SANCTUARY;
+#elif VERSION_STRING == TBC
+    return hasPlayerFlags(PLAYER_FLAG_SANCTUARY);
+#elif VERSION_STRING == Classic
+    return false;
+#endif
 }
 
 void Player::setSanctuaryFlag()
 {
-    addPvpFlags(U_FIELD_BYTES_FLAG_SANCTUARY);
+#if VERSION_STRING > TBC
+    addPvpFlags(PVP_STATE_FLAG_SANCTUARY);
+#elif VERSION_STRING == TBC
     addPlayerFlags(PLAYER_FLAG_SANCTUARY);
+#endif
 
     getSummonInterface()->setSanctuaryFlags(true);
 }
 
 void Player::removeSanctuaryFlag()
 {
-    removePvpFlags(U_FIELD_BYTES_FLAG_SANCTUARY);
+#if VERSION_STRING > TBC
+    removePvpFlags(PVP_STATE_FLAG_SANCTUARY);
+#elif VERSION_STRING == TBC
     removePlayerFlags(PLAYER_FLAG_SANCTUARY);
+#endif
 
     getSummonInterface()->setSanctuaryFlags(false);
 }
@@ -10350,9 +10422,9 @@ void Player::saveVoidStorage()
     }
 }
 
-bool Player::isVoidStorageUnlocked() const { return hasPlayerFlags(PLAYER_FLAGS_VOID_UNLOCKED); }
-void Player::unlockVoidStorage() { setPlayerFlags(PLAYER_FLAGS_VOID_UNLOCKED); }
-void Player::lockVoidStorage() { removePlayerFlags(PLAYER_FLAGS_VOID_UNLOCKED); }
+bool Player::isVoidStorageUnlocked() const { return hasPlayerFlags(PLAYER_FLAG_VOID_STORAGE_UNLOCKED); }
+void Player::unlockVoidStorage() { addPlayerFlags(PLAYER_FLAG_VOID_STORAGE_UNLOCKED); }
+void Player::lockVoidStorage() { removePlayerFlags(PLAYER_FLAG_VOID_STORAGE_UNLOCKED); }
 
 uint8_t Player::getNextVoidStorageFreeSlot() const
 {
@@ -10702,7 +10774,7 @@ void Player::sendTaxiNodeStatusMultiple()
         if (!creature || creature->isHostileTo(this))
             continue;
 
-        if (!(creature->getNpcFlags() & UNIT_NPC_FLAG_FLIGHTMASTER))
+        if (!creature->isTaxi())
             continue;
 
         const auto nearestNode = sTaxiMgr.getNearestTaxiNode(creature->GetPosition(), creature->GetMapId(), GetTeam());
@@ -11794,7 +11866,7 @@ void Player::setServersideDrunkValue(uint16_t newDrunkenValue, uint32_t itemId)
     sendNewDrunkStatePacket(newDrunkenState, itemId);
 }
 
-DrunkenState Player::getDrunkStateByValue(uint16_t value)
+PlayerBytes3_DrunkValue Player::getDrunkStateByValue(uint16_t value)
 {
     if (value >= 23000)
         return DRUNKEN_SMASHED;
@@ -14185,8 +14257,20 @@ void Player::saveToDB(bool newCharacter /* =false */)
     if (hasPlayerFlags(PLAYER_FLAG_PVP_TOGGLE))
         removePlayerFlags(PLAYER_FLAG_PVP_TOGGLE);
 
+#if VERSION_STRING < WotLK
     if (hasPlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP))
         removePlayerFlags(PLAYER_FLAG_FREE_FOR_ALL_PVP);
+#endif
+
+#if VERSION_STRING >= WotLK
+    if (hasPlayerFlags(PLAYER_FLAG_DEVELOPER))
+        removePlayerFlags(PLAYER_FLAG_DEVELOPER);
+#endif
+
+#if VERSION_STRING == TBC
+    if (hasPlayerFlags(PLAYER_FLAG_SANCTUARY))
+        removePlayerFlags(PLAYER_FLAG_SANCTUARY);
+#endif
 
     ss << getPlayerFlags() << ", " << getPlayerFieldBytes() << ", ";
 
@@ -14685,7 +14769,6 @@ void Player::loadFromDBProc(QueryResultVector& results)
     setHoverHeight(1.0f);
 #endif
 
-    setPvpFlags(U_FIELD_BYTES_FLAG_UNK2 | U_FIELD_BYTES_FLAG_SANCTUARY);
     setBoundingRadius(0.388999998569489f);
     setCombatReach(1.5f);
 
@@ -16479,11 +16562,13 @@ void Player::modifyBonuses(uint32_t type, int32_t val, bool apply)
             m_manaFromItems += val;
         }
         break;
+#if VERSION_STRING >= WotLK
         case ITEM_MOD_ARMOR_PENETRATION_RATING:
         {
             modCombatRating(CR_ARMOR_PENETRATION, val);
         }
         break;
+#endif
         case ITEM_MOD_SPELL_POWER:
         {
             for (uint8_t school = 1; school < 7; ++school)

--- a/src/world/Objects/Units/Players/Player.hpp
+++ b/src/world/Objects/Units/Players/Player.hpp
@@ -174,9 +174,6 @@ public:
     uint8_t getFacialFeatures() const;
     void setFacialFeatures(uint8_t feature);
 
-    uint8_t getBytes2UnknownField() const;
-    void setBytes2UnknownField(uint8_t value);
-
     uint8_t getBankSlots() const;
     void setBankSlots(uint8_t slots);
 
@@ -200,8 +197,10 @@ public:
     uint8_t getPvpRank() const;
     void setPvpRank(uint8_t rank);
 
+#if VERSION_STRING >= TBC
     uint8_t getArenaFaction() const;
     void setArenaFaction(uint8_t faction);
+#endif
     // bytes3 end
     //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -246,8 +245,35 @@ public:
     // VisibleItem end
     //////////////////////////////////////////////////////////////////////////////////////////
 
+    uint64_t getInventorySlotItemGuid(uint8_t slot) const;
+    void setInventorySlotItemGuid(uint8_t slot, uint64_t guid);
+
+    uint64_t getPackSlotItemGuid(uint8_t slot) const;
+    void setPackSlotItemGuid(uint8_t slot, uint64_t guid);
+
+    uint64_t getBankSlotItemGuid(uint8_t slot) const;
+    void setBankSlotItemGuid(uint8_t slot, uint64_t guid);
+
+    uint64_t getBankBagSlotItemGuid(uint8_t slot) const;
+    void setBankBagSlotItemGuid(uint8_t slot, uint64_t guid);
+
     uint64_t getVendorBuybackSlot(uint8_t slot) const;
     void setVendorBuybackSlot(uint8_t slot, uint64_t guid);
+
+#if VERSION_STRING < Cata
+    uint64_t getKeyRingSlotItemGuid(uint8_t slot) const;
+    void setKeyRingSlotItemGuid(uint8_t slot, uint64_t guid);
+#endif
+
+#if VERSION_STRING == TBC
+    uint64_t getVanityPetSlotItemGuid(uint8_t slot) const;
+    void setVanityPetSlotItemGuid(uint8_t slot, uint64_t guid);
+#endif
+
+#if VERSION_STRING == WotLK
+    uint64_t getCurrencyTokenSlotItemGuid(uint8_t slot) const;
+    void setCurrencyTokenSlotItemGuid(uint8_t slot, uint64_t guid);
+#endif
 
     uint64_t getFarsightGuid() const;
     void setFarsightGuid(uint64_t farsightGuid);
@@ -440,8 +466,13 @@ public:
     uint32_t getPlayerFieldBytes() const;
     void setPlayerFieldBytes(uint32_t bytes);
 
-    uint8_t getActionBarId() const;
-    void setActionBarId(uint8_t actionBarId);
+    uint8_t getPlayerFieldBytesMiscFlag() const;
+    void setPlayerFieldBytesMiscFlag(uint8_t miscFlag);
+    void addPlayerFieldBytesMiscFlag(uint8_t miscFlag);
+    void removePlayerFieldBytesMiscFlag(uint8_t miscFlag);
+
+    uint8_t getEnabledActionBars() const;
+    void setEnabledActionBars(uint8_t actionBarId);
     // playerfieldbytes end
 
 #if VERSION_STRING < Cata
@@ -476,6 +507,11 @@ public:
     // playerfieldbytes2 start
     uint32_t getPlayerFieldBytes2() const;
     void setPlayerFieldBytes2(uint32_t bytes);
+
+    uint8_t getAuraVision() const;
+    void setAuraVision(uint8_t auraVision);
+    void addAuraVision(uint8_t auraVision);
+    void removeAuraVision(uint8_t auraVision);
     // playerfieldbytes2 end
 
     uint32_t getCombatRating(uint8_t combatRating) const;
@@ -491,9 +527,6 @@ public:
     void setArenaTeamMemberRank(uint8_t teamSlot, uint32_t rank);
     // field_arena_team_info end
 #endif
-
-    uint64_t getInventorySlotItemGuid(uint8_t index) const;
-    void setInventorySlotItemGuid(uint8_t index, uint64_t guid);
 
 #if VERSION_STRING > Classic
 #if VERSION_STRING < Cata
@@ -1665,7 +1698,7 @@ private:
 public:
     uint16_t getServersideDrunkValue() const;
     void setServersideDrunkValue(uint16_t newDrunkValue, uint32_t itemId = 0);
-    static DrunkenState getDrunkStateByValue(uint16_t value);
+    static PlayerBytes3_DrunkValue getDrunkStateByValue(uint16_t value);
     void handleSobering();
 
 private:
@@ -1834,15 +1867,15 @@ public:
     void sendEmptyPetSpellList();
     void sendInitialWorldstates();
 
-    bool isPvpFlagSet() override;
+    bool isPvpFlagSet() const override;
     void setPvpFlag() override;
     void removePvpFlag() override;
 
-    bool isFfaPvpFlagSet() override;
+    bool isFfaPvpFlagSet() const override;
     void setFfaPvpFlag() override;
     void removeFfaPvpFlag() override;
 
-    bool isSanctuaryFlagSet() override;
+    bool isSanctuaryFlagSet() const override;
     void setSanctuaryFlag() override;
     void removeSanctuaryFlag() override;
 

--- a/src/world/Objects/Units/Players/PlayerDefines.hpp
+++ b/src/world/Objects/Units/Players/PlayerDefines.hpp
@@ -274,7 +274,7 @@ enum Standing : uint8_t
     STANDING_EXALTED
 };
 
-enum PlayerFlags
+enum PlayerFlags : uint32_t
 {
     PLAYER_FLAG_NONE                    = 0x00000000,
     PLAYER_FLAG_PARTY_LEADER            = 0x00000001, // (TODO: implement for all versions) Informs players outside of your group who is your group leader
@@ -284,34 +284,57 @@ enum PlayerFlags
     PLAYER_FLAG_DEATH_WORLD_ENABLE      = 0x00000010, // Adds death glow to the world
     PLAYER_FLAG_RESTING                 = 0x00000020, // Applies rested state on your character portrait
     PLAYER_FLAG_ADMIN                   = 0x00000040, // Unknown effect in 3.3.5a
-    PLAYER_FLAG_FREE_FOR_ALL_PVP        = 0x00000080, // Unknown in 3.3.5a, pre-wotlk FFA-pvp tag
+#if VERSION_STRING < WotLK
+    PLAYER_FLAG_FREE_FOR_ALL_PVP        = 0x00000080, // Applies FFA-pvp tag
+#else
+    PLAYER_FLAG_UNK8                    = 0x00000080,
+#endif
     PLAYER_FLAG_PVP_GUARD_ATTACKABLE    = 0x00000100, // Player will be attacked by neutral guards
     PLAYER_FLAG_PVP_TOGGLE              = 0x00000200, // Toggles PvP combat on/off
     PLAYER_FLAG_NOHELM                  = 0x00000400, // Hides helm
     PLAYER_FLAG_NOCLOAK                 = 0x00000800, // Hides cloak
     PLAYER_FLAG_PLAYED_3_HOURS          = 0x00001000, // Obsolete: "You have more than 3 hours of online time. You will receive 1/2 money and XP during this period."
     PLAYER_FLAG_PLAYED_5_HOURS          = 0x00002000, // Obsolete: "You have more than 5 hours of online time. You will not be able to gain loot, XP, or complete quests."
-    PLAYER_FLAG_UNK1                    = 0x00004000,
-    // TBC flags begin (needs verification)
+#if VERSION_STRING > Classic
+    PLAYER_FLAG_UNK15                   = 0x00004000,
+#if VERSION_STRING == TBC
+    PLAYER_FLAG_UNK16                   = 0x00008000,
+#else
     PLAYER_FLAG_DEVELOPER               = 0x00008000, // <Dev> tag ingame
+#endif
+#if VERSION_STRING == TBC
     PLAYER_FLAG_SANCTUARY               = 0x00010000, // Makes player unattackable, added in sanctuary areas
-    PLAYER_FLAG_UNK2                    = 0x00020000, // Toggles 'Taxi Time Test' and FPS counter, unused
-    // WoTLK flags begin
+#else
+    PLAYER_FLAG_UNK17                   = 0x00010000,
+#endif
+    PLAYER_FLAG_TAXI_TIME_TEST          = 0x00020000, // Toggles 'Taxi Time Test' and FPS counter, unused
+#if VERSION_STRING == TBC
+    PLAYER_FLAG_UNK19                   = 0x00040000,
+#else
     PLAYER_FLAG_PVP_TIMER               = 0x00040000, // PvP timer after toggling manually PvP combat state off
-    PLAYER_FLAG_UNK3                    = 0x00080000,
-    PLAYER_FLAG_UNK4                    = 0x00100000,
-    PLAYER_FLAG_UNK5                    = 0x00200000,
-    PLAYER_FLAG_UNK6                    = 0x00400000,
+#endif
+    PLAYER_FLAG_UNK20                   = 0x00080000,
+    PLAYER_FLAG_UNK21                   = 0x00100000,
+    PLAYER_FLAG_UNK22                   = 0x00200000,
+    PLAYER_FLAG_UNK23                   = 0x00400000,
+#if VERSION_STRING > TBC
     PLAYER_FLAG_PREVENT_SPELL_CAST      = 0x00800000, // Prevents spell casting but excludes auto attack, used by Bladestorm for example
+#if VERSION_STRING < Mop
     PLAYER_FLAG_PREVENT_MELEE_SPELLS    = 0x01000000, // Prevents melee spell casting and includes auto attack, unused?
+#else
+    PLAYER_FLAG_BATTLE_PET              = 0x01000000, // Related to Battle Pets
+#endif
     PLAYER_FLAG_NO_XP                   = 0x02000000, // (TODO: implement this and remove variable from player class) Disables XP gain and hides XP bar
-    // Cataclysm flags begin (needs verification)
-    PLAYER_FLAG_UNK7                    = 0x04000000,
-    PLAYER_FLAGS_AUTO_DECLINE_GUILD     = 0x08000000,
-    PLAYER_FLAGS_GUILD_LVL_ENABLED      = 0x10000000,
-    PLAYER_FLAGS_VOID_UNLOCKED          = 0x20000000,
-    PLAYER_FLAG_UNK9                    = 0x40000000,
-    PLAYER_FLAG_UNK10                   = 0x80000000
+    PLAYER_FLAG_UNK27                   = 0x04000000,
+#if VERSION_STRING > WotLK
+    PLAYER_FLAG_DECLINE_GUILD_INVITES   = 0x08000000, // Automatically declines guild invites
+    PLAYER_FLAG_GUILD_LVL_ENABLED       = 0x10000000, // ??
+    PLAYER_FLAG_VOID_STORAGE_UNLOCKED   = 0x20000000, // Player has bought Void Storage
+    PLAYER_FLAG_UNK31                   = 0x40000000,
+    PLAYER_FLAG_UNK32                   = 0x80000000
+#endif
+#endif
+#endif
 };
 
 enum CustomizeFlags
@@ -426,13 +449,48 @@ enum ModType
     MOD_SPELL     = 2
 };
 
-enum DrunkenState
+// byte value (PLAYER_BYTES_3, 1)
+enum PlayerBytes3_DrunkValue : uint8_t
 {
-    DRUNKEN_SOBER    = 0,
-    DRUNKEN_TIPSY    = 1,
-    DRUNKEN_DRUNK    = 2,
-    DRUNKEN_SMASHED  = 3
+    DRUNKEN_SOBER                      = 0x00,
+    DRUNKEN_TIPSY                      = 0x01,
+    DRUNKEN_DRUNK                      = 0x02,
+    DRUNKEN_SMASHED                    = 0x03
 };
+
+// byte value (PLAYER_FIELD_BYTES, 0)
+enum PlayerFieldBytes_MiscFlags : uint8_t
+{
+    PLAYER_MISC_FLAG_NONE              = 0x00,
+    PLAYER_MISC_FLAG_UNK1              = 0x01,
+    PLAYER_MISC_FLAG_UNK2              = 0x02,
+    PLAYER_MISC_FLAG_UNK3              = 0x04,
+    PLAYER_MISC_FLAG_SHOW_RELEASE_TIME = 0x08, // Displays time when spirit is released
+    PLAYER_MISC_FLAG_UNK5              = 0x10,
+    PLAYER_MISC_FLAG_UNK6              = 0x20,
+    PLAYER_MISC_FLAG_UNK7              = 0x40,
+    PLAYER_MISC_FLAG_UNK8              = 0x80,
+    PLAYER_MISC_FLAG_ALL               = 0xFF
+};
+
+#if VERSION_STRING < Mop
+// byte value
+// classic - tbc (PLAYER_FIELD_BYTES2, 1)
+// wotlk - cata (PLAYER_FIELD_BYTES2, 3)
+enum PlayerFieldBytes2_AuraVision : uint8_t
+{
+    AURA_VISION_NONE                   = 0x00,
+    AURA_VISION_UNK1                   = 0x01,
+    AURA_VISION_UNK2                   = 0x02,
+    AURA_VISION_UNK3                   = 0x04,
+    AURA_VISION_UNK4                   = 0x08,
+    AURA_VISION_UNK5                   = 0x10,
+    AURA_VISION_STEALTH                = 0x20,
+    AURA_VISION_INVISIBILITY           = 0x40,
+    AURA_VISION_UNK8                   = 0x80,
+    AURA_VISION_ALL                    = 0xFF
+};
+#endif
 
 /**
     TalentTree table
@@ -656,12 +714,21 @@ enum PlayerCombatRating : uint8_t
     CR_WEAPON_SKILL_OFFHAND             = 21,
     CR_WEAPON_SKILL_RANGED              = 22,   // Not used
     CR_EXPERTISE                        = 23,
+#if VERSION_STRING >= WotLK
     CR_ARMOR_PENETRATION                = 24,
+#endif
 #if VERSION_STRING >= Cata
     CR_MASTERY                          = 25,
-    MAX_PCR                             = 26
+#endif
+#if VERSION_STRING >= Mop
+    CR_PVP_POWER                        = 26,
+#endif
+
+#if VERSION_STRING == Classic
+    // TODO: sort out fields properly for classic
+    MAX_PCR                             = 20
 #else
-    MAX_PCR                             = 25
+    MAX_PCR
 #endif
 };
 

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -360,14 +360,23 @@ public:
     uint8_t getStandState() const;
     void setStandState(uint8_t standState);
 
+#if VERSION_STRING < WotLK
+    uint8_t getPetLoyalty() const;
+    void setPetLoyalty(uint8_t loyalty);
+#elif VERSION_STRING < Mop
     uint8_t getPetTalentPoints() const;
     void setPetTalentPoints(uint8_t talentPoints);
+#endif
 
     uint8_t getStandStateFlags() const;
     void setStandStateFlags(uint8_t standStateFlags);
+    void addStandStateFlags(uint8_t standStateFlags);
+    void removeStandStateFlags(uint8_t standStateFlags);
 
+#if VERSION_STRING != Classic
     uint8_t getAnimationFlags() const;
     void setAnimationFlags(uint8_t animationFlags);
+#endif
     //bytes_1 end
 
     // Note; this is not same as serverside PetCache::number or Pet::m_petId, this is clientside pet number which is pet's low guid
@@ -451,16 +460,24 @@ public:
     uint8_t getSheathType() const;
     void setSheathType(uint8_t sheathType);
 
+#if VERSION_STRING == TBC
+    uint8_t getPositiveAuraLimit() const;
+    void setPositiveAuraLimit(uint8_t limit);
+#elif VERSION_STRING >= WotLK
     uint8_t getPvpFlags() const;
     void setPvpFlags(uint8_t pvpFlags);
     void addPvpFlags(uint8_t pvpFlags);
     void removePvpFlags(uint8_t pvpFlags);
+#endif
 
+#if VERSION_STRING >= TBC
     uint8_t getPetFlags() const;
     void setPetFlags(uint8_t petFlags);
     void addPetFlags(uint8_t petFlags);
     void removePetFlags(uint8_t petFlags);
+#endif
 
+    //bytes_1 in classic
     uint8_t getShapeShiftForm() const;
     void setShapeShiftForm(uint8_t shapeShiftForm);
     uint32_t getShapeShiftMask() const { return 1 << (getShapeShiftForm() - 1); }
@@ -589,7 +606,6 @@ public:
     void setMoveDisableGravity(bool disable_gravity);
     void setMoveWalk(bool set_walk);
     void setFacing(float newo);     //only working if creature is idle
-    void setAnimationTier(AnimationTier  tier);
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // used for handling fall
@@ -1002,15 +1018,15 @@ public:
 
     void sendEnvironmentalDamageLogPacket(uint64_t guid, uint8_t type, uint32_t damage, uint64_t unk = 0);
 
-    virtual bool isPvpFlagSet();
+    virtual bool isPvpFlagSet() const;
     virtual void setPvpFlag();
     virtual void removePvpFlag();
 
-    virtual bool isFfaPvpFlagSet();
+    virtual bool isFfaPvpFlagSet() const;
     virtual void setFfaPvpFlag();
     virtual void removeFfaPvpFlag();
 
-    virtual bool isSanctuaryFlagSet();
+    virtual bool isSanctuaryFlagSet() const;
     virtual void setSanctuaryFlag();
     virtual void removeSanctuaryFlag();
 
@@ -1146,7 +1162,7 @@ public:
     void handleSpellClick(Unit* clicker);
 #endif
 
-    bool isMounted() const { return hasUnitFlags(UNIT_FLAG_MOUNT); }
+    bool isMounted() const;
     void mount(uint32_t mount, uint32_t vehicleId = 0, uint32_t creatureEntry = 0);
     void dismount(bool resummonPet = true);
 

--- a/src/world/Objects/Units/UnitDefines.hpp
+++ b/src/world/Objects/Units/UnitDefines.hpp
@@ -824,112 +824,131 @@ enum UnitStates
     UNIT_STATE_NOT_MOVE                 = UNIT_STATE_ROOTED | UNIT_STATE_STUNNED | UNIT_STATE_DIED | UNIT_STATE_DISTRACTED,
 
     UNIT_STATE_ALL_ERASABLE             = UNIT_STATE_ALL_STATE_SUPPORTED & ~(UNIT_STATE_IGNORE_PATHFINDING),
-    UNIT_STATE_ALL_STATE                = 0xffffffff
+    UNIT_STATE_ALL_STATE                = 0xFFFFFFFF
 };
 
-// byte flags value (UNIT_FIELD_BYTES_1,0)
-enum StandState : uint16_t
+// byte flags value (UNIT_FIELD_BYTES_1, 0)
+enum UnitBytes1_StandState : uint8_t
 {
-    STANDSTATE_STAND             = 0,
-    STANDSTATE_SIT               = 1,
-    STANDSTATE_SIT_CHAIR         = 2,
-    STANDSTATE_SLEEP             = 3,
-    STANDSTATE_SIT_LOW_CHAIR     = 4,
-    STANDSTATE_SIT_MEDIUM_CHAIR  = 5,
-    STANDSTATE_SIT_HIGH_CHAIR    = 6,
-    STANDSTATE_DEAD              = 7,
-    STANDSTATE_KNEEL             = 8,
-    STANDSTATE_SUBMERGED         = 9
-    //STANDSTATE_FORM_ALL          = 0x00FF0000,
-    //STANDSTATE_FLAG_CREEP        = 0x02000000,
-    //STANDSTATE_FLAG_UNTRACKABLE  = 0x04000000,
-    //STANDSTATE_FLAG_ALL          = 0xFF000000
+    STANDSTATE_STAND             = 0x00,
+    STANDSTATE_SIT               = 0x01,
+    STANDSTATE_SIT_CHAIR         = 0x02,
+    STANDSTATE_SLEEP             = 0x03,
+    STANDSTATE_SIT_LOW_CHAIR     = 0x04,
+    STANDSTATE_SIT_MEDIUM_CHAIR  = 0x05,
+    STANDSTATE_SIT_HIGH_CHAIR    = 0x06,
+    STANDSTATE_DEAD              = 0x07,
+    STANDSTATE_KNEEL             = 0x08,
+    STANDSTATE_SUBMERGED         = 0x09
 };
 
-// byte flags value (UNIT_FIELD_BYTES_1,2)
-enum UnitStandFlags
+// byte flags value
+// classic (UNIT_FIELD_BYTES_1, 3)
+// tbc - mop (UNIT_FIELD_BYTES_1, 2)
+enum UnitBytes1_UnitStandFlags : uint8_t
 {
     UNIT_STAND_FLAGS_UNK1         = 0x01,
     UNIT_STAND_FLAGS_CREEP        = 0x02,
     UNIT_STAND_FLAGS_UNTRACKABLE  = 0x04,
     UNIT_STAND_FLAGS_UNK4         = 0x08,
     UNIT_STAND_FLAGS_UNK5         = 0x10,
+    UNIT_STAND_FLAGS_UNK6         = 0x20,
+    UNIT_STAND_FLAGS_UNK7         = 0x40,
+    UNIT_STAND_FLAGS_UNK8         = 0x80,
     UNIT_STAND_FLAGS_ALL          = 0xFF
 };
 
-// byte flags value (UNIT_FIELD_BYTES_1,3)
-enum AnimationTier : uint8_t
+#if VERSION_STRING >= TBC
+// byte flags value (UNIT_FIELD_BYTES_1, 3)
+enum UnitBytes1_AnimationFlag : uint8_t
 {
-    Ground                  = 0, // plays ground tier animations
-    Swim                    = 1, // falls back to ground tier animations, not handled by the client, should never appear in sniffs, will prevent tier change animations from playing correctly if used
-    Hover                   = 2, // plays flying tier animations or falls back to ground tier animations, automatically enables hover clientside when entering visibility with this value
-    Fly                     = 3, // plays flying tier animations
-    Submerged               = 4
+    ANIMATION_FLAG_GROUND         = 0x00,
+    ANIMATION_FLAG_ALWAYS_STAND   = 0x01,
+    ANIMATION_FLAG_HOVER          = 0x02, // Creature that can fly and are not on the ground appear to have this flag. If they are on the ground, flag is not present.
+    ANIMATION_FLAG_FLY            = 0x03,
+    ANIMATION_FLAG_SUBMERGED      = 0x04
+};
+#endif
+
+// byte value (UNIT_FIELD_BYTES_2, 0)
+enum UnitBytes2_SheathState : uint8_t
+{
+    SHEATH_STATE_UNARMED          = 0x00, // non prepared weapon
+    SHEATH_STATE_MELEE            = 0x01, // prepared melee weapon
+    SHEATH_STATE_RANGED           = 0x02  // prepared ranged weapon
 };
 
-// byte value (UNIT_FIELD_BYTES_2,0)
-enum UnitBytes2_SheathState
-{
-    SHEATH_STATE_UNARMED  = 0,              // non prepared weapon
-    SHEATH_STATE_MELEE    = 1,              // prepared melee weapon
-    SHEATH_STATE_RANGED   = 2               // prepared ranged weapon
-};
-
+#if VERSION_STRING == TBC
 // UNIT_FIELD_BYTES_2, 1
-enum UnitBytes2_PvPFlags : uint8_t
+enum UnitBytes2_PositiveAuraLimit : uint8_t
 {
-    U_FIELD_BYTES_FLAG_PVP          = 0x01,
-    U_FIELD_BYTES_FLAG_UNK1         = 0x02,
-    U_FIELD_BYTES_FLAG_FFA_PVP      = 0x04,
-    U_FIELD_BYTES_FLAG_SANCTUARY    = 0x08,
-    U_FIELD_BYTES_FLAG_AURAS        = 0x10,
-    U_FIELD_BYTES_FLAG_UNK2         = 0x20,
-    U_FIELD_BYTES_FLAG_UNK3         = 0x40,
-    U_FIELD_BYTES_FLAG_UNK4         = 0x80
+    POS_AURA_LIMIT_CREATURE       = 0x10, // 16 buff slots for npcs (40 debuffs)
+    POS_AURA_LIMIT_PVP_ATTACKABLE = 0x28, // 40 buff slots for players and pets (16 debuffs)
 };
-
-// byte flags value (UNIT_FIELD_BYTES_2,2)
-enum UnitBytes2_PetFlags
+#elif VERSION_STRING >= WotLK
+// UNIT_FIELD_BYTES_2, 1
+enum UnitBytes2_PvPStateFlags : uint8_t
 {
-    UNIT_CAN_BE_RENAMED     = 0x01,
-    UNIT_CAN_BE_ABANDONED   = 0x02,
+    PVP_STATE_FLAG_NONE           = 0x00,
+    PVP_STATE_FLAG_PVP            = 0x01,
+    PVP_STATE_FLAG_UNK2           = 0x02,
+    PVP_STATE_FLAG_FFA_PVP        = 0x04,
+    PVP_STATE_FLAG_SANCTUARY      = 0x08,
+    PVP_STATE_FLAG_UNK5           = 0x10,
+    PVP_STATE_FLAG_UNK6           = 0x20,
+    PVP_STATE_FLAG_UNK7           = 0x40,
+    PVP_STATE_FLAG_UNK8           = 0x80,
+    PVP_STATE_FLAG_ALL            = 0xFF
 };
+#endif
 
-// byte value (UNIT_FIELD_BYTES_2,3)
-enum ShapeshiftForm : uint8_t
+#if VERSION_STRING >= TBC
+// byte flags value (UNIT_FIELD_BYTES_2, 2)
+enum UnitBytes2_PetFlags : uint8_t
 {
-    FORM_NORMAL             = 0x00,
-    FORM_CAT                = 0x01,
-    FORM_TREE               = 0x02,
-    FORM_TRAVEL             = 0x03,
-    FORM_AQUA               = 0x04,
-    FORM_BEAR               = 0x05,
-    FORM_AMBIENT            = 0x06,
-    FORM_GHOUL              = 0x07,
-    FORM_DIREBEAR           = 0x08,
-    FORM_SKELETON           = 0x0A,
-    FORM_TEST_OF_STRENGTH   = 0x0B,
-    FORM_BLB_PLAYER         = 0x0C,
-    FORM_SHADOWDANCE        = 0x0D,
-    FORM_CREATUREBEAR       = 0x0E,
-    FORM_CREATURECAT        = 0x0F,
-    FORM_GHOSTWOLF          = 0x10,
-    FORM_BATTLESTANCE       = 0x11,
-    FORM_DEFENSIVESTANCE    = 0x12,
-    FORM_BERSERKERSTANCE    = 0x13,
-    FORM_TEST               = 0x14,
-    FORM_ZOMBIE             = 0x15,
-    FORM_METAMORPHOSIS      = 0x16,
-    FORM_DEMON              = 0x17,
-    FORM_UNK2               = 0x18,
-    FORM_UNDEAD             = 0x19,
-    FORM_MASTER_ANGLER      = 0x1A,
-    FORM_SWIFT              = 0x1B,
-    FORM_SHADOW             = 0x1C,
-    FORM_FLIGHT             = 0x1D,
-    FORM_STEALTH            = 0x1E,
-    FORM_MOONKIN            = 0x1F,
-    FORM_SPIRITOFREDEMPTION = 0x20
+    PET_FLAG_NONE                 = 0x00,
+    PET_FLAG_CAN_BE_RENAMED       = 0x01,
+    PET_FLAG_CAN_BE_ABANDONED     = 0x02
+};
+#endif
+
+// byte value
+// classic (UNIT_FIELD_BYTES_1, 2)
+// tbc - mop (UNIT_FIELD_BYTES_2, 3)
+enum UnitBytes_ShapeshiftForm : uint8_t
+{
+    FORM_NORMAL                   = 0x00,
+    FORM_CAT                      = 0x01,
+    FORM_TREE                     = 0x02,
+    FORM_TRAVEL                   = 0x03,
+    FORM_AQUA                     = 0x04,
+    FORM_BEAR                     = 0x05,
+    FORM_AMBIENT                  = 0x06,
+    FORM_GHOUL                    = 0x07,
+    FORM_DIREBEAR                 = 0x08,
+    FORM_SKELETON                 = 0x0A,
+    FORM_TEST_OF_STRENGTH         = 0x0B,
+    FORM_BLB_PLAYER               = 0x0C,
+    FORM_SHADOWDANCE              = 0x0D,
+    FORM_CREATUREBEAR             = 0x0E,
+    FORM_CREATURECAT              = 0x0F,
+    FORM_GHOSTWOLF                = 0x10,
+    FORM_BATTLESTANCE             = 0x11,
+    FORM_DEFENSIVESTANCE          = 0x12,
+    FORM_BERSERKERSTANCE          = 0x13,
+    FORM_TEST                     = 0x14,
+    FORM_ZOMBIE                   = 0x15,
+    FORM_METAMORPHOSIS            = 0x16,
+    FORM_DEMON                    = 0x17,
+    FORM_UNK2                     = 0x18,
+    FORM_UNDEAD                   = 0x19,
+    FORM_MASTER_ANGLER            = 0x1A,
+    FORM_SWIFT                    = 0x1B,
+    FORM_SHADOW                   = 0x1C,
+    FORM_FLIGHT                   = 0x1D,
+    FORM_STEALTH                  = 0x1E,
+    FORM_MOONKIN                  = 0x1F,
+    FORM_SPIRITOFREDEMPTION       = 0x20
 };
 
 enum UnitFieldFlags : uint32_t // UNIT_FIELD_FLAGS #46 - these are client flags
@@ -940,15 +959,24 @@ enum UnitFieldFlags : uint32_t // UNIT_FIELD_FLAGS #46 - these are client flags
     UNIT_FLAG_NON_ATTACKABLE                    = 0x00000002, // 2            2  client won't let you attack them
     UNIT_FLAG_LOCK_PLAYER                       = 0x00000004, // 3            4  ? does nothing to client (probably wrong) - only taxi code checks this
     UNIT_FLAG_PVP_ATTACKABLE                    = 0x00000008, // 4            8  makes players and NPCs attackable / not attackable
+#if VERSION_STRING == Classic
+    UNIT_FLAG_PET_CAN_BE_RENAMED                = 0x00000010, // 5           16  UnitBytes2 in tbc+
+    UNIT_FLAG_PET_CAN_BE_ABANDONED              = 0x00000020, // 6           32  UnitBytes2 in tbc+
+#else
     UNIT_FLAG_UNKNOWN_5                         = 0x00000010, // 5           16  ? some NPCs have this
     UNIT_FLAG_NO_REAGANT_COST                   = 0x00000020, // 6           32  no reagant cost
+#endif
     UNIT_FLAG_PLUS_MOB                          = 0x00000040, // 7           64  ? some NPCs have this (Rare/Elite/Boss?)
-    UNIT_FLAG_IGNORE_CREATURE_COMBAT            = 0x00000080, // 8          128  unit will not enter combat with creatures
+    UNIT_FLAG_UNKNOWN_8                         = 0x00000080, // 8          128  ? can change attackable status
     UNIT_FLAG_IGNORE_PLAYER_COMBAT              = 0x00000100, // 9          256  unit will not enter combat with players
-    UNIT_FLAG_IGNORE_PLAYER_NPC                 = 0x00000200, // 10         512  ? some NPCs have this
+    UNIT_FLAG_IGNORE_CREATURE_COMBAT            = 0x00000200, // 10         512  unit will not enter combat with creatures
     UNIT_FLAG_LOOTING                           = 0x00000400, // 11        1024
     UNIT_FLAG_PET_IN_COMBAT                     = 0x00000800, // 12        2048  on player pets: whether the pet is chasing a target to attack || on other units: whether any of the unit's minions is in combat
+#if VERSION_STRING <= TBC
     UNIT_FLAG_PVP                               = 0x00001000, // 13        4096  sets PvP flag
+#else
+    UNIT_FLAG_UNKNOWN_13                        = 0x00001000, // 13        4096
+#endif
     UNIT_FLAG_SILENCED                          = 0x00002000, // 14        8192
     UNIT_FLAG_DEAD                              = 0x00004000, // 15       16384  used for special "dead" NPCs like Withered Corpses
     UNIT_FLAG_SWIMMING                          = 0x00008000, // 16       32768  shows swim animation in water
@@ -963,35 +991,43 @@ enum UnitFieldFlags : uint32_t // UNIT_FIELD_FLAGS #46 - these are client flags
     UNIT_FLAG_PLAYER_CONTROLLED_CREATURE        = 0x01000000, // 25    16777216
     UNIT_FLAG_NOT_SELECTABLE                    = 0x02000000, // 26    33554432  cannot select the unit
     UNIT_FLAG_SKINNABLE                         = 0x04000000, // 27    67108864
+#if VERSION_STRING == Classic
+    UNIT_FLAG_DETECT_AURAS                      = 0x08000000, // 28   134217728  Auras on unit are detectable
+#else
     UNIT_FLAG_MOUNT                             = 0x08000000, // 28   134217728  ? was MAKE_CHAR_UNTOUCHABLE (probably wrong), nothing ever set it
+#endif
     UNIT_FLAG_UNKNOWN_29                        = 0x10000000, // 29   268435456
     UNIT_FLAG_FEIGN_DEATH                       = 0x20000000, // 30   536870912
     UNIT_FLAG_UNKNOWN_31                        = 0x40000000, // 31  1073741824  ? was WEAPON_OFF and being used for disarm
     UNIT_FLAG_IMMUNE                            = 0x80000000  // 32  2147483648
 };
 
-enum UnitFieldFlags2
+#if VERSION_STRING >= TBC
+enum UnitFieldFlags2 : uint32_t
 {
     UNIT_FLAG2_FEIGN_DEATH                      = 0x0000001,
-    UNIT_FLAG2_UNK1                             = 0x0000002,    // Hides body and body armor. Weapons, shoulder and head armors still visible
+    UNIT_FLAG2_HIDE_BODY                        = 0x0000002,    // Hides body and body armor. Weapons, shoulder and head armors still visible
     UNIT_FLAG2_UNK2                             = 0x0000004,
     UNIT_FLAG2_COMPREHEND_LANG                  = 0x0000008,    // Allows target to understand itself while talking in different language
     UNIT_FLAG2_MIRROR_IMAGE                     = 0x0000010,
     UNIT_FLAG2_UNK5                             = 0x0000020,
     UNIT_FLAG2_FORCE_MOVE                       = 0x0000040,    // Makes target to run forward
+#if VERSION_STRING >= WotLK
     UNIT_FLAG2_DISARM_OFFHAND                   = 0x0000080,
     UNIT_FLAG2_UNK8                             = 0x0000100,
     UNIT_FLAG2_UNK9                             = 0x0000200,
     UNIT_FLAG2_DISARM_RANGED                    = 0x0000400,
     UNIT_FLAG2_ENABLE_POWER_REGEN               = 0x0000800,
-    UNIT_FLAG2_RESTRICT_PARTY_INTERACTION       = 0x0001000,   // Restrict interaction to party or raid
+    UNIT_FLAG2_SPELL_CLICK_PARTY_RAID_ONLY      = 0x0001000,   // Restrict interaction to party or raid
     UNIT_FLAG2_PREVENT_SPELL_CLICK              = 0x0002000,   // Prevent spellclick
     UNIT_FLAG2_ALLOW_ENEMY_INTERACT             = 0x0004000,
     UNIT_FLAG2_DISABLE_TURN                     = 0x0008000,
     UNIT_FLAG2_UNK10                            = 0x0010000,
     UNIT_FLAG2_PLAY_DEATH_ANIM                  = 0x0020000,   // Plays special death animation upon death
     UNIT_FLAG2_ALLOW_CHEAT_SPELLS               = 0x0040000    // Allows casting spells with AttributesExG & SP_ATTR_EX_G_IS_CHEAT_SPELL
+#endif
 };
+#endif
 
 enum UnitDynamicFlags
 {
@@ -1041,16 +1077,16 @@ struct TransportData
 struct UnitFlagNames
 {
     uint32_t Flag;
-    const char* Name;
+    std::string_view Name;
 };
 
 struct UnitDynFlagNames
 {
     uint32_t Flag;
-    const char* Name;
+    std::string_view Name;
 };
 
-static const char* POWERTYPE[] =
+static inline constexpr std::string_view POWERTYPE[] =
 {
     "Mana",
     "Rage",
@@ -1061,21 +1097,30 @@ static const char* POWERTYPE[] =
     "Runic Power"
 };
 
-static const UnitFlagNames UnitFlagToName[] =
+static inline constexpr UnitFlagNames UnitFlagToName[] =
 {
     { UNIT_FLAG_SERVER_CONTROLLED, "UNIT_FLAG_SERVER_CONTROLLED" },
     { UNIT_FLAG_NON_ATTACKABLE, "UNIT_FLAG_NON_ATTACKABLE" },
     { UNIT_FLAG_LOCK_PLAYER, "UNIT_FLAG_LOCK_PLAYER" },
     { UNIT_FLAG_PVP_ATTACKABLE, "UNIT_FLAG_PVP_ATTACKABLE" },
+#if VERSION_STRING == Classic
+    { UNIT_FLAG_PET_CAN_BE_RENAMED, "UNIT_FLAG_PET_CAN_BE_RENAMED" },
+    { UNIT_FLAG_PET_CAN_BE_ABANDONED, "UNIT_FLAG_PET_CAN_BE_ABANDONED" },
+#else
     { UNIT_FLAG_UNKNOWN_5, "UNIT_FLAG_UNKNOWN_5" },
     { UNIT_FLAG_NO_REAGANT_COST, "UNIT_FLAG_NO_REAGANT_COST" },
+#endif
     { UNIT_FLAG_PLUS_MOB, "UNIT_FLAG_PLUS_MOB" },
-    { UNIT_FLAG_IGNORE_CREATURE_COMBAT, "UNIT_FLAG_IGNORE_CREATURE_COMBAT" },
+    { UNIT_FLAG_UNKNOWN_8, "UNIT_FLAG_UNKNOWN_8" },
     { UNIT_FLAG_IGNORE_PLAYER_COMBAT, "UNIT_FLAG_IGNORE_PLAYER_COMBAT" },
-    { UNIT_FLAG_IGNORE_PLAYER_NPC, "UNIT_FLAG_IGNORE_PLAYER_NPC" },
+    { UNIT_FLAG_IGNORE_CREATURE_COMBAT, "UNIT_FLAG_IGNORE_CREATURE_COMBAT" },
     { UNIT_FLAG_LOOTING, "UNIT_FLAG_LOOTING" },
     { UNIT_FLAG_PET_IN_COMBAT, "UNIT_FLAG_PET_IN_COMBAT" },
+#if VERSION_STRING <= TBC
     { UNIT_FLAG_PVP, "UNIT_FLAG_PVP" },
+#else
+    { UNIT_FLAG_UNKNOWN_13, "UNIT_FLAG_UNKNOWN_13" },
+#endif
     { UNIT_FLAG_SILENCED, "UNIT_FLAG_SILENCED" },
     { UNIT_FLAG_DEAD, "UNIT_FLAG_DEAD" },
     { UNIT_FLAG_SWIMMING, "UNIT_FLAG_SWIMMING" },
@@ -1090,41 +1135,49 @@ static const UnitFlagNames UnitFlagToName[] =
     { UNIT_FLAG_PLAYER_CONTROLLED_CREATURE, "UNIT_FLAG_PLAYER_CONTROLLED_CREATURE" },
     { UNIT_FLAG_NOT_SELECTABLE, "UNIT_FLAG_NOT_SELECTABLE" },
     { UNIT_FLAG_SKINNABLE, "UNIT_FLAG_SKINNABLE" },
+#if VERSION_STRING == Classic
+    { UNIT_FLAG_DETECT_AURAS, "UNIT_FLAG_DETECT_AURAS" },
+#else
     { UNIT_FLAG_MOUNT, "UNIT_FLAG_MOUNT" },
+#endif
     { UNIT_FLAG_UNKNOWN_29, "UNIT_FLAG_UNKNOWN_29" },
     { UNIT_FLAG_FEIGN_DEATH, "UNIT_FLAG_FEIGN_DEATH" },
     { UNIT_FLAG_UNKNOWN_31, "UNIT_FLAG_UNKNOWN_31" },
     { UNIT_FLAG_IMMUNE, "UNIT_FLAG_IMMUNE" }
 };
 
-static uint32_t numflags = sizeof(UnitFlagToName) / sizeof(UnitFlagNames);
+static inline constexpr uint32_t numflags = sizeof(UnitFlagToName) / sizeof(UnitFlagNames);
 
-static const UnitFlagNames UnitFlagToName2[] =
+#if VERSION_STRING >= TBC
+static inline constexpr UnitFlagNames UnitFlagToName2[] =
 {
     { UNIT_FLAG2_FEIGN_DEATH, "UNIT_FLAG2_FEIGN_DEATH" },
-    { UNIT_FLAG2_UNK1, "UNIT_FLAG2_UNK1" },
+    { UNIT_FLAG2_HIDE_BODY, "UNIT_FLAG2_HIDE_BODY" },
     { UNIT_FLAG2_UNK2, "UNIT_FLAG2_UNK2" },
     { UNIT_FLAG2_COMPREHEND_LANG, "UNIT_FLAG2_COMPREHEND_LANG" },
     { UNIT_FLAG2_MIRROR_IMAGE, "UNIT_FLAG2_MIRROR_IMAGE" },
     { UNIT_FLAG2_UNK5, "UNIT_FLAG2_UNK5" },
     { UNIT_FLAG2_FORCE_MOVE, "UNIT_FLAG2_FORCE_MOVE" },
+#if VERSION_STRING >= WotLK
     { UNIT_FLAG2_DISARM_OFFHAND, "UNIT_FLAG2_DISARM_OFFHAND" },
     { UNIT_FLAG2_UNK8, "UNIT_FLAG2_UNK8" },
     { UNIT_FLAG2_UNK9, "UNIT_FLAG2_UNK9" },
     { UNIT_FLAG2_DISARM_RANGED, "UNIT_FLAG2_DISARM_RANGED" },
     { UNIT_FLAG2_ENABLE_POWER_REGEN, "UNIT_FLAG2_ENABLE_POWER_REGEN" },
-    { UNIT_FLAG2_RESTRICT_PARTY_INTERACTION, "UNIT_FLAG2_RESTRICT_PARTY_INTERACTION" },
+    { UNIT_FLAG2_SPELL_CLICK_PARTY_RAID_ONLY, "UNIT_FLAG2_SPELL_CLICK_PARTY_RAID_ONLY" },
     { UNIT_FLAG2_PREVENT_SPELL_CLICK, "UNIT_FLAG2_PREVENT_SPELL_CLICK" },
     { UNIT_FLAG2_ALLOW_ENEMY_INTERACT, "UNIT_FLAG2_ALLOW_ENEMY_INTERACT" },
     { UNIT_FLAG2_DISABLE_TURN, "UNIT_FLAG2_DISABLE_TURN" },
     { UNIT_FLAG2_UNK10, "UNIT_FLAG2_UNK10" },
     { UNIT_FLAG2_PLAY_DEATH_ANIM, "UNIT_FLAG2_PLAY_DEATH_ANIM" },
     { UNIT_FLAG2_ALLOW_CHEAT_SPELLS, "UNIT_FLAG2_ALLOW_CHEAT_SPELLS" }
+#endif
 };
 
-static uint32_t numflags2 = sizeof(UnitFlagToName2) / sizeof(UnitFlagNames);
+static inline constexpr uint32_t numflags2 = sizeof(UnitFlagToName2) / sizeof(UnitFlagNames);
+#endif
 
-static const UnitDynFlagNames UnitDynFlagToName[] =
+static inline constexpr UnitDynFlagNames UnitDynFlagToName[] =
 {
     { U_DYN_FLAG_LOOTABLE, "U_DYN_FLAG_LOOTABLE" },
     { U_DYN_FLAG_UNIT_TRACKABLE, "U_DYN_FLAG_UNIT_TRACKABLE" },
@@ -1134,16 +1187,16 @@ static const UnitDynFlagNames UnitDynFlagToName[] =
     { U_DYN_FLAG_DEAD, "U_DYN_FLAG_DEAD" }
 };
 
-static uint32_t numdynflags = sizeof(UnitDynFlagToName) / sizeof(UnitDynFlagNames);
+static inline constexpr uint32_t numdynflags = sizeof(UnitDynFlagToName) / sizeof(UnitDynFlagNames);
 
-static const char* GENDER[] =
+static inline constexpr std::string_view GENDER[] =
 {
     "male",
     "female",
     "neutral"
 };
 
-static const char* CLASS[] =
+static inline constexpr std::string_view CLASS[] =
 {
     "invalid 0",
     "warrior",
@@ -1159,41 +1212,45 @@ static const char* CLASS[] =
     "druid"
 };
 
-static const char* SHEATSTATE[] =
+static inline constexpr std::string_view SHEATSTATE[] =
 {
     "none",
     "melee",
     "ranged"
 };
 
+#if VERSION_STRING >= WotLK
 struct UnitPvPFlagNames
 {
     uint32_t Flag;
-    const char* Name;
+    std::string_view Name;
 };
 
-static const UnitPvPFlagNames UnitPvPFlagToName[] =
+static inline constexpr UnitPvPFlagNames UnitPvPFlagToName[] =
 {
-    { U_FIELD_BYTES_FLAG_PVP, "U_FIELD_BYTES_FLAG_PVP" },
-    { U_FIELD_BYTES_FLAG_FFA_PVP, "U_FIELD_BYTES_FLAG_FFA_PVP" },
-    { U_FIELD_BYTES_FLAG_SANCTUARY, "U_FIELD_BYTES_FLAG_SANCTUARY" }
+    { PVP_STATE_FLAG_PVP, "PVP_STATE_FLAG_PVP" },
+    { PVP_STATE_FLAG_FFA_PVP, "PVP_STATE_FLAG_FFA_PVP" },
+    { PVP_STATE_FLAG_SANCTUARY, "PVP_STATE_FLAG_SANCTUARY" }
 };
 
-static const uint32_t numpvpflags = sizeof(UnitPvPFlagToName) / sizeof(UnitPvPFlagNames);
+static inline constexpr uint32_t numpvpflags = sizeof(UnitPvPFlagToName) / sizeof(UnitPvPFlagNames);
+#endif
 
+#if VERSION_STRING >= TBC
 struct PetFlagNames
 {
     uint32_t Flag;
-    const char* Name;
+    std::string_view Name;
 };
 
-static const PetFlagNames PetFlagToName[] =
+static inline constexpr PetFlagNames PetFlagToName[] =
 {
-    { UNIT_CAN_BE_RENAMED, "UNIT_CAN_BE_RENAMED" },
-    { UNIT_CAN_BE_ABANDONED, "UNIT_CAN_BE_ABANDONED" }
+    { PET_FLAG_CAN_BE_RENAMED, "PET_FLAG_CAN_BE_RENAMED" },
+    { PET_FLAG_CAN_BE_ABANDONED, "PET_FLAG_CAN_BE_ABANDONED" }
 };
 
-static const uint32_t numpetflags = sizeof(PetFlagToName) / sizeof(PetFlagNames);
+static inline constexpr uint32_t numpetflags = sizeof(PetFlagToName) / sizeof(PetFlagNames);
+#endif
 
 enum UnitSpeedType : uint8_t
 {

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -69,8 +69,8 @@
 #include "Utilities/Benchmark.hpp"
 
 // DB version
-static const char* REQUIRED_CHAR_DB_VERSION = "20250119-00_character_db_version";
-static const char* REQUIRED_WORLD_DB_VERSION = "20250112-00_world_db_version";
+static const char* REQUIRED_CHAR_DB_VERSION = "20250516-00_characters";
+static const char* REQUIRED_WORLD_DB_VERSION = "20250516-00_creature_spawns";
 
 volatile bool Master::m_stopEvent = false;
 
@@ -305,6 +305,9 @@ bool Master::Run(int /*argc*/, char** /*argv*/)
 
     ThreadPool.Startup();
     auto startTime = Util::TimeNow();
+
+    // Call once to initialize EventMgr and to prevent crash on possible startup error -Appled
+    sEventMgr;
 
     sWorld.initialize();
 

--- a/src/world/Server/Packets/Handlers/GuildHandler.cpp
+++ b/src/world/Server/Packets/Handlers/GuildHandler.cpp
@@ -1158,9 +1158,9 @@ void WorldSession::handleAutoDeclineGuildInvites(WorldPacket& recvPacket)
     bool enabled = enable > 0 ? true : false;
 
     if (enabled)
-        _player->addPlayerFlags(PLAYER_FLAGS_AUTO_DECLINE_GUILD);
+        _player->addPlayerFlags(PLAYER_FLAG_DECLINE_GUILD_INVITES);
     else
-        _player->removePlayerFlags(PLAYER_FLAGS_AUTO_DECLINE_GUILD);
+        _player->removePlayerFlags(PLAYER_FLAG_DECLINE_GUILD_INVITES);
 #endif
 }
 

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -569,7 +569,7 @@ void WorldSession::handleSetActionBarTogglesOpcode(WorldPacket& recvPacket)
 
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_SET_ACTIONBAR_TOGGLES: {} (actionbarId)", srlPacket.actionbarId);
 
-    _player->setActionBarId(srlPacket.actionbarId);
+    _player->setEnabledActionBars(srlPacket.actionbarId);
 }
 
 void WorldSession::handleLootRollOpcode(WorldPacket& recvPacket)

--- a/src/world/Server/Packets/Handlers/PetHandler.cpp
+++ b/src/world/Server/Packets/Handlers/PetHandler.cpp
@@ -441,7 +441,11 @@ void WorldSession::handlePetRename(WorldPacket& recvPacket)
     pet->rename(newName);
 
     pet->setSheathType(SHEATH_STATE_MELEE);
-    pet->removePetFlags(UNIT_CAN_BE_RENAMED);
+#if VERSION_STRING == Classic
+    pet->removeUnitFlags(UNIT_FLAG_PET_CAN_BE_RENAMED);
+#else
+    pet->removePetFlags(PET_FLAG_CAN_BE_RENAMED);
+#endif
 
     if (pet->getPlayerOwner() != nullptr)
     {
@@ -492,8 +496,10 @@ void WorldSession::handlePetUnlearn(WorldPacket& recvPacket)
 #endif
 
     pet->WipeTalents();
+#if VERSION_STRING == WotLK || VERSION_STRING == Cata
     pet->setPetTalentPoints(pet->GetTPsForLevel(pet->getLevel()));
     pet->SendTalentsToOwner();
+#endif
 }
 
 void WorldSession::handlePetSpellAutocast(WorldPacket& recvPacket)

--- a/src/world/Server/Packets/Handlers/TaxiHandler.cpp
+++ b/src/world/Server/Packets/Handlers/TaxiHandler.cpp
@@ -124,7 +124,7 @@ void WorldSession::handleTaxiQueryAvaibleNodesOpcode(WorldPacket& recvPacket)
     sLogger.debug("WORLD: Received CMSG_TAXIQUERYAVAILABLENODES");
 
     // cheating checks
-    Creature* unit = GetPlayer()->getCreatureWhenICanInteract(WoWGuid(srlPacket.creatureGuid), UNIT_NPC_FLAG_FLIGHTMASTER);
+    Creature* unit = GetPlayer()->getCreatureWhenICanInteract(WoWGuid(srlPacket.creatureGuid), UNIT_NPC_FLAG_TAXI);
     if (!unit)
     {
         SendPacket(SmsgActivateTaxiReply(TaxiNodeError::ERR_TaxiTooFarAway).serialise().get());
@@ -153,7 +153,7 @@ void WorldSession::handleEnabletaxiOpcode(WorldPacket& recvPacket)
     sLogger.debug("WORLD: Received CMSG_ENABLETAXI");
 
     // cheating checks
-    Creature* unit = GetPlayer()->getCreatureWhenICanInteract(srlPacket.creatureGuid, UNIT_NPC_FLAG_FLIGHTMASTER);
+    Creature* unit = GetPlayer()->getCreatureWhenICanInteract(srlPacket.creatureGuid, UNIT_NPC_FLAG_TAXI);
     if (!unit)
     {
         SendPacket(SmsgActivateTaxiReply(TaxiNodeError::ERR_TaxiTooFarAway).serialise().get());
@@ -177,7 +177,7 @@ void WorldSession::handleActivateTaxiOpcode(WorldPacket& recvPacket)
 
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_ACTIVATE_TAXI");
 
-    Creature* npc = GetPlayer()->getCreatureWhenICanInteract(srlPacket.guid, UNIT_NPC_FLAG_FLIGHTMASTER);
+    Creature* npc = GetPlayer()->getCreatureWhenICanInteract(srlPacket.guid, UNIT_NPC_FLAG_TAXI);
     if (!npc)
     {
         SendPacket(SmsgActivateTaxiReply(TaxiNodeError::ERR_TaxiTooFarAway).serialise().get());
@@ -208,7 +208,7 @@ void WorldSession::handleMultipleActivateTaxiOpcode(WorldPacket& recvPacket)
 
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_ACTIVATE_TAXI_EXPRESS");
 
-    Creature* npc = GetPlayer()->getCreatureWhenICanInteract(srlPacket.guid, UNIT_NPC_FLAG_FLIGHTMASTER);
+    Creature* npc = GetPlayer()->getCreatureWhenICanInteract(srlPacket.guid, UNIT_NPC_FLAG_TAXI);
     if (!npc)
     {
         SendPacket(SmsgActivateTaxiReply(TaxiNodeError::ERR_TaxiTooFarAway).serialise().get());

--- a/src/world/Server/Script/CreatureAIScript.cpp
+++ b/src/world/Server/Script/CreatureAIScript.cpp
@@ -592,10 +592,10 @@ void CreatureAIScript::setWaypointToMove(uint32_t pathId, uint32_t pWaypointId)
     {
 #if VERSION_STRING >= WotLK
     case WAYPOINT_MOVE_TYPE_LAND:
-        init.SetAnimation(AnimationTier::Ground);
+        init.SetAnimation(ANIMATION_FLAG_GROUND);
         break;
     case WAYPOINT_MOVE_TYPE_TAKEOFF:
-        init.SetAnimation(AnimationTier::Hover);
+        init.SetAnimation(ANIMATION_FLAG_HOVER);
         break;
 #endif
     case WAYPOINT_MOVE_TYPE_RUN:

--- a/src/world/Server/UpdateFieldInclude.h
+++ b/src/world/Server/UpdateFieldInclude.h
@@ -6,12 +6,22 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 #include "AEVersion.hpp"
+#include "Utilities/Util.hpp"
 
-#include <stddef.h>
+#include <array>
+#include <cstddef>
 
 #define getOffsetForStructuredField(s,m) static_cast<uint32_t>(offsetof(s,m) / 4)
+
+template <typename T>
+concept isStdArray = Util::is_size_based_specialization_of_v<T, std::array>;
+
+// Works for both std::array and C style arrays
+#define getOffsetForStructuredArrayField(s,m,index) \
+    (isStdArray<decltype(s::m)> || std::is_array_v<decltype(s::m)> ? \
+        static_cast<uint32_t>((offsetof(s,m) + sizeof(s::m[0]) * index) / 4) : \
+        getOffsetForStructuredField(s,m))
 
 #define getSizeOfStructure(s) static_cast<uint32_t>(sizeof(s) / 4)
 
 #define getSizeOfStructuredField(s,m)
-

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -1419,11 +1419,11 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
                 break;
         }
 
-        m_target->setStandStateFlags(UNIT_STAND_FLAGS_CREEP);
+        m_target->addStandStateFlags(UNIT_STAND_FLAGS_CREEP);
 #if VERSION_STRING != Mop
         if (m_target->isPlayer())
             if (const auto player = dynamic_cast<Player*>(m_target))
-                player->setPlayerFieldBytes2(0x2000);
+                player->addAuraVision(AURA_VISION_STEALTH);
 #endif
 
         m_target->removeAllAurasByAuraInterruptFlag(AURA_INTERRUPT_ON_STEALTH | AURA_INTERRUPT_ON_INVINCIBLE);
@@ -1548,12 +1548,12 @@ void Aura::SpellAuraModStealth(AuraEffectModifier* aurEff, bool apply)
                 break;
             default:
             {
-                m_target->setStandStateFlags(m_target->getStandStateFlags() &~UNIT_STAND_FLAGS_CREEP);
+                m_target->removeStandStateFlags(UNIT_STAND_FLAGS_CREEP);
 
                 if (p_target != nullptr)
                 {
 #if VERSION_STRING != Mop
-                    p_target->setPlayerFieldBytes2(0x2000);
+                    p_target->removeAuraVision(AURA_VISION_STEALTH);
 #endif
                     p_target->sendSpellCooldownEventPacket(m_spellInfo->getId());
 
@@ -1653,7 +1653,7 @@ void Aura::SpellAuraModInvisibility(AuraEffectModifier* aurEff, bool apply)
 #if VERSION_STRING != Mop
             if (getSpellId() == 32612)
                 if (const auto player = dynamic_cast<Player*>(m_target))
-                    player->setPlayerFieldBytes2(0x4000);   //Mage Invis self visual
+                    player->addAuraVision(AURA_VISION_INVISIBILITY);   //Mage Invis self visual
 #endif
         }
 
@@ -1667,7 +1667,7 @@ void Aura::SpellAuraModInvisibility(AuraEffectModifier* aurEff, bool apply)
 #if VERSION_STRING != Mop
             if (getSpellId() == 32612)
                 if (const auto player = dynamic_cast<Player*>(m_target))
-                    player->setPlayerFieldBytes2(0x4000);
+                    player->removeAuraVision(AURA_VISION_INVISIBILITY);
 #endif
         }
     }
@@ -2885,17 +2885,16 @@ void Aura::SpellAuraModDisarm(AuraEffectModifier* aurEff, bool apply)
             field = UnitFlag;
             flag = UNIT_FLAG_DISARMED;
             break;
-#if VERSION_STRING > Classic
+#if VERSION_STRING > TBC
+        // TODO: confirm if this actually exists in tbc -Appled
         case SPELL_AURA_MOD_DISARM_OFFHAND:
             field = UnitFlag2;
             flag = UNIT_FLAG2_DISARM_OFFHAND;
             break;
-#if VERSION_STRING > TBC
         case SPELL_AURA_MOD_DISARM_RANGED:
             field = UnitFlag2;
             flag = UNIT_FLAG2_DISARM_RANGED;
             break;
-#endif
 #endif
         default:
             return;
@@ -4069,9 +4068,9 @@ void Aura::SpellAuraModHealingPCT(AuraEffectModifier* aurEff, bool apply)
 void Aura::SpellAuraUntrackable(AuraEffectModifier* /*aurEff*/, bool apply)
 {
     if (apply)
-        m_target->setStandStateFlags(UNIT_STAND_FLAGS_UNTRACKABLE);
+        m_target->addStandStateFlags(UNIT_STAND_FLAGS_UNTRACKABLE);
     else
-        m_target->setStandStateFlags(m_target->getStandStateFlags() &~UNIT_STAND_FLAGS_UNTRACKABLE);
+        m_target->removeStandStateFlags(UNIT_STAND_FLAGS_UNTRACKABLE);
 }
 
 void Aura::SpellAuraModRangedAttackPower(AuraEffectModifier* aurEff, bool apply)
@@ -5767,6 +5766,7 @@ void Aura::SpellAuraRemoveReagentCost(AuraEffectModifier* /*aurEff*/, bool apply
     if (p_target == nullptr)
         return;
 
+#if VERSION_STRING >= TBC
     if (apply)
     {
         p_target->addUnitFlags(UNIT_FLAG_NO_REAGANT_COST);
@@ -5775,6 +5775,7 @@ void Aura::SpellAuraRemoveReagentCost(AuraEffectModifier* /*aurEff*/, bool apply
     {
         p_target->removeUnitFlags(UNIT_FLAG_NO_REAGANT_COST);
     }
+#endif
 }
 void Aura::SpellAuraBlockMultipleDamage(AuraEffectModifier* aurEff, bool apply)
 {
@@ -5802,6 +5803,7 @@ void Aura::SpellAuraAllowOnlyAbility(AuraEffectModifier* /*aurEff*/, bool apply)
     if (!p_target)
         return;
 
+#if VERSION_STRING >= WotLK
     // Generic
     if (apply)
     {
@@ -5811,6 +5813,7 @@ void Aura::SpellAuraAllowOnlyAbility(AuraEffectModifier* /*aurEff*/, bool apply)
     {
         p_target->removePlayerFlags(PLAYER_FLAG_PREVENT_SPELL_CAST);
     }
+#endif
 }
 
 void Aura::SpellAuraIncreaseAPbyStatPct(AuraEffectModifier* aurEff, bool apply)

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -5294,6 +5294,13 @@ void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
 
         if (p_caster->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
             pPet->addUnitFlags(UNIT_FLAG_PVP_ATTACKABLE);
+
+#if VERSION_STRING == TBC
+        if (p_caster->hasUnitFlags(UNIT_FLAG_PVP_ATTACKABLE))
+            pPet->setPositiveAuraLimit(POS_AURA_LIMIT_PVP_ATTACKABLE);
+        else
+            pPet->setPositiveAuraLimit(POS_AURA_LIMIT_CREATURE);
+#endif
     }
     else
     {
@@ -6159,7 +6166,11 @@ void Spell::SpellEffectRenamePet(uint8_t /*effectIndex*/)
         !static_cast< Pet* >(m_unitTarget)->getPlayerOwner() || static_cast< Pet* >(m_unitTarget)->getPlayerOwner()->getClass() != HUNTER)
         return;
 
-    m_unitTarget->addPetFlags(UNIT_CAN_BE_RENAMED);
+#if VERSION_STRING == Classic
+    m_unitTarget->addUnitFlags(UNIT_FLAG_PET_CAN_BE_RENAMED);
+#else
+    m_unitTarget->addPetFlags(PET_FLAG_CAN_BE_RENAMED);
+#endif
 }
 
 void Spell::SpellEffectRestoreHealthPct(uint8_t /*effectIndex*/)

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -4439,17 +4439,17 @@ void MySQLDataStore::loadCreatureSpawns()
 
                 cspawn->factionid = fields[11].asUint32();
                 cspawn->flags = fields[12].asUint32();
-                cspawn->bytes0 = fields[13].asUint32();
-                cspawn->bytes1 = fields[14].asUint32();
-                cspawn->bytes2 = fields[15].asUint32();
-                cspawn->emote_state = fields[16].asUint32();
-                //cspawn->respawnNpcLink = fields[17].GetUInt32();
-                cspawn->channel_spell = fields[18].asUint32();
-                cspawn->channel_target_go = fields[19].asUint32();
-                cspawn->channel_target_creature = fields[20].asUint32();
-                cspawn->stand_state = fields[21].asUint16();
-                cspawn->death_state = fields[22].asUint32();
-                cspawn->MountedDisplayID = fields[23].asUint32();
+                cspawn->pvp_flagged = fields[13].asUint8();
+                cspawn->bytes0 = fields[14].asUint32();
+                cspawn->emote_state = fields[15].asUint32();
+                //cspawn->respawnNpcLink = fields[16].GetUInt32();
+                cspawn->channel_spell = fields[17].asUint32();
+                cspawn->channel_target_go = fields[18].asUint32();
+                cspawn->channel_target_creature = fields[19].asUint32();
+                cspawn->stand_state = fields[20].asUint8();
+                cspawn->death_state = fields[21].asUint32();
+                cspawn->MountedDisplayID = fields[22].asUint32();
+                cspawn->sheath_state = fields[23].asUint8();
 
                 cspawn->Item1SlotEntry = fields[24].asUint32();
                 cspawn->Item2SlotEntry = fields[25].asUint32();

--- a/src/world/Storage/MySQLStructures.h
+++ b/src/world/Storage/MySQLStructures.h
@@ -143,17 +143,17 @@ namespace MySQLStructure
         uint32_t displayid;
         uint32_t factionid;
         uint32_t flags;
+        uint8_t pvp_flagged;
         uint32_t bytes0;
-        uint32_t bytes1;
-        uint32_t bytes2;
         uint32_t emote_state;
         //uint32_t respawnNpcLink;
         uint32_t channel_spell;
         uint32_t channel_target_go;
         uint32_t channel_target_creature;
-        uint16_t stand_state;
+        uint8_t stand_state;
         uint32_t death_state;
         uint32_t MountedDisplayID;
+        uint8_t sheath_state;
 
         // store item entry
         uint32_t Item1SlotEntry;


### PR DESCRIPTION
**Description**
- WoWData: Sort out multiversion byte fields. While at it, do some minor changes in WoWData files.
- Units: Sort out multiversion unit and player flags.
- Remove problematic version specific byte columns from databases.
- Remove code from other emulators.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [x] TBC
- [x] WotLK
- [x] Cata
