### PR TITLE
Lazypeon Quest

### DIFF
--- a/src/scripts/MiscScripts/Creatures.cpp
+++ b/src/scripts/MiscScripts/Creatures.cpp
@@ -90,24 +90,6 @@ public:
     }
 };
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// Lazy Peons
-class PeonSleepingAI : public CreatureAIScript
-{
-public:
-    static CreatureAIScript* Create(Creature* c) { return new PeonSleepingAI(c); }
-    explicit PeonSleepingAI(Creature* pCreature) : CreatureAIScript(pCreature)
-    {
-        RegisterAIUpdateEvent(3000 + Util::getRandomUInt(180000));
-    };
-
-    void AIUpdate() override
-    {
-        getCreature()->castSpell(getCreature(), 17743, true);
-        RemoveAIUpdateEvent();
-    };
-};
-
 class KirithAI : public CreatureAIScript
 {
 public:
@@ -490,7 +472,6 @@ void SetupMiscCreatures(ScriptMgr* mgr)
     mgr->register_creature_script(11120, &CrimsonHammersmith::Create);
     mgr->register_creature_script(5894, &Corrupt_Minor_Manifestation_Water_Dead::Create);
     mgr->register_creature_script(3425, &SavannahProwler::Create);
-    mgr->register_creature_script(10556, &PeonSleepingAI::Create);
     mgr->register_creature_script(7728, &KirithAI::Create);
 
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scripts/QuestScripts/Quest_Durotar.cpp
+++ b/src/scripts/QuestScripts/Quest_Durotar.cpp
@@ -9,41 +9,51 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Server/Script/CreatureAIScript.hpp"
 #include "Server/Script/QuestScript.hpp"
 
+#include <numbers>
+
 class LazyPeon : public CreatureAIScript
 {
-    static constexpr uint32_t  QUEST_LAZY_PEONS = 5441;
-    static constexpr uint32_t  GO_LUMBERPILE = 175784;
-    static constexpr uint32_t  SPELL_BUFF_SLEEP = 17743;
-    static constexpr uint32_t  SPELL_AWAKEN_PEON = 19938;
+    // Core Data
+    static constexpr uint32_t  QUEST_LAZY_PEONS     = 5441;
+    static constexpr uint32_t  GO_LUMBERPILE        = 175784;
+    static constexpr uint32_t  SPELL_BUFF_SLEEP     = 17743;
+    static constexpr uint32_t  SPELL_AWAKEN_PEON    = 19938;
 
+    // Tuning
+    static constexpr float SEARCH_RADIUS            = 30.0f;
+    static constexpr float RANDOM_MIN_DIST          = 5.0f;
+    static constexpr float RANDOM_MAX_DIST          = 15.0f;
+    static constexpr float CHOP_OFFSET_X            = -1.0f;
+
+    enum WaypointId : uint32_t
+    {
+        ToWoodpile = 1,
+        Random = 2
+    };
 
 public:
     static CreatureAIScript* Create(Creature* creature) { return new LazyPeon(creature); }
     explicit LazyPeon(Creature* pCreature) : CreatureAIScript(pCreature) {}
 
-    void OnLoad() override
+    void InitOrReset() override
     {
-        work = false;
-
-        addAIFunction([this](CreatureAIFunc pThis)
-            {
-                castSpellOnSelf(SPELL_BUFF_SLEEP);
-                repeatFunctionFromScheduler(pThis, 3min);
-            }, DoOnceScheduler(5s));
-    }
-
-    void AIUpdate(unsigned long /*time_passed*/) override
-    {
-        // when at woodpile do chopping emote
-        if (work)
-            getCreature()->emote(EMOTE_ONESHOT_WORK_CHOPWOOD);
+        getCreature()->setEmoteState(EMOTE_ONESHOT_NONE);
+        addAIFunction([this](CreatureAIFunc pThis) { castSpellOnSelf(SPELL_BUFF_SLEEP); }, DoOnceScheduler(1s));
     }
 
     void OnReachWP(uint32_t /*type*/, uint32_t id) override
     {
-        // Woodpile Reached, prepare flag for emote
-        if (id == 1)
-            work = true;
+        if (id == ToWoodpile)
+        {
+            // Woodpile Reached
+            getCreature()->setEmoteState(EMOTE_STATE_WORK_CHOPWOOD);
+            addAIFunction([this](CreatureAIFunc pThis) {handleMoveRandom(pThis); }, DoOnceScheduler(3min));
+        }
+        else if (id == Random)
+        {
+            // Random Position Reached go Back to Sleep
+            castSpellOnSelf(SPELL_BUFF_SLEEP);
+        }
     }
 
     void OnHitBySpell(uint32_t spellId, Unit* caster) override
@@ -57,6 +67,24 @@ public:
         handleWakeUp(caster);
     }
 
+    void handleMoveRandom(CreatureAIFunc pThis)
+    {
+        getCreature()->setEmoteState(EMOTE_ONESHOT_NONE);
+
+        // Move to a random point near closest wood pile
+        if (GameObject* Lumberpile = findNearestGameObject(GO_LUMBERPILE, SEARCH_RADIUS))
+        {
+            LocationVector randomPosition = Lumberpile->GetPosition();
+
+            float distance  = Util::getRandomFloat(RANDOM_MIN_DIST, RANDOM_MAX_DIST);
+            float angle     = Util::getRandomFloat(0.f, std::numbers::pi_v<float>);
+
+            getCreature()->movePositionToFirstCollision(randomPosition, distance, angle);
+
+            movePoint(Random, randomPosition);
+        }
+    }
+
     void handleWakeUp(Unit* caster)
     {
         // Remove Zzz aura
@@ -65,24 +93,36 @@ public:
         // Send chat Message
         sendDBChatMessageByIndex(0, caster);
 
-        // Quest Credit for Player
+        // Hackfix, clear AffectedUnits for Player. Quest Increment happens trough CastedSpell in QuestMgr.
         if (auto* questLog = caster->ToPlayer()->getQuestLogByQuestId(QUEST_LAZY_PEONS))
-        {
-            if (questLog->getMobCountByIndex(0) < 5)
-            {
-                questLog->setMobCountForIndex(0, questLog->getMobCountByIndex(0) + 1);
-                questLog->sendUpdateAddKill(0);
-                questLog->updatePlayerFields();
-            }
-        }
+            questLog->clearAffectedUnits();
 
         // Move to closest wood pile
-        if (GameObject* Lumberpile = findNearestGameObject(GO_LUMBERPILE, 20.0f))
-            movePoint(1, Lumberpile->GetPositionX() - 1, Lumberpile->GetPositionY(), Lumberpile->GetPositionZ());
+        if (GameObject* Lumberpile = findNearestGameObject(GO_LUMBERPILE, SEARCH_RADIUS))
+        {
+            LocationVector dest
+            {
+                Lumberpile->GetPositionX() + CHOP_OFFSET_X,
+                Lumberpile->GetPositionY(),
+                Lumberpile->GetPositionZ()
+            };
+            const float orientation = faceFromTo(getCreature(), dest.x, dest.y, Lumberpile->GetPositionX(), Lumberpile->GetPositionY());
+
+            movePoint(ToWoodpile, dest, true, orientation);
+        }
     }
 
-protected:
-    bool work{ false };
+    static constexpr float toRad(float deg) noexcept
+    {
+        return deg * std::numbers::pi_v<float> / 180.0f;
+    }
+
+    static float faceFromTo(Creature* c, float fromX, float fromY, float toX, float toY)
+    {
+        if (!c) return 0.0f;
+        const float deg = c->calcAngle(fromX, fromY, toX, toY);
+        return deg * std::numbers::pi_v<float> / 180.0f;
+    }
 };
 
 void SetupDurotar(ScriptMgr* mgr)

--- a/src/scripts/QuestScripts/Quest_Durotar.cpp
+++ b/src/scripts/QuestScripts/Quest_Durotar.cpp
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2014-2025 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#include "Setup.h"
+#include "Map/Maps/MapScriptInterface.h"
+#include "Objects/Units/Players/Player.hpp"
+#include "Server/Script/CreatureAIScript.hpp"
+#include "Server/Script/QuestScript.hpp"
+
+class LazyPeon : public CreatureAIScript
+{
+    static constexpr uint32_t  QUEST_LAZY_PEONS = 5441;
+    static constexpr uint32_t  GO_LUMBERPILE = 175784;
+    static constexpr uint32_t  SPELL_BUFF_SLEEP = 17743;
+    static constexpr uint32_t  SPELL_AWAKEN_PEON = 19938;
+
+
+public:
+    static CreatureAIScript* Create(Creature* creature) { return new LazyPeon(creature); }
+    explicit LazyPeon(Creature* pCreature) : CreatureAIScript(pCreature) {}
+
+    void OnLoad() override
+    {
+        work = false;
+
+        addAIFunction([this](CreatureAIFunc pThis)
+            {
+                castSpellOnSelf(SPELL_BUFF_SLEEP);
+                repeatFunctionFromScheduler(pThis, 3min);
+            }, DoOnceScheduler(5s));
+    }
+
+    void AIUpdate(unsigned long /*time_passed*/) override
+    {
+        // when at woodpile do chopping emote
+        if (work)
+            getCreature()->emote(EMOTE_ONESHOT_WORK_CHOPWOOD);
+    }
+
+    void OnReachWP(uint32_t /*type*/, uint32_t id) override
+    {
+        // Woodpile Reached, prepare flag for emote
+        if (id == 1)
+            work = true;
+    }
+
+    void OnHitBySpell(uint32_t spellId, Unit* caster) override
+    {
+        if (!caster || !caster->isPlayer())
+            return;
+
+        if (spellId != SPELL_AWAKEN_PEON)
+            return;
+
+        handleWakeUp(caster);
+    }
+
+    void handleWakeUp(Unit* caster)
+    {
+        // Remove Zzz aura
+        _removeAura(SPELL_BUFF_SLEEP);
+
+        // Send chat Message
+        sendDBChatMessageByIndex(0, caster);
+
+        // Quest Credit for Player
+        if (auto* questLog = caster->ToPlayer()->getQuestLogByQuestId(QUEST_LAZY_PEONS))
+        {
+            if (questLog->getMobCountByIndex(0) < 5)
+            {
+                questLog->setMobCountForIndex(0, questLog->getMobCountByIndex(0) + 1);
+                questLog->sendUpdateAddKill(0);
+                questLog->updatePlayerFields();
+            }
+        }
+
+        // Move to closest wood pile
+        if (GameObject* Lumberpile = findNearestGameObject(GO_LUMBERPILE, 20.0f))
+            movePoint(1, Lumberpile->GetPositionX() - 1, Lumberpile->GetPositionY(), Lumberpile->GetPositionZ());
+    }
+
+protected:
+    bool work{ false };
+};
+
+void SetupDurotar(ScriptMgr* mgr)
+{
+    mgr->register_creature_script(10556, &LazyPeon::Create);
+}

--- a/src/scripts/QuestScripts/Setup.cpp
+++ b/src/scripts/QuestScripts/Setup.cpp
@@ -41,6 +41,7 @@ extern "C" SCRIPT_DECL void _exp_script_register(ScriptMgr* mgr)
     SetupBlastedLands(mgr);
     SetupBloodmystIsle(mgr);
     SetupBurningSteppes(mgr);
+    SetupDurotar(mgr);
     SetupDesolace(mgr);
     SetupDragonblight(mgr);
     SetupDuskwood(mgr);

--- a/src/scripts/QuestScripts/Setup.h
+++ b/src/scripts/QuestScripts/Setup.h
@@ -29,6 +29,7 @@ void SetupBloodmystIsle(ScriptMgr* mgr);
 void SetupBurningSteppes(ScriptMgr* mgr);
 void SetupDesolace(ScriptMgr* mgr);
 void SetupDragonblight(ScriptMgr* mgr);
+void SetupDurotar(ScriptMgr* mgr);
 void SetupDuskwood(ScriptMgr* mgr);
 void SetupDustwallowMarsh(ScriptMgr* mgr);
 void SetupEasternPlaguelands(ScriptMgr* mgr);

--- a/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/ItemSpells_1.cpp
@@ -205,40 +205,6 @@ bool BanishExile(uint8_t effectIndex, Spell* pSpell)
     return true;
 }
 
-bool ForemansBlackjack(uint8_t /*effectIndex*/, Spell* pSpell)
-{
-    Unit* target = pSpell->getUnitTarget();
-    if (!pSpell->getPlayerCaster() || !target || !target->isCreature())
-        return true;
-
-    // check to see that we have the correct creature
-    Creature* c_target = static_cast<Creature*>(target);
-    if (c_target->getEntry() != 10556 || !c_target->hasAurasWithId(17743))
-        return true;
-
-    // Start moving again
-    if (target->getAIInterface())
-        target->stopMoving();
-
-    // Remove Zzz aura
-    c_target->removeAllAuras();
-
-    pSpell->getPlayerCaster()->sendPlayObjectSoundPacket(c_target->getGuid(), 6197);
-
-    // send chat message
-    char msg[100];
-    sprintf(msg, "Ow! Ok, I'll get back to work, %s", pSpell->getPlayerCaster()->getName().c_str());
-    target->sendChatMessage(CHAT_MSG_MONSTER_SAY, LANG_UNIVERSAL, msg);
-
-    c_target->emote(EMOTE_STATE_WORK_CHOPWOOD);
-
-    // Add timed event to return lazy peon to Zzz after 5-10 minutes (spell 17743)
-    SpellInfo const* pSpellEntry = sSpellMgr.getSpellInfo(17743);
-    sEventMgr.AddEvent(target, &Unit::eventCastSpell, target, pSpellEntry, EVENT_UNK, 300000 + Util::getRandomUInt(300000), 1, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
-
-    return true;
-}
-
 bool NetherWraithBeacon(uint8_t /*effectIndex*/, Spell* pSpell)
 {
     if (!pSpell->getPlayerCaster())
@@ -932,7 +898,6 @@ void SetupLegacyItemSpells_1(ScriptMgr* mgr)
     mgr->register_dummy_spell(13120, &NetOMatic);                   // Net-o-Matic
     uint32_t BanishExileIds[] = { 4130, 4131, 4132, 0 };
     mgr->register_dummy_spell(BanishExileIds, &BanishExile);        // Essence of the Exile Quest
-    mgr->register_dummy_spell(19938, &ForemansBlackjack);           // Lazy Peons Quest
     mgr->register_dummy_spell(39105, &NetherWraithBeacon);          // Spellfire Tailor Quest
     mgr->register_dummy_spell(30458, &NighInvulnBelt);              // Nigh Invulnerability Belt
 


### PR DESCRIPTION
**Description**
Fix the “Lazy Peon” quest and update findNearestCreature/findNearestGameObject to search neighboring cells instead of only the current one.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [x] WotLK
- [] Cata
