### PR TITLE
fix fmt style

### DIFF
--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -3745,9 +3745,9 @@ SpellProc* Unit::addProcTriggerSpell(SpellInfo const* spellInfo, SpellInfo const
     if (spellProcHolder == nullptr)
     {
         if (originalSpellInfo != nullptr)
-            sLogger.failure("Unit::addProcTriggerSpell : Spell id {} tried to add a non-existent spell to Unit %p as SpellProc", originalSpellInfo->getId(), fmt::ptr(this));
+            sLogger.failure("Unit::addProcTriggerSpell : Spell id {} tried to add a non-existent spell to Unit {} as SpellProc", originalSpellInfo->getId(), fmt::ptr(this));
         else
-            sLogger.failure("Unit::addProcTriggerSpell : Something tried to add a non-existent spell to Unit %p as SpellProc", fmt::ptr(this));
+            sLogger.failure("Unit::addProcTriggerSpell : Something tried to add a non-existent spell to Unit {} as SpellProc", fmt::ptr(this));
         return nullptr;
     }
 


### PR DESCRIPTION
test

11:31:50 [ERROR][MAJOR]: Unit::addProcTriggerSpell : Spell id 5301 tried to add a non-existent spell to Unit ****0x7f99b80bdb10**** as SpellProc

You can check the logs, I think you have this error.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.
