### PR TITLE
Rewrite pet spell map and pet spell AI logic

### DIFF
--- a/sql/character/updates/20250921-00_playerpets.sql
+++ b/sql/character/updates/20250921-00_playerpets.sql
@@ -1,0 +1,6 @@
+-- Generate new action bars on next summon
+UPDATE `playerpets` SET `actionbar`='';
+-- Pet::addSpell will set this correct on next summon
+UPDATE `playerpetspells` SET `flags`=0x81;
+
+INSERT INTO `character_db_version` (`id`, `LastUpdate`) VALUES ('15', '20250921-00_playerpets');

--- a/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Saurfang.cpp
+++ b/src/scripts/InstanceScripts/Wotlk/IcecrownCitadel/Saurfang.cpp
@@ -1275,7 +1275,7 @@ void BoilingBlood::filterEffectTargets(Spell* spell, uint8_t /*effectIndex*/, st
     // Should be casted on 3 random targets
     if (effectTargets->size() > 3)
     {
-        Util::randomShuffleVector(effectTargets);
+        Util::randomShuffleVector(*effectTargets);
         effectTargets->erase(effectTargets->begin() + 3, effectTargets->end());
     }
 }

--- a/src/scripts/LuaEngine/LuaUnit.cpp
+++ b/src/scripts/LuaEngine/LuaUnit.cpp
@@ -5964,7 +5964,7 @@ int LuaUnit::ResetPetTalents(lua_State* /*L*/, Unit* ptr)
     {
         pet->WipeTalents();
 #if VERSION_STRING == WotLK || VERSION_STRING == Cata
-        pet->setPetTalentPoints(pet->GetTPsForLevel(pet->getLevel()));
+        pet->setPetTalentPoints(pet->getTotalTalentPoints());
         pet->SendTalentsToOwner();
 #endif
     }

--- a/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/MiscSpells.cpp
@@ -200,10 +200,9 @@ bool NorthRendInscriptionResearch(uint8_t /*effectIndex*/, Spell* s)
         std::vector<uint32_t> discoverableGlyphs;
 
         // how many of these are the right type (minor/major) of glyph, and learnable by the player
-        const auto skillBounds = sSpellMgr.getSkillEntryForSkillBounds(SKILL_INSCRIPTION);
-        for (auto skillItr = skillBounds.first; skillItr != skillBounds.second; ++skillItr)
+        const auto skillRange = sSpellMgr.getSkillEntryRangeForSkill(SKILL_INSCRIPTION);
+        for (const auto& [_, skill_line_ability] : skillRange)
         {
-            auto skill_line_ability = skillItr->second;
             if (skill_line_ability->next == 0)
             {
                 SpellInfo const* se1 = sSpellMgr.getSpellInfo(skill_line_ability->spell);

--- a/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
+++ b/src/scripts/SpellHandlers/LegacyFiles/WarriorSpells.cpp
@@ -126,7 +126,7 @@ bool Charge(uint8_t effectIndex, Spell* s)
     uint32_t rage_to_gen = s->getSpellInfo()->getEffectBasePoints(effectIndex) + 1;
     if (s->getPlayerCaster())
     {
-        for (std::set<uint32_t>::iterator itr = s->getPlayerCaster()->getSpellSet().begin(); itr != s->getPlayerCaster()->getSpellSet().end(); ++itr)
+        for (auto itr = s->getPlayerCaster()->getSpellSet().begin(); itr != s->getPlayerCaster()->getSpellSet().end(); ++itr)
         {
             if (*itr == 12697)
             {

--- a/src/shared/Utilities/Random.cpp
+++ b/src/shared/Utilities/Random.cpp
@@ -7,6 +7,13 @@ This file is released under the MIT license. See README-MIT for more information
 
 namespace Util
 {
+    std::mt19937& getRandomEngine()
+    {
+        static std::random_device rd;
+        static std::mt19937 mt(rd());
+        return mt;
+    }
+
     //////////////////////////////////////////////////////////////////////////////////////////
     // Random number helper functions
 
@@ -17,10 +24,9 @@ namespace Util
 
     int getRandomInt(int start, int end)
     {
-        std::random_device rd;
-        std::mt19937 mt(rd());
+        auto& engine = getRandomEngine();
         std::uniform_int_distribution<int> dist(start, end);
-        return dist(mt);
+        return dist(engine);
     }
 
     uint32_t getRandomUInt(uint32_t end)
@@ -30,10 +36,9 @@ namespace Util
 
     uint32_t getRandomUInt(uint32_t start, uint32_t end)
     {
-        std::random_device rd;
-        std::mt19937 mt(rd());
+        auto& engine = getRandomEngine();
         std::uniform_int_distribution<uint32_t> dist(start, end);
-        return dist(mt);
+        return dist(engine);
     }
 
     float getRandomFloat(float end)
@@ -43,10 +48,9 @@ namespace Util
 
     float getRandomFloat(float start, float end)
     {
-        std::random_device rd;
-        std::mt19937 mt(rd());
+        auto& engine = getRandomEngine();
         std::uniform_real_distribution<float> dist(start, end);
-        return dist(mt);
+        return dist(engine);
     }
 
     bool checkChance(uint32_t val)

--- a/src/shared/Utilities/Random.hpp
+++ b/src/shared/Utilities/Random.hpp
@@ -56,12 +56,12 @@ namespace Util
     // Container helper functions
 
     template<typename T>
-    inline void randomShuffleVector(std::vector<T>* vector)
+    inline void randomShuffleVector(std::vector<T>& vector)
     {
         std::random_device rd;
         std::mt19937 mt(rd());
 
-        std::shuffle(vector->begin(), vector->end(), mt);
+        std::shuffle(vector.begin(), vector.end(), mt);
     }
 
     template <class C>

--- a/src/shared/Utilities/Random.hpp
+++ b/src/shared/Utilities/Random.hpp
@@ -11,6 +11,9 @@ This file is released under the MIT license. See README-MIT for more information
 
 namespace Util
 {
+    // Use always this instead of creating new mt19937!
+    std::mt19937& getRandomEngine();
+
     //////////////////////////////////////////////////////////////////////////////////////////
     // Random number helper functions
 
@@ -58,10 +61,8 @@ namespace Util
     template<typename T>
     inline void randomShuffleVector(std::vector<T>& vector)
     {
-        std::random_device rd;
-        std::mt19937 mt(rd());
-
-        std::shuffle(vector.begin(), vector.end(), mt);
+        auto& engine = getRandomEngine();
+        std::shuffle(vector.begin(), vector.end(), engine);
     }
 
     template <class C>

--- a/src/world/Chat/Commands/DebugCommands.cpp
+++ b/src/world/Chat/Commands/DebugCommands.cpp
@@ -135,7 +135,7 @@ bool ChatCommandHandler::HandleMoveHardcodedScriptsToDBCommand(const char* args,
             if (map_cell != nullptr)
                 map_cell->setLoaded();
 
-            for (const auto& aiSpells : creature->getAIInterface()->mCreatureAISpells)
+            for (const auto& aiSpells : creature->getAIInterface()->getCreatureAISpells())
             {
                 if (aiSpells->fromDB)
                     continue;

--- a/src/world/Chat/Commands/PetCommands.cpp
+++ b/src/world/Chat/Commands/PetCommands.cpp
@@ -204,7 +204,7 @@ bool ChatCommandHandler::HandlePetAddSpellCommand(const char* args, WorldSession
         return true;
     }
 
-    pet->AddSpell(spell_entry, true);
+    pet->addSpell(spell_entry);
 
     greenSystemMessage(m_session, "Added spell {} to {}'s pet.", SpellId, selected_player->getName());
 
@@ -236,7 +236,7 @@ bool ChatCommandHandler::HandlePetRemoveSpellCommand(const char* args, WorldSess
         return true;
     }
 
-    pet->RemoveSpell(SpellId);
+    pet->removeSpell(SpellId);
 
     greenSystemMessage(m_session, "Removed spell {} from {}'s pet.", SpellId, selected_player->getName());
 
@@ -289,7 +289,7 @@ bool ChatCommandHandler::HandlePetSetLevelCommand(const char* args, WorldSession
     selected_pet->setPetExperience(0);
     selected_pet->setPetNextLevelExperience(selected_pet->getNextLevelXp(newLevel));
     selected_pet->applyStatsForLevel();
-    selected_pet->UpdateSpellList();
+    selected_pet->updateSpellList();
 
     if (selected_player != m_session->GetPlayer())
     {

--- a/src/world/Macros/PetMacros.hpp
+++ b/src/world/Macros/PetMacros.hpp
@@ -6,53 +6,7 @@ This file is released under the MIT license. See README-MIT for more information
 #pragma once
 
 /// -
-#define PET_WATER_ELEMENTAL 510
-#define PET_WATER_ELEMENTAL_NEW 37994
-#define PET_IMP 416
-#define PET_VOIDWALKER 1860
-#define PET_SUCCUBUS 1863
-#define PET_FELHUNTER 417
-#define PET_FELGUARD 17252
-#define PET_SHADOWFIEND 19668
-#define PET_GHOUL 26125
-
-/// -
-//#define SPIRITWOLF 29264
-
-/// -
-//#define DANCINGRUNEWEAPON 27893
-
-/// -
-#define PET_SPELL_SPAM_COOLDOWN 2000        // applied only to spells that have no cooldown
-
-/// -
 #define PET_TALENT_TREE_START 409           // Tenacity
 
 /// -
 #define PET_TALENT_TREE_END 411             // Cunning
-
-/// -
-//#define PET_DELAYED_REMOVAL_TIME 60000    // 1 min
-
-/// -
-#define DEFAULT_SPELL_STATE 0x8100
-
-/// -
-#define AUTOCAST_SPELL_STATE 0xC100
-
-/// -
-#define PET_HAPPINESS_UPDATE_VALUE 333000
-
-/// -
-#define PET_HAPPINESS_UPDATE_TIMER 7500
-
-/// -
-#define PET_ACTION_ACTION 0x700             // 1792
-
-/// -
-#define PET_ACTION_STATE 0x600              // 1536
-
-///\todo grep see the way pet spells contain the same flag?
-#define PET_ACTION_SPELL 0xC100             // 49408
-#define PET_ACTION_SPELL_1 0x8100           // 33024
-#define PET_ACTION_SPELL_2 0x0100           // 256

--- a/src/world/Management/AchievementMgr.cpp
+++ b/src/world/Management/AchievementMgr.cpp
@@ -944,7 +944,7 @@ void AchievementMgr::updateAchievementCriteria(AchievementCriteriaTypes _type)
             case ACHIEVEMENT_CRITERIA_TYPE_NUMBER_OF_MOUNTS:
             {
                 // achievementCriteria field4 = 777 for mounts, 778 for companion pets
-                SpellSet::iterator sl = getPlayer()->getSpellSet().begin();
+                auto sl = getPlayer()->getSpellSet().begin();
                 uint32_t nm = 0;
                 while (sl != getPlayer()->getSpellSet().end())
                 {

--- a/src/world/Management/LFG/LFGMgr.cpp
+++ b/src/world/Management/LFG/LFGMgr.cpp
@@ -2105,12 +2105,12 @@ LfgReward const* LfgMgr::GetRandomDungeonReward(uint32_t dungeon, uint8_t level)
 {
     sLogger.debug("Get Reward dungeon id = {} level = {}", dungeon, level);
     LfgReward const* rew = NULL;
-    LfgRewardMapBounds bounds = m_RewardMap.equal_range(dungeon & 0x00FFFFFF);
-    for (LfgRewardMap::const_iterator itr = bounds.first; itr != bounds.second; ++itr)
+    auto bounds = m_RewardMap.equal_range(dungeon & 0x00FFFFFF);
+    for (const auto& itr : std::ranges::subrange(bounds.first, bounds.second))
     {
-        rew = itr->second.get();
+        rew = itr.second.get();
         // ordered properly at loading
-        if (itr->second->maxLevel >= level)
+        if (itr.second->maxLevel >= level)
             break;
     }
 

--- a/src/world/Management/Loot/LootTemplate.cpp
+++ b/src/world/Management/Loot/LootTemplate.cpp
@@ -22,8 +22,8 @@ void LootTemplate::addEntry(LootStoreItem& item)
 void LootTemplate::generateLoot(Loot& loot, uint8_t lootDifficulty) const
 {
     // Randomize our Loot
-    auto lootEntries = Entries;
-    Util::randomShuffleVector(&lootEntries);
+    LootStoreItemList lootEntries = Entries;
+    Util::randomShuffleVector(lootEntries);
 
     // Rolling items
     for (const auto& lootStoreItem : lootEntries)

--- a/src/world/Objects/Units/Creatures/Creature.h
+++ b/src/world/Objects/Units/Creatures/Creature.h
@@ -57,6 +57,8 @@ public:
 
     void OnLoaded();
 
+    virtual void sendSpellsToController(Unit* controller, uint32_t duration);
+
     GameEvent * mEvent = nullptr;
 
     // npc flag helper
@@ -283,8 +285,6 @@ public:
 
         void OnRemoveCorpse();
         void OnRespawn(WorldMap* m);
-
-        void buildPetSpellList(WorldPacket & data);
 
     private:
         // Waypoint path

--- a/src/world/Objects/Units/Creatures/PetDefines.hpp
+++ b/src/world/Objects/Units/Creatures/PetDefines.hpp
@@ -8,6 +8,38 @@ This file is released under the MIT license. See README-MIT for more information
 #include "AEVersion.hpp"
 #include <cstdint>
 
+static inline constexpr int32_t PET_HAPPINESS_UPDATE_VALUE = 333000;
+static inline constexpr uint16_t PET_HAPPINESS_UPDATE_TIMER = 7500;
+
+static inline constexpr uint8_t PET_MAX_ACTION_BAR_SLOT = 10;
+
+union PetActionButtonData
+{
+    struct Parts
+    {
+        uint32_t spellId : 24;
+        uint32_t state   : 8;
+    } parts;
+    uint32_t raw;
+};
+
+enum PetEntries : uint32_t
+{
+    PET_WATER_ELEMENTAL                 = 510,
+    PET_WATER_ELEMENTAL_NEW             = 37994,
+    PET_IMP                             = 416,
+    PET_VOIDWALKER                      = 1860,
+    PET_SUCCUBUS                        = 1863,
+    PET_FELHUNTER                       = 417,
+    PET_INFERNAL                        = 89,
+    PET_DOOMGUARD                       = 11859,
+    PET_FELGUARD                        = 17252,
+    PET_SHADOWFIEND                     = 19668,
+    PET_GHOUL                           = 26125,
+    PET_DANCING_RUNEWEAPON              = 27893,
+    PET_SPIRITWOLF                      = 29264
+};
+
 /* Taken from ItemPetFood.dbc
  * Each value is equal to a flag
  * so 1 << PET_FOOD_BREAD for example
@@ -26,6 +58,7 @@ enum PetFoodDiets : uint8_t
     PET_FOOD_RAW_FISH                   /// not used in pet diet
 };
 
+// Used with PET_SPELL_STATE_SET_REACT
 enum PetReactStates : uint8_t
 {
     PET_STATE_PASSIVE                   = 0,
@@ -33,6 +66,7 @@ enum PetReactStates : uint8_t
     PET_STATE_AGGRESSIVE                = 2
 };
 
+// Used with PET_SPELL_STATE_SET_ACTION
 enum PetCommands : uint8_t
 {
     PET_ACTION_STAY                     = 0,
@@ -50,14 +84,15 @@ enum PetActionFeedback : uint8_t
     PET_FEEDBACK_CANT_ATTACK_TARGET
 };
 
-enum PetSpells : uint32_t
+enum PetSpellState : uint8_t
 {
-    PET_SPELL_PASSIVE                   = 0x06000000,
-    PET_SPELL_DEFENSIVE,
-    PET_SPELL_AGRESSIVE,
-    PET_SPELL_STAY                      = 0x07000000,
-    PET_SPELL_FOLLOW,
-    PET_SPELL_ATTACK
+    PET_SPELL_STATE_PASSIVE             = 0x01, // passive spell
+    PET_SPELL_STATE_SET_REACT           = 0x06,
+    PET_SPELL_STATE_SET_ACTION          = 0x07,
+
+    PET_SPELL_STATE_DEFAULT             = 0x81, // castable spell
+    PET_SPELL_STATE_AUTOCAST            = 0xC1, // enabled autocast
+    PET_SPELL_STATE_NOT_SPELL           = 0x04  // react or action
 };
 
 enum PetSlots : uint8_t

--- a/src/world/Objects/Units/Creatures/Summons/SummonHandler.cpp
+++ b/src/world/Objects/Units/Creatures/Summons/SummonHandler.cpp
@@ -38,7 +38,7 @@ void SummonHandler::addSummonToHandler(Summon* summon)
             if (m_pet != nullptr)
             {
                 m_owner->setSummonGuid(m_pet->getGuid());
-                m_pet->SendSpellsToOwner();
+                m_pet->sendSpellsToController(m_owner, m_pet->getTimeLeft());
             }
         }
         return;
@@ -60,7 +60,7 @@ void SummonHandler::addSummonToHandler(Summon* summon)
         case SUMMON_SLOT_MINIPET:
         case SUMMON_SLOT_QUEST:
         {
-            const uint8_t slot = summon->getSummonProperties()->Slot - 1;
+            const uint8_t slot = static_cast<uint8_t>(summon->getSummonProperties()->Slot) - 1;
 
             // Send summon to totem bar
             if (summon->getSummonProperties()->Slot != SUMMON_SLOT_MINIPET)
@@ -100,20 +100,20 @@ void SummonHandler::removeSummonFromHandler(Summon* summon)
             if (!m_summons.empty())
             {
                 Summon* newCurrentPet = nullptr;
-                for (const auto& summon : m_summons)
+                for (const auto& existingSummon : m_summons)
                 {
-                    if (!summon->isPet() || !summon->isAlive())
+                    if (!existingSummon->isPet() || !existingSummon->isAlive())
                         continue;
 
-                    if (summon->isPermanentSummon())
+                    if (existingSummon->isPermanentSummon())
                     {
-                        newCurrentPet = summon;
+                        newCurrentPet = existingSummon;
                         break;
                     }
                     else if (newCurrentPet == nullptr)
                     {
                         // Use possibly this pet but try find permanent pet
-                        newCurrentPet = summon;
+                        newCurrentPet = existingSummon;
                     }
                 }
 
@@ -124,7 +124,7 @@ void SummonHandler::removeSummonFromHandler(Summon* summon)
                     if (m_pet != nullptr)
                     {
                         m_owner->setSummonGuid(m_pet->getGuid());
-                        m_pet->SendSpellsToOwner();
+                        m_pet->sendSpellsToController(m_owner, m_pet->getTimeLeft());
                     }
                 }
             }
@@ -155,7 +155,7 @@ void SummonHandler::removeSummonFromHandler(Summon* summon)
         case SUMMON_SLOT_MINIPET:
         case SUMMON_SLOT_QUEST:
         {
-            const uint8_t slot = summon->getSummonProperties()->Slot - 1;
+            const uint8_t slot = static_cast<uint8_t>(summon->getSummonProperties()->Slot) - 1;
             m_summonSlots[slot] = nullptr;
         } break;
         default:
@@ -267,7 +267,7 @@ void SummonHandler::notifyOnPetDeath(Summon* pet)
             if (m_pet != nullptr)
             {
                 m_owner->setSummonGuid(m_pet->getGuid());
-                m_pet->SendSpellsToOwner();
+                m_pet->sendSpellsToController(m_owner, m_pet->getTimeLeft());
             }
             break;
         }

--- a/src/world/Objects/Units/Creatures/Vehicle.cpp
+++ b/src/world/Objects/Units/Creatures/Vehicle.cpp
@@ -612,18 +612,15 @@ bool Vehicle::tryAddPassenger(Unit* passenger, SeatMap::iterator &Seat)
         getBase()->setCharmedByGuid(passenger->getGuid());
         getBase()->addUnitFlags(UNIT_FLAG_PLAYER_CONTROLLED_CREATURE);
 
-        WorldPacket spells(SMSG_PET_SPELLS, 100);
-        getBase()->buildPetSpellList(spells);
-        passenger->sendPacket(&spells);
+        if (auto* c = getBase()->ToCreature())
+        {
+            // set Correct Faction
+            c->setFaction(passenger->getFactionTemplate());
+
+            c->sendSpellsToController(passenger, 0);
+        }
 
         static_cast<Player*>(passenger)->setMover(getBase());
-
-        // set Correct Faction
-        if (getBase()->isCreature())
-        {
-            Creature* c = static_cast<Creature*>(getBase());
-            c->setFaction(passenger->getFactionTemplate());
-        }
     }
 
     passenger->setTargetGuid(0);

--- a/src/world/Objects/Units/Players/Player.hpp
+++ b/src/world/Objects/Units/Players/Player.hpp
@@ -1926,7 +1926,6 @@ private:
 
 public:
     void buildFlagUpdateForNonGroupSet(uint32_t index, uint32_t flag);
-    void buildPetSpellList(WorldPacket& data) override;
 
     void modifyBonuses(uint32_t type, int32_t val, bool apply);
     void calcExpertise();

--- a/src/world/Objects/Units/Players/PlayerDefines.hpp
+++ b/src/world/Objects/Units/Players/PlayerDefines.hpp
@@ -17,6 +17,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include <unordered_map>
 #include <mutex>
 #include <set>
+#include <unordered_set>
 #include <list>
 #include <memory>
 
@@ -1225,7 +1226,7 @@ private:
     std::array<ActionButton, PLAYER_ACTION_BUTTON_COUNT> mActions = { ActionButton() };
 };
 
-typedef std::set<uint32_t>                                      SpellSet;
+typedef std::unordered_set<uint32_t>                            SpellSet;
 typedef std::list<std::unique_ptr<classScriptOverride>>         ScriptOverrideList;
 typedef std::map<uint32_t, std::shared_ptr<ScriptOverrideList>> SpellOverrideMap;
 typedef std::map<uint32_t, std::unique_ptr<FactionReputation>>  ReputationMap;

--- a/src/world/Objects/Units/Unit.hpp
+++ b/src/world/Objects/Units/Unit.hpp
@@ -72,6 +72,7 @@ namespace MovementMgr
 }
 
 enum MovementGeneratorType : uint8_t;
+enum SpellCastResult : uint8_t;
 
 struct HealthBatchEvent
 {
@@ -163,7 +164,6 @@ public: //\todo Zyres: public fpr LuaEngine, sort out why
     // void OnPreRemoveFromWorld();                                         // not used
     // void OnRemoveFromWorld();                                            // not used
     virtual void die(Unit* pAttacker, uint32_t damage, uint32_t spellid);
-    virtual void buildPetSpellList(WorldPacket& data);
 
 private:
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -733,21 +733,21 @@ public:
     bool canDualWield() const;
     void setDualWield(bool enable);
 
-    void castSpell(uint64_t targetGuid, uint32_t spellId, bool triggered = false);
-    void castSpell(Unit* target, uint32_t spellId, bool triggered = false);
-    void castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, bool triggered = false);
-    void castSpell(Unit* target, SpellInfo const* spellInfo, bool triggered = false);
-    void castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints forcedBasepoints, bool triggered = false);
-    void castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints forcedBasePoints, bool triggered = false);
-    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasePoints, int32_t spellCharges, bool triggered = false);
-    void castSpell(SpellCastTargets targets, uint32_t spellId, bool triggered = false);
-    void castSpell(SpellCastTargets targets, SpellInfo const* spellInfo, bool triggered = false);
-    void castSpellLoc(const LocationVector location, uint32_t spellId, bool triggered = false);
-    void castSpellLoc(const LocationVector location, SpellInfo const* spellInfo, bool triggered = false);
+    SpellCastResult castSpell(uint64_t targetGuid, uint32_t spellId, bool triggered = false);
+    SpellCastResult castSpell(Unit* target, uint32_t spellId, bool triggered = false);
+    SpellCastResult castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, bool triggered = false);
+    SpellCastResult castSpell(Unit* target, SpellInfo const* spellInfo, bool triggered = false);
+    SpellCastResult castSpell(uint64_t targetGuid, uint32_t spellId, SpellForcedBasePoints forcedBasepoints, bool triggered = false);
+    SpellCastResult castSpell(Unit* target, uint32_t spellId, SpellForcedBasePoints forcedBasePoints, bool triggered = false);
+    SpellCastResult castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasePoints, int32_t spellCharges, bool triggered = false);
+    SpellCastResult castSpell(SpellCastTargets targets, uint32_t spellId, bool triggered = false);
+    SpellCastResult castSpell(SpellCastTargets targets, SpellInfo const* spellInfo, bool triggered = false);
+    SpellCastResult castSpellLoc(const LocationVector location, uint32_t spellId, bool triggered = false);
+    SpellCastResult castSpellLoc(const LocationVector location, SpellInfo const* spellInfo, bool triggered = false);
     void eventCastSpell(Unit* target, SpellInfo const* spellInfo);
 
-    void castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
-    void castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
+    SpellCastResult castSpell(uint64_t targetGuid, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
+    SpellCastResult castSpell(Unit* target, SpellInfo const* spellInfo, SpellForcedBasePoints forcedBasepoints, bool triggered);
 
     SpellProc* addProcTriggerSpell(uint32_t spellId, uint32_t originalSpellId, uint64_t casterGuid, uint32_t procChance, SpellProcFlags procFlags, SpellExtraProcFlags exProcFlags, uint32_t const* spellFamilyMask, uint32_t const* procClassMask = nullptr, Aura* createdByAura = nullptr, Object* obj = nullptr);
     // Gets proc chance and proc flags from spellInfo
@@ -809,6 +809,7 @@ public:
     Aura* getAuraWithIdForGuid(uint32_t const* auraId, uint64_t guid) const;
     Aura* getAuraWithIdForGuid(uint32_t spell_id, uint64_t guid) const;
     Aura* getAuraWithAuraEffect(AuraEffect aura_effect) const;
+    Aura* getAuraWithAuraEffectForGuid(AuraEffect aura_effect, uint64_t guid) const;
     Aura* getAuraWithVisualSlot(uint8_t visualSlot) const;
     // Note; this is internal serverside aura slot, not the slot in client
     // For clientside slot use getAuraWithVisualSlot
@@ -825,7 +826,10 @@ public:
 
     bool hasAurasWithId(uint32_t auraId) const;
     bool hasAurasWithId(uint32_t const* auraId) const;
+    bool hasAurasWithIdForGuid(uint32_t auraId, uint64_t guid) const;
+    bool hasAurasWithIdForGuid(uint32_t const* auraId, uint64_t guid) const;
     bool hasAuraWithAuraEffect(AuraEffect type) const;
+    bool hasAuraWithAuraEffectForGuid(AuraEffect type, uint64_t guid) const;
     bool hasAuraWithMechanic(SpellMechanic mechanic) const;
     bool hasAuraWithSpellType(SpellTypes type, uint64_t casterGuid = 0, uint32_t skipSpellId = 0) const;
 

--- a/src/world/Server/Master.cpp
+++ b/src/world/Server/Master.cpp
@@ -69,7 +69,7 @@
 #include "Utilities/Benchmark.hpp"
 
 // DB version
-static const char* REQUIRED_CHAR_DB_VERSION = "20250516-00_characters";
+static const char* REQUIRED_CHAR_DB_VERSION = "20250921-00_playerpets";
 static const char* REQUIRED_WORLD_DB_VERSION = "20250921-01_item_properties_spells";
 
 volatile bool Master::m_stopEvent = false;

--- a/src/world/Server/Packets/CmsgPetAction.h
+++ b/src/world/Server/Packets/CmsgPetAction.h
@@ -8,28 +8,26 @@ This file is released under the MIT license. See README-MIT for more information
 #include <cstdint>
 
 #include "ManagedPacket.h"
+#include "Objects/Units/Creatures/PetDefines.hpp"
 #include "WorldPacket.h"
 
-//\brief: This packet is wrong.
 namespace AscEmu::Packets
 {
     class CmsgPetAction : public ManagedPacket
     {
     public:
         WoWGuid guid;
-        uint16_t misc;
-        uint16_t action;
+        PetActionButtonData buttonData;
         uint64_t targetguid;
 
-        CmsgPetAction() : CmsgPetAction(0, 0, 0, 0)
+        CmsgPetAction() : CmsgPetAction(0, PetActionButtonData{ .raw = 0 }, 0)
         {
         }
 
-        CmsgPetAction(uint64_t guid, uint16_t misc, uint16_t action, uint64_t targetguid) :
+        CmsgPetAction(uint64_t guid, PetActionButtonData buttonData, uint64_t targetguid) :
             ManagedPacket(CMSG_PET_ACTION, 20),
             guid(guid),
-            misc(misc),
-            action(action),
+            buttonData(buttonData),
             targetguid(targetguid)
         {
         }
@@ -43,7 +41,7 @@ namespace AscEmu::Packets
         bool internalDeserialise(WorldPacket& packet) override
         {
             uint64_t unpacked_guid;
-            packet >> unpacked_guid >> misc >> action >> targetguid;
+            packet >> unpacked_guid >> buttonData.raw >> targetguid;
             guid.Init(unpacked_guid);
             return true;
         }

--- a/src/world/Server/Packets/Handlers/NPCHandler.cpp
+++ b/src/world/Server/Packets/Handlers/NPCHandler.cpp
@@ -490,11 +490,14 @@ void WorldSession::sendTrainerList(Creature* creature)
             if (requiredSpellCount >= maxRequiredCount)
                 break;
 
-            const auto requiredSpells = sSpellMgr.getSpellsRequiredForSpellBounds(requiredSpell);
-            for (auto itr = requiredSpells.first; itr != requiredSpells.second && requiredSpellCount <= maxRequiredCount; ++itr)
+            const auto requiredSpells = sSpellMgr.getSpellsRequiredRangeForSpell(requiredSpell);
+            for (const auto& itr : requiredSpells)
             {
-                data << uint32_t(itr->second);
+                data << uint32_t(itr.second);
                 ++requiredSpellCount;
+
+                if (requiredSpellCount > maxRequiredCount)
+                    break;
             }
 
             if (requiredSpellCount >= maxRequiredCount)
@@ -556,10 +559,10 @@ TrainerSpellState WorldSession::trainerGetSpellStatus(TrainerSpell const* traine
         if (!_player->hasSpell(spellId))
             return TRAINER_SPELL_RED;
 
-        const auto spellsRequired = sSpellMgr.getSpellsRequiredForSpellBounds(spellId);
-        for (auto itr = spellsRequired.first; itr != spellsRequired.second; ++itr)
+        const auto spellsRequired = sSpellMgr.getSpellsRequiredRangeForSpell(spellId);
+        for (const auto& itr : spellsRequired)
         {
-            if (!_player->hasSpell(itr->second))
+            if (!_player->hasSpell(itr.second))
                 return TRAINER_SPELL_RED;
         }
     }

--- a/src/world/Server/Packets/Handlers/SpellHandler.cpp
+++ b/src/world/Server/Packets/Handlers/SpellHandler.cpp
@@ -267,7 +267,7 @@ void WorldSession::handlePetCastSpell(WorldPacket& recvPacket)
     if (_player->getPet() == petUnit)
     {
         // Check does the pet have the spell
-        if (!dynamic_cast<Pet*>(petUnit)->HasSpell(srlPacket.spellId))
+        if (!dynamic_cast<Pet*>(petUnit)->hasSpell(srlPacket.spellId))
             return;
     }
     // If pet is charmed or possessed by player

--- a/src/world/Server/Packets/SmsgPetCastFailed.h
+++ b/src/world/Server/Packets/SmsgPetCastFailed.h
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2014-2025 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "ManagedPacket.h"
+#include <cstdint>
+
+namespace AscEmu::Packets
+{
+    class SmsgPetCastFailed : public ManagedPacket
+    {
+    public:
+        uint8_t unk;
+        uint32_t spellId;
+        uint8_t reason;
+
+        SmsgPetCastFailed() : SmsgPetCastFailed(0, 0)
+        {
+        }
+
+        SmsgPetCastFailed(uint32_t spellId, uint8_t reason) :
+            ManagedPacket(SMSG_PET_CAST_FAILED, 0),
+            unk(0),
+            spellId(spellId),
+            reason(reason)
+        {
+        }
+
+    protected:
+        size_t expectedSize() const override { return static_cast<size_t>(1 + 4 + 1); }
+
+        bool internalSerialise(WorldPacket& packet) override
+        {
+            packet << unk << spellId << reason;
+            return true;
+        }
+
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
+    };
+}

--- a/src/world/Server/Packets/SmsgPetSpells.h
+++ b/src/world/Server/Packets/SmsgPetSpells.h
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2014-2025 AscEmu Team <http://www.ascemu.org>
+This file is released under the MIT license. See README-MIT for more information.
+*/
+
+#pragma once
+
+#include "AEVersion.hpp"
+#include "ManagedPacket.h"
+
+#include <cstdint>
+
+namespace AscEmu::Packets
+{
+    static inline constexpr uint8_t MAX_ACTION_SLOT = 10;
+    using SmsgPetSpellsVector = std::vector<uint32_t>;
+    using SmsgPetActionsArray = std::array<uint32_t, MAX_ACTION_SLOT>;
+
+    static inline constexpr uint32_t packPetActionButtonData(uint32_t spellId, uint8_t state)
+    {
+        return (static_cast<uint32_t>(state) << 24) | spellId;
+    }
+
+    class SmsgPetSpells : public ManagedPacket
+    {
+    public:
+        uint64_t guid;
+        uint16_t family;
+        uint32_t expireDuration;
+        uint8_t reactState; // 0x0 = passive, 0x1 = defensive, 0x2 = aggressive
+        uint8_t petAction; // 0x0 = stay, 0x1 = follow, 0x2 = attack
+        uint16_t flags; // flags: 0xFF = disabled pet bar (eg. when pet stunned)
+        SmsgPetActionsArray actions;
+        SmsgPetSpellsVector spells;
+        uint8_t cooldowns;
+
+        bool resetSpells = false;
+
+        SmsgPetSpells() : SmsgPetSpells(0, 0, 0, 0, 0, 0, SmsgPetActionsArray(), SmsgPetSpellsVector())
+        {
+        }
+
+        SmsgPetSpells(uint64_t guid, uint16_t family, uint32_t expireDuration, uint8_t reactState, uint8_t petAction,
+            uint16_t flags, SmsgPetActionsArray&& actions, SmsgPetSpellsVector&& spells) :
+            ManagedPacket(SMSG_PET_SPELLS, 0),
+            guid(guid),
+            family(family),
+            expireDuration(expireDuration),
+            reactState(reactState),
+            petAction(petAction),
+            flags(flags),
+            actions(std::move(actions)),
+            spells(std::move(spells)),
+            cooldowns(0)
+        {
+        }
+
+        // Used with guid 0 to remove spells
+        SmsgPetSpells(uint64_t guid) :
+            ManagedPacket(SMSG_PET_SPELLS, 0),
+            guid(guid),
+            family(0),
+            expireDuration(0),
+            reactState(0),
+            petAction(0),
+            flags(0),
+            actions(SmsgPetActionsArray()),
+            spells(SmsgPetSpellsVector()),
+            cooldowns(0),
+            resetSpells(true)
+        {
+        }
+
+    protected:
+#if VERSION_STRING < WotLK
+        size_t expectedSize() const override { return resetSpells ?
+            8 :
+            static_cast<size_t>(8 + 4 + 1 + 1 + 2 + (4 * MAX_ACTION_SLOT)) + 1 + (4 * spells.size()) + 1; }
+#else
+        size_t expectedSize() const override { return resetSpells ?
+            8 :
+            static_cast<size_t>(8 + 2 + 4 + 1 + 1 + 2 + (4 * MAX_ACTION_SLOT)) + 1 + (4 * spells.size()) + 1; }
+#endif
+
+        bool internalSerialise(WorldPacket& packet) override
+        {
+            if (resetSpells)
+            {
+                packet << guid;
+                return true;
+            }
+
+            packet << guid;
+#if VERSION_STRING >= WotLK
+            packet << family;
+#endif
+            packet << expireDuration << reactState << petAction << flags;
+            // Action bar
+            for (const auto slot : actions)
+                packet << slot;
+
+            // Spell book
+            packet << uint8_t(spells.size());
+            if (!spells.empty())
+            {
+                for (const auto spell : spells)
+                    packet << spell;
+            }
+
+            // TODO: cooldowns
+            packet << cooldowns;
+            return true;
+        }
+
+        bool internalDeserialise(WorldPacket& /*packet*/) override { return false; }
+    };
+}

--- a/src/world/Server/Script/AIUtils.cpp
+++ b/src/world/Server/Script/AIUtils.cpp
@@ -5,8 +5,7 @@ This file is released under the MIT license. See README-MIT for more information
 
 #include "AIUtils.hpp"
 #include "Debugging/Errors.h"
-
-#include <random>
+#include "Utilities/Random.hpp"
 
 std::chrono::milliseconds SchedulerArgs::randtime(std::chrono::milliseconds min, std::chrono::milliseconds max)
 {
@@ -14,8 +13,7 @@ std::chrono::milliseconds SchedulerArgs::randtime(std::chrono::milliseconds min,
     ASSERT(diff >= 0)
     ASSERT(diff <= (uint32_t)-1)
 
-    std::random_device rd;
-    std::mt19937_64 rng(rd());
+    auto& rng = Util::getRandomEngine();
     std::uniform_int_distribution<long long> uni(0, diff);
 
     return min + std::chrono::milliseconds(uni(rng));

--- a/src/world/Server/Script/CreatureAIFunctionScheduler.cpp
+++ b/src/world/Server/Script/CreatureAIFunctionScheduler.cpp
@@ -177,7 +177,7 @@ void CreatureAIFunctionScheduler::update(unsigned long time_passed)
     // Randomize the order of functions
     // Warning when 2 functions have 2 seconds timer the first always would executes before the second one...
     // Randomizing the order could lead to unexpected behaviour when u rely on the order of insertion
-    Util::randomShuffleVector(&mCreatureAIFunctions);
+    Util::randomShuffleVector(mCreatureAIFunctions);
 
     // Delete functions marked for removal
     mCreatureAIFunctions.erase(std::remove_if(mCreatureAIFunctions.begin(), mCreatureAIFunctions.end(), [](const auto& function) {

--- a/src/world/Spell/Spell.Legacy.cpp
+++ b/src/world/Spell/Spell.Legacy.cpp
@@ -1199,7 +1199,7 @@ void Spell::SendInterrupted(uint8_t result)
     Player* plr = p_caster;
     if (plr == nullptr && m_caster->isPet())
     {
-        static_cast<Pet*>(m_caster)->SendCastFailed(getSpellInfo()->getId(), result);
+        static_cast<Pet*>(m_caster)->sendPetCastFailed(getSpellInfo()->getId(), result);
     }
     else
     {

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -2693,9 +2693,9 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
                 if (newSpell == nullptr)
                     return SPELL_FAILED_NOT_KNOWN;
 
-                const auto learnStatus = pet->CanLearnSpell(newSpell);
-                if (learnStatus != 0)
-                    return SpellCastResult(learnStatus);
+                const auto learnStatus = pet->canLearnSpell(newSpell);
+                if (learnStatus != SPELL_CAST_SUCCESS)
+                    return learnStatus;
             } break;
             case SPELL_EFFECT_POWER_BURN:
             case SPELL_EFFECT_POWER_DRAIN:

--- a/src/world/Spell/SpellAuraEffects.cpp
+++ b/src/world/Spell/SpellAuraEffects.cpp
@@ -1602,10 +1602,9 @@ void Aura::spellAuraEffectPeriodicLeech(AuraEffectModifier* aurEff, bool apply)
                         continue;
 
                     auto _continue = false;
-                    const auto spellSkillBounds = sSpellMgr.getSkillEntryForSpellBounds(aura->getSpellId());
-                    for (auto spellSkillItr = spellSkillBounds.first; spellSkillItr != spellSkillBounds.second; ++spellSkillItr)
+                    const auto spellSkillRange = sSpellMgr.getSkillEntryRangeForSpell(aura->getSpellId());
+                    for (const auto& [_, skill_line_ability] : spellSkillRange)
                     {
-                        auto skill_line_ability = spellSkillItr->second;
                         if (skill_line_ability->skilline != SKILL_AFFLICTION)
                         {
                             _continue = true;

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -938,20 +938,7 @@ void Aura::SpellAuraModCharm(AuraEffectModifier* aurEff, bool apply)
 
         if (caster->getSession())   // crashfix
         {
-            WorldPacket data(SMSG_PET_SPELLS, 500);
-            data << target->getGuid();
-            data << uint16_t(0);
-            data << uint32_t(0x1000);
-            data << uint32_t(0x100);
-            data << uint32_t(PET_SPELL_ATTACK);
-            data << uint32_t(PET_SPELL_FOLLOW);
-            data << uint32_t(PET_SPELL_STAY);
-            for (uint8_t i = 0; i < 4; i++)
-                data << uint32_t(0);
-            data << uint32_t(PET_SPELL_AGRESSIVE);
-            data << uint32_t(PET_SPELL_DEFENSIVE);
-            data << uint32_t(PET_SPELL_PASSIVE);
-            caster->getSession()->SendPacket(&data);
+            target->sendSpellsToController(caster, getMaxDuration());
             target->SetEnslaveSpell(m_spellInfo->getId());
         }
     }
@@ -967,9 +954,7 @@ void Aura::SpellAuraModCharm(AuraEffectModifier* aurEff, bool apply)
         if (caster->getSession() != nullptr)   // crashfix
         {
             caster->setCharmGuid(0);
-            WorldPacket data(SMSG_PET_SPELLS, 8);
-            data << uint64_t(0);
-            caster->getSession()->SendPacket(&data);
+            caster->sendEmptyPetSpellList();
             target->SetEnslaveSpell(0);
         }
     }

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -4276,7 +4276,7 @@ void Spell::SpellEffectLearnPetSpell(uint8_t effectIndex)
         if (!pPet->isHunterPet())
             p_caster->addSummonSpell(m_unitTarget->getEntry(), getSpellInfo()->getEffectTriggerSpell(effectIndex));
 
-        pPet->AddSpell(sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(effectIndex)), true);
+        pPet->addSpell(sSpellMgr.getSpellInfo(getSpellInfo()->getEffectTriggerSpell(effectIndex)));
 
         // Send Packet
         /*      WorldPacket data(SMSG_SET_EXTRA_AURA_INFO_OBSOLETE, 22);
@@ -5271,7 +5271,7 @@ void Spell::SpellEffectSummonDeadPet(uint8_t /*effectIndex*/)
         pPet->setHealth(pPet->getMaxHealth() * damage / 100);
         pPet->setDeathState(ALIVE);
         pPet->getAIInterface()->handleEvent(EVENT_FOLLOWOWNER, pPet, 0);
-        pPet->SendSpellsToOwner();
+        pPet->sendSpellsToController(p_caster, pPet->getTimeLeft());
 
         // Restore unit and pvp flags that were resetted on death
         if (p_caster->isPvpFlagSet())

--- a/src/world/Spell/SpellInfo.cpp
+++ b/src/world/Spell/SpellInfo.cpp
@@ -1171,10 +1171,9 @@ bool SpellInfo::canKnowOnlySingleRank() const
 
     const auto isSpellAutoLearnedFromSkill = [](uint32_t spellId) -> bool
     {
-        const auto spellBounds = sSpellMgr.getSkillEntryForSpellBounds(spellId);
-        for (auto spellItr = spellBounds.first; spellItr != spellBounds.second; ++spellItr)
+        const auto spellRange = sSpellMgr.getSkillEntryRangeForSpell(spellId);
+        for (const auto& [_, skillEntry] : spellRange)
         {
-            const auto skillEntry = spellItr->second;
             if (skillEntry->acquireMethod != 1)
                 continue;
             if (skillEntry->minSkillLineRank > 0)

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -271,9 +271,10 @@ SpellMechanic const* SpellMgr::getCrowdControlMechanicList([[maybe_unused]]bool 
     }
 }
 
-SpellRequiredMapBounds SpellMgr::getSpellsRequiredForSpellBounds(uint32_t spellId) const
+SpellRequiredMapRange SpellMgr::getSpellsRequiredRangeForSpell(uint32_t spellId) const
 {
-    return mSpellRequired.equal_range(spellId);
+    const auto [begin, end] = mSpellRequired.equal_range(spellId);
+    return std::ranges::subrange(begin, end);
 }
 
 SpellsRequiringSpellMap SpellMgr::getSpellsRequiringSpell() const
@@ -281,17 +282,18 @@ SpellsRequiringSpellMap SpellMgr::getSpellsRequiringSpell() const
     return mSpellsRequiringSpell;
 }
 
-SpellsRequiringSpellMapBounds SpellMgr::getSpellsRequiringSpellBounds(uint32_t spellId) const
+SpellsRequiringSpellMapRange SpellMgr::getSpellsRequiringSpellRange(uint32_t spellId) const
 {
-    return mSpellsRequiringSpell.equal_range(spellId);
+    const auto [begin, end] = mSpellsRequiringSpell.equal_range(spellId);
+    return std::ranges::subrange(begin, end);
 }
 
 bool SpellMgr::isSpellRequiringSpell(uint32_t spellId, uint32_t requiredSpellId) const
 {
-    auto spellsRequiringSpell = getSpellsRequiringSpellBounds(requiredSpellId);
-    for (auto itr = spellsRequiringSpell.first; itr != spellsRequiringSpell.second; ++itr)
+    auto spellsRequiringSpell = getSpellsRequiringSpellRange(requiredSpellId);
+    for (const auto& itr : spellsRequiringSpell)
     {
-        if (itr->second == spellId)
+        if (itr.second == spellId)
             return true;
     }
 
@@ -318,22 +320,23 @@ void SpellMgr::reloadSpellDisabled()
     loadSpellDisabled();
 }
 
-SpellSkillAbilityMapBounds SpellMgr::getSkillEntryForSpellBounds(uint32_t spellId) const
+SpellSkillAbilityMapRange SpellMgr::getSkillEntryRangeForSpell(uint32_t spellId) const
 {
-    return mSpellSkillsMap.equal_range(spellId);
+    const auto [begin, end] = mSpellSkillsMap.equal_range(spellId);
+    return std::ranges::subrange(begin, end);
 }
 
-SkillSkillAbilityMapBounds SpellMgr::getSkillEntryForSkillBounds(uint16_t skillId) const
+SkillSkillAbilityMapRange SpellMgr::getSkillEntryRangeForSkill(uint16_t skillId) const
 {
-    return mSkillSpellsMap.equal_range(skillId);
+    const auto [begin, end] = mSkillSpellsMap.equal_range(skillId);
+    return std::ranges::subrange(begin, end);
 }
 
 WDB::Structures::SkillLineAbilityEntry const* SpellMgr::getFirstSkillEntryForSpell(uint32_t spellId, Player const* forPlayer/* = nullptr*/) const
 {
-    const auto spellSkillBounds = getSkillEntryForSpellBounds(spellId);
-    for (auto spellSkillItr = spellSkillBounds.first; spellSkillItr != spellSkillBounds.second; ++spellSkillItr)
+    const auto spellSkillRange = getSkillEntryRangeForSpell(spellId);
+    for (const auto& [_, skillEntry] : spellSkillRange)
     {
-        const auto skillEntry = spellSkillItr->second;
         if (forPlayer != nullptr)
         {
             if (skillEntry->race_mask != 0 && !(skillEntry->race_mask & forPlayer->getRaceMask()))

--- a/src/world/Spell/SpellMgr.hpp
+++ b/src/world/Spell/SpellMgr.hpp
@@ -5,15 +5,12 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma once
 
-//#include "Spell.hpp"
-//#include "SpellAura.hpp"
-//#include "SpellInfo.hpp"
-#include "SpellTargetConstraint.hpp"
-//#include "Storage/WDB/WDBStructures.hpp"
 #include "Definitions/SpellMechanics.hpp"
 #include "Objects/Units/Players/PlayerDefines.hpp"
+#include "SpellTargetConstraint.hpp"
 
 #include <memory>
+#include <ranges>
 
 namespace WDB::Structures
 {
@@ -48,10 +45,10 @@ typedef std::multimap<uint32_t, uint32_t> SpellRequiredMap;
 typedef std::multimap<uint32_t, uint32_t> SpellsRequiringSpellMap;
 typedef std::unordered_multimap<uint16_t, WDB::Structures::SkillLineAbilityEntry const*> SkillSkillAbilityMap;
 typedef std::unordered_multimap<uint32_t, WDB::Structures::SkillLineAbilityEntry const*> SpellSkillAbilityMap;
-typedef std::pair<SpellRequiredMap::const_iterator, SpellRequiredMap::const_iterator> SpellRequiredMapBounds;
-typedef std::pair<SpellsRequiringSpellMap::const_iterator, SpellsRequiringSpellMap::const_iterator> SpellsRequiringSpellMapBounds;
-typedef std::pair<SkillSkillAbilityMap::const_iterator, SkillSkillAbilityMap::const_iterator> SkillSkillAbilityMapBounds;
-typedef std::pair<SpellSkillAbilityMap::const_iterator, SpellSkillAbilityMap::const_iterator> SpellSkillAbilityMapBounds;
+using SpellRequiredMapRange = std::ranges::subrange<SpellRequiredMap::const_iterator>;
+using SpellsRequiringSpellMapRange = std::ranges::subrange<SpellsRequiringSpellMap::const_iterator>;
+using SkillSkillAbilityMapRange = std::ranges::subrange<SkillSkillAbilityMap::const_iterator>;
+using SpellSkillAbilityMapRange = std::ranges::subrange<SpellSkillAbilityMap::const_iterator>;
 
 typedef std::map<uint32_t, std::unique_ptr<SpellTargetConstraint>> SpellTargetConstraintMap;
 
@@ -98,9 +95,9 @@ public:
     SpellMechanic const* getCrowdControlMechanicList(bool includeSilence) const;
 
     // Spell required
-    SpellRequiredMapBounds getSpellsRequiredForSpellBounds(uint32_t spellId) const;
+    SpellRequiredMapRange getSpellsRequiredRangeForSpell(uint32_t spellId) const;
     SpellsRequiringSpellMap getSpellsRequiringSpell() const;
-    SpellsRequiringSpellMapBounds getSpellsRequiringSpellBounds(uint32_t spellId) const;
+    SpellsRequiringSpellMapRange getSpellsRequiringSpellRange(uint32_t spellId) const;
     bool isSpellRequiringSpell(uint32_t spellId, uint32_t requiredSpellId) const;
     uint32_t getSpellRequired(uint32_t spellId) const;
 
@@ -109,9 +106,9 @@ public:
 
     // Skills
     // Returns skill ability entries by spell id
-    SpellSkillAbilityMapBounds getSkillEntryForSpellBounds(uint32_t spellId) const;
+    SpellSkillAbilityMapRange getSkillEntryRangeForSpell(uint32_t spellId) const;
     // Returns skill ability entries by skill id
-    SkillSkillAbilityMapBounds getSkillEntryForSkillBounds(uint16_t skillId) const;
+    SkillSkillAbilityMapRange getSkillEntryRangeForSkill(uint16_t skillId) const;
     // Use forPlayer if you want to see if skill ability entry fits for player
     WDB::Structures::SkillLineAbilityEntry const* getFirstSkillEntryForSpell(uint32_t spellId, Player const* forPlayer = nullptr) const;
 

--- a/src/world/Storage/MySQLDataStore.cpp
+++ b/src/world/Storage/MySQLDataStore.cpp
@@ -3552,7 +3552,7 @@ void MySQLDataStore::loadLocalesAchievementReward()
 
 MySQLStructure::LocalesAchievementReward const* MySQLDataStore::getLocalizedAchievementReward(uint32_t entry, uint32_t gender, uint32_t sessionLocale)
 {
-    for (auto localesAchievementReward : _localesAchievementRewardStore)
+    for (const auto& localesAchievementReward : _localesAchievementRewardStore)
     {
         if (localesAchievementReward.entry == entry && localesAchievementReward.languageCode == sessionLocale)
         {


### PR DESCRIPTION
**Description**
Pets: Rewrite pet spell map and pet spell AI logic
Packets: Correct structure in CMSG_PET_ACTION and in CMSG_PET_SET_ACTION
Packets: Serialise SMSG_PET_CAST_FAILED and SMSG_PET_SPELLS
Utils: Improve random number generator
Misc: Fix non pch build
Scripts: Minor addition to Lazy Peon quest script

Fixes https://github.com/AscEmu/AscEmu/issues/1251 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [ ] Classic
- [x] TBC
- [x] WotLK
- [x] Cata
