### PR TITLE
Implement support declined names (with Cyrillic client)

### DIFF
--- a/src/world/Objects/Units/Players/Player.hpp
+++ b/src/world/Objects/Units/Players/Player.hpp
@@ -659,6 +659,8 @@ public:
     utf8_string getName() const;
     void setName(std::string name);
 
+    const DeclinedNamesArray& getDeclinedNames() const;
+
     uint32_t getLoginFlag() const;
     void setLoginFlag(uint32_t flag);
 
@@ -730,6 +732,7 @@ private:
     uint32_t m_classicMaxLevel = 60;
 
     utf8_string m_name;
+    DeclinedNamesArray m_declinedNames;
 
     uint32_t m_loginFlag = LOGIN_NO_FLAG;
 
@@ -1973,6 +1976,9 @@ public:
 
     bool saveReputations(bool newCharacter, QueryBuffer* buf);
     bool saveSkills(bool newCharacter, QueryBuffer* buf);
+
+    void loadDeclinedNames(QueryResult* result);
+    void saveDeclinedNames(DeclinedNamesArray const& declinedNames);
 
     bool m_firstLogin = false;
 

--- a/src/world/Objects/Units/Players/PlayerDefines.hpp
+++ b/src/world/Objects/Units/Players/PlayerDefines.hpp
@@ -38,6 +38,10 @@ class Aura;
 class Group;
 class Field;
 
+static inline constexpr uint8_t MAX_DECLINED_NAMES = 5;
+static inline constexpr uint8_t MAX_DECLINED_NAME_LENGTH = 15;
+using DeclinedNamesArray = std::array<std::string, MAX_DECLINED_NAMES>;
+
 enum PlayerTeam : uint8_t
 {
     TEAM_ALLIANCE = 0,

--- a/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
+++ b/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
@@ -7,6 +7,7 @@ This file is released under the MIT license. See README-MIT for more information
 #include <cstdint>
 
 #include "ManagedPacket.h"
+#include "Objects/Units/Players/PlayerDefines.hpp"
 #include "WorldPacket.h"
 
 namespace AscEmu::Packets
@@ -16,15 +17,17 @@ namespace AscEmu::Packets
     public:
         uint64_t guid;
         std::string name;
+        DeclinedNamesArray declinedNames;
 
-        CmsgSetPlayerDeclinedNames() : CmsgSetPlayerDeclinedNames(0, "")
+        CmsgSetPlayerDeclinedNames() : CmsgSetPlayerDeclinedNames(0, "", DeclinedNamesArray())
         {
         }
 
-        CmsgSetPlayerDeclinedNames(uint64_t guid, std::string name) :
-            ManagedPacket(CMSG_SET_PLAYER_DECLINED_NAMES, 8),
+        CmsgSetPlayerDeclinedNames(uint64_t guid, std::string name, DeclinedNamesArray&& declinedNames) :
+            ManagedPacket(CMSG_SET_PLAYER_DECLINED_NAMES, 8 + 1 + 1 + 1 + 1 + 1 + 1),
             guid(guid),
-            name(name)
+            name(name),
+            declinedNames(std::move(declinedNames))
         {
         }
 
@@ -36,6 +39,8 @@ namespace AscEmu::Packets
         bool internalDeserialise(WorldPacket& packet) override
         {
             packet >> guid >> name;
+            for (uint8_t i = 0; i < MAX_DECLINED_NAMES; ++i)
+                packet >> declinedNames[i];
             return true;
         }
     };

--- a/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
+++ b/src/world/Server/Packets/CmsgSetPlayerDeclinedNames.h
@@ -17,17 +17,16 @@ namespace AscEmu::Packets
     public:
         uint64_t guid;
         std::string name;
-        DeclinedNamesArray declinedNames;
+        std::array<std::string, 5> declinedNames;
 
-        CmsgSetPlayerDeclinedNames() : CmsgSetPlayerDeclinedNames(0, "", DeclinedNamesArray())
+        CmsgSetPlayerDeclinedNames() : CmsgSetPlayerDeclinedNames(0, "")
         {
         }
 
-        CmsgSetPlayerDeclinedNames(uint64_t guid, std::string name, DeclinedNamesArray&& declinedNames) :
-            ManagedPacket(CMSG_SET_PLAYER_DECLINED_NAMES, 8 + 1 + 1 + 1 + 1 + 1 + 1),
+        CmsgSetPlayerDeclinedNames(uint64_t guid, std::string name) :
+            ManagedPacket(CMSG_SET_PLAYER_DECLINED_NAMES, 8),
             guid(guid),
-            name(name),
-            declinedNames(std::move(declinedNames))
+            name(name)
         {
         }
 
@@ -39,9 +38,18 @@ namespace AscEmu::Packets
         bool internalDeserialise(WorldPacket& packet) override
         {
             packet >> guid >> name;
-            for (uint8_t i = 0; i < MAX_DECLINED_NAMES; ++i)
+            for (size_t i = 0; i < declinedNames.size(); i++)
+            {
+                if (packet.rpos() >= packet.size())
+                {
+                    declinedNames[i].clear();
+                    continue;
+                }
+
                 packet >> declinedNames[i];
-            return true;
+            }
+
+        return true;
         }
     };
 }

--- a/src/world/Server/Packets/Handlers/CharacterHandler.cpp
+++ b/src/world/Server/Packets/Handlers/CharacterHandler.cpp
@@ -767,14 +767,16 @@ void WorldSession::handleSetPlayerDeclinedNamesOpcode(WorldPacket& recvPacket)
     for (auto& name : srlPacket.declinedNames)
     {
         if (name.length() > MAX_DECLINED_NAME_LENGTH)
-            name = name.substr(0, MAX_DECLINED_NAME_LENGTH);
+            name.resize(MAX_DECLINED_NAME_LENGTH);
     }
 
-    //\todo check utf8 and cyrillic chars
-    const uint32_t error = 0;     // 0 = success, 1 = error
+    uint8_t result = SmsgSetPlayerDeclinedNamesResult::OK;
+
+    /*if (auto result : srlPacket.declinedNames)
+        result = SmsgSetPlayerDeclinedNamesResult::ERROR_INVALID;*/
 
     GetPlayer()->saveDeclinedNames(srlPacket.declinedNames);
-    SendPacket(SmsgSetPlayerDeclinedNamesResult(error, srlPacket.guid).serialise().get());
+    SendPacket(SmsgSetPlayerDeclinedNamesResult(result).serialise().get());
 }
 
 void WorldSession::characterEnumProc(QueryResult* result)

--- a/src/world/Server/Packets/Handlers/CharacterHandler.cpp
+++ b/src/world/Server/Packets/Handlers/CharacterHandler.cpp
@@ -764,9 +764,16 @@ void WorldSession::handleSetPlayerDeclinedNamesOpcode(WorldPacket& recvPacket)
     if (!srlPacket.deserialise(recvPacket))
         return;
 
+    for (auto& name : srlPacket.declinedNames)
+    {
+        if (name.length() > MAX_DECLINED_NAME_LENGTH)
+            name = name.substr(0, MAX_DECLINED_NAME_LENGTH);
+    }
+
     //\todo check utf8 and cyrillic chars
     const uint32_t error = 0;     // 0 = success, 1 = error
 
+    GetPlayer()->saveDeclinedNames(srlPacket.declinedNames);
     SendPacket(SmsgSetPlayerDeclinedNamesResult(error, srlPacket.guid).serialise().get());
 }
 

--- a/src/world/Server/Packets/SmsgSetPlayerDeclinedNamesResult.h
+++ b/src/world/Server/Packets/SmsgSetPlayerDeclinedNamesResult.h
@@ -14,24 +14,29 @@ namespace AscEmu::Packets
     class SmsgSetPlayerDeclinedNamesResult : public ManagedPacket
     {
     public:
-        uint32_t error;
-        uint64_t guid;
+        uint8_t result;
 
-        SmsgSetPlayerDeclinedNamesResult() : SmsgSetPlayerDeclinedNamesResult(0, 0)
+        enum Result : uint8_t
+        {
+            OK              = 0,
+            ERROR_INVALID   = 1,
+            // ERROR_NOT_FOUND = 2
+        };
+
+        SmsgSetPlayerDeclinedNamesResult() : SmsgSetPlayerDeclinedNamesResult(OK)
         {
         }
 
-        SmsgSetPlayerDeclinedNamesResult(uint32_t error, uint64_t guid) :
-            ManagedPacket(SMSG_SET_PLAYER_DECLINED_NAMES_RESULT, 12),
-            error(error),
-            guid(guid)
+        SmsgSetPlayerDeclinedNamesResult(uint8_t result) :
+            ManagedPacket(SMSG_SET_PLAYER_DECLINED_NAMES_RESULT, 1),
+            result(result)
         {
         }
 
     protected:
         bool internalSerialise(WorldPacket& packet) override
         {
-            packet << error << guid;
+            packet << result;
             return true;
         }
 


### PR DESCRIPTION
what is he [Declension](https://en.wikipedia.org/wiki/Declension). The version for "English nicknames" does not change.
<img width="762" height="450" alt="image" src="https://github.com/user-attachments/assets/61769217-31b4-4816-93e1-9e97c0aa94f4" />

the values ​​are not saved, they are updated every time 

```
CREATE TABLE IF NOT EXISTS `character_declinedname` (
    `guid` INT UNSIGNED NOT NULL,
    `genitive` VARCHAR(15) NOT NULL DEFAULT '',
    `dative` VARCHAR(15) NOT NULL DEFAULT '',
    `accusative` VARCHAR(15) NOT NULL DEFAULT '',
    `instrumental` VARCHAR(15) NOT NULL DEFAULT '',
    `prepositional` VARCHAR(15) NOT NULL DEFAULT '',
    PRIMARY KEY (`guid`),
    CONSTRAINT `fk_declined_char_guid` FOREIGN KEY (`guid`)
        REFERENCES `characters` (`guid`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```


the result should be similar to this

https://github.com/mangos/mangos-svn/commit/4151bdd56857d42d7ea5e6ddfb23897015b3c0f4
https://github.com/mangos/mangos-svn/commit/656aa017c1b3f6a5c46195908998ecd638fe77e6
https://github.com/mangos/mangos-svn/commit/4a2975acaa284684e060ef18012b9a35d2f951eb (conf)

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

version Appled 👌
I thought it could be restored (https://github.com/AscEmu/AscEmu/pull/1259)
