### PR TITLE
Packet: fix SmsgLogoutResponse (Vanilla support)

### DIFF
--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -288,7 +288,6 @@ void WorldSession::handleTutorialReset(WorldPacket& /*recvPacket*/)
 
 void WorldSession::handleLogoutRequestOpcode(WorldPacket& /*recvPacket*/)
 {
-#if VERSION_STRING >= TBC // support classic
     if (!sHookInterface.OnLogoutRequest(_player))
     {
         SendPacket(SmsgLogoutResponse(true).serialise().get());
@@ -329,7 +328,6 @@ void WorldSession::handleLogoutRequestOpcode(WorldPacket& /*recvPacket*/)
     _player->setStandState(STANDSTATE_SIT);
 
     SetLogoutTimer(PLAYER_LOGOUT_DELAY);
-#endif
 }
 
 void WorldSession::handleSetSheathedOpcode(WorldPacket& recvPacket)

--- a/src/world/Server/Packets/SmsgLogoutResponse.h
+++ b/src/world/Server/Packets/SmsgLogoutResponse.h
@@ -17,31 +17,47 @@ namespace AscEmu::Packets
         bool logout_denied;
 
         uint32_t fail_reason;
-        uint8_t unk2;
+        uint8_t result;
 
         SmsgLogoutResponse() : SmsgLogoutResponse(false)
         {
         }
 
+#if VERSION_STRING == Classic
+        SmsgLogoutResponse(uint8_t result) :
+            ManagedPacket(SMSG_LOGOUT_RESPONSE, 1),
+            result(result)
+#else
         SmsgLogoutResponse(bool logout_denied) :
             ManagedPacket(SMSG_LOGOUT_RESPONSE, 5),
             logout_denied(logout_denied),
             fail_reason(0),
-            unk2(0)
+            result(0)
+#endif
         {
         }
 
     protected:
         bool internalSerialise(WorldPacket& packet) override
         {
+#if VERSION_STRING == Classic
+            packet << result;
+            return true;
+#else
             packet << (logout_denied ? uint32_t(1) : uint32_t(0)) << uint8_t(0);
             return true;
+#endif
         }
 
         bool internalDeserialise(WorldPacket& packet) override
         {
-            packet >> fail_reason >> unk2;
+#if VERSION_STRING == Classic
+            packet >> result;
             return true;
+#else
+            packet >> fail_reason >> result;
+            return true;
+#endif
         }
     };
 }


### PR DESCRIPTION
**Description**

This is the second vanilla fix. Updated SmsgLogoutResponse.

**Todo / Checklist**
 - [x] Target is branch develop. 
 - [x] Detailed description about this pull request.
 - [x] Checked AE-Coding standards.

**Tests Performed:** 
  - [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
  - [x] Server startup.
  - [x] Log into world.

**Multiversion Ingame Tests Performed:**
  - [x] Classic
  - [x] Cata

