### PR TITLE
Fixed wrong structur in wow-unit field_bytes_0

### DIFF
--- a/src/world/Data/WoWUnit.hpp
+++ b/src/world/Data/WoWUnit.hpp
@@ -19,6 +19,20 @@ This file is released under the MIT license. See README-MIT for more information
 
 #pragma pack(push, 1)
 
+#if VERSION_STRING == Mop
+union field_bytes_0_union
+{
+    struct parts
+    {
+        uint8_t race;
+        uint8_t unit_class;
+        uint8_t class_spec;
+        uint8_t gender;
+    } s;
+
+    uint32_t raw;
+};
+#else
 union field_bytes_0_union
 {
     struct parts
@@ -28,8 +42,10 @@ union field_bytes_0_union
         uint8_t gender;
         uint8_t power_type;
     } s;
+
     uint32_t raw;
 };
+#endif
 
 union unit_virtual_item_info
 {
@@ -42,6 +58,7 @@ union unit_virtual_item_info
         uint8_t inventory_type;
         uint8_t sheath;
     } fields;
+
     uint64_t raw;
 };
 
@@ -499,6 +516,7 @@ union field_bytes_1_union
         uint8_t stand_state_flag;
         uint8_t animation_flag;
     } s;
+
     uint32_t raw;
 };
 
@@ -511,6 +529,7 @@ union field_bytes_2_union
         uint8_t pet_flag;
         uint8_t shape_shift_form;
     } s;
+
     uint32_t raw;
 };
 

--- a/src/world/Objects/Units/Creatures/Vehicle.cpp
+++ b/src/world/Objects/Units/Creatures/Vehicle.cpp
@@ -9,7 +9,6 @@ This file is released under the MIT license. See README-MIT for more information
 #include "Management/ObjectMgr.hpp"
 #include "Storage/MySQLDataStore.hpp"
 #include "Spell/SpellAura.hpp"
-#include "Spell/Definitions/PowerType.hpp"
 #include "Server/Packets/SmsgControlVehicle.h"
 #include "Server/Script/CreatureAIScript.hpp"
 #include "Movement/MovementManager.h"
@@ -111,18 +110,18 @@ void Vehicle::initMovementFlags()
 void Vehicle::initVehiclePowerTypes()
 {
     // Set Correct Power Type
-    switch (_vehicleInfo->powerType)
+    switch (static_cast<VehiclePower>(_vehicleInfo->powerType))
     {
-        case POWER_TYPE_STEAM:
-        case POWER_TYPE_HEAT:
-        case POWER_TYPE_BLOOD:
-        case POWER_TYPE_OOZE:
-        case POWER_TYPE_WRATH:
+        case VehiclePower::STEAM:
+        case VehiclePower::HEAT:
+        case VehiclePower::BLOOD:
+        case VehiclePower::OOZE:
+        case VehiclePower::WRATH:
             _owner->setPowerType(POWER_TYPE_ENERGY);
             _owner->setMaxPower(POWER_TYPE_ENERGY, 100);
             _owner->setPower(POWER_TYPE_ENERGY, 100);
             break;
-        case POWER_TYPE_PYRITE:
+        case VehiclePower::PYRITE:
             _owner->setPowerType(POWER_TYPE_ENERGY);
             _owner->setMaxPower(POWER_TYPE_ENERGY, 50);
             _owner->setPower(POWER_TYPE_ENERGY, 50);

--- a/src/world/Objects/Units/Creatures/VehicleDefines.hpp
+++ b/src/world/Objects/Units/Creatures/VehicleDefines.hpp
@@ -11,6 +11,55 @@ This file is released under the MIT license. See README-MIT for more information
 #include <unordered_map>
 #include <cstdint>
 
+enum class VehiclePower : uint32_t
+{
+    STEAM               = 61,
+    PYRITE              = 41,
+    HEAT                = 101,
+    OOZE                = 121,
+    BLOOD               = 141,
+    WRATH               = 142,
+#if VERSION_STRING == Mop
+    ARCANE_ENERGY       = 143,
+    LIFE_ENERGY         = 144,
+    SUN_ENERGY          = 145,
+    SWING_VELOCITY      = 146,
+    SHADOWFLAME_ENERGY  = 147,
+    BLUE_POWER          = 148,
+    PURPLE_POWER        = 149,
+    GREEN_POWER         = 150,
+    ORANGE_POWER        = 151,
+    ENERGY_2            = 153,
+    ARCANEENERGY        = 161,
+    WIND_1              = 162,
+    WIND_2              = 163,
+    WIND_3              = 164,
+    FUEL                = 165,
+    SUN_POWER           = 166,
+    TWILIGHT_ENERGY     = 169,
+    VENOM               = 174,
+    ORANGE_2            = 176,
+    CONSUMING_FLAME     = 177,
+    PYROCLASTIC_FRENZY  = 178,
+    FLASHFIRE           = 179,
+    FEL_ENERGY          = 181,
+    BACK_HEAT           = 183,
+    JADE_POWER          = 187,
+    COBALT_POWER        = 188,
+    JASPER_POWER        = 189,
+    AMETHYST_POWER      = 190,
+    ARCANE_ENERGY_2     = 191,
+    RED_POWER           = 192,
+    RED_2               = 196,
+    WILLPOWER           = 198,
+    DARK_POWER          = 199,
+    GOLD_POWER          = 200,
+    RESONANCE           = 201,
+    SHA_ENERGY          = 203,
+    FOOD                = 206
+#endif
+};
+
 enum VehicleStatus
 {
     STATUS_NONE                     = 0,
@@ -60,8 +109,9 @@ struct PassengerInfo
 struct VehicleSeatAddon
 {
     VehicleSeatAddon() = default;
-    VehicleSeatAddon(float orientatonOffset, LocationVector exitLv, uint8_t param) :
-        seatOrientationOffset(orientatonOffset), exitLocation(exitLv), exitParameter(VehicleExitParameters(param)) { }
+
+    VehicleSeatAddon(float orientationOffset, LocationVector exitLv, uint8_t param) :
+        seatOrientationOffset(orientationOffset), exitLocation(exitLv), exitParameter(static_cast<VehicleExitParameters>(param)) { }
 
     float seatOrientationOffset = 0.f;
     LocationVector exitLocation = { 0.f, 0.f, 0.f, 0.f };
@@ -98,6 +148,7 @@ struct VehicleAccessory
 {
     VehicleAccessory(uint32_t entry, int8_t seatId, bool isMinion, uint8_t summonType, uint32_t summonTime) :
         accessoryEntry(entry), isMinion(isMinion), summonTime(summonTime), seatId(seatId), summonedType(summonType) { }
+
     uint32_t accessoryEntry;
     bool isMinion;
     uint32_t summonTime;

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -480,6 +480,25 @@ void Unit::setClass(uint8_t class_) { write(unitData()->field_bytes_0.s.unit_cla
 uint8_t Unit::getGender() const { return unitData()->field_bytes_0.s.gender; }
 void Unit::setGender(uint8_t gender) { write(unitData()->field_bytes_0.s.gender, gender); }
 
+#if VERSION_STRING == Mop
+PowerType Unit::getPowerType() const { return static_cast<PowerType>(unitData()->display_power); }
+void Unit::setPowerType(uint8_t powerType)
+{
+    write(static_cast<uint8_t>(unitData()->display_power), powerType); // TODO: Check if this works correctly, might need to be changed to write(unitData()->display_power, powerType) instead
+
+#if VERSION_STRING == TBC
+    // TODO Fix this later
+    return;
+#endif
+
+    // Update power type also to group
+    const auto plr = getPlayerOwnerOrSelf();
+    if (plr == nullptr || !plr->IsInWorld() || plr->getGroup() == nullptr)
+        return;
+
+    plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_POWER_TYPE : GROUP_UPDATE_FLAG_PET_POWER_TYPE);
+}
+#else
 PowerType Unit::getPowerType() const { return static_cast<PowerType>(unitData()->field_bytes_0.s.power_type); }
 void Unit::setPowerType(uint8_t powerType)
 {
@@ -497,6 +516,7 @@ void Unit::setPowerType(uint8_t powerType)
 
     plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_POWER_TYPE : GROUP_UPDATE_FLAG_PET_POWER_TYPE);
 }
+#endif
 //bytes_0 end
 
 uint32_t Unit::getHealth() const { return unitData()->health; }

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -484,12 +484,7 @@ void Unit::setGender(uint8_t gender) { write(unitData()->field_bytes_0.s.gender,
 PowerType Unit::getPowerType() const { return static_cast<PowerType>(unitData()->display_power); }
 void Unit::setPowerType(uint8_t powerType)
 {
-    write(static_cast<uint8_t>(unitData()->display_power), powerType); // TODO: Check if this works correctly, might need to be changed to write(unitData()->display_power, powerType) instead
-
-#if VERSION_STRING == TBC
-    // TODO Fix this later
-    return;
-#endif
+    write(unitData()->display_power, static_cast<uint32_t>(powerType));
 
     // Update power type also to group
     const auto plr = getPlayerOwnerOrSelf();

--- a/src/world/Spell/Definitions/PowerType.hpp
+++ b/src/world/Spell/Definitions/PowerType.hpp
@@ -16,6 +16,8 @@ enum PowerType : int16_t
     POWER_TYPE_ENERGY           = 3,
 #if VERSION_STRING < Cata
     POWER_TYPE_HAPPINESS        = 4,
+#elif VERSION_STRING == Mop
+    POWER_TYPE_HAPPINESS        = 4,
 #else
     POWER_TYPE_UNK4             = 4,
 #endif
@@ -34,13 +36,7 @@ enum PowerType : int16_t
     POWER_TYPE_SHADOW_ORBS      = 13,
     POWER_TYPE_BURNING_EMBERS   = 14,
     POWER_TYPE_DEMONIC_FURY     = 15,
+    POWER_TYPE_ARCANE_CHARGES   = 16,
 #endif
-    TOTAL_PLAYER_POWER_TYPES,
-    // Vehicle power types
-    POWER_TYPE_STEAM            = 61,
-    POWER_TYPE_PYRITE           = 41,
-    POWER_TYPE_HEAT             = 101,
-    POWER_TYPE_OOZE             = 121,
-    POWER_TYPE_BLOOD            = 141,
-    POWER_TYPE_WRATH            = 142
+    TOTAL_PLAYER_POWER_TYPES
 };

--- a/src/world/Spell/Definitions/PowerType.hpp
+++ b/src/world/Spell/Definitions/PowerType.hpp
@@ -17,7 +17,7 @@ enum PowerType : int16_t
 #if VERSION_STRING < Cata
     POWER_TYPE_HAPPINESS        = 4,
 #elif VERSION_STRING == Mop
-    POWER_TYPE_HAPPINESS        = 4,
+    POWER_TYPE_LIGHT_FORCE      = 4, // MoP: A part of the Force that should be used by monks (removed in MoP Beta)
 #else
     POWER_TYPE_UNK4             = 4,
 #endif
@@ -32,11 +32,12 @@ enum PowerType : int16_t
     POWER_TYPE_ALTERNATIVE      = 10, // Every player class has this, used in quests
 #endif
 #if VERSION_STRING >= Mop
-    POWER_TYPE_CHI              = 12,
-    POWER_TYPE_SHADOW_ORBS      = 13,
-    POWER_TYPE_BURNING_EMBERS   = 14,
-    POWER_TYPE_DEMONIC_FURY     = 15,
-    POWER_TYPE_ARCANE_CHARGES   = 16,
+    POWER_TYPE_DARK_FORCE       = 11, // MoP: A part of the Force that should be used by monks (removed in MoP Beta)
+    POWER_TYPE_CHI              = 12, // MoP: Used by monks
+    POWER_TYPE_SHADOW_ORBS      = 13, // MoP: Used by shadow priests
+    POWER_TYPE_BURNING_EMBERS   = 14, // MoP: Used by destruction warlocks
+    POWER_TYPE_DEMONIC_FURY     = 15, // MoP: Used by demonology warlocks
+    POWER_TYPE_ARCANE_CHARGES   = 16, // MoP: Used by arcane mages
 #endif
     TOTAL_PLAYER_POWER_TYPES
 };


### PR DESCRIPTION
**Description**
- Wrong gender position causes visuals bugs in other playerfaces
- power_type is in wow-uni display_power
- Move vehicle powertypes to own enum
- Add missing vehicle powertypes

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

<!--
**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [] WotLK
- [] Cata
- [x] MoP
-->
