### PR TITLE
Fix W4 warnings in Classic and TBC + Activate W4 Flag (MSVC)

### DIFF
--- a/cmake/Compilers/msvc.cmake
+++ b/cmake/Compilers/msvc.cmake
@@ -45,7 +45,7 @@ endif ()
 # dll warning 4251 disabled by default.
 if (BUILD_WITH_WARNINGS)
     add_compile_options(
-	/W3
+	/W4
 	/external:anglebrackets
 	/external:W3
 	/wd4251 # Suppress DLL-interface warning

--- a/src/scripts/LuaEngine/LuaGlobalFunctions.cpp
+++ b/src/scripts/LuaEngine/LuaGlobalFunctions.cpp
@@ -138,7 +138,7 @@ int LuaGlobalFunctions::logcol(lua_State* L)
     return 0;
 }
 
-int LuaGlobalFunctions::WorldDBQuery(lua_State* /*L*/)
+int LuaGlobalFunctions::WorldDBQuery(lua_State* L)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -153,7 +153,7 @@ int LuaGlobalFunctions::WorldDBQuery(lua_State* /*L*/)
     return 1;
 }
 
-int LuaGlobalFunctions::CharDBQuery(lua_State* /*L*/)
+int LuaGlobalFunctions::CharDBQuery(lua_State* L)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -168,7 +168,7 @@ int LuaGlobalFunctions::CharDBQuery(lua_State* /*L*/)
     return 1;
 }
 
-int LuaGlobalFunctions::WorldDBQueryTable(lua_State* /*L*/)
+int LuaGlobalFunctions::WorldDBQueryTable(lua_State* L)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -183,7 +183,7 @@ int LuaGlobalFunctions::WorldDBQueryTable(lua_State* /*L*/)
     return 1;
 }
 
-int LuaGlobalFunctions::CharDBQueryTable(lua_State* /*L*/)
+int LuaGlobalFunctions::CharDBQueryTable(lua_State* L)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)

--- a/src/scripts/LuaEngine/LuaGlobalFunctions.cpp
+++ b/src/scripts/LuaEngine/LuaGlobalFunctions.cpp
@@ -138,7 +138,7 @@ int LuaGlobalFunctions::logcol(lua_State* L)
     return 0;
 }
 
-int LuaGlobalFunctions::WorldDBQuery(lua_State* L)
+int LuaGlobalFunctions::WorldDBQuery(lua_State* /*L*/)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -153,7 +153,7 @@ int LuaGlobalFunctions::WorldDBQuery(lua_State* L)
     return 1;
 }
 
-int LuaGlobalFunctions::CharDBQuery(lua_State* L)
+int LuaGlobalFunctions::CharDBQuery(lua_State* /*L*/)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -168,7 +168,7 @@ int LuaGlobalFunctions::CharDBQuery(lua_State* L)
     return 1;
 }
 
-int LuaGlobalFunctions::WorldDBQueryTable(lua_State* L)
+int LuaGlobalFunctions::WorldDBQueryTable(lua_State* /*L*/)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)
@@ -183,7 +183,7 @@ int LuaGlobalFunctions::WorldDBQueryTable(lua_State* L)
     return 1;
 }
 
-int LuaGlobalFunctions::CharDBQueryTable(lua_State* L)
+int LuaGlobalFunctions::CharDBQueryTable(lua_State* /*L*/)
 {
     const char* qStr = luaL_checkstring(L, 1);
     if (qStr == nullptr)

--- a/src/scripts/LuaEngine/LuaUnit.cpp
+++ b/src/scripts/LuaEngine/LuaUnit.cpp
@@ -5820,8 +5820,8 @@ int LuaUnit::GetTalentPoints(lua_State* L, Unit* ptr)
         return 0;
     }
 
-    const uint32_t spec = static_cast<uint32_t>(luaL_checkinteger(L, 1)); //0 or 1
 #ifdef FT_DUAL_SPEC
+    const uint32_t spec = static_cast<uint32_t>(luaL_checkinteger(L, 1)); //0 or 1
     PlayerSpec plrSpec = dynamic_cast<Player*>(ptr)->m_specs[spec];
 #else
     PlayerSpec plrSpec = static_cast<Player*>(ptr)->m_spec;
@@ -5896,7 +5896,7 @@ int LuaUnit::GetGuildMembers(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::AddAchievement(lua_State* L, Unit* ptr)
+int LuaUnit::AddAchievement([[maybe_unused]] lua_State* L, Unit* ptr)
 {
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isPlayer())
     {
@@ -5914,7 +5914,7 @@ int LuaUnit::AddAchievement(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::RemoveAchievement(lua_State* L, Unit* ptr)
+int LuaUnit::RemoveAchievement([[maybe_unused]] lua_State* L, Unit* ptr)
 {
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isPlayer())
     {
@@ -5928,7 +5928,7 @@ int LuaUnit::RemoveAchievement(lua_State* L, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::HasAchievement(lua_State* L, Unit* ptr)
+int LuaUnit::HasAchievement([[maybe_unused]] lua_State* L, Unit* ptr)
 {
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isPlayer())
     {
@@ -6441,7 +6441,7 @@ int LuaUnit::GetQuestObjectiveCompletion(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::IsOnVehicle(lua_State* L, Unit* ptr)
+int LuaUnit::IsOnVehicle([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6457,7 +6457,7 @@ int LuaUnit::IsOnVehicle(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::SpawnAndEnterVehicle(lua_State* L, Unit* ptr)
+int LuaUnit::SpawnAndEnterVehicle([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6505,7 +6505,7 @@ int LuaUnit::SpawnAndEnterVehicle(lua_State* L, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::DismissVehicle(lua_State* /*L*/, Unit* ptr)
+int LuaUnit::DismissVehicle(lua_State* /*L*/, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6539,7 +6539,7 @@ int LuaUnit::DismissVehicle(lua_State* /*L*/, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::AddVehiclePassenger(lua_State* L, Unit* ptr)
+int LuaUnit::AddVehiclePassenger([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6580,7 +6580,7 @@ int LuaUnit::AddVehiclePassenger(lua_State* L, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::HasEmptyVehicleSeat(lua_State* L, Unit* ptr)
+int LuaUnit::HasEmptyVehicleSeat([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6607,7 +6607,7 @@ int LuaUnit::HasEmptyVehicleSeat(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::EnterVehicle(lua_State* L, Unit* ptr)
+int LuaUnit::EnterVehicle([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6627,7 +6627,7 @@ int LuaUnit::EnterVehicle(lua_State* L, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::ExitVehicle(lua_State* /*L*/, Unit* ptr)
+int LuaUnit::ExitVehicle(lua_State* /*L*/, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6648,7 +6648,7 @@ int LuaUnit::ExitVehicle(lua_State* /*L*/, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::GetVehicleBase(lua_State* L, Unit* ptr)
+int LuaUnit::GetVehicleBase([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6666,7 +6666,7 @@ int LuaUnit::GetVehicleBase(lua_State* L, Unit* ptr)
     return 1;
 }
 
-int LuaUnit::EjectAllVehiclePassengers(lua_State* /*L*/, Unit* ptr)
+int LuaUnit::EjectAllVehiclePassengers(lua_State* /*L*/, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6683,7 +6683,7 @@ int LuaUnit::EjectAllVehiclePassengers(lua_State* /*L*/, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::EjectVehiclePassengerFromSeat(lua_State* L, Unit* ptr)
+int LuaUnit::EjectVehiclePassengerFromSeat([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())
@@ -6709,7 +6709,7 @@ int LuaUnit::EjectVehiclePassengerFromSeat(lua_State* L, Unit* ptr)
     return 0;
 }
 
-int LuaUnit::MoveVehiclePassengerToSeat(lua_State* L, Unit* ptr)
+int LuaUnit::MoveVehiclePassengerToSeat([[maybe_unused]] lua_State* L, [[maybe_unused]] Unit* ptr)
 {
 #ifdef FT_VEHICLES
     if (ptr == nullptr || !ptr->IsInWorld() || !ptr->isCreatureOrPlayer())

--- a/src/scripts/MiscScripts/GameObjectTeleportTable.cpp
+++ b/src/scripts/MiscScripts/GameObjectTeleportTable.cpp
@@ -46,7 +46,7 @@ public:
             GameobjectTeleport* gt = itr->second;
             uint32_t required_level = gt->req_level;
             uint8_t req_class = gt->req_class;
-            uint32_t req_achievement = gt->req_achievement;
+            [[maybe_unused]] uint32_t req_achievement = gt->req_achievement;
 
             if (required_level > pPlayer->getLevel())
             {
@@ -78,6 +78,7 @@ public:
             }
         }
     }
+
     static GameObjectAIScript* Create(GameObject* GO) { return new CustomTeleport(GO); }
 };
 

--- a/src/scripts/QuestScripts/Quest_Dragonblight.cpp
+++ b/src/scripts/QuestScripts/Quest_Dragonblight.cpp
@@ -61,7 +61,7 @@ public:
 class WrathGateQuestCinema : public QuestScript
 {
 public:
-    void OnQuestComplete(Player* mTarget, QuestLogEntry* /*qLogEntry*/) override
+    void OnQuestComplete([[maybe_unused]] Player* mTarget, QuestLogEntry* /*qLogEntry*/) override
     {
 #if VERSION_STRING > TBC
         // send packet for movie

--- a/src/scripts/SpellHandlers/Scripts/Mage.cpp
+++ b/src/scripts/SpellHandlers/Scripts/Mage.cpp
@@ -151,7 +151,7 @@ public:
 class Impact : public SpellScript
 {
 public:
-    void onCreateSpellProc(SpellProc* proc, Object* /*obj*/) override
+    void onCreateSpellProc([[maybe_unused]] SpellProc* proc, Object* /*obj*/) override
     {
         // TODO: classic and tbc masks
 #if VERSION_STRING >= WotLK

--- a/src/tools/ToolsCataMop/map_extractor/System.cpp
+++ b/src/tools/ToolsCataMop/map_extractor/System.cpp
@@ -421,7 +421,7 @@ void ReadLiquidMaterialTable()
     for (uint32_t x = 0; x < dbc.getRecordCount(); ++x)
     {
         LiquidMaterialEntry& liquidType = LiquidMaterials[dbc.getRecord(x).getUInt(0)];
-        liquidType.LVF = dbc.getRecord(x).getUInt(1);
+        liquidType.LVF = static_cast<int8_t>(dbc.getRecord(x).getUInt(1));
     }
 
     printf("Done! (" SZFMTD " LiquidMaterials loaded)\n", LiquidMaterials.size());
@@ -448,7 +448,7 @@ void ReadLiquidObjectTable()
     for (uint32_t x = 0; x < dbc.getRecordCount(); ++x)
     {
         LiquidObjectEntry& liquidType = LiquidObjects[dbc.getRecord(x).getUInt(0)];
-        liquidType.LiquidTypeID = dbc.getRecord(x).getUInt(3);
+        liquidType.LiquidTypeID = static_cast<uint16_t>(dbc.getRecord(x).getUInt(3));
     }
 
     printf("Done! (" SZFMTD " LiquidObjects loaded)\n", LiquidObjects.size());
@@ -474,8 +474,8 @@ void ReadLiquidTypeTable()
     for (uint32_t x = 0; x < dbc.getRecordCount(); ++x)
     {
         LiquidTypeEntry& liquidType = LiquidTypes[dbc.getRecord(x).getUInt(0)];
-        liquidType.SoundBank = dbc.getRecord(x).getUInt(3);
-        liquidType.MaterialID = dbc.getRecord(x).getUInt(14);
+        liquidType.SoundBank = static_cast<uint8_t>(dbc.getRecord(x).getUInt(3));
+        liquidType.MaterialID = static_cast<uint8_t>(dbc.getRecord(x).getUInt(14));
     }
 
     SFileCloseFile(dbcFile);
@@ -640,7 +640,7 @@ bool ConvertADT(std::string const& inputPath, std::string const& outputPath, int
         }
 
         // Area data
-        area_ids[mcnk->iy][mcnk->ix] = mcnk->areaid;
+        area_ids[mcnk->iy][mcnk->ix] = static_cast<uint16_t>(mcnk->areaid);
 
         // Height
         // Height values for triangles stored in order:
@@ -762,7 +762,7 @@ bool ConvertADT(std::string const& inputPath, std::string const& outputPath, int
         }
 
         // Hole data
-        holes[mcnk->iy][mcnk->ix] = mcnk->holes;
+        holes[mcnk->iy][mcnk->ix] = static_cast<uint16_t>(mcnk->holes);
         if (!hasHoles && mcnk->holes != 0)
             hasHoles = true;
     }
@@ -1039,10 +1039,10 @@ bool ConvertADT(std::string const& inputPath, std::string const& outputPath, int
         liquidHeader.fourcc = *reinterpret_cast<uint32_t const*>(MAP_LIQUID_MAGIC);
         liquidHeader.flags = 0;
         liquidHeader.liquidType = 0;
-        liquidHeader.offsetX = minX;
-        liquidHeader.offsetY = minY;
-        liquidHeader.width = maxX - minX + 1 + 1;
-        liquidHeader.height = maxY - minY + 1 + 1;
+        liquidHeader.offsetX = static_cast<uint8_t>(minX);
+        liquidHeader.offsetY = static_cast<uint8_t>(minY);
+        liquidHeader.width = static_cast<uint8_t>(maxX - minX + 1 + 1);
+        liquidHeader.height = static_cast<uint8_t>(maxY - minY + 1 + 1);
         liquidHeader.liquidLevel = minHeight;
 
         if (maxHeight == minHeight)
@@ -1395,22 +1395,22 @@ void ExtractCameraFiles()
     for (std::string thisFile : camerafiles)
     {
         std::string filename = path;
-        HANDLE dbcFile = nullptr;
+        HANDLE fileHandle = nullptr;
         filename += (thisFile.c_str() + strlen("Cameras\\"));
 
         if (FileExists(filename.c_str()))
             continue;
 
-        if (!SFileOpenFileEx(WorldMpq, thisFile.c_str(), SFILE_OPEN_FROM_MPQ, &dbcFile))
+        if (!SFileOpenFileEx(WorldMpq, thisFile.c_str(), SFILE_OPEN_FROM_MPQ, &fileHandle))
         {
             printf("Unable to open file %s in the archive\n", thisFile.c_str());
             continue;
         }
 
-        if (ExtractFile(dbcFile, filename.c_str()))
+        if (ExtractFile(fileHandle, filename.c_str()))
             ++count;
 
-        SFileCloseFile(dbcFile);
+        SFileCloseFile(fileHandle);
     }
     printf("Extracted %u camera files\n", count);
 }

--- a/src/tools/ToolsCataMop/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/ToolsCataMop/mmaps_generator/TerrainBuilder.cpp
@@ -766,12 +766,13 @@ namespace MMAP
                                     }
 
                                     uint32_t liqOffset = meshData.liquidVerts.size() / 3;
-                                    for (uint32_t i = 0; i < liqVerts.size(); ++i)
-                                        meshData.liquidVerts.append(liqVerts[i].y, liqVerts[i].z, liqVerts[i].x);
 
-                                    for (uint32_t i = 0; i < liqTris.size() / 3; ++i)
+                                    for (uint32_t j = 0; j < liqVerts.size(); ++j)
+                                        meshData.liquidVerts.append(liqVerts[j].y, liqVerts[j].z, liqVerts[j].x);
+
+                                    for (uint32_t j = 0; j < liqTris.size() / 3; ++j)
                                     {
-                                        meshData.liquidTris.append(liqTris[i*3+1] + liqOffset, liqTris[i*3+2] + liqOffset, liqTris[i*3] + liqOffset);
+                                        meshData.liquidTris.append(liqTris[j*3+1] + liqOffset, liqTris[j*3+2] + liqOffset, liqTris[j*3] + liqOffset);
                                         meshData.liquidType.append(type);
                                     }
                     }

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/model.cpp
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/model.cpp
@@ -178,15 +178,15 @@ ModelInstance::ModelInstance(MPQFile& f, char const* ModelInstName, uint32_t map
         return;
 
     uint16_t adtId = 0;// not used for models
-    uint32_t flags = MOD_M2;
+    uint32_t instanceFlags = MOD_M2;
     if (tileX == 65 && tileY == 65)
-        flags |= MOD_WORLDSPAWN;
+        instanceFlags |= MOD_WORLDSPAWN;
 
     //write mapID, tileX, tileY, Flags, ID, Pos, Rot, Scale, name
     fwrite(&mapID, sizeof(uint32_t), 1, pDirfile);
     fwrite(&tileX, sizeof(uint32_t), 1, pDirfile);
     fwrite(&tileY, sizeof(uint32_t), 1, pDirfile);
-    fwrite(&flags, sizeof(uint32_t), 1, pDirfile);
+    fwrite(&instanceFlags, sizeof(uint32_t), 1, pDirfile);
     fwrite(&adtId, sizeof(uint16_t), 1, pDirfile);
     fwrite(&id, sizeof(uint32_t), 1, pDirfile);
     fwrite(&pos, sizeof(float), 3, pDirfile);

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -272,9 +272,10 @@ bool FileExists(const char* file)
 
 void strToLower(char* str)
 {
-    while(*str)
+    while (*str)
     {
-        *str=tolower(*str);
+        // Cast input to unsigned char for safety, and the int result back to char
+        *str = static_cast<char>(std::tolower(static_cast<unsigned char>(*str)));
         ++str;
     }
 }
@@ -341,7 +342,7 @@ void ReadLiquidTypeTableDBC()
     memset(LiqType, 0xff, (LiqType_maxid + 1) * sizeof(uint16_t));
 
     for (size_t x = 0; x < LiqType_count; ++x)
-        LiqType[dbc.getRecord(x).getUInt(0)] = dbc.getRecord(x).getUInt(3);
+        LiqType[dbc.getRecord(x).getUInt(0)] = static_cast<uint16_t>(dbc.getRecord(x).getUInt(3));
 
     printf("Done! (%zu LiqTypes loaded)\n", LiqType_count);
 #endif

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/vmapexport.cpp
@@ -299,7 +299,7 @@ void ReadLiquidTypeTableDBC()
     memset(LiqType, 0xff, (LiqType_maxid + 1) * sizeof(uint16_t));
 
     for(uint32_t x = 0; x < LiqType_count; ++x)
-        LiqType[dbc.getRecord(x).getUInt(0)] = dbc.getRecord(x).getUInt(3);
+        LiqType[dbc.getRecord(x).getUInt(0)] = static_cast<uint16_t>(dbc.getRecord(x).getUInt(3));
 
     printf("Done! (%u LiqTypes loaded)\n", (unsigned int)LiqType_count);
 #else

--- a/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/ToolsCataMop/vmap_tools/vmap4_extractor/wmo.cpp
@@ -380,7 +380,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         for (int i = 0; i<3 * nColTriangles; ++i)
         {
             assert(MoviEx[i] < nVertices);
-            MoviEx[i] = IndexRenum[MoviEx[i]];
+            MoviEx[i] = static_cast<uint16_t>(IndexRenum[MoviEx[i]]);
         }
 
         // write triangle indices
@@ -457,7 +457,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
             }
         }
 
-        hlq->type = liquidEntry;
+        hlq->type = static_cast<short>(liquidEntry);
 
         /* std::ofstream llog("Buildings/liquid.log", ios_base::out | ios_base::app);
         llog << filename;

--- a/src/world/Chat/Commands/CharacterCommands.cpp
+++ b/src/world/Chat/Commands/CharacterCommands.cpp
@@ -1292,7 +1292,6 @@ bool ChatCommandHandler::HandleCharSetGenderCommand(const char* args, WorldSessi
     if (player_target == nullptr)
         return true;
 
-    uint32_t displayId = player_target->getNativeDisplayId();
     uint8_t gender;
     if (*args == 0)
     {
@@ -1300,9 +1299,8 @@ bool ChatCommandHandler::HandleCharSetGenderCommand(const char* args, WorldSessi
     }
     else
     {
-        gender = (uint8_t)atoi(args);
-        if (gender > 1)
-            gender = 1;
+        gender = static_cast<uint8_t>(atoi(args));
+        gender = std::min<uint8_t>(gender, 1);
     }
 
     if (gender == player_target->getGender())
@@ -1315,6 +1313,8 @@ bool ChatCommandHandler::HandleCharSetGenderCommand(const char* args, WorldSessi
     systemMessage(m_session, "Set {}'s gender to {}({}).", player_target->getName(), gender ? "Female" : "Male", gender);
 
 #if VERSION_STRING > Classic
+    uint32_t displayId = player_target->getNativeDisplayId();
+
     if (player_target->getGender() == 0)
     {
         player_target->setDisplayId((player_target->getRace() == RACE_BLOODELF) ? ++displayId : --displayId);
@@ -1650,7 +1650,7 @@ bool ChatCommandHandler::HandleCharSetTalentpointsCommand(const char* args, Worl
 }
 
 //.character set title
-bool ChatCommandHandler::HandleCharSetTitleCommand(const char* args, WorldSession* m_session)
+bool ChatCommandHandler::HandleCharSetTitleCommand([[maybe_unused]] const char* args, WorldSession* m_session)
 {
 #if VERSION_STRING > Classic
     auto player_target = GetSelectedPlayer(m_session, true, true);

--- a/src/world/Chat/Commands/GameMasterCommands.cpp
+++ b/src/world/Chat/Commands/GameMasterCommands.cpp
@@ -117,12 +117,11 @@ bool ChatCommandHandler::HandleGMBlockWhispersCommand(const char* args, WorldSes
 }
 
 //.gm devtag
-bool ChatCommandHandler::HandleGMDevTagCommand(const char* args, WorldSession* m_session)
+bool ChatCommandHandler::HandleGMDevTagCommand([[maybe_unused]] const char* args, [[maybe_unused]] WorldSession* m_session)
 {
+#if VERSION_STRING >= WotLK
     auto player = m_session->GetPlayer();
     bool toggle_no_notice = std::string(args) == "no_notice" ? true : false;
-
-#if VERSION_STRING >= WotLK
     if (player->hasPlayerFlags(PLAYER_FLAG_DEVELOPER))
     {
         if (!toggle_no_notice)

--- a/src/world/Management/ArenaTeam.cpp
+++ b/src/world/Management/ArenaTeam.cpp
@@ -299,10 +299,11 @@ void ArenaTeam::setLeader(CachedCharacterInfo const* cachedCharInfo)
 
         sendPacket(SmsgMessageChat(SystemMessagePacket(buffer)).serialise().get());
 
-        const uint32_t old_leader = m_leader;
         m_leader = cachedCharInfo->guid;
 
 #if VERSION_STRING != Classic
+        const uint32_t old_leader = m_leader;
+
         for (uint32_t i = 0; i < m_memberCount; ++i)
         {
             if (m_members[i].Info)

--- a/src/world/Management/Battleground/BattlegroundMgr.cpp
+++ b/src/world/Management/Battleground/BattlegroundMgr.cpp
@@ -71,9 +71,8 @@ void BattlegroundManager::registerMapForBgType(uint32_t type, uint32_t map)
 }
 
 #if VERSION_STRING <= WotLK
-void BattlegroundManager::handleBattlegroundListPacket(WorldSession* session, uint32_t battlegroundType, uint8_t from)
+void BattlegroundManager::handleBattlegroundListPacket(WorldSession* session, uint32_t battlegroundType, [[maybe_unused]] uint8_t from)
 {
-
     WorldPacket data(SMSG_BATTLEFIELD_LIST, 18);
 
 #if VERSION_STRING == WotLK

--- a/src/world/Management/ItemInterface.cpp
+++ b/src/world/Management/ItemInterface.cpp
@@ -3856,7 +3856,7 @@ void ItemInterface::CheckAreaItems()
     }
 }
 
-uint32_t ItemInterface::GetEquippedCountByItemLimit(uint32_t LimitId)
+uint32_t ItemInterface::GetEquippedCountByItemLimit([[maybe_unused]] uint32_t LimitId)
 {
     uint32_t count = 0;
 #if VERSION_STRING > Classic

--- a/src/world/Management/ObjectMgr.cpp
+++ b/src/world/Management/ObjectMgr.cpp
@@ -1990,7 +1990,7 @@ void ObjectMgr::loadInstanceEncounters()
     sLogger.info("ObjectMgr : Loaded {} instance encounters in {} ms", count, static_cast<uint32_t>(Util::GetTimeDifferenceToNow(startTime)));
 }
 
-DungeonEncounterList const* ObjectMgr::getDungeonEncounterList(uint32_t _mapId, uint8_t _difficulty) const
+DungeonEncounterList const* ObjectMgr::getDungeonEncounterList(uint32_t _mapId, [[maybe_unused]] uint8_t _difficulty) const
 {
 #if VERSION_STRING >= WotLK
     std::unordered_map<uint32_t, DungeonEncounterList>::const_iterator itr = m_dungeonEncounterStore.find(uint32_t(uint16_t(_mapId) | (uint32_t(_difficulty) << 16)));

--- a/src/world/Management/TaxiMgr.cpp
+++ b/src/world/Management/TaxiMgr.cpp
@@ -48,7 +48,7 @@ TaxiPath::TaxiPath()
     m_taximask.fill(0);
 }
 
-void TaxiPath::initTaxiNodesForLevel(uint32_t race, uint32_t chrClass, uint8_t level)
+void TaxiPath::initTaxiNodesForLevel(uint32_t race, [[maybe_unused]] uint32_t chrClass, uint8_t level)
 {
 #if VERSION_STRING >= WotLK
     // class specific initial known nodes
@@ -121,7 +121,7 @@ void TaxiPath::initTaxiNodesForLevel(uint32_t race, uint32_t chrClass, uint8_t l
             setTaximaskNode(2);
             break;
 #endif
-#if VERSION_STRING >= Mop   
+#if VERSION_STRING >= Mop
         case RACE_PANDAREN_ALLIANCE:
             setTaximaskNode(2);
             break;

--- a/src/world/Management/TaxiMgr.cpp
+++ b/src/world/Management/TaxiMgr.cpp
@@ -48,7 +48,7 @@ TaxiPath::TaxiPath()
     m_taximask.fill(0);
 }
 
-void TaxiPath::initTaxiNodesForLevel(uint32_t race, [[maybe_unused]] uint32_t chrClass, uint8_t level)
+void TaxiPath::initTaxiNodesForLevel(uint32_t race, [[maybe_unused]] uint32_t chrClass, [[maybe_unused]] uint8_t level)
 {
 #if VERSION_STRING >= WotLK
     // class specific initial known nodes

--- a/src/world/Management/WorldStatesHandler.cpp
+++ b/src/world/Management/WorldStatesHandler.cpp
@@ -83,7 +83,7 @@ void WorldStatesHandler::BuildInitWorldStatesForZone(uint32_t _zone, uint32_t _a
         ++count;
     }
 
-    _data.put<uint16_t>(count_pos, count);
+    _data.put<uint16_t>(count_pos, static_cast<uint16_t>(count));
 #endif
 }
 

--- a/src/world/Map/Maps/BaseMap.cpp
+++ b/src/world/Map/Maps/BaseMap.cpp
@@ -128,7 +128,7 @@ bool BaseMap::isInstanceableMap() const
     return _mapEntry->isInstanceableMap() && _mapInfo->isInstanceableMap();
 }
 
-bool BaseMap::getEntrancePos(int32_t& mapid, float& x, float& y) const
+bool BaseMap::getEntrancePos([[maybe_unused]] int32_t& mapid, [[maybe_unused]] float& x, [[maybe_unused]] float& y) const
 {
 #if VERSION_STRING > Classic
     if (!_mapEntry)

--- a/src/world/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/world/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -200,7 +200,7 @@ void FlightPathMovementGenerator::setCurrentNodeAfterTeleport()
     }
 }
 
-void FlightPathMovementGenerator::doEventIfAny(Player* player, WDB::Structures::TaxiPathNodeEntry const* node, bool departure)
+void FlightPathMovementGenerator::doEventIfAny([[maybe_unused]] Player* player, [[maybe_unused]] WDB::Structures::TaxiPathNodeEntry const* node, [[maybe_unused]] bool departure)
 {
 #if VERSION_STRING >= TBC
     if (uint32_t eventid = departure ? node->departureEventID : node->arivalEventID)

--- a/src/world/Objects/GameObject.cpp
+++ b/src/world/Objects/GameObject.cpp
@@ -186,7 +186,7 @@ void GameObject::setLevel(uint32_t level) { write(gameObjectData()->level, level
 uint8_t GameObject::getState() const
 {
 #if VERSION_STRING <= TBC
-    return gameObjectData()->state;
+    return static_cast<uint8_t>(gameObjectData()->state);
 #elif VERSION_STRING >= WotLK
     return gameObjectData()->bytes_1.bytes_1_gameobject.state;
 #endif
@@ -203,7 +203,7 @@ void GameObject::setState(uint8_t state)
 uint8_t GameObject::getGoType() const
 {
 #if VERSION_STRING <= TBC
-    return gameObjectData()->type;
+    return static_cast<uint8_t>(gameObjectData()->type);
 #elif VERSION_STRING >= WotLK
     return gameObjectData()->bytes_1.bytes_1_gameobject.type;
 #endif
@@ -221,7 +221,7 @@ void GameObject::setGoType(uint8_t type)
 uint8_t GameObject::getArtKit() const
 {
 #if VERSION_STRING <= TBC
-    return gameObjectData()->art_kit;
+    return static_cast<uint8_t>(gameObjectData()->art_kit);
 #elif VERSION_STRING >= WotLK
     return gameObjectData()->bytes_1.bytes_1_gameobject.art_kit;
 #endif
@@ -249,7 +249,7 @@ void GameObject::setArtKit(uint8_t artkit)
 uint8_t GameObject::getAnimationProgress() const
 {
 #if VERSION_STRING <= TBC
-    return gameObjectData()->animation_progress;
+    return static_cast<uint8_t>(gameObjectData()->animation_progress);
 #elif VERSION_STRING >= WotLK
     return gameObjectData()->bytes_1.bytes_1_gameobject.animation_progress;
 #endif
@@ -2573,7 +2573,7 @@ void GameObject_Destructible::Damage(uint32_t damage, uint64_t AttackerGUID, uin
     setDestructibleState(newState, false);
 }
 
-void GameObject_Destructible::SendDamagePacket(uint32_t damage, uint64_t AttackerGUID, uint64_t ControllerGUID, uint32_t SpellID)
+void GameObject_Destructible::SendDamagePacket([[maybe_unused]] uint32_t damage, [[maybe_unused]] uint64_t AttackerGUID, [[maybe_unused]] uint64_t ControllerGUID, [[maybe_unused]] uint32_t SpellID)
 {
 #if VERSION_STRING > TBC
     sendMessageToSet(SmsgDestructibleBuildingDamage(GetNewGUID(), AttackerGUID, ControllerGUID, damage, SpellID).serialise().get(), false, false);

--- a/src/world/Objects/Item.cpp
+++ b/src/world/Objects/Item.cpp
@@ -845,7 +845,7 @@ uint8_t Item::getSocketSlotCount([[maybe_unused]]bool includePrismatic/* = true*
 
 #endif
 
-uint32_t Item::countGemsWithLimitId(uint32_t limitId)
+uint32_t Item::countGemsWithLimitId([[maybe_unused]] uint32_t limitId)
 {
 #if VERSION_STRING > Classic
     uint32_t result = 0;
@@ -867,7 +867,7 @@ uint32_t Item::countGemsWithLimitId(uint32_t limitId)
 #endif
 }
 
-bool Item::isGemRelated(WDB::Structures::SpellItemEnchantmentEntry const* enchantment)
+bool Item::isGemRelated([[maybe_unused]] WDB::Structures::SpellItemEnchantmentEntry const* enchantment)
 {
 #if VERSION_STRING > Classic
     if (getItemProperties()->SocketBonus == enchantment->Id)
@@ -875,7 +875,7 @@ bool Item::isGemRelated(WDB::Structures::SpellItemEnchantmentEntry const* enchan
 
     return enchantment->GemEntry != 0;
 #else
-    return 0;
+    return false;
 #endif
 }
 

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -2567,7 +2567,7 @@ void Object::buildMovementUpdate(ByteBuffer* data, uint8_t updateFlags, Player* 
 #endif
 
 #if VERSION_STRING == TBC
-void Object::buildMovementUpdate(ByteBuffer* data, uint8_t updateFlags, Player* target)
+void Object::buildMovementUpdate(ByteBuffer* data, uint8_t updateFlags, [[maybe_unused]] Player* target)
 {
     *data << uint8_t(updateFlags);
 

--- a/src/world/Objects/Object.cpp
+++ b/src/world/Objects/Object.cpp
@@ -2452,7 +2452,7 @@ uint32_t Object::BuildValuesUpdateBlockForPlayer(ByteBuffer* buf, UpdateMask* ma
 
 // MIT Start
 #if VERSION_STRING == Classic
-void Object::buildMovementUpdate(ByteBuffer* data, uint8_t updateFlags, Player* target)
+void Object::buildMovementUpdate(ByteBuffer* data, uint8_t updateFlags, [[maybe_unused]] Player* target)
 {
     *data << uint8_t(updateFlags);
 

--- a/src/world/Objects/Units/Creatures/Pet.cpp
+++ b/src/world/Objects/Units/Creatures/Pet.cpp
@@ -1162,7 +1162,7 @@ uint32_t Pet::getUntrainCost()
 }
 #endif
 
-void Pet::_addSpell(SpellInfo const* spellInfo, bool silently, uint8_t spellState)
+void Pet::_addSpell(SpellInfo const* spellInfo, [[maybe_unused]] bool silently, uint8_t spellState)
 {
     if (spellInfo == nullptr)
         return;

--- a/src/world/Objects/Units/Players/DeathKnight.cpp
+++ b/src/world/Objects/Units/Players/DeathKnight.cpp
@@ -24,7 +24,7 @@
 #include "Server/WorldSession.h"
 #include "Server/Packets/SmsgConvertRune.h"
 
-void DeathKnight::SendRuneUpdate(uint8_t slot)
+void DeathKnight::SendRuneUpdate([[maybe_unused]] uint8_t slot)
 {
 #if VERSION_STRING > TBC
     getSession()->SendPacket(AscEmu::Packets::SmsgConvertRune(slot, m_runes[slot].type).serialise().get());

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -796,13 +796,14 @@ void Player::setPlayerFlags(uint32_t flags)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update player flags also to group
     if (!IsInWorld() || getGroup() == nullptr)
         return;
 
     addGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
+#endif
 }
 
 void Player::addPlayerFlags(uint32_t flags) { setPlayerFlags(getPlayerFlags() | flags); }
@@ -4584,7 +4585,7 @@ void Player::addSkillLine(uint16_t skillLine, uint16_t currentValue, uint16_t ma
     if (!initializeProfession)
         currentValue = currentValue < 1 ? 1U : currentValue;
 
-    const auto onLearnedNewSkill = [&](uint16_t curVal, uint16_t skillStep, bool isPrimaryProfession) -> void
+    const auto onLearnedNewSkill = [&](uint16_t curVal, [[maybe_unused]] uint16_t skillStep, bool isPrimaryProfession) -> void
     {
 #if VERSION_STRING >= Cata
         // Profession skill line
@@ -9483,7 +9484,7 @@ void Player::sendDestroyObjectPacket(uint64_t destroyedGuid)
     m_session->SendPacket(SmsgDestroyObject(destroyedGuid).serialise().get());
 }
 
-void Player::sendEquipmentSetUseResultPacket(uint8_t result)
+void Player::sendEquipmentSetUseResultPacket([[maybe_unused]] uint8_t result)
 {
 #if VERSION_STRING > TBC
     m_session->SendPacket(SmsgEquipmentSetUseResult(result).serialise().get());
@@ -9624,7 +9625,7 @@ void Player::sendEquipmentSetList()
 #endif
 }
 
-void Player::sendEquipmentSetSaved(uint32_t setId, uint32_t setGuid)
+void Player::sendEquipmentSetSaved([[maybe_unused]] uint32_t setId, [[maybe_unused]] uint32_t setGuid)
 {
 #if VERSION_STRING > TBC
     WorldPacket data(SMSG_EQUIPMENT_SET_SAVED, 12);

--- a/src/world/Objects/Units/Players/Player.cpp
+++ b/src/world/Objects/Units/Players/Player.cpp
@@ -8399,7 +8399,7 @@ void Player::updatePvPCurrencies()
     this->updateArenaPoints();
 }
 
-bool Player::hasPvPTitle(RankTitles title)
+bool Player::hasPvPTitle([[maybe_unused]] RankTitles title)
 {
 #if VERSION_STRING > Classic
     const auto index = static_cast<uint8_t>(title / 32);
@@ -8410,7 +8410,7 @@ bool Player::hasPvPTitle(RankTitles title)
 #endif
 }
 
-void Player::setKnownPvPTitle(RankTitles title, bool set)
+void Player::setKnownPvPTitle([[maybe_unused]] RankTitles title, [[maybe_unused]] bool set)
 {
 #if VERSION_STRING > Classic
     if (!set && !hasPvPTitle(title))
@@ -12995,9 +12995,9 @@ void Player::loadFieldsFromString(const char* string, uint16_t /*firstField*/, u
 
 void Player::calcExpertise()
 {
+#if VERSION_STRING != Classic
     int32_t modifier = 0;
 
-#if VERSION_STRING != Classic
     setExpertise(0);
     setOffHandExpertise(0);
 
@@ -15612,7 +15612,7 @@ void Player::updateStats()
         float value = getModCastSpeed() * m_spellHasteRatingBonus / haste; // remove previous mod and apply current
 
         setModCastSpeed(value);
-        m_spellHasteRatingBonus = haste;    // keep value for next run
+        m_spellHasteRatingBonus = haste; // keep value for next run
     }
 
     // Shield Block
@@ -15620,11 +15620,10 @@ void Player::updateStats()
     if (itemShield != nullptr && itemShield->getItemProperties()->InventoryType == INVTYPE_SHIELD)
     {
         float block_multiplier = (100.0f + m_modBlockAbsorbValue) / 100.0f;
-        if (block_multiplier < 1.0f)
-            block_multiplier = 1.0f;
+        block_multiplier = std::max(block_multiplier, 1.0f);
 
-        int32_t blockable_damage = Util::float2int32((itemShield->getItemProperties()->Block + m_modBlockValueFromSpells + getCombatRating(CR_BLOCK) + (str / 2.0f) - 1.0f) * block_multiplier);
 #if VERSION_STRING != Classic
+        int32_t blockable_damage = Util::float2int32((itemShield->getItemProperties()->Block + m_modBlockValueFromSpells + getCombatRating(CR_BLOCK) + (str / 2.0f) - 1.0f) * block_multiplier);
         setShieldBlock(blockable_damage);
 #endif
     }

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -8036,7 +8036,7 @@ bool Unit::isMounted() const
 #endif
 }
 
-void Unit::mount(uint32_t mount, [[maybe_unused]] uint32_t VehicleId, [[maybe_unused]] uint32_t creatureEntry)
+void Unit::mount([[maybe_unused]] uint32_t mount, [[maybe_unused]] uint32_t VehicleId, [[maybe_unused]] uint32_t creatureEntry)
 {
 #if VERSION_STRING == Classic
     // TODO
@@ -8087,7 +8087,7 @@ void Unit::mount(uint32_t mount, [[maybe_unused]] uint32_t VehicleId, [[maybe_un
 #endif
 }
 
-void Unit::dismount(bool resummonPet/* = true*/)
+void Unit::dismount([[maybe_unused]] bool resummonPet/* = true*/)
 {
     if (!isMounted())
         return;
@@ -9938,7 +9938,6 @@ DamageInfo Unit::strike(Unit* pVictim, WeaponDamageType weaponType, SpellInfo co
     uint16_t SubClassSkill = SKILL_UNARMED;
 
     bool backAttack = !pVictim->isInFront(this);
-    uint32_t vskill = 0;
     bool disable_dR = false;
 
     if (ability)
@@ -9952,6 +9951,7 @@ DamageInfo Unit::strike(Unit* pVictim, WeaponDamageType weaponType, SpellInfo co
     }
 
 #if VERSION_STRING >= TBC // support classic
+    uint32_t vskill = 0;
     //////////////////////////////////////////////////////////////////////////////////////////
     //Victim Skill Base Calculation
     if (pVictim->isPlayer())

--- a/src/world/Objects/Units/Unit.cpp
+++ b/src/world/Objects/Units/Unit.cpp
@@ -106,6 +106,8 @@ This file is released under the MIT license. See README-MIT for more information
 #include <Server/Packets/SmsgSplineMoveSetUnset.h>
 #include <Server/Packets/SmsgSplineSetSpeed.h>
 
+#include <algorithm>
+
 using namespace AscEmu::Packets;
 
 Unit::Unit() :
@@ -502,7 +504,7 @@ void Unit::setPowerType(uint8_t powerType)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update power type also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -510,6 +512,7 @@ void Unit::setPowerType(uint8_t powerType)
         return;
 
     plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_POWER_TYPE : GROUP_UPDATE_FLAG_PET_POWER_TYPE);
+#endif
 }
 #endif
 //bytes_0 end
@@ -518,15 +521,14 @@ uint32_t Unit::getHealth() const { return unitData()->health; }
 void Unit::setHealth(uint32_t health)
 {
     const auto maxHealth = getMaxHealth();
-    if (health > maxHealth)
-        health = maxHealth;
+    health = std::min(health, maxHealth);
 
     write(unitData()->health, health);
 
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update health also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -534,14 +536,14 @@ void Unit::setHealth(uint32_t health)
         return;
 
     plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_CUR_HP : GROUP_UPDATE_FLAG_PET_CUR_HP);
+#endif
 }
 void Unit::modHealth(int32_t health)
 {
     int32_t newHealth = getHealth();
     newHealth += health;
 
-    if (newHealth < 0)
-        newHealth = 0;
+    newHealth = std::max(newHealth, 0);
 
     setHealth(newHealth);
 }
@@ -580,7 +582,7 @@ uint32_t Unit::getPower(PowerType type) const
     }
 }
 
-void Unit::setPower(PowerType type, uint32_t value, bool sendPacket/* = true*/, bool skipObjectUpdate/* = false*/)
+void Unit::setPower(PowerType type, uint32_t value, [[maybe_unused]] bool sendPacket/* = true*/, bool skipObjectUpdate/* = false*/)
 {
     if (type == POWER_TYPE_HEALTH)
     {
@@ -589,8 +591,7 @@ void Unit::setPower(PowerType type, uint32_t value, bool sendPacket/* = true*/, 
     }
 
     const auto maxPower = getMaxPower(type);
-    if (value > maxPower)
-        value = maxPower;
+    value = std::min(value, maxPower);
 
     if (getPower(type) == value)
         return;
@@ -633,7 +634,7 @@ void Unit::setPower(PowerType type, uint32_t value, bool sendPacket/* = true*/, 
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Send power update to client
     if (sendPacket)
@@ -645,6 +646,7 @@ void Unit::setPower(PowerType type, uint32_t value, bool sendPacket/* = true*/, 
         return;
 
     plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_CUR_POWER : GROUP_UPDATE_FLAG_PET_CUR_POWER);
+#endif
 }
 
 void Unit::modPower(PowerType type, int32_t value)
@@ -652,8 +654,7 @@ void Unit::modPower(PowerType type, int32_t value)
     int32_t newPower = getPower(type);
     newPower += value;
 
-    if (newPower < 0)
-        newPower = 0;
+    newPower = std::max(newPower, 0);
 
     setPower(type, newPower);
 }
@@ -666,7 +667,7 @@ void Unit::setMaxHealth(uint32_t maxHealth)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update health also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -675,14 +676,15 @@ void Unit::setMaxHealth(uint32_t maxHealth)
 
     if (maxHealth < getHealth())
         setHealth(maxHealth);
+#endif
 }
+
 void Unit::modMaxHealth(int32_t maxHealth)
 {
     int32_t newMaxHealth = getMaxHealth();
     newMaxHealth += maxHealth;
 
-    if (newMaxHealth < 0)
-        newMaxHealth = 0;
+    newMaxHealth = std::max(newMaxHealth, 0);
 
     setMaxHealth(newMaxHealth);
 }
@@ -761,7 +763,7 @@ void Unit::setMaxPower(PowerType type, uint32_t value)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update power also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -770,6 +772,7 @@ void Unit::setMaxPower(PowerType type, uint32_t value)
 
     if (value < getPower(type))
         setPower(type, value);
+#endif
 }
 
 void Unit::modMaxPower(PowerType type, int32_t value)
@@ -777,8 +780,7 @@ void Unit::modMaxPower(PowerType type, int32_t value)
     int32_t newValue = getMaxPower(type);
     newValue += value;
 
-    if (newValue < 0)
-        newValue = 0;
+    newValue = std::max(newValue, 0);
 
     setMaxPower(type, newValue);
 }
@@ -979,7 +981,7 @@ void Unit::setLevel(uint32_t level)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update level also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -988,6 +990,7 @@ void Unit::setLevel(uint32_t level)
 
     //\ todo: missing update flag for pet level
     plr->addGroupUpdateFlag(isPlayer() ? GROUP_UPDATE_FLAG_LEVEL : 0);
+#endif
 }
 
 uint32_t Unit::getFactionTemplate() const { return unitData()->faction_template; }
@@ -1251,7 +1254,7 @@ void Unit::setAuraApplication(Aura const* aur)
 
     const uint32_t stackAmount = aur->getSpellInfo()->getMaxstack() > 0 ? aur->getStackCount() : aur->getCharges();
     // Client expects count - 1
-    const uint8_t count = stackAmount <= 255 ? stackAmount - 1 : 255 - 1;
+    const uint8_t count = static_cast<uint8_t>(stackAmount <= 255 ? stackAmount - 1 : 255 - 1);
 
     auto val = getAuraApplication(index);
     val &= ~(0xFF << byte);
@@ -1293,7 +1296,7 @@ void Unit::setDisplayId(uint32_t id)
 #if VERSION_STRING == TBC
     // TODO Fix this later
     return;
-#endif
+#else
 
     // Update display id also to group
     const auto plr = getPlayerOwnerOrSelf();
@@ -1302,6 +1305,7 @@ void Unit::setDisplayId(uint32_t id)
 
     //\ todo: missing update flag for player display id
     plr->addGroupUpdateFlag(isPlayer() ? 0 : GROUP_UPDATE_FLAG_PET_MODEL_ID);
+#endif
 }
 void Unit::resetDisplayId()
 {
@@ -2226,7 +2230,7 @@ void Unit::setMoveSwim(bool set_swim)
     }
 }
 
-void Unit::setMoveDisableGravity(bool disable_gravity)
+void Unit::setMoveDisableGravity([[maybe_unused]] bool disable_gravity)
 {
 #if VERSION_STRING > TBC
     if (isPlayer())
@@ -4564,7 +4568,7 @@ bool Unit::hasAuraWithSpellType(SpellTypes type, uint64_t casterGuid/* = 0*/, ui
     return false;
 }
 
-bool Unit::hasAuraState(AuraState state, SpellInfo const* spellInfo, Unit const* caster) const
+bool Unit::hasAuraState(AuraState state, [[maybe_unused]] SpellInfo const* spellInfo, [[maybe_unused]] Unit const* caster) const
 {
 #if VERSION_STRING >= WotLK
     if (caster != nullptr && spellInfo != nullptr && caster->hasAuraWithAuraEffect(SPELL_AURA_IGNORE_TARGET_AURA_STATE))
@@ -6211,12 +6215,12 @@ uint8_t Unit::getPowerPct(PowerType powerType) const
     return static_cast<uint8_t>(getPower(powerType) * 100 / getMaxPower(powerType));
 }
 
-void Unit::sendPowerUpdate([[maybe_unused]]bool self)
+void Unit::sendPowerUpdate([[maybe_unused]] bool self)
 {
+#if VERSION_STRING >= WotLK
     // Save current power so the same amount is sent to player and everyone else
     const auto powerAmount = getPower(getPowerType());
 
-#if VERSION_STRING >= WotLK
     sendMessageToSet(SmsgPowerUpdate(GetNewGUID(), static_cast<uint8_t>(getPowerType()), powerAmount).serialise().get(), self);
 #endif
 }
@@ -8001,7 +8005,7 @@ void Unit::handleSpellClick(Unit* clicker)
         Unit* caster = (clickPair.castFlags & NPC_CLICK_CAST_CASTER_CLICKER) ? clicker : this;
         Unit* target = (clickPair.castFlags & NPC_CLICK_CAST_TARGET_CLICKER) ? clicker : this;
         auto* const unitOwner = getUnitOwner();
-        uint64_t origCasterGUID = (unitOwner && clickPair.castFlags & NPC_CLICK_CAST_ORIG_CASTER_OWNER) ? unitOwner->getGuid() : clicker->getGuid();
+        [[maybe_unused]] uint64_t origCasterGUID = (unitOwner && clickPair.castFlags & NPC_CLICK_CAST_ORIG_CASTER_OWNER) ? unitOwner->getGuid() : clicker->getGuid();
 
         SpellInfo const* spellEntry = sSpellMgr.getSpellInfo(clickPair.spellId);
 
@@ -8032,7 +8036,7 @@ bool Unit::isMounted() const
 #endif
 }
 
-void Unit::mount(uint32_t mount, uint32_t VehicleId, uint32_t creatureEntry)
+void Unit::mount(uint32_t mount, [[maybe_unused]] uint32_t VehicleId, [[maybe_unused]] uint32_t creatureEntry)
 {
 #if VERSION_STRING == Classic
     // TODO
@@ -8994,10 +8998,10 @@ void Unit::giveGroupXP(Unit* unitVictim, Player* playerInGroup)
     }
 }
 
-void Unit::calculateResistanceReduction(Unit* unitVictim, DamageInfo* damageInfo, SpellInfo const* spellInfoAbility, float armorPctReduce)
+void Unit::calculateResistanceReduction(Unit* unitVictim, DamageInfo* damageInfo, SpellInfo const* spellInfoAbility, [[maybe_unused]] float armorPctReduce)
 {
     float averageResistance = 0.0f;
-    
+
     if ((*damageInfo).schoolMask == SCHOOL_MASK_NORMAL)
     {
         float armorReduction;

--- a/src/world/Server/Packets/Handlers/CalendarHandler.cpp
+++ b/src/world/Server/Packets/Handlers/CalendarHandler.cpp
@@ -42,7 +42,7 @@ void WorldSession::handleCalendarGetNumPending(WorldPacket& /*recvPacket*/)
 #endif
 }
 
-void WorldSession::handleCalendarAddEvent(WorldPacket& recvPacket)
+void WorldSession::handleCalendarAddEvent([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     // Create an Event and save it to char db 
@@ -153,7 +153,7 @@ void WorldSession::handleCalendarEventModeratorStatus(WorldPacket& /*recvPacket*
 #endif
 }
 
-void WorldSession::sendCalendarRaidLockout(InstanceSaved const* save, bool add)
+void WorldSession::sendCalendarRaidLockout([[maybe_unused]] InstanceSaved const* save, [[maybe_unused]] bool add)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "SMSG_CALENDAR_RAID_LOCKOUT_ADDED/REMOVED");
@@ -175,7 +175,7 @@ void WorldSession::sendCalendarRaidLockout(InstanceSaved const* save, bool add)
 #endif
 }
 
-void WorldSession::sendCalendarRaidLockoutUpdated(InstanceSaved const* save)
+void WorldSession::sendCalendarRaidLockoutUpdated([[maybe_unused]] InstanceSaved const* save)
 {
 #if VERSION_STRING > TBC
     if (!save)

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -2759,7 +2759,7 @@ void WorldSession::handleCancelTemporaryEnchantmentOpcode(WorldPacket& recvPacke
     item->removeAllEnchantments(true);
 }
 
-void WorldSession::handleInsertGemOpcode(WorldPacket& recvPacket)
+void WorldSession::handleInsertGemOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > Classic
     CmsgSocketGems srlPacket;

--- a/src/world/Server/Packets/Handlers/ItemHandler.cpp
+++ b/src/world/Server/Packets/Handlers/ItemHandler.cpp
@@ -407,7 +407,7 @@ void WorldSession::handleSwapItemOpcode(WorldPacket& recvPacket)
         srlPacket.destSlot, srlPacket.srcInventorySlot, srlPacket.srcSlot);
 }
 
-void WorldSession::sendRefundInfo(uint64_t GUID)
+void WorldSession::sendRefundInfo([[maybe_unused]] uint64_t GUID)
 {
 #if VERSION_STRING == WotLK
     if (!_player || !_player->IsInWorld())
@@ -784,7 +784,7 @@ void WorldSession::sendReforgeResult([[maybe_unused]] bool success)
 #endif
 }
 
-void WorldSession::handleItemRefundInfoOpcode(WorldPacket& recvPacket)
+void WorldSession::handleItemRefundInfoOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING >= WotLK
     CmsgItemrefundinfo srlPacket;
@@ -797,7 +797,7 @@ void WorldSession::handleItemRefundInfoOpcode(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleItemRefundRequestOpcode(WorldPacket& recvPacket)
+void WorldSession::handleItemRefundRequestOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING >= WotLK
     CmsgItemrefundrequest srlPacket;
@@ -3064,7 +3064,7 @@ void WorldSession::handleWrapItemOpcode(WorldPacket& recvPacket)
     dst->saveToDB(srlPacket.destBagSlot, srlPacket.destSlot, false, nullptr);
 }
 
-void WorldSession::handleEquipmentSetUse(WorldPacket& data)
+void WorldSession::handleEquipmentSetUse([[maybe_unused]] WorldPacket& data)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_EQUIPMENT_SET_USE");
@@ -3137,7 +3137,7 @@ void WorldSession::handleEquipmentSetUse(WorldPacket& data)
 #endif
 }
 
-void WorldSession::handleEquipmentSetSave(WorldPacket& data)
+void WorldSession::handleEquipmentSetSave([[maybe_unused]] WorldPacket& data)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_EQUIPMENT_SET_SAVE");
@@ -3179,7 +3179,7 @@ void WorldSession::handleEquipmentSetSave(WorldPacket& data)
 #endif
 }
 
-void WorldSession::handleEquipmentSetDelete(WorldPacket& data)
+void WorldSession::handleEquipmentSetDelete([[maybe_unused]] WorldPacket& data)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "Received CMSG_EQUIPMENT_SET_DELETE");

--- a/src/world/Server/Packets/Handlers/LfgHandler.cpp
+++ b/src/world/Server/Packets/Handlers/LfgHandler.cpp
@@ -54,7 +54,7 @@ void BuildPartyLockDungeonBlock(WorldPacket& data, const LfgLockPartyMap& lockMa
 }
 
 //not used cata
-void WorldSession::sendLfgUpdateSearch(bool update)
+void WorldSession::sendLfgUpdateSearch([[maybe_unused]] bool update)
 {
 #if VERSION_STRING > TBC
     SendPacket(SmsgLfgUpdateSearch(update).serialise().get());
@@ -70,21 +70,21 @@ void WorldSession::sendLfgDisabled()
     SendPacket(&data);
 }
 
-void WorldSession::sendLfgOfferContinue(uint32_t dungeonEntry)
+void WorldSession::sendLfgOfferContinue([[maybe_unused]] uint32_t dungeonEntry)
 {
 #if VERSION_STRING > TBC
     SendPacket(SmsgLfgOfferContinue(dungeonEntry).serialise().get());
 #endif
 }
 
-void WorldSession::sendLfgTeleportError(uint8_t error)
+void WorldSession::sendLfgTeleportError([[maybe_unused]] uint8_t error)
 {
 #if VERSION_STRING > TBC
     SendPacket(SmsgLfgTeleportDenied(error).serialise().get());
 #endif
 }
 
-void WorldSession::sendLfgJoinResult(const LfgJoinResultData& joinData)
+void WorldSession::sendLfgJoinResult([[maybe_unused]] const LfgJoinResultData& joinData)
 {
 #if VERSION_STRING > TBC
     uint32_t size = 0;
@@ -95,15 +95,15 @@ void WorldSession::sendLfgJoinResult(const LfgJoinResultData& joinData)
 
     WorldPacket data(SMSG_LFG_JOIN_RESULT, 4 + 4 + size);
 
-    data << uint32_t(joinData.result);        // Check Result
-    data << uint32_t(joinData.state);         // Check Value
+    data << uint32_t(joinData.result); // Check Result
+    data << uint32_t(joinData.state); // Check Value
     if (!joinData.lockmap.empty())
         BuildPartyLockDungeonBlock(data, joinData.lockmap);
     SendPacket(&data);
 #endif
 }
 
-void WorldSession::sendLfgUpdatePlayer(const LfgUpdateData& updateData)
+void WorldSession::sendLfgUpdatePlayer([[maybe_unused]] const LfgUpdateData& updateData)
 {
 #if VERSION_STRING > TBC
     bool queued = false;
@@ -151,7 +151,7 @@ void WorldSession::sendLfgUpdatePlayer(const LfgUpdateData& updateData)
 #endif
 }
 
-void WorldSession::sendLfgUpdateParty(const LfgUpdateData& updateData)
+void WorldSession::sendLfgUpdateParty([[maybe_unused]] const LfgUpdateData& updateData)
 {
 #if VERSION_STRING > TBC
     bool isJoining = false;
@@ -211,7 +211,7 @@ void WorldSession::sendLfgUpdateParty(const LfgUpdateData& updateData)
 #endif
 }
 
-void WorldSession::sendLfgRoleChosen(uint64_t guid, uint8_t roles)
+void WorldSession::sendLfgRoleChosen([[maybe_unused]] uint64_t guid, [[maybe_unused]] uint8_t roles)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "SMSG_LFG_ROLE_CHOSEN {} guid: {} roles: {}", _player->getGuid(), guid, roles);
@@ -220,7 +220,7 @@ void WorldSession::sendLfgRoleChosen(uint64_t guid, uint8_t roles)
 #endif
 }
 
-void WorldSession::sendLfgRoleCheckUpdate(const LfgRoleCheck* pRoleCheck)
+void WorldSession::sendLfgRoleCheckUpdate([[maybe_unused]] const LfgRoleCheck* pRoleCheck)
 {
 #if VERSION_STRING > TBC
 
@@ -288,7 +288,7 @@ void WorldSession::sendLfgRoleCheckUpdate(const LfgRoleCheck* pRoleCheck)
 #endif
 }
 
-void WorldSession::sendLfgQueueStatus(uint32_t dungeon, int32_t waitTime, int32_t avgWaitTime, int32_t waitTimeTanks, int32_t waitTimeHealer, int32_t waitTimeDps, uint32_t queuedTime, uint8_t tanks, uint8_t healers, uint8_t dps)
+void WorldSession::sendLfgQueueStatus([[maybe_unused]] uint32_t dungeon, [[maybe_unused]] int32_t waitTime, [[maybe_unused]] int32_t avgWaitTime, [[maybe_unused]] int32_t waitTimeTanks, [[maybe_unused]] int32_t waitTimeHealer, [[maybe_unused]] int32_t waitTimeDps, [[maybe_unused]] uint32_t queuedTime, [[maybe_unused]] uint8_t tanks, [[maybe_unused]] uint8_t healers, [[maybe_unused]] uint8_t dps)
 {
 #if VERSION_STRING > TBC
     sLogger.debugFlag(AscEmu::Logging::LF_OPCODE, "SMSG_LFG_QUEUE_STATUS {} dungeon: {} - waitTime: {} - avgWaitTime: {} - waitTimeTanks: {} - waitTimeHealer: {} - waitTimeDps: {} - queuedTime: {} - tanks: {} - healers: {} - dps: {}", _player->getGuid(), dungeon, waitTime, avgWaitTime, waitTimeTanks, waitTimeHealer, waitTimeDps, queuedTime, tanks, healers, dps);
@@ -310,7 +310,7 @@ void WorldSession::sendLfgQueueStatus(uint32_t dungeon, int32_t waitTime, int32_
 #endif
 }
 
-void WorldSession::sendLfgPlayerReward(uint32_t RandomDungeonEntry, uint32_t DungeonEntry, uint8_t done, const LfgReward* reward, QuestProperties const* qReward)
+void WorldSession::sendLfgPlayerReward([[maybe_unused]] uint32_t RandomDungeonEntry, [[maybe_unused]] uint32_t DungeonEntry, [[maybe_unused]] uint8_t done, [[maybe_unused]] const LfgReward* reward, [[maybe_unused]] QuestProperties const* qReward)
 {
 #if VERSION_STRING > TBC
     if (!RandomDungeonEntry || !DungeonEntry || !qReward)
@@ -350,7 +350,7 @@ void WorldSession::sendLfgPlayerReward(uint32_t RandomDungeonEntry, uint32_t Dun
 #endif
 }
 
-void WorldSession::sendLfgBootPlayer(const LfgPlayerBoot* pBoot)
+void WorldSession::sendLfgBootPlayer([[maybe_unused]] const LfgPlayerBoot* pBoot)
 {
 #if VERSION_STRING > TBC
     uint64_t guid = _player->getGuid();
@@ -389,7 +389,7 @@ void WorldSession::sendLfgBootPlayer(const LfgPlayerBoot* pBoot)
 #endif
 }
 
-void WorldSession::sendLfgUpdateProposal(uint32_t proposalId, const LfgProposal* pProp)
+void WorldSession::sendLfgUpdateProposal([[maybe_unused]] uint32_t proposalId, [[maybe_unused]] const LfgProposal* pProp)
 {
 #if VERSION_STRING > TBC
     if (!pProp)
@@ -499,7 +499,7 @@ void WorldSession::handleLfgLockInfoOpcode([[maybe_unused]] WorldPacket& recvPac
 #endif
 }
 
-void WorldSession::handleLfgJoinOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgJoinOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     sLogger.debug("CMSG_LFG_JOIN");
@@ -557,7 +557,7 @@ void WorldSession::handleLfgLeaveOpcode(WorldPacket& /*recvPacket*/)
 #endif
 }
 
-void WorldSession::handleLfgSearchOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgSearchOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgSearchLfgJoin srlPacket;
@@ -569,7 +569,7 @@ void WorldSession::handleLfgSearchOpcode(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleLfgSearchLeaveOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgSearchLeaveOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgSearchLfgLeave srlPacket;
@@ -581,7 +581,7 @@ void WorldSession::handleLfgSearchLeaveOpcode(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleLfgProposalResultOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgProposalResultOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgLfgProposalResult srlPacket;
@@ -595,7 +595,7 @@ void WorldSession::handleLfgProposalResultOpcode(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleLfgSetRolesOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgSetRolesOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgLfgSetRoles srlPacket;
@@ -612,7 +612,7 @@ void WorldSession::handleLfgSetRolesOpcode(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleLfgSetBootVoteOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgSetBootVoteOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgLfgSetBootVote srlPacket;
@@ -708,7 +708,7 @@ void WorldSession::handleLfgPlayerLockInfoRequestOpcode(WorldPacket& /*recvPacke
 #endif
 }
 
-void WorldSession::handleLfgTeleportOpcode(WorldPacket& recvPacket)
+void WorldSession::handleLfgTeleportOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgLfgTeleport srlPacket;

--- a/src/world/Server/Packets/Handlers/MiscHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MiscHandler.cpp
@@ -571,7 +571,7 @@ void WorldSession::handleWorldStateUITimerUpdate(WorldPacket& /*recvPacket*/)
 #endif
 }
 
-void WorldSession::handleGameobjReportUseOpCode(WorldPacket& recvPacket)
+void WorldSession::handleGameobjReportUseOpCode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgGameobjReportUse srlPacket;
@@ -624,7 +624,7 @@ void WorldSession::handleDungeonDifficultyOpcode(WorldPacket& recvPacket)
     }
 }
 
-void WorldSession::handleRaidDifficultyOpcode(WorldPacket& recvPacket)
+void WorldSession::handleRaidDifficultyOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     MsgSetRaidDifficulty srlPacket;
@@ -1764,7 +1764,7 @@ void WorldSession::handleRequestCemeteryListOpcode(WorldPacket& /*recvPacket*/)
 
 
 
-void WorldSession::handleRemoveGlyph(WorldPacket& recvPacket)
+void WorldSession::handleRemoveGlyph([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgRemoveGlyph srlPacket;
@@ -1800,7 +1800,7 @@ namespace BarberShopResult
 }
 #endif
 
-void WorldSession::handleBarberShopResult(WorldPacket& recvPacket)
+void WorldSession::handleBarberShopResult([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     // todo: Here was SMSG_BARBER_SHOP:RESULT... maybe itr is MSG or it was just wrong. Check it!
@@ -2857,7 +2857,7 @@ void WorldSession::HandleMirrorImageOpcode(WorldPacket& recv_data)
     sLogger.debug("Sent SMSG_MIRRORIMAGE_DATA");
 }
 
-void WorldSession::sendClientCacheVersion(uint32_t version)
+void WorldSession::sendClientCacheVersion([[maybe_unused]] uint32_t version)
 {
 #if VERSION_STRING > TBC
     WorldPacket data(SMSG_CLIENTCACHE_VERSION, 4);

--- a/src/world/Server/Packets/Handlers/MovementHandler.cpp
+++ b/src/world/Server/Packets/Handlers/MovementHandler.cpp
@@ -437,7 +437,7 @@ void WorldSession::handleMovementOpcodes(WorldPacket& recvData)
     // but we should already received the active mover
     sessionMovementInfo.guid = m_MoverWoWGuid;
 
-    WorldPacket data(opcode, recvData.size());
+    WorldPacket data(static_cast<uint16_t>(opcode), recvData.size());
     data << sessionMovementInfo;
     mover->sendMessageToSet(&data, false);
 

--- a/src/world/Server/Packets/Handlers/PetHandler.cpp
+++ b/src/world/Server/Packets/Handlers/PetHandler.cpp
@@ -686,7 +686,7 @@ void WorldSession::handlePetLearnTalent([[maybe_unused]] WorldPacket& recvPacket
 #endif
 }
 
-void WorldSession::handleDismissCritter(WorldPacket& recvPacket)
+void WorldSession::handleDismissCritter([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgDismissCritter srlPacket;

--- a/src/world/Server/Packets/Handlers/QueryHandler.cpp
+++ b/src/world/Server/Packets/Handlers/QueryHandler.cpp
@@ -122,7 +122,7 @@ void WorldSession::handleQueryTimeOpcode(WorldPacket& /*recvPacket*/)
     SendPacket(SmsgQueryTimeResponse(UNIXTIME).serialise().get());
 }
 
-void WorldSession::handleAchievmentQueryOpcode(WorldPacket& recvPacket)
+void WorldSession::handleAchievmentQueryOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgInspectAchievements srlPacket;

--- a/src/world/Server/Packets/Handlers/QuestHandler.cpp
+++ b/src/world/Server/Packets/Handlers/QuestHandler.cpp
@@ -378,7 +378,7 @@ void WorldSession::handleQuestQueryOpcode(WorldPacket& recvPacket)
 }
 
 
-void WorldSession::handleQuestPOIQueryOpcode(WorldPacket& recvPacket)
+void WorldSession::handleQuestPOIQueryOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgQuestPoiQuery srlPacket;

--- a/src/world/Server/Packets/Handlers/TaxiHandler.cpp
+++ b/src/world/Server/Packets/Handlers/TaxiHandler.cpp
@@ -143,7 +143,7 @@ void WorldSession::handleTaxiQueryAvaibleNodesOpcode(WorldPacket& recvPacket)
     sendTaxiMenu(unit);
 }
 
-void WorldSession::handleEnabletaxiOpcode(WorldPacket& recvPacket)
+void WorldSession::handleEnabletaxiOpcode([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgEnabletaxi srlPacket;

--- a/src/world/Server/Packets/Handlers/VehicleHandler.cpp
+++ b/src/world/Server/Packets/Handlers/VehicleHandler.cpp
@@ -16,14 +16,14 @@ This file is released under the MIT license. See README-MIT for more information
 
 using namespace AscEmu::Packets;
 
-void WorldSession::handleDismissVehicle(WorldPacket& recvPacket)
+void WorldSession::handleDismissVehicle([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     uint64_t vehicleGUID = _player->getCharmGuid();
 
-    if (!vehicleGUID)   // something wrong here...
+    if (!vehicleGUID) // something wrong here...
     {
-        recvPacket.rfinish();   // prevent warnings spam
+        recvPacket.rfinish(); // prevent warnings spam
         return;
     }
 
@@ -32,7 +32,7 @@ void WorldSession::handleDismissVehicle(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleRequestVehiclePreviousSeat(WorldPacket& recvPacket)
+void WorldSession::handleRequestVehiclePreviousSeat([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     if (GetPlayer()->getVehicleBase() == nullptr)
@@ -52,7 +52,7 @@ void WorldSession::handleRequestVehiclePreviousSeat(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleRequestVehicleNextSeat(WorldPacket& recvPacket)
+void WorldSession::handleRequestVehicleNextSeat([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     if (GetPlayer()->getVehicleBase() == nullptr)
@@ -72,7 +72,7 @@ void WorldSession::handleRequestVehicleNextSeat(WorldPacket& recvPacket)
 #endif
 }
 
-void WorldSession::handleRequestVehicleSwitchSeat(WorldPacket& recvPacket)
+void WorldSession::handleRequestVehicleSwitchSeat([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     Unit* vehicle_base = GetPlayer()->getVehicleBase();
@@ -154,7 +154,7 @@ void WorldSession::handleChangeSeatsOnControlledVehicle([[maybe_unused]]WorldPac
 #endif
 }
 
-void WorldSession::handleRemoveVehiclePassenger(WorldPacket& recvPacket)
+void WorldSession::handleRemoveVehiclePassenger([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     Vehicle* vehicle = _player->getVehicleKit();
@@ -199,7 +199,7 @@ void WorldSession::handleLeaveVehicle(WorldPacket& /*recvPacket*/)
 #endif
 }
 
-void WorldSession::handleEnterVehicle(WorldPacket& recvPacket)
+void WorldSession::handleEnterVehicle(WorldPacket& [[maybe_unused]] recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgPlayerVehicleEnter srlPacket;

--- a/src/world/Server/Packets/Handlers/VehicleHandler.cpp
+++ b/src/world/Server/Packets/Handlers/VehicleHandler.cpp
@@ -106,7 +106,7 @@ void WorldSession::handleRequestVehicleSwitchSeat([[maybe_unused]] WorldPacket& 
 #endif
 }
 
-void WorldSession::handleChangeSeatsOnControlledVehicle([[maybe_unused]]WorldPacket& recvPacket)
+void WorldSession::handleChangeSeatsOnControlledVehicle([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     Unit* vehicle_base = GetPlayer()->getVehicleBase();
@@ -122,9 +122,9 @@ void WorldSession::handleChangeSeatsOnControlledVehicle([[maybe_unused]]WorldPac
         return;
 
 #if VERSION_STRING < Cata
-    uint64_t guid = srlPacket.sourceGuid;               // current vehicle guid
+    uint64_t guid = srlPacket.sourceGuid; // current vehicle guid
 #endif
-    uint64_t accessory = srlPacket.destinationGuid;     // accessory guid
+    uint64_t accessory = srlPacket.destinationGuid; // accessory guid
 
     vehicle_base->obj_movement_info = srlPacket.movementInfo;
     int8_t seatId = srlPacket.seat;
@@ -160,7 +160,7 @@ void WorldSession::handleRemoveVehiclePassenger([[maybe_unused]] WorldPacket& re
     Vehicle* vehicle = _player->getVehicleKit();
     if (!vehicle)
     {
-        recvPacket.rfinish();   // prevent warnings spam
+        recvPacket.rfinish(); // prevent warnings spam
         return;
     }
 
@@ -178,8 +178,7 @@ void WorldSession::handleRemoveVehiclePassenger([[maybe_unused]] WorldPacket& re
     if (!passengerUnit->isOnVehicle(vehicle->getBase()))
         return;
 
-    auto seat = vehicle->getSeatForPassenger(passengerUnit);
-    if (seat)
+    if (auto seat = vehicle->getSeatForPassenger(passengerUnit))
         if (seat->isEjectable())
             passengerUnit->callExitVehicle();
 #endif
@@ -199,7 +198,7 @@ void WorldSession::handleLeaveVehicle(WorldPacket& /*recvPacket*/)
 #endif
 }
 
-void WorldSession::handleEnterVehicle(WorldPacket& [[maybe_unused]] recvPacket)
+void WorldSession::handleEnterVehicle([[maybe_unused]] WorldPacket& recvPacket)
 {
 #if VERSION_STRING > TBC
     CmsgPlayerVehicleEnter srlPacket;

--- a/src/world/Server/Packets/SmsgSetExtraAuraInfo.h
+++ b/src/world/Server/Packets/SmsgSetExtraAuraInfo.h
@@ -47,7 +47,7 @@ namespace AscEmu::Packets
             return true;
         }
 
-        bool internalDeserialise(WorldPacket& packet) override
+        bool internalDeserialise(WorldPacket& /*packet*/) override
         {
             return true;
         }

--- a/src/world/Server/World.cpp
+++ b/src/world/Server/World.cpp
@@ -297,7 +297,7 @@ void World::addSession(std::unique_ptr<WorldSession> sessionHolder)
     {
         std::lock_guard<std::mutex> guard(mSessionLock);
 
-        auto* worldSession = sessionHolder.get();
+        [[maybe_unused]] auto* worldSession = sessionHolder.get();
         mActiveSessionMapStore[sessionHolder->GetAccountId()] = std::move(sessionHolder);
 
         if (static_cast<uint32_t>(mActiveSessionMapStore.size()) > getPeakSessionCount())

--- a/src/world/Spell/Spell.cpp
+++ b/src/world/Spell/Spell.cpp
@@ -2127,7 +2127,7 @@ SpellCastResult Spell::canCast(const bool secondCheck, uint32_t* parameter1, uin
             if (areaEntry == nullptr)
                 return SPELL_FAILED_NOT_HERE;
 
-            const auto requireAreaId = static_cast<uint32_t>(getSpellInfo()->getRequiresAreaId());
+            [[maybe_unused]] const auto requireAreaId = static_cast<uint32_t>(getSpellInfo()->getRequiresAreaId());
 #if VERSION_STRING == TBC
             if (requireAreaId != areaEntry->id && requireAreaId != areaEntry->zone)
             {

--- a/src/world/Spell/SpellAura.cpp
+++ b/src/world/Spell/SpellAura.cpp
@@ -874,7 +874,7 @@ void Aura::periodicTick(AuraEffectModifier* aurEff)
     if (scriptResult == SpellScriptExecuteState::EXECUTE_PREVENT)
         return;
 
-    int32_t customDamage = 0;
+    [[maybe_unused]] int32_t customDamage = 0;
     auto effectIntValue = static_cast<int32_t>(std::ceil(effectFloatValue));
 
     switch (aurEff->getAuraEffectType())

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -2562,7 +2562,7 @@ void Aura::SpellAuraModBlockPerc(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraModCritPerc(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModCritPerc([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING >= TBC // support classic
     if (p_target != nullptr)
@@ -3225,7 +3225,7 @@ void Aura::SpellAuraModDamagePercDone(AuraEffectModifier* aurEff, bool apply)
     m_target->calculateDamage();
 }
 
-void Aura::SpellAuraModPercStat(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModPercStat([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING >= TBC // support classic
     int32_t val;
@@ -4176,7 +4176,7 @@ void Aura::SpellAuraModManaRegInterrupt(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraModTotalStatPerc(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModTotalStatPerc([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING >= TBC // support classic
     int32_t val;
@@ -4736,7 +4736,7 @@ void Aura::SpellAuraModSpellDamageByAP(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraIncreaseHealingByAttribute(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraIncreaseHealingByAttribute([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > Classic
     int32_t val = aurEff->getEffectDamage();
@@ -4780,7 +4780,7 @@ void Aura::SpellAuraIncreaseHealingByAttribute(AuraEffectModifier* aurEff, bool 
 #endif
 }
 
-void Aura::SpellAuraModHealingByAP(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModHealingByAP([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > Classic
     int32_t val;
@@ -4821,7 +4821,7 @@ void Aura::SpellAuraModHealingByAP(AuraEffectModifier* aurEff, bool apply)
 #endif
 }
 
-void Aura::SpellAuraModHealingDone(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModHealingDone([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > Classic
     int32_t val;
@@ -5393,7 +5393,7 @@ void Aura::SpellAuraRegenManaStatPCT(AuraEffectModifier* aurEff, bool apply)
     static_cast<Player*>(m_target)->updateStats();
 }
 
-void Aura::SpellAuraSpellHealingStatPCT(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraSpellHealingStatPCT([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING >= TBC // support classic
     if (!m_target->isPlayer())
@@ -5595,7 +5595,7 @@ void Aura::SpellAuraExpertise(AuraEffectModifier* /*aurEff*/, bool /*apply*/)
     p_target->calcExpertise();
 }
 
-void Aura::SpellAuraForceMoveForward(AuraEffectModifier* /*aurEff*/, bool apply)
+void Aura::SpellAuraForceMoveForward(AuraEffectModifier* /*aurEff*/, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING != Classic
     if (apply)
@@ -5605,7 +5605,7 @@ void Aura::SpellAuraForceMoveForward(AuraEffectModifier* /*aurEff*/, bool apply)
 #endif
 }
 
-void Aura::SpellAuraComprehendLang(AuraEffectModifier* /*aurEff*/, bool apply)
+void Aura::SpellAuraComprehendLang(AuraEffectModifier* /*aurEff*/, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING != Classic
     if (apply)
@@ -5743,7 +5743,7 @@ void Aura::SpellAuraAddHealth(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraRemoveReagentCost(AuraEffectModifier* /*aurEff*/, bool apply)
+void Aura::SpellAuraRemoveReagentCost(AuraEffectModifier* /*aurEff*/, [[maybe_unused]] bool apply)
 {
     if (p_target == nullptr)
         return;

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -3729,7 +3729,7 @@ void Aura::SpellAuraFeatherFall(AuraEffectModifier* /*aurEff*/, bool apply)
     }
 }
 
-void Aura::SpellAuraHover(AuraEffectModifier* [[maybe_unused]] aurEff, [[maybe_unused]] bool apply)
+void Aura::SpellAuraHover([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > TBC
     mPositive = true;
@@ -3737,7 +3737,7 @@ void Aura::SpellAuraHover(AuraEffectModifier* [[maybe_unused]] aurEff, [[maybe_u
     if (apply)
     {
         m_target->setMoveHover(true);
-        m_target->setHoverHeight(float(aurEff->getEffectDamage()) / 2);
+        m_target->setHoverHeight(static_cast<float>(aurEff->getEffectDamage()) / 2);
     }
     else
     {

--- a/src/world/Spell/SpellAuras.Legacy.cpp
+++ b/src/world/Spell/SpellAuras.Legacy.cpp
@@ -1871,7 +1871,7 @@ void Aura::SpellAuraReflectSpells(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraModStat(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModStat([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > TBC // support classic
     int32_t stat = aurEff->getEffectMiscValue();
@@ -2485,7 +2485,7 @@ void Aura::SpellAuraTrackResources(AuraEffectModifier* aurEff, bool apply)
     }
 }
 
-void Aura::SpellAuraModParryPerc(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModParryPerc([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > TBC // support classic
     //if (m_target->getObjectTypeId() == TYPEID_PLAYER)
@@ -2512,7 +2512,7 @@ void Aura::SpellAuraModParryPerc(AuraEffectModifier* aurEff, bool apply)
 #endif
 }
 
-void Aura::SpellAuraModDodgePerc(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraModDodgePerc([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > TBC // support classic
     // if (m_target->getObjectTypeId() == TYPEID_PLAYER)
@@ -3729,7 +3729,7 @@ void Aura::SpellAuraFeatherFall(AuraEffectModifier* /*aurEff*/, bool apply)
     }
 }
 
-void Aura::SpellAuraHover(AuraEffectModifier* aurEff, bool apply)
+void Aura::SpellAuraHover(AuraEffectModifier* [[maybe_unused]] aurEff, [[maybe_unused]] bool apply)
 {
 #if VERSION_STRING > TBC
     mPositive = true;
@@ -5658,7 +5658,7 @@ void Aura::SpellAuraReduceEffectDuration(AuraEffectModifier* aurEff, bool apply)
 
 // Caster = player
 // Target = vehicle
-void Aura::HandleAuraControlVehicle(AuraEffectModifier* aurEff, bool apply)
+void Aura::HandleAuraControlVehicle([[maybe_unused]] AuraEffectModifier* aurEff, [[maybe_unused]] bool apply)
 {
 #ifdef FT_VEHICLES
     if (!getCaster())
@@ -5779,7 +5779,7 @@ void Aura::SpellAuraModMechanicDmgTakenPct(AuraEffectModifier* aurEff, bool appl
         m_target->m_modDamageTakenByMechPct[aurEff->getEffectMiscValue()] -= (float)aurEff->getEffectDamage() / 100;
 }
 
-void Aura::SpellAuraAllowOnlyAbility(AuraEffectModifier* /*aurEff*/, bool apply)
+void Aura::SpellAuraAllowOnlyAbility(AuraEffectModifier* /*aurEff*/, [[maybe_unused]] bool apply)
 {
     // cannot perform any abilities, currently only works on players
     if (!p_target)

--- a/src/world/Spell/SpellEffects.Legacy.cpp
+++ b/src/world/Spell/SpellEffects.Legacy.cpp
@@ -3095,7 +3095,7 @@ void Spell::SpellEffectSummonPossessed(uint32_t /*i*/, WDB::Structures::SummonPr
     p_caster->possess(s, 1000);
 }
 
-void Spell::SpellEffectSummonCompanion(uint32_t /*i*/, WDB::Structures::SummonPropertiesEntry const* spe, CreatureProperties const* properties_, LocationVector & v)
+void Spell::SpellEffectSummonCompanion(uint32_t /*i*/, [[maybe_unused]] WDB::Structures::SummonPropertiesEntry const* spe, [[maybe_unused]] CreatureProperties const* properties_, [[maybe_unused]] LocationVector& v)
 {
     if (u_caster == nullptr)
         return;
@@ -3107,14 +3107,14 @@ void Spell::SpellEffectSummonCompanion(uint32_t /*i*/, WDB::Structures::SummonPr
         if (critter == nullptr)
             return;
 
-        auto creature = static_cast< Creature* >(critter);
+        auto creature = static_cast<Creature*>(critter);
 
         uint32_t currententry = creature->GetCreatureProperties()->Id;
 
         creature->RemoveFromWorld(false, true);
         u_caster->setCritterGuid(0);
 
-        // Before WOTLK when you casted the companion summon spell the second time it removed the companion
+        // Before WOTLK when you cast the companion summon spell the second time it removed the companion
         // Customized servers or old databases could still use this method
         if (properties_->Id == currententry)
             return;
@@ -4579,7 +4579,7 @@ void Spell::SpellEffectAddFarsight(uint8_t effectIndex) // Add Farsight
     p_caster->getWorldMap()->changeFarsightLocation(p_caster, dynObj);
 }
 
-void Spell::SpellEffectUseGlyph(uint8_t effectIndex)
+void Spell::SpellEffectUseGlyph([[maybe_unused]] uint8_t effectIndex)
 {
 #if VERSION_STRING > TBC
     if (!p_caster)
@@ -6068,7 +6068,7 @@ void Spell::SpellEffectDualWield2H(uint8_t /*effectIndex*/)
     m_playerTarget->setDualWield2H(true);
 }
 
-void Spell::SpellEffectEnchantItemPrismatic(uint8_t effectIndex)
+void Spell::SpellEffectEnchantItemPrismatic([[maybe_unused]] uint8_t effectIndex)
 {
 #if VERSION_STRING < WotLK
     return;

--- a/src/world/Spell/SpellMgr.cpp
+++ b/src/world/Spell/SpellMgr.cpp
@@ -402,7 +402,7 @@ bool SpellMgr::checkLocation(SpellInfo const* spellInfo, uint32_t zone_id, uint3
     // Normal case
     if (spellInfo->getRequiresAreaId() > 0)
     {
-        const auto requireAreaId = static_cast<uint32_t>(spellInfo->getRequiresAreaId());
+        [[maybe_unused]] const auto requireAreaId = static_cast<uint32_t>(spellInfo->getRequiresAreaId());
 #if VERSION_STRING == TBC
         if (requireAreaId != zone_id && requireAreaId != area_id)
             return false;

--- a/src/world/Storage/WDB/WDBStores.cpp
+++ b/src/world/Storage/WDB/WDBStores.cpp
@@ -300,9 +300,9 @@ bool loadDBCs()
 
                 // Classic has only one Difficulty - Same reset Time - and only 5 or 40 man Raids
                 if (!entry->getResetTimeHeroic())
-                    sMapDifficultyMap[Util::MAKE_PAIR32(entry->id, InstanceDifficulty::Difficulties::DUNGEON_NORMAL)] = WDB::Structures::MapDifficulty(entry->getResetTimeNormal(), maxPlayers, false);
+                    sMapDifficultyMap[Util::MAKE_PAIR32(static_cast<uint16_t>(entry->id), InstanceDifficulty::Difficulties::DUNGEON_NORMAL)] = WDB::Structures::MapDifficulty(entry->getResetTimeNormal(), maxPlayers, false);
                 else
-                    sMapDifficultyMap[Util::MAKE_PAIR32(entry->id, InstanceDifficulty::Difficulties::DUNGEON_HEROIC)] = WDB::Structures::MapDifficulty(entry->getResetTimeHeroic(), maxPlayers, false);
+                    sMapDifficultyMap[Util::MAKE_PAIR32(static_cast<uint16_t>(entry->id), InstanceDifficulty::Difficulties::DUNGEON_HEROIC)] = WDB::Structures::MapDifficulty(entry->getResetTimeHeroic(), maxPlayers, false);
             }
         }
 #endif


### PR DESCRIPTION
**Description**
Fix W4 Warnings
- Classic
- TBC
- Cata/Mop Tools

Activate W4 CMake flag vor MS VC (msvc.cmake)

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [] Classic
- [] TBC
- [] WotLK
- [] Cata
- [x] Mop
