### PR TITLE
Improve build configuration and enable compiler warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ init:
   - cmd: msbuild /version
 
 install:
-  - git submodule update --init --recursive
+  - git submodule update --init --recursive --depth 1
 
 before_build:
   - cmd: echo %Image%
@@ -32,5 +32,5 @@ before_build:
 build_script:
   - cmd: mkdir ascemu_build
   - cmd: cd ascemu_build
-  - cmd: cmake ../ -G "Visual Studio 17 2022" -A %Platform% -DBUILD_WITH_WARNINGS=0 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_TOOLS=1 -DASCEMU_VERSION=%ASC_VERSION%
-  - cmd: msbuild Ascemu.sln
+  - cmd: cmake ../ -G "Visual Studio 17 2022" -A %Platform% -DBUILD_WITH_WARNINGS=1 -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_TOOLS=1 -DASCEMU_VERSION=%ASC_VERSION%
+  - cmd: msbuild Ascemu.sln /m /v:m /p:WarningLevel=4

--- a/src/world/Server/Packets/CmsgListInventory.h
+++ b/src/world/Server/Packets/CmsgListInventory.h
@@ -41,9 +41,9 @@ namespace AscEmu::Packets
         bool internalDeserialise(WorldPacket& packet) override
         {
 #if VERSION_STRING <= Cata
-            uint64_t unpacked_guid;
-            packet >> guid;
-            guid.init(unpacked_guid);
+            uint64_t unpackedGuid;
+            packet >> unpackedGuid;
+            guid.init(unpackedGuid);
 #else // Mop
             guid[6] = packet.readBit();
             guid[7] = packet.readBit();


### PR DESCRIPTION
**Description**
Enable compiler warnings (BUILD_WITH_WARNINGS=1) and set warning level to 4 in msbuild. Add build parallelization (/m flag) and improve CI performance with shallow submodule cloning. Fix variable naming convention from snake_case to camelCase in CmsgListInventory packet handler.

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Multiversion Ingame Tests Performed:**
- [x] Cata
- [x] Mop

