### PR TITLE
void SessionLog::write(std::string_view message) - this feature is currently not in use

### DIFF
--- a/src/shared/Logging/Log.cpp
+++ b/src/shared/Logging/Log.cpp
@@ -75,7 +75,6 @@ void WorldPacketLog::disablePacketLog()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // SessionLog functions
-
 SessionLog::SessionLog(const char* filename, bool open)
 {
 #if defined(linux) || defined(__linux) || defined(FreeBSD) || defined(__FreeBSD__) || defined(__APPLE__)
@@ -118,24 +117,5 @@ void SessionLog::closeSessionLog()
         fflush(mSessionLogFile);
         fclose(mSessionLogFile);
         mSessionLogFile = nullptr;
-    }
-}
-
-void SessionLog::write(const char* format, ...)
-{
-    if (mSessionLogFile != nullptr)
-    {
-        char out[32768];
-        va_list ap;
-
-        va_start(ap, format);
-
-        std::string current_time = "[" + Util::GetCurrentDateTimeString() + "] ";
-        sprintf(out, current_time.c_str());
-
-        size_t l = strlen(out);
-        vsnprintf(&out[l], 32768 - l, format, ap);
-        fprintf(mSessionLogFile, "%s\n", out);
-        va_end(ap);
     }
 }

--- a/src/shared/Logging/Log.hpp
+++ b/src/shared/Logging/Log.hpp
@@ -65,11 +65,8 @@ public:
     bool isSessionLogOpen();
     void closeSessionLog();
 
-    void write(const char* format, ...);
-
+    //////////////////////////////////////////////////////////////////////////////////////////
     // WorldSession.cpp
-    void write(WorldSession* session, const char* format, ...);
-
     template <typename... Args>
     void writefromsession(WorldSession* session, fmt::format_string<Args...> format, Args&&... args)
     {
@@ -78,4 +75,3 @@ public:
 
     void writefromsession(WorldSession* session,std::string_view message);
 };
-

--- a/src/world/Server/WorldSession.cpp
+++ b/src/world/Server/WorldSession.cpp
@@ -514,38 +514,6 @@ void SessionLog::writefromsession(WorldSession* session, std::string_view messag
     fflush(mSessionLogFile);
 }
 
-void SessionLog::write(WorldSession* session, const char* format, ...)
-{
-    if (isSessionLogOpen())
-    {
-        va_list ap;
-        va_start(ap, format);
-
-        // Get current time
-        std::string current_time = "[" + Util::GetCurrentDateTimeString() + "] ";
-
-        // Format the fixed part of the log entry using AscEmu::StringFormat
-        std::string logEntry = AscEmu::StringFormat("{}Account {} [{}], IP {}, Player {} :: ",
-            current_time,
-            session->GetAccountId(),
-            session->GetAccountName(),
-            session->GetSocket() ? session->GetSocket()->getRemoteIp() : "NOIP",
-            session->GetPlayer() ? session->GetPlayer()->getName() : "nologin");
-
-        // Use a buffer to format the variable arguments (like vsnprintf)
-        char messageBuffer[1024];
-        vsnprintf(messageBuffer, sizeof(messageBuffer), format, ap);
-        va_end(ap);
-
-        // Append the formatted message to the log entry
-        logEntry += messageBuffer;
-
-        // Write to the log file
-        fprintf(mSessionLogFile, "%s\n", logEntry.c_str());
-        fflush(mSessionLogFile);
-    }
-}
-
 void WorldSession::sendSystemMessagePacket(std::string& _message)
 {
     SmsgMessageChat messagePacket(SystemMessagePacket{_message});


### PR DESCRIPTION
remove 
void SessionLog::write(std::string_view message) 
void write(WorldSession* session, fmt::format_string<Args...> format, Args&&... args) 

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Ingame Tests Performed (at least one):**
- [x] WotLK
- [x] Cata
