### PR TITLE
Fix debug build on gcc/clang

### DIFF
--- a/.github/workflows/clang-linux-test-x64.yml
+++ b/.github/workflows/clang-linux-test-x64.yml
@@ -24,11 +24,11 @@ jobs:
           sudo apt-get install -y \
             zlib1g-dev \
             libssl-dev \
-            libpcre3-dev \
+            libpcre2-dev \
             libbz2-dev \
             default-libmysqlclient-dev \
             libmysql++-dev \
-            lld \
+            mold \
             ninja-build
 
       - name: AscEmu Build ${{ matrix.version }}

--- a/.github/workflows/gcc-linux-test-x64.yml
+++ b/.github/workflows/gcc-linux-test-x64.yml
@@ -26,9 +26,10 @@ jobs:
             gcc \
             g++ \
             ninja-build \
+            mold \
             zlib1g-dev \
             libssl-dev \
-            libpcre3-dev \
+            libpcre2-dev \
             libbz2-dev \
             default-libmysqlclient-dev \
             libmysql++-dev

--- a/.github/workflows/gcc-raspberryPI-test-x64.yml
+++ b/.github/workflows/gcc-raspberryPI-test-x64.yml
@@ -30,9 +30,10 @@ jobs:
           g++ \
           cmake \
           ninja-build \
+          mold \
           zlib1g-dev \
           libssl-dev \
-          libpcre3-dev \
+          libpcre2-dev \
           libbz2-dev \
           default-libmysqlclient-dev \
           libmysql++-dev

--- a/cmake/Compilers/clang.cmake
+++ b/cmake/Compilers/clang.cmake
@@ -14,9 +14,6 @@ message(STATUS "Applying settings for ${CMAKE_CXX_COMPILER}")
 # check support for unordered_map/set
 add_compile_options(-DHAS_CXX0X)
 
-# apply base flags (optimization level 2)
-add_compile_options(-O2)
-
 if (IS_64BIT)
     add_compile_options(-fPIC)
 endif ()
@@ -28,34 +25,47 @@ else ()
 endif ()
 
 # ==== Fast linker & debug info optimization ====
-# Prefer LLD, fallback to gold; add Split DWARF for faster debug builds.
+# Prefer Mold, then LLD, fallback to gold; add Split DWARF for faster debug builds.
 # Guard to avoid double injection if included multiple times.
 if(NOT DEFINED FAST_LINKER_CONFIGURED)
   set(FAST_LINKER_CONFIGURED ON)
+  set(SELECTED_LINKER "default")
 
-  # Try LLD first
+  # Try Mold first
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} -fuse-ld=lld -Wl,--version 
+    COMMAND ${CMAKE_C_COMPILER} -fuse-ld=mold -Wl,--version
     OUTPUT_VARIABLE LD_VERSION
     ERROR_QUIET
   )
-  if("${LD_VERSION}" MATCHES "LLD")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
-    message(STATUS "Linker: Using LLD")
+  if("${LD_VERSION}" MATCHES "mold")
+    add_link_options("-fuse-ld=mold")
+    set(SELECTED_LINKER "Mold")
+    message(STATUS "Linker: Using Mold")
   else()
-    # Fallback to gold
+    # Try next LLD
     execute_process(
-      COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version 
+      COMMAND ${CMAKE_C_COMPILER} -fuse-ld=lld -Wl,--version
       OUTPUT_VARIABLE LD_VERSION
       ERROR_QUIET
     )
-    if("${LD_VERSION}" MATCHES "GNU gold")
-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
-      message(STATUS "Linker: Using GNU gold")
+    if("${LD_VERSION}" MATCHES "LLD")
+      add_link_options("-fuse-ld=lld")
+      set(SELECTED_LINKER "LLD")
+      message(STATUS "Linker: Using LLD")
     else()
-      message(STATUS "Linker: Using system default")
+      # Fallback to gold
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version
+        OUTPUT_VARIABLE LD_VERSION
+        ERROR_QUIET
+      )
+      if("${LD_VERSION}" MATCHES "GNU gold")
+        add_link_options("-fuse-ld=gold")
+        set(SELECTED_LINKER "gold")
+        message(STATUS "Linker: Using GNU gold")
+      else()
+        message(STATUS "Linker: Using system default")
+      endif()
     endif()
   endif()
 
@@ -67,12 +77,12 @@ endif()
 # === Debug info & faster relinks (single-config friendly) ===
 # Avoid generator-expressions for Debug+RelWithDebInfo to prevent misparsing.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-gsplit-dwarf -fdebug-types-section)
-    add_link_options(-Wl --gdb-index)
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-gsplit-dwarf)
-    add_link_options(-Wl --gdb-index)
+  add_compile_options(-gsplit-dwarf)
+
+  if(SELECTED_LINKER STREQUAL "Mold" OR SELECTED_LINKER STREQUAL "gold" OR SELECTED_LINKER STREQUAL "LLD")
+    add_link_options(LINKER:--gdb-index)
   endif()
+  # System default linker (usually GNU bfd ld) does not support gdb-index as efficiently as other linkers
+  # Keep disabled for compatibility issues
 endif()
 # === End debug info block ===

--- a/cmake/Compilers/gcc.cmake
+++ b/cmake/Compilers/gcc.cmake
@@ -14,9 +14,6 @@ message(STATUS "Applying settings for ${CMAKE_CXX_COMPILER}")
 # check support for unordered_map/set
 add_compile_options(-DHAS_CXX0X)
 
-# apply base flags (optimization level 2)
-add_compile_options(-O2)
-
 if (IS_64BIT)
     add_compile_options(-fPIC)
 endif ()
@@ -28,34 +25,47 @@ else ()
 endif ()
 
 # ==== Fast linker & debug info optimization ====
-# Prefer LLD, fallback to gold; add Split DWARF for faster debug builds.
+# Prefer Mold, then LLD, fallback to gold; add Split DWARF for faster debug builds.
 # Guard to avoid double injection if included multiple times.
 if(NOT DEFINED FAST_LINKER_CONFIGURED)
   set(FAST_LINKER_CONFIGURED ON)
+  set(SELECTED_LINKER "default")
 
-  # Try LLD first
+  # Try Mold first
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} -fuse-ld=lld -Wl,--version 
+    COMMAND ${CMAKE_C_COMPILER} -fuse-ld=mold -Wl,--version
     OUTPUT_VARIABLE LD_VERSION
     ERROR_QUIET
   )
-  if("${LD_VERSION}" MATCHES "LLD")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
-    message(STATUS "Linker: Using LLD")
+  if("${LD_VERSION}" MATCHES "mold")
+    add_link_options("-fuse-ld=mold")
+    set(SELECTED_LINKER "Mold")
+    message(STATUS "Linker: Using Mold")
   else()
-    # Fallback to gold
+    # Try next LLD
     execute_process(
-      COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version 
+      COMMAND ${CMAKE_C_COMPILER} -fuse-ld=lld -Wl,--version
       OUTPUT_VARIABLE LD_VERSION
       ERROR_QUIET
     )
-    if("${LD_VERSION}" MATCHES "GNU gold")
-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
-      message(STATUS "Linker: Using GNU gold")
+    if("${LD_VERSION}" MATCHES "LLD")
+      add_link_options("-fuse-ld=lld")
+      set(SELECTED_LINKER "LLD")
+      message(STATUS "Linker: Using LLD")
     else()
-      message(STATUS "Linker: Using system default")
+      # Fallback to gold
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version
+        OUTPUT_VARIABLE LD_VERSION
+        ERROR_QUIET
+      )
+      if("${LD_VERSION}" MATCHES "GNU gold")
+        add_link_options("-fuse-ld=gold")
+        set(SELECTED_LINKER "gold")
+        message(STATUS "Linker: Using GNU gold")
+      else()
+        message(STATUS "Linker: Using system default")
+      endif()
     endif()
   endif()
 
@@ -67,12 +77,14 @@ endif()
 # === Debug info & faster relinks (single-config friendly) ===
 # Avoid generator-expressions for Debug+RelWithDebInfo to prevent misparsing.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-gsplit-dwarf -fdebug-types-section)
-    add_link_options(-Wl --gdb-index)
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-gsplit-dwarf)
-    add_link_options(-Wl --gdb-index)
+  add_compile_options(-gsplit-dwarf -fdebug-types-section)
+
+  # Do not use gdb-indexing for gcc if LLD linker is being used, split-dwarf is already enough
+  # gdb-index do not seem to work with modern gcc and LLD and it causes lots of warnings due to compatibility issues -Appled
+  if(SELECTED_LINKER STREQUAL "Mold" OR SELECTED_LINKER STREQUAL "gold")
+    add_link_options(LINKER:--gdb-index)
   endif()
+  # System default linker (usually GNU bfd ld) does not support gdb-index as efficiently as other linkers
+  # Keep disabled for compatibility issues
 endif()
 # === End debug info block ===

--- a/cmake/Systems/Apple.cmake
+++ b/cmake/Systems/Apple.cmake
@@ -16,12 +16,12 @@ find_package(Threads REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(BZip2 REQUIRED)
 
-if (CMAKE_C_COMPILER MATCHES "gcc" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
-elseif (CMAKE_C_COMPILER MATCHES "clang" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else ()
-    message(FATAL_ERROR "Compiler is not supported")
+    message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} is not supported")
 endif ()
 
 # check for database update files

--- a/cmake/Systems/FreeBSD.cmake
+++ b/cmake/Systems/FreeBSD.cmake
@@ -12,12 +12,12 @@ find_package(Threads REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(BZip2 REQUIRED)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else ()
-    message(FATAL_ERROR "Compiler is not supported")
+    message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} is not supported")
 endif ()
 
 # check for database update files

--- a/cmake/Systems/Linux.cmake
+++ b/cmake/Systems/Linux.cmake
@@ -14,12 +14,12 @@ find_package(Threads REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(BZip2 REQUIRED)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/gcc.cmake)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/clang.cmake)
 else ()
-    message(FATAL_ERROR "Compiler is not supported")
+    message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} is not supported")
 endif ()
 
 # check for database update files

--- a/cmake/Systems/Windows.cmake
+++ b/cmake/Systems/Windows.cmake
@@ -19,7 +19,7 @@ set(EXTRA_LIBS
 if (MSVC)
     include(${CMAKE_SOURCE_DIR}/cmake/Compilers/msvc.cmake)
 else ()
-    message(FATAL_ERROR "Compiler is not supported")
+    message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} is not supported")
 endif ()
 
 # check for db update files


### PR DESCRIPTION
**Description**
- CMake: Fix debug build on gcc/clang
- - Add support for Mold
- Update workflows
- - Update one deprecated package

**Todo / Checklist**
- [x] Target is branch develop.
- [x] Detailed description about this pull request.
- [x] Checked AE-Coding standards.

**Tests Performed:** 
- [x] Build AE with "TREAT_WARNINGS_AS_ERRORS" flag turned on.
- [x] Server startup.
- [x] Log into world.

**Ingame Tests Performed (at least one):**
- [ ] Classic
- [ ] TBC
- [x] WotLK
- [ ] Cata
- [ ] Mop
